### PR TITLE
Implement QM9 dataset

### DIFF
--- a/configs/dataset/graph/QM9.yaml
+++ b/configs/dataset/graph/QM9.yaml
@@ -1,0 +1,41 @@
+# QM9: ~130k molecules, 19 regression targets (PyG stores all in y; loader keeps one).
+# Target index 0..18 — see https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.datasets.QM9.html
+
+# Dataset loader config
+loader:
+  _target_: topobench.data.loaders.graph.MoleculeDatasetLoader
+  parameters:
+    data_domain: graph
+    data_type: QM9
+    data_name: QM9
+    data_dir: ${paths.data_dir}/${dataset.loader.parameters.data_domain}/${dataset.loader.parameters.data_type}
+    qm9_target_index: ${dataset.parameters.qm9_target_index}
+
+# Dataset parameters
+parameters:
+  qm9_target_index: 0 # QM9 has 19 targets. This is index of the target to use. Do Lookup on https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.datasets.QM9.html
+  num_features:
+    - 11 # PyG QM9 atom features (x)
+    - 4 # edge_attr (one-hot bond type). Use a model that handles edge_attr, otherwise ignored.
+  num_classes: 1
+  task: regression
+  loss_type: mse
+  monitor_metric: mae
+  task_level: graph
+  max_dim_if_lifted: 3
+  preserve_edge_attr_if_lifted: ${set_preserve_edge_attr:${model.model_name},True}
+
+# splits
+split_params:
+  learning_setting: inductive
+  data_split_dir: ${paths.data_dir}/data_splits/${dataset.loader.parameters.data_name}
+  data_seed: 0
+  split_type: random
+  k: 10
+  train_prop: 0.5
+
+# Dataloader parameters
+dataloader_params:
+  batch_size: 128
+  num_workers: 0
+  pin_memory: False

--- a/topobench/data/loaders/graph/molecule_datasets.py
+++ b/topobench/data/loaders/graph/molecule_datasets.py
@@ -1,18 +1,18 @@
-"""Loaders for Molecule datasets (ZINC and AQSOL)."""
+"""Loaders for Molecule datasets (ZINC, AQSOL, and QM9)."""
 
 import os
 from pathlib import Path
 
 import numpy as np
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from torch_geometric.data import Dataset
-from torch_geometric.datasets import AQSOL, ZINC
+from torch_geometric.datasets import AQSOL, QM9, ZINC
 
 from topobench.data.loaders.base import AbstractLoader
 
 
 class MoleculeDatasetLoader(AbstractLoader):
-    """Load molecule datasets (ZINC and AQSOL) with predefined splits.
+    """Load molecule datasets (ZINC and AQSOL) with predefined splits, or QM9.
 
     Parameters
     ----------
@@ -21,6 +21,7 @@ class MoleculeDatasetLoader(AbstractLoader):
             - data_dir: Root directory for data
             - data_name: Name of the dataset
             - data_type: Type of the dataset (e.g., "molecule")
+            - qm9_target_index: (QM9 only) Which of the 19 regression targets to use (default 0).
     """
 
     def __init__(self, parameters: DictConfig) -> None:
@@ -40,12 +41,35 @@ class MoleculeDatasetLoader(AbstractLoader):
         RuntimeError
             If dataset loading fails.
         """
+        if self.parameters.data_name == "QM9":
+            dataset = QM9(root=str(self.root_data_dir))
+            self._collapse_qm9_targets(dataset)
+            return dataset
 
         self._load_splits()
         split_idx = self._prepare_split_idx()
         combined_dataset = self._combine_splits()
         combined_dataset.split_idx = split_idx
         return combined_dataset
+
+    def _collapse_qm9_targets(self, dataset: QM9) -> None:
+        """Keep a single regression target; QM9 stores 19 columns in ``y``."""
+        target_idx = int(
+            OmegaConf.select(self.parameters, "qm9_target_index", default=0)
+        )
+        if target_idx < 0 or target_idx > 18:
+            raise ValueError(
+                f"qm9_target_index must be in [0, 18], got {target_idx}."
+            )
+        data = dataset._data
+        if data.y is None:
+            return
+        if data.y.dim() != 2 or data.y.size(1) <= target_idx:
+            raise ValueError(
+                "QM9 expected batched y with shape [num_graphs, 19]."
+            )
+        # One scalar per graph ([num_graphs]) so batched labels are [B], not [B, 1, 1]
+        data.y = data.y[:, target_idx].contiguous()
 
     def _load_splits(self) -> None:
         """Load the dataset splits for the specified dataset."""

--- a/topobench/data/preprocessor/preprocessor.py
+++ b/topobench/data/preprocessor/preprocessor.py
@@ -7,8 +7,8 @@ import time
 import torch
 import torch_geometric
 from torch_geometric.io import fs
-from omegaconf import OmegaConf
 from tqdm import tqdm
+
 from topobench.data.utils import (
     ensure_serializable,
     load_inductive_splits,
@@ -197,7 +197,7 @@ class PreProcessor(torch_geometric.data.InMemoryDataset):
         if self.pre_transform is not None:
             print(f"\nApplying transforms to {len(data_list)} graphs...")
             self.data_list = [
-                self.pre_transform(d) 
+                self.pre_transform(d)
                 for d in tqdm(data_list, desc="Processing graphs", unit="graph")
             ]
         else:


### PR DESCRIPTION
Implementation of QM9 via pyg class. Loaded similarly to ZINC and AQSOL but then implemented similar to fe. MUTAG (node and edge attr with dims listed, no fixed splits so random splits). 

Works perfectly fine like other models with edge attributes for graph models that do NOT take edge attributes into account. In config I added, just like in ZINC: 
**"preserve_edge_attr_if_lifted: ${set_preserve_edge_attr:${model.model_name},True}"**
However, I found that Hopse always turns this off in the hydra resolve, so not per se preserving edge attributes. So though Hopse runs perfectly for this dataset too, I am unsure of the use of the edge attributes. I will further investigate (since other datasets we will use for hopse can also have edge attr.) and open an issue if necessary.