### PR TITLE
Fix deprecations

### DIFF
--- a/test/transforms/liftings/graph2simplicial/test_latentclique_lifting.py
+++ b/test/transforms/liftings/graph2simplicial/test_latentclique_lifting.py
@@ -73,7 +73,7 @@ class TestLatentCliqueCoverLifting:
         # (or, equivalently, the SC has a simplex in its facets set if complex_dim = |maximal_clique|-1)
 
         # Convert adjacency matrix to NetworkX graph
-        G_from_latent_complex = nx.from_numpy_matrix(
+        G_from_latent_complex = nx.from_numpy_array(
             edge_prob_one_adj.to_dense().numpy()
         )
         G_input = nx.Graph()
@@ -95,7 +95,7 @@ class TestLatentCliqueCoverLifting:
         # (or, equivalently, there is no subset of the 1-skeleton of the SC isomorphic to the input graph)
 
         # Convert adjacency matrix to NetworkX graph
-        G_from_latent_complex = nx.from_numpy_matrix(
+        G_from_latent_complex = nx.from_numpy_array(
             edge_prob_any_adj.to_dense().numpy()
         )
         G_input = nx.Graph()

--- a/test/transforms/liftings/pointcloud2hypergraph/test_mogmst_lifting.py
+++ b/test/transforms/liftings/pointcloud2hypergraph/test_mogmst_lifting.py
@@ -28,7 +28,7 @@ class TestMoGMSTLifting:
                 [0.16, 0.45],
             ]
         )
-        self.data = Data(x=pos, y=torch.tensor(y))
+        self.data = Data(x=pos, y=y)
 
         # Initialise the HypergraphKHopLifting class
         self.lifting = MoGMSTLifting(min_components=3, random_state=0)

--- a/topobench/__init__.py
+++ b/topobench/__init__.py
@@ -3,6 +3,7 @@
 # torch >= 2.6 defaults to weights_only=True in torch.load, but OGB and
 # older PyG code serialize these classes. Register them as safe so that
 # torch.load works without weights_only=False everywhere.
+import numpy as np
 import torch
 
 if hasattr(torch.serialization, "add_safe_globals"):
@@ -13,15 +14,24 @@ if hasattr(torch.serialization, "add_safe_globals"):
         NodeStorage,
     )
 
-    torch.serialization.add_safe_globals(
-        [
-            DataEdgeAttr,
-            DataTensorAttr,
-            GlobalStorage,
-            NodeStorage,
-            EdgeStorage,
-        ]
-    )
+    safe_globals = [
+        DataEdgeAttr,
+        DataTensorAttr,
+        GlobalStorage,
+        NodeStorage,
+        EdgeStorage,
+        np.core.multiarray.scalar,
+        np.dtype,
+    ]
+    # numpy >= 1.25 uses typed DType subclasses (e.g. Int64DType) in pickle
+    # streams; register all of them so weights_only=True succeeds.
+    import numpy.dtypes
+
+    for name in dir(numpy.dtypes):
+        obj = getattr(numpy.dtypes, name)
+        if isinstance(obj, type) and name.endswith("DType"):
+            safe_globals.append(obj)
+    torch.serialization.add_safe_globals(safe_globals)
 
 # Import submodules
 from . import (

--- a/topobench/__init__.py
+++ b/topobench/__init__.py
@@ -1,5 +1,28 @@
 """TopoBench: A library for benchmarking of topological models."""
 
+# torch >= 2.6 defaults to weights_only=True in torch.load, but OGB and
+# older PyG code serialize these classes. Register them as safe so that
+# torch.load works without weights_only=False everywhere.
+import torch
+
+if hasattr(torch.serialization, "add_safe_globals"):
+    from torch_geometric.data.data import DataEdgeAttr, DataTensorAttr
+    from torch_geometric.data.storage import (
+        EdgeStorage,
+        GlobalStorage,
+        NodeStorage,
+    )
+
+    torch.serialization.add_safe_globals(
+        [
+            DataEdgeAttr,
+            DataTensorAttr,
+            GlobalStorage,
+            NodeStorage,
+            EdgeStorage,
+        ]
+    )
+
 # Import submodules
 from . import (
     data,

--- a/topobench/transforms/data_manipulations/group_homophily.py
+++ b/topobench/transforms/data_manipulations/group_homophily.py
@@ -85,7 +85,9 @@ class GroupCombinatorialHomophily(torch_geometric.transforms.BaseTransform):
             if max_k != 1:
                 H_k = H[:, torch.where(he_cardinalities == max_k)[0]].clone()
 
-                he_cardinalities_k = torch.tensor(H_k.sum(0), dtype=torch.long)
+                he_cardinalities_k = (
+                    H_k.sum(0).detach().clone().to(dtype=torch.long)
+                )
                 Dt, D = self.calculate_D_matrix(
                     H_k,
                     labels,

--- a/topobench/transforms/liftings/pointcloud2simplicial/random_flag_complex.py
+++ b/topobench/transforms/liftings/pointcloud2simplicial/random_flag_complex.py
@@ -85,7 +85,7 @@ class RandomFlagComplexLifting(PointCloud2SimplicialLifting):
         for i in range(n):
             st.insert([i])
 
-        graph: nx.Graph = nx.from_numpy_matrix(adj_mat).to_undirected()
+        graph: nx.Graph = nx.from_numpy_array(adj_mat).to_undirected()
 
         # Insert all edges
         for v, u in graph.edges:

--- a/uv_env_setup.sh
+++ b/uv_env_setup.sh
@@ -19,19 +19,16 @@ echo "======================================================="
 # ------------------------------------------------------------------------------
 TORCH_VER="2.3.0"
 
-if [ "$PLATFORM" == "cpu" ]; then
-    TARGET_INDEX="pytorch-cpu"
-    PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VER}+cpu.html"
-elif [ "$PLATFORM" == "cu118" ]; then
-    TARGET_INDEX="pytorch-cu118"
-    PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VER}+cu118.html"
-elif [ "$PLATFORM" == "cu121" ]; then
-    TARGET_INDEX="pytorch-cu121"
-    PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VER}+cu121.html"
-else
-    echo "❌ Error: Invalid platform '$PLATFORM'. Use: cpu, cu118, or cu121."
-    return 1 2>/dev/null || exit 1
-fi
+case "$PLATFORM" in
+    cpu|cu118|cu121)
+        TARGET_INDEX="pytorch-${PLATFORM}"
+        PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VER}+${PLATFORM}.html"
+        ;;
+    *)
+        echo "❌ Error: Invalid platform '$PLATFORM'. Use: cpu, cu118, or cu121."
+        return 1 2>/dev/null || exit 1
+        ;;
+esac
 
 echo "⚙️  Updating pyproject.toml..."
 


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## PR series: #303 #307 308 #309

This PR is only for commits 1b244e58ef8b52b0859917f9c21eb92835c85057..70959fcac9030854de9ec55ba132818b29b63f79. It is number 3 in a series of staged PRs, building upon #305 by adding commits 1b244e58ef8b52b0859917f9c21eb92835c85057..70959fcac9030854de9ec55ba132818b29b63f79; if #305 is rejected, the commits in this PR need to be reviewed.

## Description

This PR fixes deprecation warnings in preparation for my subsequent PR to unpin torch. It includes commits

 1. A basic refactoring
 2. Specifies safe_globals for `torch.load`. This is good practice vs. allowing PyG to fall back to `weights_only=False`. Currently this provides no security benefit, but it will do in the future if my [PyG PR](https://github.com/pyg-team/pytorch_geometric/pull/10666) is accepted.
  3. Extend safe_globals list
  4. Fix various other deprecation warnings.

Overall, the 4 commits in this PR should be fairly benign, reduce various warning messages, and make TopoBench more amenable to upgrade beyond torch 2.3.0.

## Issue

This is preparation for fixing issue #306.