### PR TITLE
Fix issue where setup script can close the user's terminal

### DIFF
--- a/test/test_uv_env_setup.py
+++ b/test/test_uv_env_setup.py
@@ -1,0 +1,26 @@
+"""Tests for uv_env_setup.sh error handling."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_source_invalid_platform_does_not_kill_shell():
+    """Verify sourcing with invalid platform does not kill the shell.
+
+    If the script uses bare `exit 1`, sourcing it kills the shell
+    (subshell exits). If it uses `return 1`, the subshell survives
+    and the sentinel `STILL_ALIVE` is printed.
+    """
+    script = Path(__file__).parents[1] / "uv_env_setup.sh"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source {script} INVALID 2>/dev/null; echo STILL_ALIVE",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert "STILL_ALIVE" in result.stdout, (
+        "Shell was killed by `exit 1` instead of `return 1`"
+    )

--- a/uv_env_setup.sh
+++ b/uv_env_setup.sh
@@ -30,7 +30,7 @@ elif [ "$PLATFORM" == "cu121" ]; then
     PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VER}+cu121.html"
 else
     echo "❌ Error: Invalid platform '$PLATFORM'. Use: cpu, cu118, or cu121."
-    exit 1
+    return 1 2>/dev/null || exit 1
 fi
 
 echo "⚙️  Updating pyproject.toml..."


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## PR series: #303 307 #308 #309

This PR is only for commits 193bac1c6138ce102a6cecb4be52e8faac7abfa2..02bcc2c5333748ede324625627eb5e9f025c4543. It is number 2 in a series of staged PRs, building upon #303 by adding commits 193bac1c6138ce102a6cecb4be52e8faac7abfa2..02bcc2c5333748ede324625627eb5e9f025c4543; if #303 is rejected, these commits can be cherry-picked.

## Description

Commits:

 1. Simply use `return` instead of `exit`; the exact same pattern that is used elsewhere in the file. Simple, one-line change.
 2. Add a test to prevent this from happening again. Maybe that's overkill.

## Issue

Fixes #305.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily whitespace/EOL normalization, minor wording fixes, and adding pre-commit hooks; no functional runtime logic is altered beyond developer tooling and tests/docs.
> 
> **Overview**
> Normalizes formatting across the repo by fixing missing end-of-file newlines and trailing whitespace in many YAML configs, docs, scripts, and tests.
> 
> Strengthens contributor tooling by expanding `.pre-commit-config.yaml` with standard hygiene checks (EOF fixer, trailing whitespace, AST/JSON/symlink checks) and aligning CI/workflow/config files accordingly (e.g., `.gitignore` for `uv.lock`, minor workflow/codecov YAML cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193bac1c6138ce102a6cecb4be52e8faac7abfa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->