### PR TITLE
Support CUDA 12.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ TopoBench now uses [**uv**](https://docs.astral.sh/uv/), an extremely fast Pytho
 3.  **Initialize Environment**:
     Use our centralized setup script to handle Python 3.11 virtualization and specialized hardware (CUDA) mapping.
     ```bash
-    # Usage: source uv_env_setup.sh [cpu|cu118|cu121]
+    # Usage: source uv_env_setup.sh [cpu|cu118|cu121|cu128]
     source uv_env_setup.sh cpu
     ```
     *This script performs the following:*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.11, <3.12"
 
 dependencies=[
-    "torch==2.3.0",
+    "torch>=2.3.0",
     "tqdm",
     "charset-normalizer",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,17 +115,13 @@ explicit = true
 # Default find-links (will be overwritten by bash script)
 [tool.uv]
 find-links = ["https://data.pyg.org/whl/torch-2.3.0+cu121.html"]
+no-build-package = ["torch-scatter", "torch-sparse", "torch-cluster"]
 
 [tool.uv.sources]
 torch = [
     { index = "pytorch-cpu", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
     { index = "pytorch-cu121", marker = "sys_platform == 'linux'" },
 ]
-
-[tool.uv.extra-build-dependencies]
-torch-cluster = ["torch==2.3.0"]
-torch-scatter = ["torch==2.3.0"]
-torch-sparse = ["torch==2.3.0"]
 
 # ==============================================================================
 #  TOOL CONFIGS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,11 @@ name = "pytorch-cu121"
 url = "https://download.pytorch.org/whl/cu121"
 explicit = true
 
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
 # Default find-links (will be overwritten by bash script)
 [tool.uv]
 find-links = ["https://data.pyg.org/whl/torch-2.3.0+cu121.html"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,16 @@ dependencies=[
     "topomodelx @ git+https://github.com/pyt-team/TopoModelX.git",
     "toponetx @ git+https://github.com/pyt-team/TopoNetX.git@c378925",
     "lightning==2.4.0",
+]
+
+[project.optional-dependencies]
+# Required for NSD, ED-GNN, and point cloud lifting backbones.
+# Wheels must match your PyTorch + CUDA version; see find-links below.
+sparse = [
     "torch-scatter",
     "torch-sparse",
     "torch-cluster",
 ]
-
-[project.optional-dependencies]
 doc = [
     "jupyter",
     "nbsphinx",
@@ -87,7 +91,7 @@ test = [
 ]
 
 dev = ["TopoBench[test, lint]"]
-all = ["TopoBench[dev, doc]"]
+all = ["TopoBench[dev, doc, sparse]"]
 
 [project.urls]
 homepage="https://geometric-intelligence.github.io/topobench/index.html"
@@ -173,7 +177,7 @@ disable_error_code = ["import-untyped"]
 plugins = "numpy.typing.mypy_plugin"
 
 [[tool.mypy.overrides]]
-module = ["torch_cluster.*","networkx.*","scipy.spatial","scipy.sparse","toponetx.classes.simplicial_complex"]
+module = ["torch_cluster.*","torch_sparse.*","torch_scatter.*","networkx.*","scipy.spatial","scipy.sparse","toponetx.classes.simplicial_complex"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,0 +1,32 @@
+"""Tests for package import behavior."""
+
+import subprocess
+import sys
+
+
+def test_import_without_sparse():
+    """Verify topobench imports without torch_sparse/scatter/cluster.
+
+    Runs in a subprocess that blocks the sparse imports via sys.modules
+    to avoid modifying the test environment.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys;"
+            "sys.modules['torch_sparse'] = None;"
+            "sys.modules['torch_scatter'] = None;"
+            "sys.modules['torch_cluster'] = None;"
+            "import topobench;"
+            "from topobench.nn.backbones.graph import BACKBONE_CLASSES;"
+            "from topobench.nn.backbones.hypergraph import BACKBONE_CLASSES;"
+            "print('ok')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import topobench failed without sparse packages:\n{result.stderr}"
+    )
+    assert "ok" in result.stdout

--- a/topobench/data/utils/io_utils.py
+++ b/topobench/data/utils/io_utils.py
@@ -12,7 +12,6 @@ import torch
 import torch_geometric
 from toponetx.classes import SimplicialComplex
 from torch_geometric.data import Data
-from torch_sparse import coalesce
 
 from topobench.data.utils import get_complex_connectivity
 
@@ -370,6 +369,8 @@ def load_hypergraph_pickle_dataset(data_dir, data_name):
     torch_geometric.data.Data
         Hypergraph dataset.
     """
+    from torch_sparse import coalesce
+
     data_dir = osp.join(data_dir, data_name)
 
     # Load node features:
@@ -478,6 +479,8 @@ def load_hypergraph_content_dataset(data_dir, data_name):
     torch_geometric.data.Data
         Hypergraph dataset.
     """
+    from torch_sparse import coalesce
+
     # data_dir = osp.join(data_dir, data_name)
 
     p2idx_features_labels = osp.join(data_dir, f"{data_name}.content")

--- a/topobench/dataloader/utils.py
+++ b/topobench/dataloader/utils.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import torch
 import torch_geometric
-from torch_sparse import SparseTensor
 
 
 class DomainData(torch_geometric.data.Data):
@@ -70,6 +69,8 @@ def to_data_list(batch):
     list
         List of data objects.
     """
+    from torch_sparse import SparseTensor
+
     for key, _ in batch:
         if batch[key].is_sparse:
             sparse_data = batch[key].coalesce()

--- a/topobench/nn/backbones/graph/nsd_utils/inductive_discrete_models.py
+++ b/topobench/nn/backbones/graph/nsd_utils/inductive_discrete_models.py
@@ -12,7 +12,6 @@ This module implements three variants of inductive sheaf diffusion:
 
 import torch
 import torch.nn.functional as F
-import torch_sparse
 from torch import nn
 
 from .laplacian_builders import (
@@ -102,6 +101,8 @@ class InductiveDiscreteDiagSheafDiffusion(SheafDiffusion):
         torch.Tensor
             Output node features of shape [num_nodes, output_dim].
         """
+        import torch_sparse
+
         # Get actual number of nodes dynamically
         actual_num_nodes = x.size(0)
 
@@ -281,6 +282,8 @@ class InductiveDiscreteBundleSheafDiffusion(SheafDiffusion):
         torch.Tensor
             Output node features of shape [num_nodes, output_dim].
         """
+        import torch_sparse
+
         # Get actual number of nodes dynamically
         actual_num_nodes = x.size(0)
 
@@ -453,6 +456,8 @@ class InductiveDiscreteGeneralSheafDiffusion(SheafDiffusion):
         torch.Tensor
             Output node features of shape [num_nodes, output_dim].
         """
+        import torch_sparse
+
         # Get actual number of nodes dynamically
         actual_num_nodes = x.size(0)
 

--- a/topobench/nn/backbones/graph/nsd_utils/laplacian_builders.py
+++ b/topobench/nn/backbones/graph/nsd_utils/laplacian_builders.py
@@ -14,7 +14,6 @@ import sys
 import torch
 from torch import nn
 from torch_geometric.utils import degree
-from torch_scatter import scatter_add
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from .laplace import (
@@ -170,6 +169,8 @@ class DiagLaplacianBuilder(LaplacianBuilder):
         saved_tril_maps : torch.Tensor
             Saved lower triangular restriction maps for analysis.
         """
+        from torch_scatter import scatter_add
+
         assert len(maps.size()) == 2
         assert maps.size(1) == self.d
         left_idx, right_idx = self.left_right_idx
@@ -352,6 +353,8 @@ class GeneralLaplacianBuilder(LaplacianBuilder):
         saved_tril_maps : torch.Tensor
             Saved lower triangular transport maps for analysis.
         """
+        from torch_scatter import scatter_add
+
         left_idx, right_idx = self.left_right_idx
         tril_row, tril_col = self.vertex_tril_idx
         tril_indices, diag_indices = self.tril_indices, self.diag_indices

--- a/topobench/nn/backbones/hypergraph/edgnn.py
+++ b/topobench/nn/backbones/hypergraph/edgnn.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch_geometric
-import torch_scatter
 
 
 class EDGNN(nn.Module):
@@ -482,6 +481,8 @@ class EquivSetConv(nn.Module):
         Tensor
             Output features.
         """
+        import torch_scatter
+
         N = X.shape[-2]
 
         Xve = self.W1(X)[..., vertex, :]  # [nnz, C]
@@ -562,6 +563,8 @@ class JumpLinkConv(nn.Module):
         Tensor
             Output features.
         """
+        import torch_scatter
+
         N = X.shape[-2]
 
         Xve = X[..., vertex, :]  # [nnz, C]
@@ -666,6 +669,8 @@ class MeanDegConv(nn.Module):
         Tensor
             Output features.
         """
+        import torch_scatter
+
         N = X.shape[-2]
 
         Xve = self.W1(X[..., vertex, :])  # [nnz, C]

--- a/topobench/transforms/liftings/pointcloud2hypergraph/pointnet_lifting.py
+++ b/topobench/transforms/liftings/pointcloud2hypergraph/pointnet_lifting.py
@@ -2,7 +2,6 @@
 
 import torch
 import torch_geometric
-from torch_cluster import fps, radius
 
 from topobench.transforms.liftings.pointcloud2hypergraph.base import (
     PointCloud2HypergraphLifting,
@@ -45,6 +44,7 @@ class PointNetLifting(PointCloud2HypergraphLifting):
         dict
             The lifted topology.
         """
+        from torch_cluster import fps, radius
 
         batch = (
             torch.zeros(data.num_nodes, dtype=torch.long)

--- a/topobench/transforms/liftings/pointcloud2hypergraph/voronoi_lifting.py
+++ b/topobench/transforms/liftings/pointcloud2hypergraph/voronoi_lifting.py
@@ -2,7 +2,6 @@
 
 import torch
 import torch_geometric
-from torch_cluster import fps, knn
 
 from topobench.transforms.liftings.pointcloud2hypergraph.base import (
     PointCloud2HypergraphLifting,
@@ -37,6 +36,7 @@ class VoronoiLifting(PointCloud2HypergraphLifting):
         dict
             The lifted topology.
         """
+        from torch_cluster import fps, knn
 
         # Sample FPS induced Voronoi graph
         support_idcs = fps(data.x, ratio=self.support_ratio)

--- a/uv_env_setup.sh
+++ b/uv_env_setup.sh
@@ -3,7 +3,7 @@
 # ==============================================================================
 # 🛠️  TopoBench Environment Setup Script (Py3.11 + Dynamic CUDA)
 # ==============================================================================
-# usage: bash uv_env_setup.sh [cpu|cu118|cu121]
+# usage: bash uv_env_setup.sh [cpu|cu118|cu121|cu128]
 # ==============================================================================
 
 PLATFORM="${1:-cpu}"
@@ -18,11 +18,11 @@ echo "======================================================="
 # Configuration
 # ------------------------------------------------------------------------------
 case "$PLATFORM" in
-    cpu|cu118|cu121)
+    cpu|cu118|cu121|cu128)
         TARGET_INDEX="pytorch-${PLATFORM}"
         ;;
     *)
-        echo "❌ Error: Invalid platform '$PLATFORM'. Use: cpu, cu118, or cu121."
+        echo "❌ Error: Invalid platform '$PLATFORM'. Use: cpu, cu118, cu121, or cu128."
         return 1 2>/dev/null || exit 1
         ;;
 esac

--- a/uv_env_setup.sh
+++ b/uv_env_setup.sh
@@ -17,12 +17,9 @@ echo "======================================================="
 # ------------------------------------------------------------------------------
 # Configuration
 # ------------------------------------------------------------------------------
-TORCH_VER="2.3.0"
-
 case "$PLATFORM" in
     cpu|cu118|cu121)
         TARGET_INDEX="pytorch-${PLATFORM}"
-        PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VER}+${PLATFORM}.html"
         ;;
     *)
         echo "❌ Error: Invalid platform '$PLATFORM'. Use: cpu, cu118, or cu121."
@@ -32,20 +29,13 @@ esac
 
 echo "⚙️  Updating pyproject.toml..."
 
-# 1. Update the 'find-links' URL for PyG extensions
+# Update the torch source index for Linux
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    # MacOS sed
-    sed -i '' "s|find-links = \[\".*\"\]|find-links = [\"${PYG_URL}\"]|g" pyproject.toml
-    # Update Linux Source Marker
     sed -i '' "s/index = \"pytorch-[a-z0-9]*\", marker = \"sys_platform == 'linux'/index = \"${TARGET_INDEX}\", marker = \"sys_platform == 'linux'/g" pyproject.toml
 else
-    # Linux sed
-    sed -i "s|find-links = \[\".*\"\]|find-links = [\"${PYG_URL}\"]|g" pyproject.toml
-    # Update Linux Source Marker
     sed -i "s/index = \"pytorch-[a-z0-9]*\", marker = \"sys_platform == 'linux'/index = \"${TARGET_INDEX}\", marker = \"sys_platform == 'linux'/g" pyproject.toml
 fi
 
-echo "✅ Set PyG Links to : ${PYG_URL}"
 echo "✅ Set Torch Index to: ${TARGET_INDEX}"
 
 # ------------------------------------------------------------------------------
@@ -55,8 +45,26 @@ echo ""
 echo "🧹 Cleaning old lockfile..."
 rm -f uv.lock
 
+# Dry-run to detect which torch version will be installed
+TORCH_VER=$(uv sync --dry-run --python 3.11 2>&1 \
+    | grep '+ torch==' | sed 's/.*+ torch==//')
+if [ -z "$TORCH_VER" ]; then
+    # Fallback: read from existing venv (dry-run reports nothing if already installed)
+    TORCH_VER=$(.venv/bin/python -c "import torch; print(torch.__version__)" 2>/dev/null)
+fi
+if [ -z "$TORCH_VER" ]; then
+    echo "❌ Error: Could not detect torch version."
+    return 1 2>/dev/null || exit 1
+fi
+PYG_URL="https://data.pyg.org/whl/torch-${TORCH_VER}.html"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s|find-links = \[\".*\"\]|find-links = [\"${PYG_URL}\"]|g" pyproject.toml
+else
+    sed -i "s|find-links = \[\".*\"\]|find-links = [\"${PYG_URL}\"]|g" pyproject.toml
+fi
+echo "✅ Set PyG Links to : ${PYG_URL} (torch ${TORCH_VER})"
+
 echo "📦 Syncing Environment (Python 3.11)..."
-# Force Python 3.11 creation
 if ! uv sync --python 3.11 --all-extras; then
     echo "❌ uv sync failed."
     return 1 2>/dev/null || exit 1


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## PR series: #303 #307 #308 309

This PR is only for commits da969a23e9817a17eda903fe40992b5571d989d3..9741e9345284f4b6b2c1116ee18e32eb1fa26f4d. It is number 3 in a series of staged PRs, building upon #308 by adding commits da969a23e9817a17eda903fe40992b5571d989d3..9741e9345284f4b6b2c1116ee18e32eb1fa26f4d; if #308 is rejected, the commits in this PR need to be manually reviewed. In particular, 2953cfb90693a436be6a5e09a9abb1eb80be70a0 is required so that the OGB dataset loader does not crash.

## Description

Commits:

 1. Loosens the torch pin from `==2.3.0` to `>=2.3.0`.
 2. Set 3 torch sparse packages to not build from source because I was having issues with the source build taking priority.
 3. Add CUDA 12.8 support. Fixes #306.
 4. Make it so backbone-specific imports are optional.
 5. Add tests for 4.
 
The last two shouldn't affect users who do the automated install, but for users who are playing around with later CUDA versions, later torch versions, etc, having those dependencies as optional makes things easier as you have less dependencies to manage if you're not using those backbones.

If you don't want to support torch >2.3.0, we could add a CLI option to use a specific torch version and update the installation instructions to use that, noting that non-2.3.0 versions are experimental. However, it would be good to support >2.3.0 torch versions because GPUs that require them are only becoming more common.

## Issue

Fixes #306.