### PR TITLE
Gpse module and config

### DIFF
--- a/configs/run.yaml
+++ b/configs/run.yaml
@@ -4,8 +4,8 @@
 # order of defaults determines the order in which configs override each other
 defaults:
   - _self_
-  - dataset: graph/NCI1
-  - model: cell/hopse_g
+  - dataset: simplicial/mantra_betti_numbers
+  - model: simplicial/hopse_m
   - transforms: ${get_default_transform:${dataset},${model}} #no_transform
   - optimizer: default
   - loss: default

--- a/topobench/transforms/data_manipulations/add_gpse_information.py
+++ b/topobench/transforms/data_manipulations/add_gpse_information.py
@@ -326,7 +326,7 @@ class AddGPSEInformation(torch_geometric.transforms.BaseTransform):
         )
         
         with torch.inference_mode():
-            expanded_out, _ = self.model.forward(input_graph)
+            expanded_out, _ = self.model(input_graph)
 
         # Only grab the cells we are interested in
         x_out = expanded_out[:n_dst_cells]


### PR DESCRIPTION
Automatic small consistency fixes detected by CursorBot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the default dataset/model used by `configs/run.yaml`, which can alter training behavior and results. The GPSE invocation change is small but could affect runtime if the model’s `forward` signature differs from direct `__call__` usage.
> 
> **Overview**
> Updates the default training configuration to run on the simplicial `mantra_betti_numbers` dataset with the `hopse_m` model instead of the previous graph defaults.
> 
> Fixes the GPSE transform (`AddGPSEInformation`) to invoke the pretrained model via `self.model(input_graph)` rather than calling `forward` directly when computing inter-rank embeddings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc74e14a976c922fdd5f6025adec40d35c4c10b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->