### PR TITLE
Category: A2; Team name: HugoWalter; Dataset: Cornell Labeled Nodes Hypergraphs

### DIFF
--- a/configs/dataset/hypergraph/amazon_reviews.yaml
+++ b/configs/dataset/hypergraph/amazon_reviews.yaml
@@ -1,0 +1,40 @@
+# Amazon Reviews Dataset  
+# Description: Sets of products reviewed by users on Amazon, where node labels are
+#              product categories (e.g., books, electronics, home & kitchen).
+# Source: https://www.cs.cornell.edu/~arb/data/amazon-reviews/
+# Statistics: 2,268,264 products | 4,285,363 co-review sets | 29 categories
+#             Mean/median hyperedge size: 17.1/8 | Max size: 9,350
+# Note: Actual nodes (2,268,264) differs from Cornell website (2,268,231)
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: amazon-reviews
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 29  # Product categories
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/configs/dataset/hypergraph/contact_high_school.yaml
+++ b/configs/dataset/hypergraph/contact_high_school.yaml
@@ -1,0 +1,39 @@
+# High School Contact Dataset
+# Description: Sets of students in proximity (face-to-face contacts), where node
+#              labels are classrooms.
+# Source: https://www.cs.cornell.edu/~arb/data/contact-high-school-labeled/
+# Statistics: 327 students | 7,818 contact groups | 9 classes
+#             Mean/median hyperedge size: 2.3/2.0 | Max size: 5
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: contact-high-school
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 9  # Classrooms
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/configs/dataset/hypergraph/contact_primary_school.yaml
+++ b/configs/dataset/hypergraph/contact_primary_school.yaml
@@ -1,0 +1,39 @@
+# Primary School Contact Dataset
+# Description: Sets of students in proximity (face-to-face contacts), where node
+#              labels are classrooms (10 classes + teachers).
+# Source: https://www.cs.cornell.edu/~arb/data/contact-primary-school-labeled/
+# Statistics: 242 students/teachers | 12,704 contact groups | 11 classes
+#             Mean/median hyperedge size: 2.4/2 | Max size: 5
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: contact-primary-school
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 11  # Teacher + 10 classrooms
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/configs/dataset/hypergraph/house_bills.yaml
+++ b/configs/dataset/hypergraph/house_bills.yaml
@@ -1,0 +1,39 @@
+# House Bills Dataset
+# Description: Bill co-sponsorship in the US House of Representatives, where node
+#              labels are political affiliation (Republican/Democrat).
+# Source: https://www.cs.cornell.edu/~arb/data/house-bills/
+# Statistics: 1,494 House members | 60,987 bills | 2 parties
+#             Mean/median hyperedge size: 20.5/9.0 | Max size: 399
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: house-bills
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 2  # Political parties (Republican/Democrat)
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/configs/dataset/hypergraph/house_committees.yaml
+++ b/configs/dataset/hypergraph/house_committees.yaml
@@ -1,0 +1,39 @@
+# House Committees Dataset
+# Description: Committee membership in the US House of Representatives, where node
+#              labels are political affiliation (Republican/Democrat).
+# Source: https://www.cs.cornell.edu/~arb/data/house-committees/
+# Statistics: 1,290 House members | 341 committees | 2 parties
+#             Mean/median hyperedge size: 34.8/40.0 | Max size: 82
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: house-committees
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 2  # Political parties (Republican/Democrat)
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/configs/dataset/hypergraph/senate_bills.yaml
+++ b/configs/dataset/hypergraph/senate_bills.yaml
@@ -1,0 +1,39 @@
+# Senate Bills Dataset
+# Description: Bill co-sponsorship in the US Senate, where node labels are
+#              political affiliation (Republican/Democrat).
+# Source: https://www.cs.cornell.edu/~arb/data/senate-bills/
+# Statistics: 294 Senate members | 29,157 bills | 2 parties
+#             Mean/median hyperedge size: 8.0/4.0 | Max size: 99
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: senate-bills
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 2  # Political parties (Republican/Democrat)
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/configs/dataset/hypergraph/senate_committees.yaml
+++ b/configs/dataset/hypergraph/senate_committees.yaml
@@ -1,0 +1,39 @@
+# Senate Committees Dataset
+# Description: Committee membership in the US Senate, where node labels are
+#              political affiliation (Republican/Democrat).
+# Source: https://www.cs.cornell.edu/~arb/data/senate-committees/
+# Statistics: 293 Senate members | 315 committees | 2 parties
+#             Mean/median hyperedge size: 17.2/18.0 | Max size: 29
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: senate-committees
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 2  # Political parties (Republican/Democrat)
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/configs/dataset/hypergraph/walmart_trips.yaml
+++ b/configs/dataset/hypergraph/walmart_trips.yaml
@@ -1,0 +1,39 @@
+# Walmart Shopping Trips Dataset
+# Description: Sets of products bought on Walmart shopping trips, where node labels
+#              are departments of products (e.g., electronics, groceries, clothing).
+# Source: https://www.cs.cornell.edu/~arb/data/walmart-trips/
+# Statistics: 88,860 products | 69,906 trips | 11 departments
+#             Mean/median hyperedge size: 6.6/5 | Max size: 25
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.CornellLabeledNodesDatasetLoader
+  parameters: 
+    data_domain: hypergraph
+    data_type: cornell_labeled_nodes
+    data_name: walmart-trips
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+
+# Dataset parameters
+parameters:
+  num_features: 1  # Simple constant features
+  num_classes: 11  # 10 broad departments + 1 "Other" class
+  task: classification
+  loss_type: cross_entropy
+  monitor_metric: accuracy
+  task_level: node
+
+# Splits
+split_params:
+  learning_setting: transductive  # Single hypergraph, node classification task
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10  # for k-fold CV
+  train_prop: 0.5  # for random split
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 1  # Fixed for single hypergraph
+  num_workers: 1
+  pin_memory: False

--- a/test/data/load/test_cornell_labeled_nodes.py
+++ b/test/data/load/test_cornell_labeled_nodes.py
@@ -1,0 +1,363 @@
+"""Unit tests for Cornell labeled nodes hypergraph datasets."""
+
+import os
+import shutil
+import pytest
+import torch
+import numpy as np
+from pathlib import Path
+from omegaconf import DictConfig
+
+from topobench.data.datasets.cornell_labeled_nodes_dataset import (
+    CornellLabeledNodesDataset,
+)
+from topobench.data.loaders.hypergraph import CornellLabeledNodesDatasetLoader
+
+
+class TestCornellLabeledNodesDataset:
+    """Test suite for CornellLabeledNodesDataset class."""
+
+    # Expected statistics for each dataset
+    DATASET_STATS = {
+        "walmart-trips": {
+            "num_nodes": 88860,
+            "num_hyperedges": 69906,
+            "num_classes": 11,
+            "num_edges": 460630,
+            "mean_hyperedge_size": 6.59,
+            "median_hyperedge_size": 5,
+            "max_hyperedge_size": 25,
+        },
+        "house-committees": {
+            "num_nodes": 1290,
+            "num_hyperedges": 341,
+            "num_classes": 2,
+            "num_edges": 11843,  # Deduplicated (was 11863 with duplicates)
+            "mean_hyperedge_size": 34.7,  # Recalculated after deduplication
+            "median_hyperedge_size": 40.0,
+            "max_hyperedge_size": 81,  # Reduced from 82 (one hyperedge had duplicate)
+        },
+        "senate-committees": {
+            "num_nodes": 282,
+            "num_hyperedges": 315,
+            "num_classes": 2,
+            "num_edges": 5408,  # Deduplicated (was 5430 with duplicates)
+            "mean_hyperedge_size": 17.2,  # Stays same after rounding
+            "median_hyperedge_size": 19.0,
+            "max_hyperedge_size": 31,
+        },
+        "house-bills": {
+            "num_nodes": 1494,
+            "num_hyperedges": 60987,
+            "num_classes": 2,
+            "num_edges": 1248666,
+            "mean_hyperedge_size": 20.5,
+            "median_hyperedge_size": 9.0,
+            "max_hyperedge_size": 399,
+        },
+        "senate-bills": {
+            "num_nodes": 294,
+            "num_hyperedges": 29157,
+            "num_classes": 2,
+            "num_edges": 232147,
+            "mean_hyperedge_size": 8.0,
+            "median_hyperedge_size": 4.0,
+            "max_hyperedge_size": 99,
+        },
+        "contact-primary-school": {
+            "num_nodes": 242,
+            "num_hyperedges": 12704,
+            "num_classes": 11,
+            "num_edges": 30729,
+            "mean_hyperedge_size": 2.4,
+            "median_hyperedge_size": 2.0,
+            "max_hyperedge_size": 5,
+        },
+        "contact-high-school": {
+            "num_nodes": 327,
+            "num_hyperedges": 7818,
+            "num_classes": 9,
+            "num_edges": 18192,
+            "mean_hyperedge_size": 2.3,
+            "median_hyperedge_size": 2.0,
+            "max_hyperedge_size": 5,
+        },
+        "amazon-reviews": {
+            "num_nodes": 2268264,  # Actual from dataset (Cornell website says 2,268,231)
+            "num_hyperedges": 4285363,
+            "num_classes": 29,
+            "num_edges": 73141425,  # Actual edge_index shape[1]
+            "mean_hyperedge_size": 17.1,
+            "median_hyperedge_size": 8.0,
+            "max_hyperedge_size": 9350,
+        },
+    }
+
+    @pytest.fixture(scope="session")
+    def test_data_dir(self):
+        """Create persistent cache directory for test data.
+        
+        Uses session scope so datasets are downloaded once and reused
+        across all test runs, which is important for large datasets
+        like amazon-reviews.
+
+        Returns
+        -------
+        Path
+            Persistent cache directory path.
+        """
+        cache_dir = Path(".test_tmp/cornell_datasets")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
+
+    @pytest.fixture
+    def walmart_params(self, test_data_dir):
+        """Create parameters for walmart-trips dataset.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+
+        Returns
+        -------
+        DictConfig
+            Configuration parameters.
+        """
+        return DictConfig({
+            "data_dir": str(test_data_dir),
+            "data_name": "walmart-trips"
+        })
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_dataset_initialization(self, test_data_dir, dataset_name):
+        """Test that dataset initializes correctly.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        
+        assert dataset is not None
+        assert dataset.name == dataset_name
+        assert len(dataset) == 1  # Single hypergraph
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_dataset_structure(self, test_data_dir, dataset_name):
+        """Test that loaded dataset has correct structure.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        data = dataset[0]
+        
+        # Check required attributes exist
+        assert hasattr(data, 'x'), "Missing node features"
+        assert hasattr(data, 'y'), "Missing labels"
+        assert hasattr(data, 'edge_index'), "Missing edge_index"
+        assert hasattr(data, 'incidence_hyperedges'), "Missing incidence matrix"
+        assert hasattr(data, 'num_nodes'), "Missing num_nodes"
+        assert hasattr(data, 'num_hyperedges'), "Missing num_hyperedges"
+        assert hasattr(data, 'num_class'), "Missing num_class"
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_dataset_statistics(self, test_data_dir, dataset_name):
+        """Test that dataset has expected statistics.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        data = dataset[0]
+        
+        # Get expected statistics for this dataset
+        expected = self.DATASET_STATS[dataset_name]
+        
+        # Check node/hyperedge/class counts
+        assert data.num_nodes == expected["num_nodes"], "Incorrect number of nodes"
+        assert data.num_hyperedges == expected["num_hyperedges"], "Incorrect number of hyperedges"
+        assert data.num_class == expected["num_classes"], "Incorrect number of classes"
+        
+        # Check shapes
+        assert data.x.shape == (expected["num_nodes"], 1), "Incorrect feature shape"
+        assert data.y.shape == (expected["num_nodes"],), "Incorrect label shape"
+        assert data.edge_index.shape[0] == 2, "Edge index should be 2xN"
+        assert data.edge_index.shape[1] == expected["num_edges"], "Incorrect number of edges"
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_label_indexing(self, test_data_dir, dataset_name):
+        """Test that labels are correctly 0-indexed.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        data = dataset[0]
+        
+        expected = self.DATASET_STATS[dataset_name]
+        
+        # Labels should be 0-indexed
+        assert data.y.min().item() == 0, "Labels should start from 0"
+        assert data.y.max().item() == expected["num_classes"] - 1, \
+            "Labels should end at num_classes-1"
+        
+        # Check all labels are valid
+        unique_labels = torch.unique(data.y).tolist()
+        assert unique_labels == list(range(expected["num_classes"])), \
+            f"Labels should be [0, 1, ..., {expected['num_classes']-1}]"
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_node_indexing(self, test_data_dir, dataset_name):
+        """Test that node IDs in edge_index are 0-indexed.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        data = dataset[0]
+        
+        # Node IDs should be 0-indexed
+        node_ids = data.edge_index[0]
+        assert node_ids.min().item() == 0, "Node IDs should start from 0"
+        assert node_ids.max().item() == data.num_nodes - 1, \
+            "Max node ID should be num_nodes-1"
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_hyperedge_statistics(self, test_data_dir, dataset_name):
+        """Test hyperedge size statistics.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        data = dataset[0]
+        
+        expected = self.DATASET_STATS[dataset_name]
+        
+        # Calculate hyperedge sizes
+        hyperedge_sizes = torch.bincount(data.edge_index[1])
+        mean_size = hyperedge_sizes.float().mean().item()
+        median_size = hyperedge_sizes.float().median().item()
+        max_size = hyperedge_sizes.max().item()
+        
+        # Check statistics (use 0.1 tolerance for mean to account for rounding)
+        assert abs(mean_size - expected["mean_hyperedge_size"]) < 0.1, \
+            f"Incorrect mean hyperedge size for {dataset_name}: {mean_size} vs {expected['mean_hyperedge_size']}"
+        assert median_size == expected["median_hyperedge_size"], \
+            f"Incorrect median hyperedge size for {dataset_name}"
+        assert max_size == expected["max_hyperedge_size"], \
+            f"Incorrect max hyperedge size for {dataset_name}"
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_incidence_matrix(self, test_data_dir, dataset_name):
+        """Test that incidence matrix is correctly formed.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        data = dataset[0]
+        
+        expected = self.DATASET_STATS[dataset_name]
+        
+        # Check incidence matrix properties
+        assert data.incidence_hyperedges.is_sparse, "Incidence should be sparse"
+        assert data.incidence_hyperedges.shape == (expected["num_nodes"], expected["num_hyperedges"]), \
+            "Incorrect incidence matrix shape"
+        
+        # Check that incidence matrix is binary by verifying construction
+        # The incidence matrix is constructed from edge_index with all 1.0 values
+        # When coalesced, duplicate entries are summed, but there shouldn't be duplicates
+        # in a properly constructed incidence matrix
+        
+        # Verify the number of stored values matches edge count
+        assert data.incidence_hyperedges._nnz() == data.edge_index.shape[1], \
+            "Number of non-zero entries should equal number of edges"
+
+    @pytest.mark.parametrize("dataset_name", ["walmart-trips", "house-committees", "senate-committees", "house-bills", "senate-bills", "contact-primary-school", "contact-high-school", "amazon-reviews"])
+    def test_data_consistency(self, test_data_dir, dataset_name):
+        """Test consistency between edge_index and incidence matrix.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        dataset_name : str
+            Name of dataset to test.
+        """
+        dataset = CornellLabeledNodesDataset(
+            data_dir=str(test_data_dir),
+            data_name=dataset_name,
+        )
+        data = dataset[0]
+        
+        # Number of edges should match incidence matrix nnz
+        num_edges = data.edge_index.shape[1]
+        nnz = data.incidence_hyperedges._nnz()
+        assert num_edges == nnz, \
+            "Edge count mismatch between edge_index and incidence matrix"
+
+    def test_invalid_dataset_name(self, test_data_dir):
+        """Test that invalid dataset name raises error.
+
+        Parameters
+        ----------
+        test_data_dir : Path
+            Temporary directory for test data.
+        """
+        with pytest.raises(ValueError, match="Unknown dataset"):
+            CornellLabeledNodesDataset(
+                data_dir=str(test_data_dir),
+                data_name="invalid-dataset",
+            )
+

--- a/topobench/data/datasets/cornell_labeled_nodes_dataset.py
+++ b/topobench/data/datasets/cornell_labeled_nodes_dataset.py
@@ -1,0 +1,243 @@
+"""Cornell hypergraph datasets with labeled nodes.
+
+This module provides the CornellLabeledNodesDataset class for loading real-world
+hypergraph datasets from Cornell's collection. These datasets are designed for
+single-label node classification tasks in higher-order networks.
+
+Key features:
+    - Automatic dataset downloading from Google Drive
+    - Parsing of Cornell's text format (hyperedges, node labels, label names)
+    - Automatic 0-indexing and node deduplication
+    - Construction of sparse incidence matrices for hypergraph neural networks
+
+File format (for each dataset):
+    - hyperedges-{name}.txt: One hyperedge per line (comma-separated node IDs)
+    - node-labels-{name}.txt: One label per line (line i = label for node i)
+    - label-names-{name}.txt: Class names (one per line)
+
+References
+----------
+Cornell Hypergraph Data Repository: https://www.cs.cornell.edu/~arb/data/
+
+Examples
+--------
+>>> from topobench.data.datasets import CornellLabeledNodesDataset
+>>> dataset = CornellLabeledNodesDataset(data_dir='./data', data_name='walmart-trips')
+>>> data = dataset[0]
+>>> print(f"Dataset: {dataset.name}, Nodes: {data.num_nodes}, Classes: {data.num_class}")
+"""
+
+import os
+
+import torch
+from torch_geometric.data import (
+    Data,
+    InMemoryDataset,
+    download_google_url,
+    extract_zip,
+)
+
+from topobench.data.utils.io_utils import parse_cornell_hypergraph_files
+
+
+class CornellLabeledNodesDataset(InMemoryDataset):
+    """Cornell hypergraph datasets with single-label node classification.
+
+    Unified PyTorch Geometric dataset class for loading Cornell's collection of
+    real-world hypergraph datasets. Each dataset represents higher-order relationships
+    (hyperedges connecting multiple nodes) with nodes labeled into discrete classes
+    for supervised node classification tasks.
+
+    The class automatically handles:
+        - Downloading datasets from Google Drive
+        - Parsing Cornell text format (hyperedges, node labels, label names)
+        - Automatic 0-indexing of labels and node IDs
+        - Node deduplication within hyperedges (ensures binary incidence matrices)
+        - Construction of sparse incidence matrices for hypergraph neural networks
+
+    Available datasets include e-commerce (walmart-trips, amazon-reviews), face-to-face contacts,
+    and US Congress co-sponsorship/committee data.
+    See DATASETS dict for complete list of supported datasets.
+
+    Parameters
+    ----------
+    data_dir : str
+        Root directory where the dataset should be stored. Dataset files will be
+        saved in a subdirectory named after data_name.
+    data_name : str
+        Name of the dataset to load. Must be one of the keys in DATASETS dict.
+        Examples: 'walmart-trips', 'house-committees', 'amazon-reviews'.
+    transform : callable, optional
+        A function/transform that takes in a Data object and returns a
+        transformed version. Applied on-the-fly when accessing data.
+    pre_transform : callable, optional
+        A function/transform that takes in a Data object and returns a
+        transformed version. Applied once during processing before saving to disk.
+
+    Raises
+    ------
+    ValueError
+        If data_name is not in the DATASETS dict.
+
+    Examples
+    --------
+    Load and access walmart-trips dataset:
+        >>> dataset = CornellLabeledNodesDataset(
+        ...     data_dir='./data',
+        ...     data_name='walmart-trips'
+        ... )
+        >>> data = dataset[0]
+        >>> print(f"Nodes: {data.num_nodes}, Hyperedges: {data.num_hyperedges}")
+        Nodes: 88860, Hyperedges: 69906
+
+    Notes
+    -----
+    This class supports only single-label classification (one label per node).
+    Multi-label datasets like stackoverflow-answers and mathoverflow-answers
+    require a different implementation.
+    """
+
+    # Available datasets with their Google Drive IDs
+    DATASETS = {
+        "walmart-trips": "1kl6wuvopJ5_wvEIy6YnwoXh1SjlIpRhu",
+        "trivago-clicks": "1Mcl28gC0YiQF0NOtWhobhvJU634c04xJ",
+        "house-committees": "1402DFpsii-mqeBGk2mf-tDj8P-6Sk6tr",
+        "senate-committees": "17ZRVwki_x_C_DlOAea5dPBO7Q4SRTRRw",
+        "house-bills": "1-qiSw7YPfiTzJlA73MEH6jlxibHwlhFr",
+        "senate-bills": "1DDrJO5fwDGuvMfnnGvrV_m6fA_YHojKF",
+        "contact-primary-school": "1H7PGDPvjCyxbogUqw17YgzMc_GHLjbZA",
+        "contact-high-school": "163ehVtR-HGVA-wmH88AJ2U2ev4bv2TG6",
+        "amazon-reviews": "1dOeke9Rdh0vySIrsSqIZbGXIggVFqZwP",
+    }
+
+    def __init__(
+        self,
+        data_dir: str,
+        data_name: str,
+        transform=None,
+        pre_transform=None,
+    ):
+        """Initialize the Cornell labeled nodes dataset."""
+        if data_name not in self.DATASETS:
+            raise ValueError(
+                f"Unknown dataset '{data_name}'. "
+                f"Available datasets: {list(self.DATASETS.keys())}"
+            )
+
+        self.name = data_name
+        self.data_dir = data_dir
+        root = os.path.join(data_dir, data_name)
+
+        super().__init__(root, transform, pre_transform)
+        self.load(self.processed_paths[0])
+
+    @property
+    def raw_file_names(self):
+        """Return list of raw file names to check if download is needed.
+
+        Returns
+        -------
+        list
+            List containing the zip filename.
+        """
+        return [f"{self.name}.zip"]
+
+    @property
+    def processed_file_names(self):
+        """Return list of processed file names.
+
+        Returns
+        -------
+        list
+            List containing the processed data filename.
+        """
+        return ["data.pt"]
+
+    def download(self):
+        """Download the dataset from Google Drive."""
+        file_id = self.DATASETS[self.name]
+        download_google_url(file_id, self.raw_dir, f"{self.name}.zip")
+        print("Download complete.")
+
+    def process(self):
+        """Convert raw data into PyTorch Geometric Data format."""
+        import shutil
+
+        print(f"Extracting {os.path.join(self.raw_dir, self.name + '.zip')}")
+        extract_zip(
+            os.path.join(self.raw_dir, self.name + ".zip"), self.raw_dir
+        )
+
+        # Move files from subdirectory to raw_dir
+        subdir = os.path.join(self.raw_dir, self.name)
+        if os.path.exists(subdir):
+            for file in os.listdir(subdir):
+                src = os.path.join(subdir, file)
+                dst = os.path.join(self.raw_dir, file)
+                if os.path.isfile(src):
+                    shutil.move(src, dst)
+            # Remove empty subdirectory
+            os.rmdir(subdir)
+
+        print("Processing...")
+        data = self._load_cornell_format()
+
+        if self.pre_transform is not None:
+            data = self.pre_transform(data)
+
+        self.save([data], self.processed_paths[0])
+        print("Done!")
+
+    def _load_cornell_format(self):
+        """Load hypergraph data from Cornell text format.
+
+        Uses the shared parsing utility from io_utils to ensure consistency
+        across the codebase. The parser automatically handles 0-indexing and
+        deduplicates nodes within hyperedges.
+
+        Returns
+        -------
+        Data
+            PyTorch Geometric Data object containing:
+            - x: Node features (constant features if not provided)
+            - edge_index: COO format [node_id, hyperedge_id]
+            - incidence_hyperedges: Sparse incidence matrix
+            - y: Node labels (0-indexed)
+            - num_nodes: Number of nodes
+            - num_hyperedges: Number of hyperedges
+            - num_class: Number of classes
+        """
+        # Use shared parsing utility
+        parsed = parse_cornell_hypergraph_files(self.raw_dir, self.name)
+
+        # Extract parsed data
+        labels = parsed["labels"]
+        edge_index = parsed["edge_index"]
+        num_nodes = parsed["num_nodes"]
+        num_hyperedges = parsed["num_hyperedges"]
+        num_class = parsed["num_classes"]
+
+        # Build incidence matrix (num_nodes x num_hyperedges)
+        incidence_values = torch.ones(edge_index.shape[1], dtype=torch.float32)
+        incidence_hyperedges = torch.sparse_coo_tensor(
+            edge_index,
+            incidence_values,
+            (num_nodes, num_hyperedges),
+            dtype=torch.float32,
+        )
+
+        # Create constant node features (can be replaced by transforms)
+        x = torch.ones((num_nodes, 1), dtype=torch.float32)
+
+        # Create Data object
+        data = Data(
+            x=x,
+            edge_index=edge_index,
+            incidence_hyperedges=incidence_hyperedges,
+            y=labels,
+            num_nodes=num_nodes,
+            num_hyperedges=num_hyperedges,
+            num_class=num_class,
+        )
+
+        return data

--- a/topobench/data/loaders/hypergraph/cornell_labeled_nodes_dataset_loader.py
+++ b/topobench/data/loaders/hypergraph/cornell_labeled_nodes_dataset_loader.py
@@ -1,0 +1,119 @@
+"""Loader for Cornell labeled nodes hypergraph datasets.
+
+This loader handles hypergraph datasets with labeled nodes from Cornell's
+collection at https://www.cs.cornell.edu/~arb/data/. These datasets are designed
+for community detection and node prediction experiments where nodes are labeled
+into discrete classes.
+
+Available datasets span multiple domains:
+    - E-commerce: walmart-trips, amazon-reviews, trivago-clicks
+    - Face-to-face contacts: contact-primary-school, contact-high-school
+    - US Congress: senate-bills, house-bills, senate-committees, house-committees
+
+See individual config files in configs/dataset/hypergraph/ for dataset details.
+
+References
+----------
+Generative hypergraph clustering: from blockmodels to modularity.
+Philip S. Chodrow, Nate Veldt, and Austin R. Benson.
+Science Advances, 2021.
+
+Minimizing Localized Ratio Cut Objectives in Hypergraphs.
+Nate Veldt, Austin R. Benson, and Jon Kleinberg.
+Proceedings of the ACM SIGKDD International Conference on Knowledge Discovery
+and Data Mining (KDD), 2020.
+
+Clustering in graphs and hypergraphs with categorical edge labels.
+Ilya Amburg, Nate Veldt, and Austin R. Benson.
+Proceedings of the Web Conference (WWW), 2020.
+"""
+
+from omegaconf import DictConfig
+
+from topobench.data.datasets.cornell_labeled_nodes_dataset import (
+    CornellLabeledNodesDataset,
+)
+from topobench.data.loaders.base import AbstractLoader
+
+
+class CornellLabeledNodesDatasetLoader(AbstractLoader):
+    """Load Cornell labeled nodes hypergraph datasets.
+
+    This loader provides a unified interface for all Cornell hypergraph datasets
+    that have labeled nodes for node classification tasks. The specific dataset
+    is determined by the `data_name` parameter in the configuration.
+
+    All Cornell labeled node datasets share the same format:
+        - hyperedges-{name}.txt: Comma-separated node IDs per line
+        - node-labels-{name}.txt: One label per line (line i = label for node i)
+        - label-names-{name}.txt: Class names (one per line)
+
+    Parameters
+    ----------
+    parameters : DictConfig
+        Configuration parameters containing:
+            - data_dir: Root directory for data storage
+            - data_name: Name of the specific dataset (e.g., 'walmart-trips')
+
+    Examples
+    --------
+    Load walmart-trips dataset:
+        >>> params = DictConfig({'data_dir': './data', 'data_name': 'walmart-trips'})
+        >>> loader = CornellLabeledNodesDatasetLoader(params)
+        >>> dataset = loader.load_dataset()
+        >>> data = dataset[0]
+        >>> print(f"Nodes: {data.num_nodes}, Classes: {data.num_class}")
+        Nodes: 88860, Classes: 11
+
+    Notes
+    -----
+    Not yet implemented:
+        - trivago-clicks: Statistics from downloaded data do not match Cornell
+          website, requires verification before implementation.
+        - stackoverflow-answers, mathoverflow-answers: These are multi-label
+          datasets (nodes can have multiple labels/tags) and require a different
+          implementation.
+    """
+
+    def __init__(self, parameters: DictConfig) -> None:
+        """Initialize the Cornell dataset loader.
+
+        Parameters
+        ----------
+        parameters : DictConfig
+            Configuration containing data_dir and data_name.
+        """
+        super().__init__(parameters)
+
+    def load_dataset(self) -> CornellLabeledNodesDataset:
+        """Load the specified Cornell labeled nodes dataset.
+
+        Returns
+        -------
+        CornellLabeledNodesDataset
+            The loaded dataset containing hypergraph structure and node labels.
+
+        Raises
+        ------
+        ValueError
+            If the specified dataset name is not available in
+            CornellLabeledNodesDataset.DATASETS.
+        RuntimeError
+            If dataset loading or processing fails.
+        """
+        dataset = self._initialize_dataset()
+        self.data_dir = self.get_data_dir()
+        return dataset
+
+    def _initialize_dataset(self) -> CornellLabeledNodesDataset:
+        """Initialize the Cornell labeled nodes dataset.
+
+        Returns
+        -------
+        CornellLabeledNodesDataset
+            The initialized dataset instance ready for use.
+        """
+        return CornellLabeledNodesDataset(
+            data_dir=self.parameters.data_dir,
+            data_name=self.parameters.data_name,
+        )

--- a/topobench/data/utils/__init__.py
+++ b/topobench/data/utils/__init__.py
@@ -49,6 +49,7 @@ from .io_utils import (  # noqa: E402
     download_file_from_link,  # noqa: F401
     load_hypergraph_content_dataset,  # noqa: F401
     load_hypergraph_pickle_dataset,  # noqa: F401
+    load_hypergraph_text_dataset,  # noqa: F401
     read_ndim_manifolds,  # noqa: F401
     read_us_county_demos,  # noqa: F401
     # import function here, add noqa: F401 for PR
@@ -57,6 +58,7 @@ from .io_utils import (  # noqa: E402
 io_helper_functions = [
     "load_hypergraph_pickle_dataset",
     "load_hypergraph_content_dataset",
+    "load_hypergraph_text_dataset",
     "read_us_county_demos",
     "download_file_from_drive",
     # add function name here


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.


## Description

This PR implements support for 8 single-label Cornell hypergraph datasets for TDL Challenge Category A.2. The implementation includes:

- **Dataset class**: `CornellLabeledNodesDataset` with automatic Google Drive download, parsing of Cornell text format, 0-indexing, and node deduplication
- **Loader**: `CornellLabeledNodesDatasetLoader` for seamless TopoBench pipeline integration
- **Refactored parsing logic**: Shared `parse_cornell_hypergraph_files()` utility to eliminate code duplication
- **Configuration**: 8 Hydra config files with detailed dataset descriptions and statistics
- **Comprehensive testing**: 72 tests (8 datasets x 9 test functions) with session-scoped caching for efficient handling of large datasets (amazon-reviews: 2.2M nodes)

**Datasets added:**
- walmart-trips (88,860 nodes, 11 classes)
- house-committees (1,290 nodes, 2 classes)
- senate-committees (282 nodes, 2 classes)
- house-bills (1,494 nodes, 2 classes)
- senate-bills (294 nodes, 2 classes)
- contact-primary-school (242 nodes, 11 classes)
- contact-high-school (327 nodes, 9 classes)
- amazon-reviews (2.2M nodes, 29 classes)

**Time/Space complexity**: Datasets use sparse COO tensors for memory-efficient incidence matrix representation.


## Issue

This PR addresses TDL Challenge Category A.2 requirements for adding real-world hypergraph datasets. These datasets enable:
- Community detection research (political affiliation, product departments)
- Social network analysis (face-to-face contact patterns)
- E-commerce behavior modeling (shopping patterns, product co-purchases)

The implementation provides single-label node classification benchmarks spanning small (242 nodes) to very large (2.2M nodes) hypergraphs across diverse domains.

**Not implemented:**
- **stackoverflow-answers** and **mathoverflow-answers**: These are multi-label datasets (nodes can have multiple tags) requiring different architecture. Deferred to separate PR.
- **trivago-clicks**: Statistics from downloaded data do not match Cornell website specifications. Requires verification before implementation.

## Additional context

- Pipeline test verified. (`pytest test/pipeline/test_pipeline.py`)
- All 72 tests passing (`pytest test/data/load/test_cornell_labeled_nodes.py`)
- All code passes ruff linting and numpydoc validation