### PR TITLE
Fix bug in defining split data seed

### DIFF
--- a/topobench/data/utils/split_utils.py
+++ b/topobench/data/utils/split_utils.py
@@ -116,7 +116,9 @@ def random_splitting(labels, parameters, root=None, global_data_seed=42):
     dict:
         Dictionary containing the train, validation and test indices with keys "train", "valid", and "test".
     """
-    fold = parameters["data_seed"]
+    fold = (
+        parameters["data_seed"] % 10
+    )  # Ensure fold is between 0 and 9, TODO: Modify hardcoded 10 split number
     data_dir = (
         parameters["data_split_dir"]
         if root is None


### PR DESCRIPTION
The number of random splits is hardcoded to 10: this PR avoids the raise of an error when data_seed is greater than 10 by taking its modulo 10 value.