### PR TITLE
Track: Track1;  Team name: yeahkitory;  Model: Bundle Neural Networks (BuNN)

### DIFF
--- a/2026_tdl_challenge/outputs/bunn_full/results.json
+++ b/2026_tdl_challenge/outputs/bunn_full/results.json
@@ -2,7 +2,7 @@
   "metadata": {
     "study_id": "bunn_full",
     "model_config": "graph/bunn",
-    "generated_at_utc": "2026-05-16T05:57:57.368562+00:00",
+    "generated_at_utc": "2026-05-16T06:06:54.792597+00:00",
     "n_runs": 72,
     "train_seeds": [
       42,
@@ -21,18 +21,18 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.9346225261688232,
-      "test_best_rerun_accuracy": 0.09880564361810684,
+      "test_loss": 2.942599296569824,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
@@ -40,35 +40,35 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         }
       },
@@ -83,18 +83,18 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.9061696529388428,
-      "test_best_rerun_accuracy": 0.09989142417907715,
+      "test_loss": 2.906785249710083,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
@@ -102,7 +102,7 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
@@ -110,7 +110,7 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
@@ -118,19 +118,19 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         }
       },
@@ -145,8 +145,8 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.926828622817993,
-      "test_best_rerun_accuracy": 0.09880564361810684,
+      "test_loss": 2.9350576400756836,
+      "test_best_rerun_accuracy": 0.09771987050771713,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -156,11 +156,11 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.09554831683635712,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09554831683635712,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
@@ -172,27 +172,27 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09554831683635712,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         }
       },
@@ -207,46 +207,46 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.933964252471924,
+      "test_loss": 2.940908432006836,
       "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
@@ -254,7 +254,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         }
       },
@@ -269,14 +269,14 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.9056692123413086,
-      "test_best_rerun_accuracy": 0.10423452407121658,
+      "test_loss": 2.906351327896118,
+      "test_best_rerun_accuracy": 0.09663408994674683,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
@@ -288,35 +288,35 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         }
       },
@@ -331,54 +331,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.925989866256714,
+      "test_loss": 2.9338459968566895,
       "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09663408994674683,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         }
       },
@@ -393,54 +393,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.935696601867676,
-      "test_best_rerun_accuracy": 0.10097719728946686,
+      "test_loss": 2.941361665725708,
+      "test_best_rerun_accuracy": 0.10314875096082687,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
-        "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
-        "h_hi__d_hi__pl_lo": {
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
-        "h_hi__d_hi__pl_hi": {
+        "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         }
       },
@@ -455,42 +455,42 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.9063291549682617,
-      "test_best_rerun_accuracy": 0.10314875096082687,
+      "test_loss": 2.9086554050445557,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09554831683635712,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
@@ -498,11 +498,11 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         }
       },
@@ -517,54 +517,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.9260518550872803,
-      "test_best_rerun_accuracy": 0.10097719728946686,
+      "test_loss": 2.935542345046997,
+      "test_best_rerun_accuracy": 0.09663408994674683,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09663408994674683,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         }
       },
@@ -579,38 +579,38 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.936049222946167,
-      "test_best_rerun_accuracy": 0.10314875096082687,
+      "test_loss": 2.9427833557128906,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
@@ -618,7 +618,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
@@ -641,8 +641,8 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.9078376293182373,
-      "test_best_rerun_accuracy": 0.10206297785043716,
+      "test_loss": 2.9101500511169434,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -652,35 +652,35 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09663408994674683,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
@@ -688,7 +688,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         }
       },
@@ -703,54 +703,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.9272987842559814,
-      "test_best_rerun_accuracy": 0.10206297785043716,
+      "test_loss": 2.936300277709961,
+      "test_best_rerun_accuracy": 0.09771987050771713,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09663408994674683,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09663408994674683,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         }
       },
@@ -765,50 +765,50 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.924868106842041,
-      "test_best_rerun_accuracy": 0.10206297785043716,
+      "test_loss": 2.935519218444824,
+      "test_best_rerun_accuracy": 0.1064060777425766,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.11183496564626694,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
@@ -827,8 +827,8 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.897615671157837,
-      "test_best_rerun_accuracy": 0.1064060777425766,
+      "test_loss": 2.898744821548462,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -838,7 +838,7 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
@@ -850,11 +850,11 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
@@ -862,15 +862,15 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
@@ -889,8 +889,8 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.9193718433380127,
-      "test_best_rerun_accuracy": 0.10423452407121658,
+      "test_loss": 2.9254488945007324,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -900,15 +900,15 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09663408994674683,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.09554831683635712,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
@@ -916,27 +916,27 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         }
       },
@@ -951,30 +951,30 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.9241905212402344,
-      "test_best_rerun_accuracy": 0.10423452407121658,
+      "test_loss": 2.9356918334960938,
+      "test_best_rerun_accuracy": 0.10532030463218689,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_lo__pl_lo": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
@@ -982,23 +982,23 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -1013,8 +1013,8 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.899684429168701,
-      "test_best_rerun_accuracy": 0.10206297785043716,
+      "test_loss": 2.9014461040496826,
+      "test_best_rerun_accuracy": 0.1074918583035469,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -1024,31 +1024,31 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
@@ -1056,11 +1056,11 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         }
       },
@@ -1075,54 +1075,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.9206252098083496,
+      "test_loss": 2.927882194519043,
       "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09554831683635712,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         }
       },
@@ -1137,22 +1137,22 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.9274954795837402,
-      "test_best_rerun_accuracy": 0.10097719728946686,
+      "test_loss": 2.93799090385437,
+      "test_best_rerun_accuracy": 0.10532030463218689,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
@@ -1160,15 +1160,15 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
@@ -1176,15 +1176,15 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1199,54 +1199,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.901872396469116,
-      "test_best_rerun_accuracy": 0.10206297785043716,
+      "test_loss": 2.9037725925445557,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1261,54 +1261,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.920147657394409,
-      "test_best_rerun_accuracy": 0.10206297785043716,
+      "test_loss": 2.9286088943481445,
+      "test_best_rerun_accuracy": 0.09880564361810684,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_hi": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
-        "h_hi__d_lo__pl_lo": {
+        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         }
       },
@@ -1323,18 +1323,18 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.9272403717041016,
-      "test_best_rerun_accuracy": 0.1074918583035469,
+      "test_loss": 2.937845230102539,
+      "test_best_rerun_accuracy": 0.1064060777425766,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
@@ -1342,19 +1342,19 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
@@ -1362,7 +1362,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
@@ -1370,7 +1370,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1385,54 +1385,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.9027609825134277,
-      "test_best_rerun_accuracy": 0.10314875096082687,
+      "test_loss": 2.905045509338379,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1447,26 +1447,26 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.9223968982696533,
-      "test_best_rerun_accuracy": 0.10206297785043716,
+      "test_loss": 2.9311137199401855,
+      "test_best_rerun_accuracy": 0.09663408994674683,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.09554831683635712,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
@@ -1474,27 +1474,27 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         }
       },
@@ -1509,26 +1509,26 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2.915515422821045,
-      "test_best_rerun_accuracy": 0.11074918508529663,
+      "test_loss": 2.9292349815368652,
+      "test_best_rerun_accuracy": 0.1074918583035469,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
@@ -1536,7 +1536,7 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
@@ -1544,19 +1544,19 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.11074918508529663,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1571,42 +1571,42 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2.8907883167266846,
-      "test_best_rerun_accuracy": 0.1074918583035469,
+      "test_loss": 2.8918867111206055,
+      "test_best_rerun_accuracy": 0.10966341197490692,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_lo": {
+        "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_hi": {
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
@@ -1618,7 +1618,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         }
       },
@@ -1633,46 +1633,46 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2.9118335247039795,
-      "test_best_rerun_accuracy": 0.10423452407121658,
+      "test_loss": 2.9175307750701904,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_hi": {
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
@@ -1680,7 +1680,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -1695,14 +1695,14 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 2.913261651992798,
+      "test_loss": 2.9273056983947754,
       "test_best_rerun_accuracy": 0.10966341197490692,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
@@ -1714,11 +1714,11 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
@@ -1726,23 +1726,23 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -1757,38 +1757,38 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 2.8900341987609863,
-      "test_best_rerun_accuracy": 0.10857763141393661,
+      "test_loss": 2.8890297412872314,
+      "test_best_rerun_accuracy": 0.1074918583035469,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_lo": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
@@ -1796,15 +1796,15 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1819,14 +1819,14 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 2.909128427505493,
+      "test_loss": 2.9153802394866943,
       "test_best_rerun_accuracy": 0.10857763141393661,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
@@ -1834,39 +1834,39 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
-        "h_mid__d_hi__pl_hi": {
+        "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1881,14 +1881,14 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 2.913783550262451,
+      "test_loss": 2.9258553981781006,
       "test_best_rerun_accuracy": 0.1064060777425766,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
@@ -1900,11 +1900,11 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
@@ -1920,7 +1920,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
@@ -1928,7 +1928,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -1943,34 +1943,34 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 2.8891212940216064,
-      "test_best_rerun_accuracy": 0.10423452407121658,
+      "test_loss": 2.8892223834991455,
+      "test_best_rerun_accuracy": 0.1064060777425766,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
@@ -1978,19 +1978,19 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.11400651186704636,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         }
       },
@@ -2005,34 +2005,34 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 2.910036087036133,
-      "test_best_rerun_accuracy": 0.10857763141393661,
+      "test_loss": 2.9169394969940186,
+      "test_best_rerun_accuracy": 0.10532030463218689,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
@@ -2044,15 +2044,15 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -2067,14 +2067,14 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 2.9138026237487793,
-      "test_best_rerun_accuracy": 0.1074918583035469,
+      "test_loss": 2.9260189533233643,
+      "test_best_rerun_accuracy": 0.10423452407121658,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
@@ -2082,27 +2082,27 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
@@ -2114,7 +2114,7 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -2129,14 +2129,14 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 2.888545513153076,
-      "test_best_rerun_accuracy": 0.10532030463218689,
+      "test_loss": 2.8871278762817383,
+      "test_best_rerun_accuracy": 0.11183496564626694,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
@@ -2144,19 +2144,19 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.11292073875665665,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
@@ -2164,19 +2164,19 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.11292073875665665,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         }
       },
@@ -2191,8 +2191,8 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 2.911616563796997,
-      "test_best_rerun_accuracy": 0.10857763141393661,
+      "test_loss": 2.9181342124938965,
+      "test_best_rerun_accuracy": 0.1074918583035469,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -2202,43 +2202,43 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -2253,77 +2253,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 47.69805145263672,
+      "test_loss": 50.58192443847656,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 47.69805145263672,
+      "test_best_rerun_mse": 50.58192443847656,
       "test_triangles_total_structural": 13.0,
-      "test_mse_by_total_triangles": 3.6690808809720554,
+      "test_mse_by_total_triangles": 3.890917264498197,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 64.4527587890625,
+          "test_best_rerun_mse": 67.16209411621094,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 21.4842529296875
+          "test_mse_by_total_triangles": 22.387364705403645
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1638.045654296875,
+          "test_best_rerun_mse": 1591.14697265625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.00931392751338
+          "test_mse_by_total_triangles": 4.865892882740826
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55.21993637084961,
+          "test_best_rerun_mse": 51.457733154296875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.5066049208334826
+          "test_mse_by_total_triangles": 0.4720892949935493
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80.57191467285156,
+          "test_best_rerun_mse": 80.9902114868164,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 0.9155899394642223
+          "test_mse_by_total_triangles": 0.9203433123501864
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 43.36471939086914,
+          "test_best_rerun_mse": 51.75804138183594,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 2.7102949619293213
+          "test_mse_by_total_triangles": 3.234877586364746
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26246.3046875,
+          "test_best_rerun_mse": 26066.802734375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 23.49713938003581
+          "test_mse_by_total_triangles": 23.33643933247538
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2381.28466796875,
+          "test_best_rerun_mse": 2330.1259765625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.537871320857558
+          "test_mse_by_total_triangles": 5.418897619912791
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2843.069091796875,
+          "test_best_rerun_mse": 2805.41748046875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.26473573196766
+          "test_mse_by_total_triangles": 8.155283373455669
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 131.73480224609375,
+          "test_best_rerun_mse": 132.38380432128906,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.2666807908278246
+          "test_mse_by_total_triangles": 1.2729211953970103
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 160928.375,
+          "test_best_rerun_mse": 160294.046875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 59.03462032281732
+          "test_mse_by_total_triangles": 58.801924752384444
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86230.625,
+          "test_best_rerun_mse": 85877.28125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 37.12037236332329
+          "test_mse_by_total_triangles": 36.96826571244081
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
@@ -2337,77 +2337,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 43.40519714355469,
+      "test_loss": 38.70568084716797,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 43.40519714355469,
+      "test_best_rerun_mse": 38.70568084716797,
       "test_triangles_total_structural": 13.0,
-      "test_mse_by_total_triangles": 3.338861318734976,
+      "test_mse_by_total_triangles": 2.9773600651667667,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 53.552886962890625,
+          "test_best_rerun_mse": 46.748390197753906,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 17.850962320963543
+          "test_mse_by_total_triangles": 15.582796732584635
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1723.3055419921875,
+          "test_best_rerun_mse": 1794.142578125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.270047529028096
+          "test_mse_by_total_triangles": 5.486674550840979
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 63.34309387207031,
+          "test_best_rerun_mse": 68.28874206542969,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.5811293015786267
+          "test_mse_by_total_triangles": 0.6265022207837586
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 115.101318359375,
+          "test_best_rerun_mse": 121.4310531616211,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.3079695268110796
+          "test_mse_by_total_triangles": 1.3798983313820579
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 45.19928741455078,
+          "test_best_rerun_mse": 42.078025817871094,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 2.824955463409424
+          "test_mse_by_total_triangles": 2.6298766136169434
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26709.115234375,
+          "test_best_rerun_mse": 26871.142578125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 23.91147290454342
+          "test_mse_by_total_triangles": 24.056528718106534
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2474.7275390625,
+          "test_best_rerun_mse": 2519.584716796875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.755180323401163
+          "test_mse_by_total_triangles": 5.859499341388082
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2951.1767578125,
+          "test_best_rerun_mse": 2999.707275390625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.579002202943315
+          "test_mse_by_total_triangles": 8.720079288926236
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 157.5531005859375,
+          "test_best_rerun_mse": 169.45448303222656,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.5149336594801683
+          "test_mse_by_total_triangles": 1.6293700291560247
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 161512.859375,
+          "test_best_rerun_mse": 161934.71875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 59.2490313187821
+          "test_mse_by_total_triangles": 59.4037853081438
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86729.046875,
+          "test_best_rerun_mse": 87033.3125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 37.33493193069307
+          "test_mse_by_total_triangles": 37.465911536805855
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
@@ -2421,77 +2421,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 13.749375343322754,
+      "test_loss": 9.755461692810059,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 13.749375343322754,
+      "test_best_rerun_mse": 9.755461692810059,
       "test_triangles_total_structural": 13.0,
-      "test_mse_by_total_triangles": 1.0576442571786733,
+      "test_mse_by_total_triangles": 0.7504201302161584,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21.883607864379883,
+          "test_best_rerun_mse": 5.8309807777404785,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 7.294535954793294
+          "test_mse_by_total_triangles": 1.9436602592468262
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1964.2408447265625,
+          "test_best_rerun_mse": 2290.204833984375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 6.0068527361668576
+          "test_mse_by_total_triangles": 7.003684507597477
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 121.90777587890625,
+          "test_best_rerun_mse": 216.86419677734375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.1184199621918005
+          "test_mse_by_total_triangles": 1.9895797869481078
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 120.49528503417969,
+          "test_best_rerun_mse": 198.63995361328125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.3692646026611328
+          "test_mse_by_total_triangles": 2.2572722001509233
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19.243982315063477,
+          "test_best_rerun_mse": 14.553197860717773,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 1.2027488946914673
+          "test_mse_by_total_triangles": 0.9095748662948608
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27076.78125,
+          "test_best_rerun_mse": 28429.0546875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 24.240627797672335
+          "test_mse_by_total_triangles": 25.45125755371531
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2722.6943359375,
+          "test_best_rerun_mse": 3186.8466796875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 6.331847292877907
+          "test_mse_by_total_triangles": 7.411271348110465
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3069.570068359375,
+          "test_best_rerun_mse": 3474.968505859375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.923168803370276
+          "test_mse_by_total_triangles": 10.101652633312137
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 183.5992431640625,
+          "test_best_rerun_mse": 271.5704650878906,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.7653773381159856
+          "test_mse_by_total_triangles": 2.611254471998948
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 162810.0,
+          "test_best_rerun_mse": 166627.09375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 59.724871606749815
+          "test_mse_by_total_triangles": 61.125126100513576
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 88188.8125,
+          "test_best_rerun_mse": 91067.7265625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 37.963328669823504
+          "test_mse_by_total_triangles": 39.20263734933276
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
@@ -2505,77 +2505,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 7.795704364776611,
+      "test_loss": 20.569120407104492,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 7.795704364776611,
+      "test_best_rerun_mse": 20.569120407104492,
       "test_triangles_total_structural": 3.0,
-      "test_mse_by_total_triangles": 2.5985681215922036,
+      "test_mse_by_total_triangles": 6.856373469034831,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.25130844116211,
+          "test_best_rerun_mse": 34.98059844970703,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 1.403946803166316
+          "test_mse_by_total_triangles": 2.690815265362079
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2443.1904296875,
+          "test_best_rerun_mse": 2565.9931640625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 7.47153036601682
+          "test_mse_by_total_triangles": 7.847073896215596
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 254.099853515625,
+          "test_best_rerun_mse": 302.9401550292969,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 2.33119131665711
+          "test_mse_by_total_triangles": 2.779267477332999
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 237.39158630371094,
+          "test_best_rerun_mse": 278.2081298828125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.69763166254217
+          "test_mse_by_total_triangles": 3.1614560213955967
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21.87163543701172,
+          "test_best_rerun_mse": 35.11799240112305,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 1.3669772148132324
+          "test_mse_by_total_triangles": 2.1948745250701904
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29132.44921875,
+          "test_best_rerun_mse": 29537.9453125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 26.080975128692927
+          "test_mse_by_total_triangles": 26.44399759400179
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3329.256591796875,
+          "test_best_rerun_mse": 3476.457275390625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 7.7424571902252906
+          "test_mse_by_total_triangles": 8.084784361373547
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3678.248291015625,
+          "test_best_rerun_mse": 3808.8818359375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 10.69258224132449
+          "test_mse_by_total_triangles": 11.072330918422965
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 316.8338317871094,
+          "test_best_rerun_mse": 354.65570068359375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 3.0464791517991285
+          "test_mse_by_total_triangles": 3.4101509681114783
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 168580.25,
+          "test_best_rerun_mse": 169527.328125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 61.84161775495231
+          "test_mse_by_total_triangles": 62.189041865370505
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 91736.953125,
+          "test_best_rerun_mse": 92488.6328125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 39.490724547998276
+          "test_mse_by_total_triangles": 39.81430598902281
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
@@ -2589,77 +2589,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 6.170844554901123,
+      "test_loss": 12.307112693786621,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 6.170844554901123,
+      "test_best_rerun_mse": 12.307112693786621,
       "test_triangles_total_structural": 3.0,
-      "test_mse_by_total_triangles": 2.056948184967041,
+      "test_mse_by_total_triangles": 4.102370897928874,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13.539021492004395,
+          "test_best_rerun_mse": 14.241485595703125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 1.0414631916926458
+          "test_mse_by_total_triangles": 1.0954988919771635
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2232.16796875,
+          "test_best_rerun_mse": 2080.790771484375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 6.826201739296636
+          "test_mse_by_total_triangles": 6.363274530533257
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 181.01718139648438,
+          "test_best_rerun_mse": 130.08067321777344,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.6607080862062786
+          "test_mse_by_total_triangles": 1.1934006717226922
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 203.01174926757812,
+          "test_best_rerun_mse": 164.12445068359375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.3069516962224785
+          "test_mse_by_total_triangles": 1.865050575949929
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16.437074661254883,
+          "test_best_rerun_mse": 16.795263290405273,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 1.0273171663284302
+          "test_mse_by_total_triangles": 1.0497039556503296
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28586.142578125,
+          "test_best_rerun_mse": 27935.66796875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 25.59189129644136
+          "test_mse_by_total_triangles": 25.00955055393912
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3082.302001953125,
+          "test_best_rerun_mse": 2863.93701171875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 7.168144190588663
+          "test_mse_by_total_triangles": 6.66031863190407
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3487.23046875,
+          "test_best_rerun_mse": 3297.23046875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 10.137297874273257
+          "test_mse_by_total_triangles": 9.584972292877907
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 255.6205291748047,
+          "test_best_rerun_mse": 217.93771362304688,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 2.4578897036038914
+          "test_mse_by_total_triangles": 2.095554938683143
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 166565.234375,
+          "test_best_rerun_mse": 164825.484375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 61.10243373991196
+          "test_mse_by_total_triangles": 60.46422757703595
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 90358.9296875,
+          "test_best_rerun_mse": 89110.6171875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 38.89751600839432
+          "test_mse_by_total_triangles": 38.36014515174344
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
@@ -2673,77 +2673,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 8.582231521606445,
+      "test_loss": 15.370939254760742,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 8.582231521606445,
+      "test_best_rerun_mse": 15.370939254760742,
       "test_triangles_total_structural": 3.0,
-      "test_mse_by_total_triangles": 2.860743840535482,
+      "test_mse_by_total_triangles": 5.123646418253581,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14.909807205200195,
+          "test_best_rerun_mse": 26.427295684814453,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 1.1469082465538611
+          "test_mse_by_total_triangles": 2.032868898831881
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2415.25048828125,
+          "test_best_rerun_mse": 2511.187744140625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 7.386087120126147
+          "test_mse_by_total_triangles": 7.679473223671636
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 243.48141479492188,
+          "test_best_rerun_mse": 288.56494140625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 2.2337744476598336
+          "test_mse_by_total_triangles": 2.647384783543578
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 216.48162841796875,
+          "test_best_rerun_mse": 260.1565246582031,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.460018504749645
+          "test_mse_by_total_triangles": 2.9563241438432173
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17.690101623535156,
+          "test_best_rerun_mse": 31.89169692993164,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 1.1056313514709473
+          "test_mse_by_total_triangles": 1.9932310581207275
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28637.525390625,
+          "test_best_rerun_mse": 29166.5625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 25.63789202383617
+          "test_mse_by_total_triangles": 26.111515219337512
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3246.3291015625,
+          "test_best_rerun_mse": 3443.672119140625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 7.549602561773256
+          "test_mse_by_total_triangles": 8.008539811954941
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3529.74560546875,
+          "test_best_rerun_mse": 3704.811767578125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 10.260888387990553
+          "test_mse_by_total_triangles": 10.76980164993641
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 290.4015808105469,
+          "test_best_rerun_mse": 339.094970703125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 2.7923228924091044
+          "test_mse_by_total_triangles": 3.260528564453125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 166951.875,
+          "test_best_rerun_mse": 168565.703125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 61.24426815847396
+          "test_mse_by_total_triangles": 61.836281410491566
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 91188.265625,
+          "test_best_rerun_mse": 92475.78125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 39.254526743435214
+          "test_mse_by_total_triangles": 39.80877367628067
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
@@ -2757,77 +2757,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 1670.96533203125,
+      "test_loss": 1522.1153564453125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1670.96533203125,
+      "test_best_rerun_mse": 1522.1153564453125,
       "test_triangles_total_structural": 327.0,
-      "test_mse_by_total_triangles": 5.109985724866208,
+      "test_mse_by_total_triangles": 4.65478702276854,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5463.966796875,
+          "test_best_rerun_mse": 5115.2900390625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 420.30513822115387
+          "test_mse_by_total_triangles": 393.48384915865387
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5639.2421875,
+          "test_best_rerun_mse": 5283.7431640625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1879.7473958333333
+          "test_mse_by_total_triangles": 1761.2477213541667
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4008.943603515625,
+          "test_best_rerun_mse": 3775.659423828125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 36.77929911482225
+          "test_mse_by_total_triangles": 34.63907728282683
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4235.53564453125,
+          "test_best_rerun_mse": 4036.016845703125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 48.1310868696733
+          "test_mse_by_total_triangles": 45.86382779208097
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5386.263671875,
+          "test_best_rerun_mse": 5163.26171875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 336.6414794921875
+          "test_mse_by_total_triangles": 322.703857421875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12701.01953125,
+          "test_best_rerun_mse": 12886.9130859375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 11.370653116606983
+          "test_mse_by_total_triangles": 11.537075278368398
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1459.775146484375,
+          "test_best_rerun_mse": 1373.031982421875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.394825922056686
+          "test_mse_by_total_triangles": 3.193097633539244
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2546.99755859375,
+          "test_best_rerun_mse": 2529.02099609375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.404062670330669
+          "test_mse_by_total_triangles": 7.351805221202762
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4077.004638671875,
+          "test_best_rerun_mse": 3968.776611328125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 39.20196767953726
+          "test_mse_by_total_triangles": 38.16131357046274
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 116171.859375,
+          "test_best_rerun_mse": 116993.296875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 42.61623601430668
+          "test_mse_by_total_triangles": 42.91757038701394
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55512.2890625,
+          "test_best_rerun_mse": 56129.59375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 23.89680975570383
+          "test_mse_by_total_triangles": 24.16254573826948
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
@@ -2841,77 +2841,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 607.85302734375,
+      "test_loss": 602.4428100585938,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 607.85302734375,
+      "test_best_rerun_mse": 602.4428100585938,
       "test_triangles_total_structural": 327.0,
-      "test_mse_by_total_triangles": 1.858877759461009,
+      "test_mse_by_total_triangles": 1.8423327524727637,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2251.075927734375,
+          "test_best_rerun_mse": 2232.9697265625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 173.15968674879807
+          "test_mse_by_total_triangles": 171.76690204326923
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2367.77294921875,
+          "test_best_rerun_mse": 2347.4912109375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 789.2576497395834
+          "test_mse_by_total_triangles": 782.4970703125
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1364.9097900390625,
+          "test_best_rerun_mse": 1348.50341796875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 12.522108165495986
+          "test_mse_by_total_triangles": 12.37159099053899
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1596.2098388671875,
+          "test_best_rerun_mse": 1568.7066650390625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 18.138748168945312
+          "test_mse_by_total_triangles": 17.82621210271662
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2248.0732421875,
+          "test_best_rerun_mse": 2228.121337890625,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 140.50457763671875
+          "test_mse_by_total_triangles": 139.25758361816406
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17172.234375,
+          "test_best_rerun_mse": 17219.046875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 15.373531222023276
+          "test_mse_by_total_triangles": 15.415440353625783
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 761.520751953125,
+          "test_best_rerun_mse": 744.4765625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 1.7709784929142443
+          "test_mse_by_total_triangles": 1.7313408430232557
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1664.4208984375,
+          "test_best_rerun_mse": 1676.1182861328125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 4.838432844295058
+          "test_mse_by_total_triangles": 4.872436878293059
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1537.681884765625,
+          "test_best_rerun_mse": 1527.4517822265625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 14.78540273813101
+          "test_mse_by_total_triangles": 14.6870363675631
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 132569.765625,
+          "test_best_rerun_mse": 132777.140625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 48.63160881327953
+          "test_mse_by_total_triangles": 48.707681814013206
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 66501.453125,
+          "test_best_rerun_mse": 66617.140625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 28.627401259147653
+          "test_mse_by_total_triangles": 28.677202163151097
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
@@ -2925,77 +2925,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 1033.7296142578125,
+      "test_loss": 1415.00732421875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1033.7296142578125,
+      "test_best_rerun_mse": 1415.00732421875,
       "test_triangles_total_structural": 327.0,
-      "test_mse_by_total_triangles": 3.1612526429902523,
+      "test_mse_by_total_triangles": 4.32723952360474,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3815.8564453125,
+          "test_best_rerun_mse": 4760.77685546875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 293.5274188701923
+          "test_mse_by_total_triangles": 366.2136042668269
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3978.76123046875,
+          "test_best_rerun_mse": 4945.31591796875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1326.2537434895833
+          "test_mse_by_total_triangles": 1648.4386393229167
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2667.453369140625,
+          "test_best_rerun_mse": 3492.3427734375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 24.472049258170873
+          "test_mse_by_total_triangles": 32.039841958142205
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2886.759765625,
+          "test_best_rerun_mse": 3640.79150390625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 32.80408824573863
+          "test_mse_by_total_triangles": 41.37263072620738
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3821.508056640625,
+          "test_best_rerun_mse": 4719.10546875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 238.84425354003906
+          "test_mse_by_total_triangles": 294.944091796875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14422.103515625,
+          "test_best_rerun_mse": 13332.96484375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 12.911462413272158
+          "test_mse_by_total_triangles": 11.936405410698299
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1009.4878540039062,
+          "test_best_rerun_mse": 1286.853271484375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 2.3476461721021074
+          "test_mse_by_total_triangles": 2.9926820267078487
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2001.9451904296875,
+          "test_best_rerun_mse": 2237.80322265625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 5.819608111714208
+          "test_mse_by_total_triangles": 6.505241926326308
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2784.544677734375,
+          "test_best_rerun_mse": 3541.109375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 26.77446805513822
+          "test_mse_by_total_triangles": 34.04912860576923
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 123114.46875,
+          "test_best_rerun_mse": 118847.21875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 45.16304796404989
+          "test_mse_by_total_triangles": 43.59765911592076
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 60566.7734375,
+          "test_best_rerun_mse": 57951.8125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 26.072653223202757
+          "test_mse_by_total_triangles": 24.946970512268617
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
@@ -3009,77 +3009,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 40.65708923339844,
+      "test_loss": 53.36748504638672,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 40.65708923339844,
+      "test_best_rerun_mse": 53.36748504638672,
       "test_triangles_total_structural": 109.0,
-      "test_mse_by_total_triangles": 0.37300081865503154,
+      "test_mse_by_total_triangles": 0.4896099545540066,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 178.07400512695312,
+          "test_best_rerun_mse": 222.12420654296875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 13.69800039438101
+          "test_mse_by_total_triangles": 17.08647742638221
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 211.64662170410156,
+          "test_best_rerun_mse": 258.2970275878906,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 70.54887390136719
+          "test_mse_by_total_triangles": 86.09900919596355
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1237.4991455078125,
+          "test_best_rerun_mse": 1131.5137939453125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.784401056598815
+          "test_mse_by_total_triangles": 3.4602868316370414
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 92.28705596923828,
+          "test_best_rerun_mse": 116.2126693725586,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.0487165451049805
+          "test_mse_by_total_triangles": 1.3205985155972568
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 168.87283325195312,
+          "test_best_rerun_mse": 224.15650939941406,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 10.55455207824707
+          "test_mse_by_total_triangles": 14.009781837463379
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24520.142578125,
+          "test_best_rerun_mse": 24010.744140625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 21.951783865823636
+          "test_mse_by_total_triangles": 21.495742292412714
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1890.79150390625,
+          "test_best_rerun_mse": 1761.8857421875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.3971895439680235
+          "test_mse_by_total_triangles": 4.097408702761628
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2421.018798828125,
+          "test_best_rerun_mse": 2323.84521484375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.037845345430596
+          "test_mse_by_total_triangles": 6.755363996638808
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 124.50513458251953,
+          "test_best_rerun_mse": 151.84478759765625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.1971647556011493
+          "test_mse_by_total_triangles": 1.4600460345928485
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 156139.890625,
+          "test_best_rerun_mse": 154576.578125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 57.278022973220835
+          "test_mse_by_total_triangles": 56.70454076485694
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 82806.5078125,
+          "test_best_rerun_mse": 81797.265625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 35.64636582544124
+          "test_mse_by_total_triangles": 35.21190943822643
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
@@ -3093,77 +3093,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 44.530391693115234,
+      "test_loss": 71.60665130615234,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 44.530391693115234,
+      "test_best_rerun_mse": 71.60665130615234,
       "test_triangles_total_structural": 109.0,
-      "test_mse_by_total_triangles": 0.4085357036065618,
+      "test_mse_by_total_triangles": 0.6569417551023151,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 202.42225646972656,
+          "test_best_rerun_mse": 303.75433349609375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 15.570942805363583
+          "test_mse_by_total_triangles": 23.36571796123798
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 233.8235321044922,
+          "test_best_rerun_mse": 342.0167236328125,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 77.94117736816406
+          "test_mse_by_total_triangles": 114.00557454427083
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1230.8720703125,
+          "test_best_rerun_mse": 1094.5240478515625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.7641347715978593
+          "test_mse_by_total_triangles": 3.347168342053708
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 135.58334350585938,
+          "test_best_rerun_mse": 180.29209899902344,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.5407198125665837
+          "test_mse_by_total_triangles": 2.04877385226163
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 203.65150451660156,
+          "test_best_rerun_mse": 307.8662109375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 12.728219032287598
+          "test_mse_by_total_triangles": 19.24163818359375
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24592.458984375,
+          "test_best_rerun_mse": 23787.66796875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 22.01652550078335
+          "test_mse_by_total_triangles": 21.296032201208593
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1864.2257080078125,
+          "test_best_rerun_mse": 1656.624267578125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.335408623273983
+          "test_mse_by_total_triangles": 3.852614575763081
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2456.45263671875,
+          "test_best_rerun_mse": 2289.778076171875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.1408506881359015
+          "test_mse_by_total_triangles": 6.656331616778706
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 164.52877807617188,
+          "test_best_rerun_mse": 204.7479248046875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.5820074815016527
+          "test_mse_by_total_triangles": 1.9687300461989183
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 155613.34375,
+          "test_best_rerun_mse": 153299.078125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 57.08486564563463
+          "test_mse_by_total_triangles": 56.235905401687454
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 82509.3828125,
+          "test_best_rerun_mse": 80883.03125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 35.518460100086095
+          "test_mse_by_total_triangles": 34.81835180800689
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
@@ -3177,77 +3177,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 81.41625213623047,
+      "test_loss": 60.59269714355469,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 81.41625213623047,
+      "test_best_rerun_mse": 60.59269714355469,
       "test_triangles_total_structural": 109.0,
-      "test_mse_by_total_triangles": 0.7469380929929401,
+      "test_mse_by_total_triangles": 0.555896304069309,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 242.3984375,
+          "test_best_rerun_mse": 100.21945190429688,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 18.646033653846153
+          "test_mse_by_total_triangles": 7.709188608022837
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 283.1308898925781,
+          "test_best_rerun_mse": 127.31500244140625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 94.37696329752605
+          "test_mse_by_total_triangles": 42.438334147135414
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1188.0439453125,
+          "test_best_rerun_mse": 1460.2777099609375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.633161912270642
+          "test_mse_by_total_triangles": 4.4656810702169345
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 135.47471618652344,
+          "test_best_rerun_mse": 83.16801452636719,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.5394854112104936
+          "test_mse_by_total_triangles": 0.9450910741632635
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 249.53802490234375,
+          "test_best_rerun_mse": 100.388671875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 15.596126556396484
+          "test_mse_by_total_triangles": 6.2742919921875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23814.568359375,
+          "test_best_rerun_mse": 25259.712890625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 21.320114914391226
+          "test_mse_by_total_triangles": 22.613887995188005
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1786.638671875,
+          "test_best_rerun_mse": 2183.628173828125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.154973655523256
+          "test_mse_by_total_triangles": 5.078205055414244
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2280.202880859375,
+          "test_best_rerun_mse": 2597.1806640625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 6.628496746684229
+          "test_mse_by_total_triangles": 7.54994379087936
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 172.8159637451172,
+          "test_best_rerun_mse": 131.8583984375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.6616919590876653
+          "test_mse_by_total_triangles": 1.2678692157451923
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 153745.265625,
+          "test_best_rerun_mse": 158055.25,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 56.39958386830521
+          "test_mse_by_total_triangles": 57.98064930300807
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 81773.5234375,
+          "test_best_rerun_mse": 84946.546875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 35.201688952862675
+          "test_mse_by_total_triangles": 36.567605198019805
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
@@ -3261,77 +3261,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 105.0186538696289,
+      "test_loss": 1629.003173828125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 105.0186538696289,
+      "test_best_rerun_mse": 1629.003173828125,
       "test_triangles_total_structural": 88.0,
-      "test_mse_by_total_triangles": 1.1933937939730557,
+      "test_mse_by_total_triangles": 18.51139970259233,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 218.2519073486328,
+          "test_best_rerun_mse": 2305.937744140625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 16.78860825758714
+          "test_mse_by_total_triangles": 177.37982647235577
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 257.5299377441406,
+          "test_best_rerun_mse": 2421.487060546875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 85.8433125813802
+          "test_mse_by_total_triangles": 807.162353515625
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1143.4588623046875,
+          "test_best_rerun_mse": 568.5394897460938,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.4968160926748855
+          "test_mse_by_total_triangles": 1.7386528738412652
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 49.85704803466797,
+          "test_best_rerun_mse": 1445.528076171875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.4574041104097979
+          "test_mse_by_total_triangles": 13.261725469466743
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 210.49058532714844,
+          "test_best_rerun_mse": 2330.699462890625,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 13.155661582946777
+          "test_mse_by_total_triangles": 145.66871643066406
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24102.6015625,
+          "test_best_rerun_mse": 16681.1875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 21.577978122202328
+          "test_mse_by_total_triangles": 14.933918979409132
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1789.410400390625,
+          "test_best_rerun_mse": 736.4339599609375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.1614195357921515
+          "test_mse_by_total_triangles": 1.7126371161882268
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2320.597900390625,
+          "test_best_rerun_mse": 1656.944091796875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 6.745924129042515
+          "test_mse_by_total_triangles": 4.816697941269985
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 129.01063537597656,
+          "test_best_rerun_mse": 1603.507568359375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.2404868786151593
+          "test_mse_by_total_triangles": 15.418342003455528
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 155028.484375,
+          "test_best_rerun_mse": 131734.09375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 56.87031708547322
+          "test_mse_by_total_triangles": 48.32505273294204
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 82047.90625,
+          "test_best_rerun_mse": 65958.421875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 35.31980467068446
+          "test_mse_by_total_triangles": 28.393638344812743
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
@@ -3345,77 +3345,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 468.1076354980469,
+      "test_loss": 428.0777282714844,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 468.1076354980469,
+      "test_best_rerun_mse": 428.0777282714844,
       "test_triangles_total_structural": 88.0,
-      "test_mse_by_total_triangles": 5.319404948841441,
+      "test_mse_by_total_triangles": 4.8645196394486865,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 777.1082763671875,
+          "test_best_rerun_mse": 721.6285400390625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 59.77755972055289
+          "test_mse_by_total_triangles": 55.5098876953125
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 841.2628173828125,
+          "test_best_rerun_mse": 783.2645874023438,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 280.4209391276042
+          "test_mse_by_total_triangles": 261.08819580078125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 691.5562744140625,
+          "test_best_rerun_mse": 733.0242919921875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 2.114850992091934
+          "test_mse_by_total_triangles": 2.2416645015051606
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 317.5474548339844,
+          "test_best_rerun_mse": 282.4901123046875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 2.9132794021466455
+          "test_mse_by_total_triangles": 2.591652406465023
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 777.248779296875,
+          "test_best_rerun_mse": 725.7152709960938,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 48.57804870605469
+          "test_mse_by_total_triangles": 45.35720443725586
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21215.07421875,
+          "test_best_rerun_mse": 21497.7890625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 18.992904403536258
+          "test_mse_by_total_triangles": 19.24600632273948
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1138.0760498046875,
+          "test_best_rerun_mse": 1172.2374267578125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 2.646688487917878
+          "test_mse_by_total_triangles": 2.726133550599564
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1834.15966796875,
+          "test_best_rerun_mse": 1895.532470703125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 5.331859499909157
+          "test_mse_by_total_triangles": 5.510268810183503
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 468.8193054199219,
+          "test_best_rerun_mse": 438.3383483886719,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 4.507877936730018
+          "test_mse_by_total_triangles": 4.214791811429537
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 145661.46875,
+          "test_best_rerun_mse": 146539.0625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 53.43414114086574
+          "test_mse_by_total_triangles": 53.75607575201761
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 75553.5859375,
+          "test_best_rerun_mse": 76095.3984375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 32.524143752690485
+          "test_mse_by_total_triangles": 32.75738202216961
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
@@ -3429,77 +3429,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 939.3889770507812,
+      "test_loss": 1217.461669921875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 939.3889770507812,
+      "test_best_rerun_mse": 1217.461669921875,
       "test_triangles_total_structural": 88.0,
-      "test_mse_by_total_triangles": 10.674874739213424,
+      "test_mse_by_total_triangles": 13.83479170365767,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1441.866943359375,
+          "test_best_rerun_mse": 1846.7745361328125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 110.912841796875
+          "test_mse_by_total_triangles": 142.05957970252405
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1541.6322021484375,
+          "test_best_rerun_mse": 1963.3277587890625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 513.8774007161459
+          "test_mse_by_total_triangles": 654.4425862630209
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 568.173583984375,
+          "test_best_rerun_mse": 559.913818359375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 1.737533895976682
+          "test_mse_by_total_triangles": 1.7122746738818808
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 799.315185546875,
+          "test_best_rerun_mse": 1111.5186767578125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 7.3331668398795875
+          "test_mse_by_total_triangles": 10.197419052823967
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1450.1435546875,
+          "test_best_rerun_mse": 1825.50390625,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 90.63397216796875
+          "test_mse_by_total_triangles": 114.093994140625
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18711.75,
+          "test_best_rerun_mse": 17713.751953125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 16.751790510295436
+          "test_mse_by_total_triangles": 15.85832762141898
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 869.3226318359375,
+          "test_best_rerun_mse": 813.5310668945312,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 2.0216805391533432
+          "test_mse_by_total_triangles": 1.8919327137082123
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1610.9373779296875,
+          "test_best_rerun_mse": 1545.7974853515625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 4.682957493981649
+          "test_mse_by_total_triangles": 4.493597341138263
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 913.8004150390625,
+          "test_best_rerun_mse": 1188.4210205078125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 8.786542452298677
+          "test_mse_by_total_triangles": 11.427125197190504
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 138339.46875,
+          "test_best_rerun_mse": 135228.609375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 50.74815434702861
+          "test_mse_by_total_triangles": 49.60697335840059
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 70931.4453125,
+          "test_best_rerun_mse": 68972.359375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 30.53441468467499
+          "test_mse_by_total_triangles": 29.69107162074903
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
@@ -3513,77 +3513,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 8.964803695678711,
+      "test_loss": 4.671425819396973,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 8.964803695678711,
+      "test_best_rerun_mse": 4.671425819396973,
       "test_triangles_total_structural": 16.0,
-      "test_mse_by_total_triangles": 0.5603002309799194,
+      "test_mse_by_total_triangles": 0.2919641137123108,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10.362617492675781,
+          "test_best_rerun_mse": 4.225337982177734,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 0.7971244225135217
+          "test_mse_by_total_triangles": 0.3250259986290565
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16.25493049621582,
+          "test_best_rerun_mse": 4.186631679534912,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 5.418310165405273
+          "test_mse_by_total_triangles": 1.395543893178304
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1938.250732421875,
+          "test_best_rerun_mse": 2079.07568359375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.927372270403287
+          "test_mse_by_total_triangles": 6.358029613436544
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 109.17376708984375,
+          "test_best_rerun_mse": 148.97109985351562,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.001594193484805
+          "test_mse_by_total_triangles": 1.366707338105648
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 118.5670166015625,
+          "test_best_rerun_mse": 149.3887939453125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.347352461381392
+          "test_mse_by_total_triangles": 1.697599931196733
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27383.37890625,
+          "test_best_rerun_mse": 27897.28125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 24.515110927708147
+          "test_mse_by_total_triangles": 24.975184646374217
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2735.539794921875,
+          "test_best_rerun_mse": 2908.453125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 6.3617204533066865
+          "test_mse_by_total_triangles": 6.763844476744186
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3152.800048828125,
+          "test_best_rerun_mse": 3307.541748046875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 9.16511642101199
+          "test_mse_by_total_triangles": 9.61494694199673
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 179.78933715820312,
+          "test_best_rerun_mse": 213.63165283203125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.728743626521184
+          "test_mse_by_total_triangles": 2.0541505080003004
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 163960.296875,
+          "test_best_rerun_mse": 165238.65625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 60.14684404805576
+          "test_mse_by_total_triangles": 60.615794662509174
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 88412.7421875,
+          "test_best_rerun_mse": 89394.5234375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 38.0597254358588
+          "test_mse_by_total_triangles": 38.48236049827809
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
@@ -3597,77 +3597,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 38.601497650146484,
+      "test_loss": 23.809764862060547,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 38.601497650146484,
+      "test_best_rerun_mse": 23.809764862060547,
       "test_triangles_total_structural": 16.0,
-      "test_mse_by_total_triangles": 2.4125936031341553,
+      "test_mse_by_total_triangles": 1.4881103038787842,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 36.05458450317383,
+          "test_best_rerun_mse": 21.141063690185547,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 2.7734295771672177
+          "test_mse_by_total_triangles": 1.6262356684758112
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44.37975311279297,
+          "test_best_rerun_mse": 23.018983840942383,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 14.793251037597656
+          "test_mse_by_total_triangles": 7.672994613647461
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1768.1513671875,
+          "test_best_rerun_mse": 1959.429931640625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.407190725344036
+          "test_mse_by_total_triangles": 5.992140463732798
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71.3517837524414,
+          "test_best_rerun_mse": 101.3534927368164,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.6546035206646
+          "test_mse_by_total_triangles": 0.9298485572184991
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 123.2713851928711,
+          "test_best_rerun_mse": 145.7002716064453,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.4008111953735352
+          "test_mse_by_total_triangles": 1.6556849046186968
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26915.45703125,
+          "test_best_rerun_mse": 27526.4609375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 24.09620146038496
+          "test_mse_by_total_triangles": 24.643205852730528
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2533.281982421875,
+          "test_best_rerun_mse": 2723.406005859375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.891353447492732
+          "test_mse_by_total_triangles": 6.333502339207849
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3017.791015625,
+          "test_best_rerun_mse": 3180.4072265625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.772648301235465
+          "test_mse_by_total_triangles": 9.24536984465843
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 162.75621032714844,
+          "test_best_rerun_mse": 195.5948028564453,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.5649635608379657
+          "test_mse_by_total_triangles": 1.8807192582350512
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 162062.921875,
+          "test_best_rerun_mse": 163717.484375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 59.450815067865
+          "test_mse_by_total_triangles": 60.05777123074101
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 87091.5546875,
+          "test_best_rerun_mse": 88273.1640625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 37.49098350731812
+          "test_mse_by_total_triangles": 37.999640147438654
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
@@ -3681,77 +3681,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 58.4522819519043,
+      "test_loss": 16.742677688598633,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 58.4522819519043,
+      "test_best_rerun_mse": 16.742677688598633,
       "test_triangles_total_structural": 16.0,
-      "test_mse_by_total_triangles": 3.6532676219940186,
+      "test_mse_by_total_triangles": 1.0464173555374146,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 50.63497543334961,
+          "test_best_rerun_mse": 13.43674373626709,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 3.8949981102576623
+          "test_mse_by_total_triangles": 1.0335956720205455
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 69.08403015136719,
+          "test_best_rerun_mse": 22.161245346069336,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 23.02801005045573
+          "test_mse_by_total_triangles": 7.387081782023112
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1677.865966796875,
+          "test_best_rerun_mse": 1920.6668701171875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.131088583476682
+          "test_mse_by_total_triangles": 5.87359899118406
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 73.78632354736328,
+          "test_best_rerun_mse": 120.9402847290039,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.6769387481409476
+          "test_mse_by_total_triangles": 1.1095438965963662
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 90.1463394165039,
+          "test_best_rerun_mse": 120.66361236572266,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.0243902206420898
+          "test_mse_by_total_triangles": 1.3711774132468484
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25994.541015625,
+          "test_best_rerun_mse": 27132.470703125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 23.27174665678156
+          "test_mse_by_total_triangles": 24.290484067256042
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2384.660400390625,
+          "test_best_rerun_mse": 2750.8837890625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.545721861373546
+          "test_mse_by_total_triangles": 6.397404160610465
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2781.413330078125,
+          "test_best_rerun_mse": 3095.08740234375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.085503866506178
+          "test_mse_by_total_triangles": 8.997347099836482
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 145.2799072265625,
+          "test_best_rerun_mse": 183.1049346923828,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.3969221848707933
+          "test_mse_by_total_triangles": 1.7606243720421424
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 159889.828125,
+          "test_best_rerun_mse": 163179.71875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 58.65364201210565
+          "test_mse_by_total_triangles": 59.860498440939104
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86092.7578125,
+          "test_best_rerun_mse": 88580.671875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 37.06102359556608
+          "test_mse_by_total_triangles": 38.13201544339216
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
@@ -3765,77 +3765,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 17320.4296875,
+      "test_loss": 17379.556640625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 17320.4296875,
+      "test_best_rerun_mse": 17379.556640625,
       "test_triangles_total_structural": 1117.0,
-      "test_mse_by_total_triangles": 15.506203838406446,
+      "test_mse_by_total_triangles": 15.55913754756043,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55621.92578125,
+          "test_best_rerun_mse": 55359.48828125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 4278.6096754807695
+          "test_mse_by_total_triangles": 4258.4221754807695
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56042.609375,
+          "test_best_rerun_mse": 55929.5859375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 18680.869791666668
+          "test_mse_by_total_triangles": 18643.1953125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 39086.9453125,
+          "test_best_rerun_mse": 39130.39453125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 119.53194285168196
+          "test_mse_by_total_triangles": 119.66481508027523
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 50840.0859375,
+          "test_best_rerun_mse": 51055.48828125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 466.42280676605503
+          "test_mse_by_total_triangles": 468.39897505733944
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 50993.390625,
+          "test_best_rerun_mse": 51372.5859375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 579.4703480113636
+          "test_mse_by_total_triangles": 583.7793856534091
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55163.8515625,
+          "test_best_rerun_mse": 55738.859375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 3447.74072265625
+          "test_mse_by_total_triangles": 3483.6787109375
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 36544.4765625,
+          "test_best_rerun_mse": 36865.63671875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 84.98715479651163
+          "test_mse_by_total_triangles": 85.73403888081396
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38679.171875,
+          "test_best_rerun_mse": 39279.0859375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 112.439453125
+          "test_mse_by_total_triangles": 114.18338935319767
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 50252.60546875,
+          "test_best_rerun_mse": 51091.90625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 483.19812950721155
+          "test_mse_by_total_triangles": 491.2683293269231
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 45357.36328125,
+          "test_best_rerun_mse": 45170.66796875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 16.638797975513572
+          "test_mse_by_total_triangles": 16.57031106703962
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18498.927734375,
+          "test_best_rerun_mse": 18701.71484375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 7.963378275667241
+          "test_mse_by_total_triangles": 8.050673630542402
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
@@ -3849,77 +3849,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 18351.25,
+      "test_loss": 18595.4609375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 18351.25,
+      "test_best_rerun_mse": 18595.4609375,
       "test_triangles_total_structural": 1117.0,
-      "test_mse_by_total_triangles": 16.42905102954342,
+      "test_mse_by_total_triangles": 16.647682128469114,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 57076.296875,
+          "test_best_rerun_mse": 57809.5625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 4390.484375
+          "test_mse_by_total_triangles": 4446.889423076923
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 57631.07421875,
+          "test_best_rerun_mse": 58289.8359375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 19210.358072916668
+          "test_mse_by_total_triangles": 19429.9453125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 40287.46484375,
+          "test_best_rerun_mse": 40730.94921875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 123.2032564029052
+          "test_mse_by_total_triangles": 124.55947773318043
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52213.953125,
+          "test_best_rerun_mse": 52867.0859375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 479.02709288990826
+          "test_mse_by_total_triangles": 485.0191370412844
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 53104.47265625,
+          "test_best_rerun_mse": 53581.2890625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 603.4599165482955
+          "test_mse_by_total_triangles": 608.8782848011364
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56861.5703125,
+          "test_best_rerun_mse": 57463.71484375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 3553.84814453125
+          "test_mse_by_total_triangles": 3591.482177734375
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38070.6328125,
+          "test_best_rerun_mse": 38442.765625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 88.53635537790697
+          "test_mse_by_total_triangles": 89.40178052325581
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 40572.328125,
+          "test_best_rerun_mse": 41251.0078125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 117.94281431686046
+          "test_mse_by_total_triangles": 119.91572038517442
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52223.90625,
+          "test_best_rerun_mse": 52872.671875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 502.15294471153845
+          "test_mse_by_total_triangles": 508.39107572115387
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44626.4140625,
+          "test_best_rerun_mse": 44435.15234375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 16.37065813004402
+          "test_mse_by_total_triangles": 16.300496090884078
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19011.26171875,
+          "test_best_rerun_mse": 18706.623046875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 8.183926697696943
+          "test_mse_by_total_triangles": 8.052786503174774
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
@@ -3933,77 +3933,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 20033.5,
+      "test_loss": 19427.259765625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 20033.5,
+      "test_best_rerun_mse": 19427.259765625,
       "test_triangles_total_structural": 1117.0,
-      "test_mse_by_total_triangles": 17.93509400179051,
+      "test_mse_by_total_triangles": 17.392354311213072,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 62027.0703125,
+          "test_best_rerun_mse": 60657.078125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 4771.313100961538
+          "test_mse_by_total_triangles": 4665.929086538462
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 62723.3046875,
+          "test_best_rerun_mse": 61325.0859375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 20907.768229166668
+          "test_mse_by_total_triangles": 20441.6953125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44238.078125,
+          "test_best_rerun_mse": 43280.53125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 135.28464258409787
+          "test_mse_by_total_triangles": 132.35636467889907
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 57118.44921875,
+          "test_best_rerun_mse": 55940.15234375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 524.022469896789
+          "test_mse_by_total_triangles": 513.2124068233945
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 57285.75390625,
+          "test_best_rerun_mse": 55820.13671875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 650.9744762073864
+          "test_mse_by_total_triangles": 634.3197354403409
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 61872.125,
+          "test_best_rerun_mse": 60378.71875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 3867.0078125
+          "test_mse_by_total_triangles": 3773.669921875
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 41639.21484375,
+          "test_best_rerun_mse": 40550.12890625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 96.83538335755814
+          "test_mse_by_total_triangles": 94.30262536337209
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44038.53515625,
+          "test_best_rerun_mse": 42418.7890625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 128.01899754723837
+          "test_mse_by_total_triangles": 123.31043332122093
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56277.984375,
+          "test_best_rerun_mse": 54987.48046875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 541.1344651442307
+          "test_mse_by_total_triangles": 528.7257737379807
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42436.109375,
+          "test_best_rerun_mse": 43057.25390625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 15.567171450843727
+          "test_mse_by_total_triangles": 15.795030779988995
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18345.900390625,
+          "test_best_rerun_mse": 18664.091796875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 7.897503396739131
+          "test_mse_by_total_triangles": 8.034477742950925
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
@@ -4017,77 +4017,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2340.60302734375,
+      "test_loss": 2270.575927734375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2340.60302734375,
+      "test_best_rerun_mse": 2270.575927734375,
       "test_triangles_total_structural": 430.0,
-      "test_mse_by_total_triangles": 5.4432628542877906,
+      "test_mse_by_total_triangles": 5.280409134265988,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7581.5517578125,
+          "test_best_rerun_mse": 7303.25146484375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 583.1962890625
+          "test_mse_by_total_triangles": 561.78857421875
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7788.39794921875,
+          "test_best_rerun_mse": 7514.427734375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2596.1326497395835
+          "test_mse_by_total_triangles": 2504.8092447916665
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2747.620361328125,
+          "test_best_rerun_mse": 2628.571533203125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 8.402508750238914
+          "test_mse_by_total_triangles": 8.038445055667049
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5849.90673828125,
+          "test_best_rerun_mse": 5694.44091796875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 53.66886915854358
+          "test_mse_by_total_triangles": 52.2425772290711
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6110.95361328125,
+          "test_best_rerun_mse": 5968.73974609375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 69.44265469637784
+          "test_mse_by_total_triangles": 67.82658802379261
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7490.45654296875,
+          "test_best_rerun_mse": 7361.89599609375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 468.1535339355469
+          "test_mse_by_total_triangles": 460.1184997558594
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11090.1904296875,
+          "test_best_rerun_mse": 11145.2548828125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 9.928550071340645
+          "test_mse_by_total_triangles": 9.977846806457027
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3574.423828125,
+          "test_best_rerun_mse": 3559.35498046875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 10.390766942223838
+          "test_mse_by_total_triangles": 10.346962152525435
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5909.15869140625,
+          "test_best_rerun_mse": 5875.0234375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 56.81883357121394
+          "test_mse_by_total_triangles": 56.49060997596154
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 108587.8046875,
+          "test_best_rerun_mse": 108869.2265625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 39.83411764031548
+          "test_mse_by_total_triangles": 39.93735383804108
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 50608.671875,
+          "test_best_rerun_mse": 50884.5625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 21.78591126775721
+          "test_mse_by_total_triangles": 21.90467606543263
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
@@ -4101,77 +4101,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1638.6312255859375,
+      "test_loss": 1538.1156005859375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1638.6312255859375,
+      "test_best_rerun_mse": 1538.1156005859375,
       "test_triangles_total_structural": 430.0,
-      "test_mse_by_total_triangles": 3.8107702920603197,
+      "test_mse_by_total_triangles": 3.5770130246184593,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5771.5703125,
+          "test_best_rerun_mse": 5603.271484375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 443.96694711538464
+          "test_mse_by_total_triangles": 431.02088341346155
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5955.93359375,
+          "test_best_rerun_mse": 5777.47998046875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1985.3111979166667
+          "test_mse_by_total_triangles": 1925.82666015625
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1866.3240966796875,
+          "test_best_rerun_mse": 1769.5185546875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.707413139693234
+          "test_mse_by_total_triangles": 5.411371726873089
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4276.8076171875,
+          "test_best_rerun_mse": 4128.8349609375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 39.23676713016055
+          "test_mse_by_total_triangles": 37.87921982511468
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4629.443359375,
+          "test_best_rerun_mse": 4458.59033203125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 52.60731090198863
+          "test_mse_by_total_triangles": 50.66579922762784
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5762.6357421875,
+          "test_best_rerun_mse": 5590.51953125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 360.16473388671875
+          "test_mse_by_total_triangles": 349.407470703125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12714.34375,
+          "test_best_rerun_mse": 12883.607421875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 11.382581692032229
+          "test_mse_by_total_triangles": 11.534115865599821
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2839.811279296875,
+          "test_best_rerun_mse": 2802.06298828125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.25526534679324
+          "test_mse_by_total_triangles": 8.145531942678053
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4514.18603515625,
+          "test_best_rerun_mse": 4383.7978515625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 43.40563495342548
+          "test_mse_by_total_triangles": 42.15190241887019
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 114743.921875,
+          "test_best_rerun_mse": 115619.4140625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 42.09241448092443
+          "test_mse_by_total_triangles": 42.41357815939105
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 54733.96875,
+          "test_best_rerun_mse": 55136.578125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 23.561760116229014
+          "test_mse_by_total_triangles": 23.735074526474385
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
@@ -4185,77 +4185,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1867.284912109375,
+      "test_loss": 2085.146728515625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1867.284912109375,
+      "test_best_rerun_mse": 2085.146728515625,
       "test_triangles_total_structural": 430.0,
-      "test_mse_by_total_triangles": 4.342523051417151,
+      "test_mse_by_total_triangles": 4.849178438408431,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6328.271484375,
+          "test_best_rerun_mse": 6836.8193359375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 486.7901141826923
+          "test_mse_by_total_triangles": 525.9091796875
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6539.7744140625,
+          "test_best_rerun_mse": 7058.61181640625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2179.9248046875
+          "test_mse_by_total_triangles": 2352.87060546875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2130.8740234375,
+          "test_best_rerun_mse": 2415.8544921875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 6.516434322438838
+          "test_mse_by_total_triangles": 7.387934226873089
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4814.78515625,
+          "test_best_rerun_mse": 5293.65185546875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 44.17234088302752
+          "test_mse_by_total_triangles": 48.56561335292431
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5092.94482421875,
+          "test_best_rerun_mse": 5477.0810546875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 57.8743730024858
+          "test_mse_by_total_triangles": 62.23955743963068
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6361.7353515625,
+          "test_best_rerun_mse": 6806.283203125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 397.60845947265625
+          "test_mse_by_total_triangles": 425.3927001953125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11929.1279296875,
+          "test_best_rerun_mse": 11550.65625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 10.679613186828558
+          "test_mse_by_total_triangles": 10.340784467323187
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3035.860107421875,
+          "test_best_rerun_mse": 3178.574951171875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.825174730877544
+          "test_mse_by_total_triangles": 9.24004346270894
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4960.0263671875,
+          "test_best_rerun_mse": 5374.06298828125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 47.69256122295673
+          "test_mse_by_total_triangles": 51.6736825796274
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 112356.5859375,
+          "test_best_rerun_mse": 110616.3359375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 41.2166492800807
+          "test_mse_by_total_triangles": 40.578259698275865
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 53577.4765625,
+          "test_best_rerun_mse": 52611.21484375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 23.063915868489023
+          "test_mse_by_total_triangles": 22.647961620210936
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
@@ -4269,77 +4269,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 4108.8876953125,
+      "test_loss": 4154.04541015625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 4108.8876953125,
+      "test_best_rerun_mse": 4154.04541015625,
       "test_triangles_total_structural": 344.0,
-      "test_mse_by_total_triangles": 11.944440974745639,
+      "test_mse_by_total_triangles": 12.075713401617007,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8632.736328125,
+          "test_best_rerun_mse": 8433.177734375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 664.056640625
+          "test_mse_by_total_triangles": 648.7059795673077
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8847.40625,
+          "test_best_rerun_mse": 8652.0234375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2949.1354166666665
+          "test_mse_by_total_triangles": 2884.0078125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3329.6064453125,
+          "test_best_rerun_mse": 3256.114501953125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 10.182282707377675
+          "test_mse_by_total_triangles": 9.957536703220565
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6770.556640625,
+          "test_best_rerun_mse": 6687.802734375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 62.11519853784404
+          "test_mse_by_total_triangles": 61.35598838876147
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7041.0966796875,
+          "test_best_rerun_mse": 6985.53857421875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 80.01246226917614
+          "test_mse_by_total_triangles": 79.3811201615767
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8522.0126953125,
+          "test_best_rerun_mse": 8491.64453125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 532.6257934570312
+          "test_mse_by_total_triangles": 530.727783203125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10508.076171875,
+          "test_best_rerun_mse": 10491.28125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 9.407409285474484
+          "test_mse_by_total_triangles": 9.392373545210384
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2842.6005859375,
+          "test_best_rerun_mse": 2814.771728515625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 6.610699037063953
+          "test_mse_by_total_triangles": 6.545980763989825
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6814.38818359375,
+          "test_best_rerun_mse": 6885.734375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 65.52296330378606
+          "test_mse_by_total_triangles": 66.208984375
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 105243.6953125,
+          "test_best_rerun_mse": 105232.765625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 38.60737172138665
+          "test_mse_by_total_triangles": 38.603362298239176
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 48513.68359375,
+          "test_best_rerun_mse": 48576.0625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 20.884065257748603
+          "test_mse_by_total_triangles": 20.91091799397331
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
@@ -4353,77 +4353,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 3464.88134765625,
+      "test_loss": 3491.754638671875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3464.88134765625,
+      "test_best_rerun_mse": 3491.754638671875,
       "test_triangles_total_structural": 344.0,
-      "test_mse_by_total_triangles": 10.072329499000727,
+      "test_mse_by_total_triangles": 10.150449531022893,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7089.6591796875,
+          "test_best_rerun_mse": 7031.07470703125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 545.3583984375
+          "test_mse_by_total_triangles": 540.8519005408654
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7280.1953125,
+          "test_best_rerun_mse": 7212.79541015625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2426.7317708333335
+          "test_mse_by_total_triangles": 2404.26513671875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2533.70458984375,
+          "test_best_rerun_mse": 2479.30517578125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 7.748332079032875
+          "test_mse_by_total_triangles": 7.58197301462156
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5419.38330078125,
+          "test_best_rerun_mse": 5360.68603515625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 49.71911285120413
+          "test_mse_by_total_triangles": 49.18060582712156
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5802.630859375,
+          "test_best_rerun_mse": 5729.18359375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 65.93898703835227
+          "test_mse_by_total_triangles": 65.10435901988636
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7063.89306640625,
+          "test_best_rerun_mse": 7001.2646484375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 441.4933166503906
+          "test_mse_by_total_triangles": 437.57904052734375
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11707.9267578125,
+          "test_best_rerun_mse": 11798.6865234375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 10.48158169902641
+          "test_mse_by_total_triangles": 10.562834846407789
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2200.927734375,
+          "test_best_rerun_mse": 2136.320556640625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.118436591569767
+          "test_mse_by_total_triangles": 4.968187341024709
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5668.0498046875,
+          "test_best_rerun_mse": 5628.91845703125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 54.50047889122596
+          "test_mse_by_total_triangles": 54.12421593299279
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 109919.0234375,
+          "test_best_rerun_mse": 110350.0859375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 40.322459074651505
+          "test_mse_by_total_triangles": 40.48058911867205
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 51599.80078125,
+          "test_best_rerun_mse": 51749.84765625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 22.212570288958243
+          "test_mse_by_total_triangles": 22.277162142165302
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
@@ -4437,77 +4437,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 3639.432861328125,
+      "test_loss": 3750.931396484375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3639.432861328125,
+      "test_best_rerun_mse": 3750.931396484375,
       "test_triangles_total_structural": 344.0,
-      "test_mse_by_total_triangles": 10.57974668990734,
+      "test_mse_by_total_triangles": 10.903870338617368,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7554.265625,
+          "test_best_rerun_mse": 8031.6376953125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 581.0973557692307
+          "test_mse_by_total_triangles": 617.8182842548077
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7783.478515625,
+          "test_best_rerun_mse": 8273.7470703125,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2594.4928385416665
+          "test_mse_by_total_triangles": 2757.9156901041665
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2756.464599609375,
+          "test_best_rerun_mse": 3054.627685546875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 8.429555350487385
+          "test_mse_by_total_triangles": 9.341369068950687
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5882.65234375,
+          "test_best_rerun_mse": 6344.45751953125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 53.96928755733945
+          "test_mse_by_total_triangles": 58.20603228927752
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6176.46044921875,
+          "test_best_rerun_mse": 6517.61767578125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 70.18705055930398
+          "test_mse_by_total_triangles": 74.06383722478694
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7575.1123046875,
+          "test_best_rerun_mse": 7980.533203125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 473.44451904296875
+          "test_mse_by_total_triangles": 498.7833251953125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11088.146484375,
+          "test_best_rerun_mse": 10800.8212890625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 9.926720218777977
+          "test_mse_by_total_triangles": 9.66949085860564
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2399.37939453125,
+          "test_best_rerun_mse": 2620.6669921875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.579952080305232
+          "test_mse_by_total_triangles": 6.094574400436047
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6007.84375,
+          "test_best_rerun_mse": 6383.22412109375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 57.76772836538461
+          "test_mse_by_total_triangles": 61.37715501051683
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 108218.765625,
+          "test_best_rerun_mse": 106763.2578125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 39.69874014123258
+          "test_mse_by_total_triangles": 39.16480477347762
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 50833.609375,
+          "test_best_rerun_mse": 50106.2890625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 21.88274187473095
+          "test_mse_by_total_triangles": 21.569646604606113
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
@@ -4521,77 +4521,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 116.66838836669922,
+      "test_loss": 117.992919921875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 116.66838836669922,
+      "test_best_rerun_mse": 117.992919921875,
       "test_triangles_total_structural": 104.0,
-      "test_mse_by_total_triangles": 1.1218114266028771,
+      "test_mse_by_total_triangles": 1.1345473069411058,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 68.22390747070312,
+          "test_best_rerun_mse": 93.88179016113281,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 5.247992882361779
+          "test_mse_by_total_triangles": 7.221676166240986
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 89.37716674804688,
+          "test_best_rerun_mse": 116.17484283447266,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 29.792388916015625
+          "test_mse_by_total_triangles": 38.72494761149088
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1519.6480712890625,
+          "test_best_rerun_mse": 1402.060302734375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 4.647241808223432
+          "test_mse_by_total_triangles": 4.287646185732034
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 43.37769317626953,
+          "test_best_rerun_mse": 37.528160095214844,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.3979604878556838
+          "test_mse_by_total_triangles": 0.3442950467450903
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 75.37981414794922,
+          "test_best_rerun_mse": 77.16397094726562,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 0.8565887971357866
+          "test_mse_by_total_triangles": 0.8768633062189276
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 64.22402954101562,
+          "test_best_rerun_mse": 96.10224914550781,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 4.014001846313477
+          "test_mse_by_total_triangles": 6.006390571594238
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25833.55078125,
+          "test_best_rerun_mse": 25314.5546875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 23.127619320725156
+          "test_mse_by_total_triangles": 22.662985396150404
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2261.90771484375,
+          "test_best_rerun_mse": 2120.159423828125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.260250499636628
+          "test_mse_by_total_triangles": 4.9306033112281975
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2740.337890625,
+          "test_best_rerun_mse": 2617.177490234375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.966098519258721
+          "test_mse_by_total_triangles": 7.608074099518532
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 159926.921875,
+          "test_best_rerun_mse": 158411.875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 58.66724940388848
+          "test_mse_by_total_triangles": 58.111472853998535
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 85411.921875,
+          "test_best_rerun_mse": 84381.546875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 36.76793881833836
+          "test_mse_by_total_triangles": 36.32438522384847
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
@@ -4605,77 +4605,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 153.7852783203125,
+      "test_loss": 162.30938720703125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 153.7852783203125,
+      "test_best_rerun_mse": 162.30938720703125,
       "test_triangles_total_structural": 104.0,
-      "test_mse_by_total_triangles": 1.478704599233774,
+      "test_mse_by_total_triangles": 1.5606671846829927,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 238.8972930908203,
+          "test_best_rerun_mse": 232.97958374023438,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 18.376714853140022
+          "test_mse_by_total_triangles": 17.92150644155649
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 267.9529724121094,
+          "test_best_rerun_mse": 258.5094909667969,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 89.31765747070312
+          "test_mse_by_total_triangles": 86.16983032226562
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1121.768310546875,
+          "test_best_rerun_mse": 1164.3760986328125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.4304841301127675
+          "test_mse_by_total_triangles": 3.560783176247133
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52.72783660888672,
+          "test_best_rerun_mse": 49.17943572998047,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.48374162026501577
+          "test_mse_by_total_triangles": 0.4511874837612887
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 143.91319274902344,
+          "test_best_rerun_mse": 148.19024658203125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.6353771903298118
+          "test_mse_by_total_triangles": 1.6839800747958096
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 237.8092498779297,
+          "test_best_rerun_mse": 236.76683044433594,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 14.863078117370605
+          "test_mse_by_total_triangles": 14.797926902770996
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24152.50390625,
+          "test_best_rerun_mse": 24242.654296875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 21.622653452327665
+          "test_mse_by_total_triangles": 21.703361053603402
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1774.751708984375,
+          "test_best_rerun_mse": 1793.6243896484375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.127329555777616
+          "test_mse_by_total_triangles": 4.17121951081032
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2330.008544921875,
+          "test_best_rerun_mse": 2371.554443359375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 6.77328065384266
+          "test_mse_by_total_triangles": 6.894053614416788
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 154642.5,
+          "test_best_rerun_mse": 154854.375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 56.72872340425532
+          "test_mse_by_total_triangles": 56.806447175348495
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 81689.375,
+          "test_best_rerun_mse": 81858.640625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 35.16546491605682
+          "test_mse_by_total_triangles": 35.23833001506672
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
@@ -4689,77 +4689,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 206.7552032470703,
+      "test_loss": 195.36289978027344,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 206.7552032470703,
+      "test_best_rerun_mse": 195.36289978027344,
       "test_triangles_total_structural": 104.0,
-      "test_mse_by_total_triangles": 1.988030800452599,
+      "test_mse_by_total_triangles": 1.8784894209641676,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 341.1517639160156,
+          "test_best_rerun_mse": 334.60870361328125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 26.24244337815505
+          "test_mse_by_total_triangles": 25.73913104717548
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 387.5005187988281,
+          "test_best_rerun_mse": 384.19305419921875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 129.16683959960938
+          "test_mse_by_total_triangles": 128.0643513997396
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1002.9974365234375,
+          "test_best_rerun_mse": 998.3646240234375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.0672704480839066
+          "test_mse_by_total_triangles": 3.0531028257597477
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 117.27730560302734,
+          "test_best_rerun_mse": 117.16985321044922,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.0759385835140123
+          "test_mse_by_total_triangles": 1.0749527817472406
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 179.74188232421875,
+          "test_best_rerun_mse": 169.71958923339844,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.0425213900479404
+          "test_mse_by_total_triangles": 1.9286316958340732
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 356.9739074707031,
+          "test_best_rerun_mse": 339.2256774902344,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 22.310869216918945
+          "test_mse_by_total_triangles": 21.20160484313965
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22994.259765625,
+          "test_best_rerun_mse": 23100.00390625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 20.585729423119965
+          "test_mse_by_total_triangles": 20.680397409355415
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1580.133544921875,
+          "test_best_rerun_mse": 1613.46240234375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.674729174236919
+          "test_mse_by_total_triangles": 3.752238144985465
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2112.046875,
+          "test_best_rerun_mse": 2124.24658203125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 6.139671148255814
+          "test_mse_by_total_triangles": 6.1751354128815406
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151546.5,
+          "test_best_rerun_mse": 151953.96875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 55.592993396918565
+          "test_mse_by_total_triangles": 55.742468360234774
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80168.15625,
+          "test_best_rerun_mse": 80563.9375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 34.5106139690056
+          "test_mse_by_total_triangles": 34.680989022815325
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
@@ -4773,77 +4773,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 27809.431640625,
+      "test_loss": 27897.501953125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 27809.431640625,
+      "test_best_rerun_mse": 27897.501953125,
       "test_triangles_total_structural": 2726.0,
-      "test_mse_by_total_triangles": 10.201552325981291,
+      "test_mse_by_total_triangles": 10.233859850742848,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 111741.40625,
+          "test_best_rerun_mse": 111865.109375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 8595.492788461539
+          "test_mse_by_total_triangles": 8605.008413461539
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 112247.65625,
+          "test_best_rerun_mse": 112632.734375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 37415.885416666664
+          "test_mse_by_total_triangles": 37544.244791666664
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 87606.9609375,
+          "test_best_rerun_mse": 88109.2734375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 267.9111955275229
+          "test_mse_by_total_triangles": 269.447319380734
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 105134.8828125,
+          "test_best_rerun_mse": 106005.046875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 964.5402092889908
+          "test_mse_by_total_triangles": 972.5233658256881
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 104868.5546875,
+          "test_best_rerun_mse": 106109.078125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1191.6881214488637
+          "test_mse_by_total_triangles": 1205.7849786931818
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 111019.4609375,
+          "test_best_rerun_mse": 112580.3203125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 6938.71630859375
+          "test_mse_by_total_triangles": 7036.27001953125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 45939.8203125,
+          "test_best_rerun_mse": 46481.5703125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 41.12786061996419
+          "test_mse_by_total_triangles": 41.61286509623993
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 83720.71875,
+          "test_best_rerun_mse": 84742.453125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 194.69934593023257
+          "test_mse_by_total_triangles": 197.07547238372092
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86278.1171875,
+          "test_best_rerun_mse": 87782.609375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 250.80848019622093
+          "test_mse_by_total_triangles": 255.18200399709303
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 103881.7734375,
+          "test_best_rerun_mse": 105829.4453125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 998.8632061298077
+          "test_mse_by_total_triangles": 1017.5908203125
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21481.53515625,
+          "test_best_rerun_mse": 22212.095703125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 9.247324647546277
+          "test_mse_by_total_triangles": 9.561814766734825
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
@@ -4857,77 +4857,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 27226.091796875,
+      "test_loss": 27070.58984375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 27226.091796875,
+      "test_best_rerun_mse": 27070.58984375,
       "test_triangles_total_structural": 2726.0,
-      "test_mse_by_total_triangles": 9.987561187408291,
+      "test_mse_by_total_triangles": 9.930517184060895,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 128647.5390625,
+          "test_best_rerun_mse": 141976.296875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 9895.96454326923
+          "test_mse_by_total_triangles": 10921.25360576923
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 129486.796875,
+          "test_best_rerun_mse": 142706.765625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 43162.265625
+          "test_mse_by_total_triangles": 47568.921875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 102479.8359375,
+          "test_best_rerun_mse": 113931.890625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 313.39399369266056
+          "test_mse_by_total_triangles": 348.41556766055044
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 121522.5703125,
+          "test_best_rerun_mse": 134343.875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1114.8859661697247
+          "test_mse_by_total_triangles": 1232.5126146788991
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 122613.984375,
+          "test_best_rerun_mse": 135285.828125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1393.340731534091
+          "test_mse_by_total_triangles": 1537.338955965909
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 128227.0078125,
+          "test_best_rerun_mse": 141245.578125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 8014.18798828125
+          "test_mse_by_total_triangles": 8827.8486328125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56392.66796875,
+          "test_best_rerun_mse": 64448.890625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 50.48582629252462
+          "test_mse_by_total_triangles": 57.698201096687555
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 98915.3671875,
+          "test_best_rerun_mse": 110308.1484375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 230.03573764534883
+          "test_mse_by_total_triangles": 256.5305777616279
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 102241.4609375,
+          "test_best_rerun_mse": 114187.6015625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 297.2135492369186
+          "test_mse_by_total_triangles": 331.9407022165698
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 120988.7578125,
+          "test_best_rerun_mse": 133578.265625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1163.3534405048076
+          "test_mse_by_total_triangles": 1284.4064002403845
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26781.001953125,
+          "test_best_rerun_mse": 30076.79296875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 11.528627616498063
+          "test_mse_by_total_triangles": 12.947392582328884
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
@@ -4941,77 +4941,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 27167.458984375,
+      "test_loss": 27926.84375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 27167.458984375,
+      "test_best_rerun_mse": 27926.84375,
       "test_triangles_total_structural": 2726.0,
-      "test_mse_by_total_triangles": 9.966052452081804,
+      "test_mse_by_total_triangles": 10.24462353264857,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 133552.109375,
+          "test_best_rerun_mse": 118311.796875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 10273.239182692309
+          "test_mse_by_total_triangles": 9100.907451923076
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 134622.1875,
+          "test_best_rerun_mse": 119281.2265625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 44874.0625
+          "test_mse_by_total_triangles": 39760.408854166664
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 106398.78125,
+          "test_best_rerun_mse": 93140.9921875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 325.3785359327217
+          "test_mse_by_total_triangles": 284.8348384938838
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126498.2734375,
+          "test_best_rerun_mse": 111802.6171875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1160.5346186926606
+          "test_mse_by_total_triangles": 1025.7120842889908
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126083.1484375,
+          "test_best_rerun_mse": 111249.4296875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1432.7630504261363
+          "test_mse_by_total_triangles": 1264.1980646306818
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 133149.34375,
+          "test_best_rerun_mse": 117891.3203125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 8321.833984375
+          "test_mse_by_total_triangles": 7368.20751953125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 58653.3828125,
+          "test_best_rerun_mse": 49518.46484375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 52.50974289391227
+          "test_mse_by_total_triangles": 44.3316605584154
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 102160.5625,
+          "test_best_rerun_mse": 88997.1953125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 237.5827034883721
+          "test_mse_by_total_triangles": 206.97022165697675
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 104976.2421875,
+          "test_best_rerun_mse": 91058.6484375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 305.16349473110466
+          "test_mse_by_total_triangles": 264.70537336482556
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 124331.796875,
+          "test_best_rerun_mse": 109839.40625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1195.498046875
+          "test_mse_by_total_triangles": 1056.1481370192307
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27002.03515625,
+          "test_best_rerun_mse": 23562.63671875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 11.623777510223848
+          "test_mse_by_total_triangles": 10.143192732996125
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
@@ -5025,77 +5025,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 24091.876953125,
+      "test_loss": 25057.58984375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 24091.876953125,
+      "test_best_rerun_mse": 25057.58984375,
       "test_triangles_total_structural": 2323.0,
-      "test_mse_by_total_triangles": 10.37101892084589,
+      "test_mse_by_total_triangles": 10.78673691078347,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 123526.71875,
+          "test_best_rerun_mse": 124193.859375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 9502.055288461539
+          "test_mse_by_total_triangles": 9553.373798076924
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 124051.6875,
+          "test_best_rerun_mse": 125002.9609375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 41350.5625
+          "test_mse_by_total_triangles": 41667.653645833336
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 98096.5390625,
+          "test_best_rerun_mse": 99078.171875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 299.98941609327215
+          "test_mse_by_total_triangles": 302.9913512996942
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 116593.1015625,
+          "test_best_rerun_mse": 118045.90625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1069.6614822247707
+          "test_mse_by_total_triangles": 1082.9899655963302
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 116368.328125,
+          "test_best_rerun_mse": 118244.4921875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1322.3673650568182
+          "test_mse_by_total_triangles": 1343.687411221591
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 122868.109375,
+          "test_best_rerun_mse": 125085.6328125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 7679.2568359375
+          "test_mse_by_total_triangles": 7817.85205078125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52983.42578125,
+          "test_best_rerun_mse": 53929.6953125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 47.43368467435094
+          "test_mse_by_total_triangles": 48.28083734333035
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 93969.34375,
+          "test_best_rerun_mse": 95572.609375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 218.53335755813953
+          "test_mse_by_total_triangles": 222.26188226744185
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 96730.3515625,
+          "test_best_rerun_mse": 98802.140625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 281.1928824491279
+          "test_mse_by_total_triangles": 287.21552507267444
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 115355.0,
+          "test_best_rerun_mse": 117943.796875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1109.1826923076924
+          "test_mse_by_total_triangles": 1134.074969951923
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26802.162109375,
+          "test_best_rerun_mse": 26901.482421875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 9.832047729044387
+          "test_mse_by_total_triangles": 9.868482179704696
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
@@ -5109,77 +5109,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 26871.220703125,
+      "test_loss": 29462.765625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 26871.220703125,
+      "test_best_rerun_mse": 29462.765625,
       "test_triangles_total_structural": 2323.0,
-      "test_mse_by_total_triangles": 11.567464788258718,
+      "test_mse_by_total_triangles": 12.683067423590185,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 128739.90625,
+          "test_best_rerun_mse": 139573.328125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 9903.069711538461
+          "test_mse_by_total_triangles": 10736.40985576923
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 129573.1640625,
+          "test_best_rerun_mse": 140306.75,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 43191.0546875
+          "test_mse_by_total_triangles": 46768.916666666664
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 102569.1875,
+          "test_best_rerun_mse": 111787.53125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 313.6672400611621
+          "test_mse_by_total_triangles": 341.8578937308869
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 121628.203125,
+          "test_best_rerun_mse": 132027.375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1115.8550745412845
+          "test_mse_by_total_triangles": 1211.2603211009175
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 122765.1875,
+          "test_best_rerun_mse": 133058.015625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1395.0589488636363
+          "test_mse_by_total_triangles": 1512.0229048295455
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 128414.25,
+          "test_best_rerun_mse": 139053.53125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 8025.890625
+          "test_mse_by_total_triangles": 8690.845703125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56480.7265625,
+          "test_best_rerun_mse": 62986.3828125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 50.564661201880035
+          "test_mse_by_total_triangles": 56.388883448970454
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 99051.0078125,
+          "test_best_rerun_mse": 108271.703125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 230.35118095930233
+          "test_mse_by_total_triangles": 251.79465843023254
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 102399.5859375,
+          "test_best_rerun_mse": 112201.3828125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 297.67321493459303
+          "test_mse_by_total_triangles": 326.1668105014535
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 121138.125,
+          "test_best_rerun_mse": 131421.40625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1164.7896634615386
+          "test_mse_by_total_triangles": 1263.6673677884614
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27184.669921875,
+          "test_best_rerun_mse": 27018.2265625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 9.972366075522745
+          "test_mse_by_total_triangles": 9.911308350146735
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
@@ -5193,77 +5193,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 32494.81640625,
+      "test_loss": 27881.54296875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 32494.81640625,
+      "test_best_rerun_mse": 27881.54296875,
       "test_triangles_total_structural": 2323.0,
-      "test_mse_by_total_triangles": 13.98829806554025,
+      "test_mse_by_total_triangles": 12.00238612516143,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 152634.359375,
+          "test_best_rerun_mse": 136008.96875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 11741.104567307691
+          "test_mse_by_total_triangles": 10462.228365384615
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 153829.640625,
+          "test_best_rerun_mse": 137058.375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 51276.546875
+          "test_mse_by_total_triangles": 45686.125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 123477.3125,
+          "test_best_rerun_mse": 108881.734375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 377.6064602446483
+          "test_mse_by_total_triangles": 332.9716647553517
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 145123.15625,
+          "test_best_rerun_mse": 129049.5390625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1331.4051032110092
+          "test_mse_by_total_triangles": 1183.9407253440368
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 144669.578125,
+          "test_best_rerun_mse": 128484.859375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1643.9724786931818
+          "test_mse_by_total_triangles": 1460.0552201704545
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 152250.828125,
+          "test_best_rerun_mse": 135637.484375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 9515.6767578125
+          "test_mse_by_total_triangles": 8477.3427734375
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 70612.546875,
+          "test_best_rerun_mse": 60240.48046875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 63.21624608325873
+          "test_mse_by_total_triangles": 53.93060024059982
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 118898.546875,
+          "test_best_rerun_mse": 104392.75,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 276.50824854651165
+          "test_mse_by_total_triangles": 242.77383720930231
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 121811.96875,
+          "test_best_rerun_mse": 106570.2265625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 354.1045603197674
+          "test_mse_by_total_triangles": 309.79717023982556
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 142723.3125,
+          "test_best_rerun_mse": 126973.2421875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1372.3395432692307
+          "test_mse_by_total_triangles": 1220.8965594951924
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27388.703125,
+          "test_best_rerun_mse": 27075.857421875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 10.047213178650036
+          "test_mse_by_total_triangles": 9.932449531135363
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s44"

--- a/2026_tdl_challenge/outputs/bunn_full/results.json
+++ b/2026_tdl_challenge/outputs/bunn_full/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "bunn_full",
+    "model_config": "graph/bunn",
+    "generated_at_utc": "2026-05-16T03:15:47.991764+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 3.014521360397339,
+      "test_best_rerun_accuracy": 0.09989142417907715,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.9218034744262695,
+      "test_best_rerun_accuracy": 0.11400651186704636,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.914597272872925,
+      "test_best_rerun_accuracy": 0.11074918508529663,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.017070770263672,
+      "test_best_rerun_accuracy": 0.09446254372596741,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.0933767631649971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09011943638324738,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.926701307296753,
+      "test_best_rerun_accuracy": 0.10857763141393661,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.9184420108795166,
+      "test_best_rerun_accuracy": 0.11292073875665665,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3.0145041942596436,
+      "test_best_rerun_accuracy": 0.09120520949363708,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09120520949363708,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.9294190406799316,
+      "test_best_rerun_accuracy": 0.1074918583035469,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.9151628017425537,
+      "test_best_rerun_accuracy": 0.11292073875665665,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 3.00780987739563,
+      "test_best_rerun_accuracy": 0.09446254372596741,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.926323890686035,
+      "test_best_rerun_accuracy": 0.11509229242801666,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.9109208583831787,
+      "test_best_rerun_accuracy": 0.11400651186704636,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.9894351959228516,
+      "test_best_rerun_accuracy": 0.1074918583035469,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.9030587673187256,
+      "test_best_rerun_accuracy": 0.12812159955501556,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.894195318222046,
+      "test_best_rerun_accuracy": 0.12269272655248642,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.9931135177612305,
+      "test_best_rerun_accuracy": 0.10423452407121658,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.909454345703125,
+      "test_best_rerun_accuracy": 0.11726384609937668,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.896246910095215,
+      "test_best_rerun_accuracy": 0.1205211728811264,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.993497610092163,
+      "test_best_rerun_accuracy": 0.09989142417907715,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.0933767631649971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.911760091781616,
+      "test_best_rerun_accuracy": 0.11726384609937668,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.89919376373291,
+      "test_best_rerun_accuracy": 0.12269272655248642,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.991920232772827,
+      "test_best_rerun_accuracy": 0.10857763141393661,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.904486656188965,
+      "test_best_rerun_accuracy": 0.1194353997707367,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.8942389488220215,
+      "test_best_rerun_accuracy": 0.12377849966287613,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13572204113006592,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2.9653916358947754,
+      "test_best_rerun_accuracy": 0.11834961920976639,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2.8840227127075195,
+      "test_best_rerun_accuracy": 0.12595005333423615,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1313789337873459,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2.8786516189575195,
+      "test_best_rerun_accuracy": 0.12595005333423615,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13572204113006592,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2.9678187370300293,
+      "test_best_rerun_accuracy": 0.11509229242801666,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2.8914196491241455,
+      "test_best_rerun_accuracy": 0.1205211728811264,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2.87847900390625,
+      "test_best_rerun_accuracy": 0.11834961920976639,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 2.956035614013672,
+      "test_best_rerun_accuracy": 0.11834961920976639,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 2.8809022903442383,
+      "test_best_rerun_accuracy": 0.1313789337873459,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 2.867300510406494,
+      "test_best_rerun_accuracy": 0.12269272655248642,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12920738756656647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12920738756656647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13572204113006592,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 2.9625256061553955,
+      "test_best_rerun_accuracy": 0.1194353997707367,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.0933767631649971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 2.875361204147339,
+      "test_best_rerun_accuracy": 0.13029316067695618,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 2.867295026779175,
+      "test_best_rerun_accuracy": 0.1335504949092865,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12920738756656647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 146.90553283691406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.90553283691406,
+      "test_triangles_total_structural": 13.0,
+      "test_mse_by_total_triangles": 11.300425602839542,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174.48585510253906,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 58.16195170084635
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1219.4583740234375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 3.729230501600726
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.91153335571289,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 0.3936837922542467
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105.74408721923828,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1.2016373547640713
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127.91765594482422,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 7.994853496551514
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24972.85546875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 22.357077411593554
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1959.8359375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 4.557757994186047
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2557.40625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 7.434320494186046
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133.66624450683594,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1.2852523510272686
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157923.5,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 57.932318415260454
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83141.71875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 35.790666702539816
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 27.655567169189453,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27.655567169189453,
+      "test_triangles_total_structural": 13.0,
+      "test_mse_by_total_triangles": 2.127351320706881,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39.581520080566406,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 13.193840026855469
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1771.7569580078125,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 5.418216996965787
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.79743194580078,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 0.9247470820715668
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109.27815246582031,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1.2417971871115945
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.4259090423584,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 1.4016193151474
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26639.55078125,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 23.849194969785138
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2640.8740234375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 6.141567496366279
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3038.257080078125,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 8.832142674645713
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195.2026824951172,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1.8769488701453576
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162118.046875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 59.471037004768895
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88349.015625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 38.03229256349548
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 35.436729431152344,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 35.436729431152344,
+      "test_triangles_total_structural": 13.0,
+      "test_mse_by_total_triangles": 2.725902263934796,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.400245666503906,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 6.466748555501302
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2540.875732421875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 7.770262178660168
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.66009521484375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 2.675780690044438
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.8428039550781,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 3.3959409540349785
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.38544464111328,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 2.58659029006958
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29648.17578125,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 26.542681988585496
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3519.655029296875,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 8.185244254178778
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3771.662353515625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 10.964134748591933
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 355.44866943359375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 3.417775667630709
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169071.484375,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 62.02182112068966
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92572.21875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 39.850287882049074
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 143.68934631347656,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 143.68934631347656,
+      "test_triangles_total_structural": 3.0,
+      "test_mse_by_total_triangles": 47.89644877115885,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119.08289337158203,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 9.160222567044771
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1286.806884765625,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 3.9351892500477827
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.10082244873047,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 0.3770717655846832
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.55374145507812,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1.1199288801713423
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.71588134765625,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 6.357242584228516
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25299.265625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 22.649297784243508
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2052.28125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 4.772747093023256
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2628.27001953125,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 7.64031982421875
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133.5175018310547,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1.2838221329909105
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158857.03125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 58.27477301907557
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83809.2421875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 36.078020743650455
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 12.124272346496582,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12.124272346496582,
+      "test_triangles_total_structural": 3.0,
+      "test_mse_by_total_triangles": 4.04142411549886,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.09190559387207,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 1.4686081226055439
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2353.3388671875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 7.196754945527523
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257.8009338378906,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 2.3651461819989965
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260.83197021484375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 2.9639996615323154
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.8988037109375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 1.8686752319335938
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28894.978515625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 25.86837825928827
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3381.36279296875,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 7.863634402252907
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3717.931884765625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 10.807941525481468
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 356.7107849121094,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 3.429911393385667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168312.046875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 61.74323069515774
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92634.3046875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 39.87701450172191
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_1-2__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 24.46746253967285,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24.46746253967285,
+      "test_triangles_total_structural": 3.0,
+      "test_mse_by_total_triangles": 8.155820846557617,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.236446380615234,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 3.4028035677396336
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2623.878662109375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 8.024093767918577
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312.4690246582031,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 2.8666882996165426
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 328.13421630859375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 3.7287979125976562
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.78572082519531,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 3.049107551574707
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29905.87109375,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 26.77338504364369
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3588.869873046875,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 8.346209007085756
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3854.202880859375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 11.204078142033067
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 379.7357482910156,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 3.6513052720289965
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169586.921875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 62.210903108950845
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92996.4375,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 40.03290464916057
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 508.7521057128906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 508.7521057128906,
+      "test_triangles_total_structural": 327.0,
+      "test_mse_by_total_triangles": 1.555816837042479,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1716.5126953125,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 132.03943810096155
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1819.7906494140625,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 606.5968831380209
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1005.2725830078125,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 9.222684247778096
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1179.88427734375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 13.40777587890625
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1658.8094482421875,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 103.67559051513672
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18419.61328125,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 16.490253608997314
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 782.8714599609375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 1.8206313022347385
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1757.0545654296875,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 5.107716759970022
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 908.493408203125,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 8.735513540414663
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138569.53125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 50.832549981658104
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69085.078125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 29.7395945436935
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 718.6046142578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 718.6046142578125,
+      "test_triangles_total_structural": 327.0,
+      "test_mse_by_total_triangles": 2.1975676276997325,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2669.510986328125,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 205.34699894831732
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2796.398681640625,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 932.1328938802084
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1772.2760009765625,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 16.259412852995986
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1804.156982421875,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 20.50178389115767
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2580.171875,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 161.2607421875
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15965.837890625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 14.293498559198747
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 806.9767456054688,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 1.8766901060592296
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1557.9459228515625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 4.528912566428961
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1658.366943359375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 15.945835993840145
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129512.6640625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 47.510148225421865
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65564.09375,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 28.2238888291003
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 593.5123291015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 593.5123291015625,
+      "test_triangles_total_structural": 327.0,
+      "test_mse_by_total_triangles": 1.8150224131546253,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2133.6552734375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 164.12732872596155
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2271.693115234375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 757.2310384114584
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1371.1273193359375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 12.579149718678325
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1413.61083984375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 16.063759543678977
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2139.496337890625,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 133.71852111816406
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17463.591796875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 15.634370453782452
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 824.2676391601562,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 1.916901486418968
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1513.7279052734375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 4.4003718176553415
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1348.9427490234375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 12.97060335599459
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133711.515625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 49.05044593727072
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67270.4453125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 28.95843534761085
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 131.4573974609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 131.4573974609375,
+      "test_triangles_total_structural": 109.0,
+      "test_mse_by_total_triangles": 1.206031169366399,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 396.6576232910156,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 30.512124868539665
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 440.6014709472656,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 146.86715698242188
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 837.0330810546875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 2.5597341928277904
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221.64662170410156,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 2.5187116102738814
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 366.7845458984375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 22.924034118652344
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22949.2890625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 20.54546916965085
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1466.3726806640625,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 3.4101690248001453
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2193.11865234375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 6.375344919603925
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 217.4273223876953,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 2.0906473306509166
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152431.09375,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 55.9174958730741
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79096.890625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 34.04945786698235
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 141.25198364257812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 141.25198364257812,
+      "test_triangles_total_structural": 109.0,
+      "test_mse_by_total_triangles": 1.29588975818879,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 369.7882995605469,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 28.44525381234976
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 409.79095458984375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 136.59698486328125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 960.1324462890625,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 2.9361848510368884
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152.4444580078125,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1.7323233864524148
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 320.3896484375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 20.02435302734375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22875.3515625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 20.479276242166517
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1615.56787109375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 3.7571345839389534
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2182.25634765625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 6.3437684524890985
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.93716430664062,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1.730165041410006
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151797.625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 55.685115553925165
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80969.3828125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 34.85552424128282
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 64.11691284179688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 64.11691284179688,
+      "test_triangles_total_structural": 109.0,
+      "test_mse_by_total_triangles": 0.5882285581816227,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.43740844726562,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 12.495185265174278
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191.545166015625,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 63.848388671875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1307.5338134765625,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 3.9985743531393347
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103.86161804199219,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1.180245659568093
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.9203643798828,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 10.182522773742676
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24979.369140625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 22.362908809870188
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2048.4755859375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 4.763896711482558
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2468.251708984375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 7.175150316815044
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.2845916748047,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1.3681210737961988
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156630.140625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 57.45786523294204
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83618.890625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 35.996078616013776
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 944.3739624023438,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 944.3739624023438,
+      "test_triangles_total_structural": 88.0,
+      "test_mse_by_total_triangles": 10.731522300026633,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1481.99072265625,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 113.99928635817308
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1570.56982421875,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 523.5232747395834
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 454.2861328125,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 1.3892542287844036
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 837.787353515625,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 7.68612250931766
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1398.5281982421875,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 87.40801239013672
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18762.19921875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 16.796955433079678
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 839.607177734375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 1.952574831940407
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1609.4266357421875,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 4.678565801576126
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 813.3270263671875,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 7.8204521766075725
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139766.328125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 51.27158038334556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70180.140625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 30.21099467283685
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 669.4231567382812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 669.4231567382812,
+      "test_triangles_total_structural": 88.0,
+      "test_mse_by_total_triangles": 7.607081326571378,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1179.9173583984375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 90.76287372295673
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1249.7540283203125,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 416.5846761067708
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 550.9205932617188,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 1.6847724564578554
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 638.7086791992188,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 5.859712653203842
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1146.1614990234375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 71.63509368896484
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19165.951171875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 17.158416447515666
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 969.2962036132812,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 2.254177217705305
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1535.16455078125,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 4.462687647619913
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 629.1400146484375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 6.0494232177734375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140568.0625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 51.56568690388848
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73106.59375,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 31.470767864829963
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 522.2561645507812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 522.2561645507812,
+      "test_triangles_total_structural": 88.0,
+      "test_mse_by_total_triangles": 5.934729142622515,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 934.7411499023438,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 71.90316537710336
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1037.1622314453125,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 345.7207438151042
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 622.4378662109375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 1.903479713183295
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 486.6128234863281,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 4.464337830149799
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 946.7542114257812,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 59.17213821411133
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20657.099609375,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 18.493374762197853
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1094.197021484375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 2.5446442360101744
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1673.883056640625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 4.865939118141352
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 526.0240478515625,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 5.057923537034255
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143761.53125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 52.73717213866471
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74496.6796875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 32.069169043263024
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 11.906838417053223,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11.906838417053223,
+      "test_triangles_total_structural": 16.0,
+      "test_mse_by_total_triangles": 0.7441774010658264,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.471094131469727,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 0.7285457024207482
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.247811794281006,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 2.082603931427002
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2085.582275390625,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 6.377927447677752
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.7725830078125,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 1.6401154404386469
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189.71617126464844,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 2.1558655825528232
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28437.83984375,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 25.45912251007162
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3048.911376953125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 7.090491574309593
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3449.79541015625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 10.028475029523982
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260.8478698730469,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 2.508152594933143
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167417.453125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 61.415059840425535
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89857.203125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 38.68153384631942
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 11.786025047302246,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11.786025047302246,
+      "test_triangles_total_structural": 16.0,
+      "test_mse_by_total_triangles": 0.7366265654563904,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.219371795654297,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 0.7091824458195612
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.222160339355469,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 2.7407201131184897
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2119.21484375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 6.480779338685015
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181.10870361328125,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 1.6615477395713876
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189.55625915527344,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 2.1540483994917436
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27959.619140625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 25.030992963854075
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3074.026123046875,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 7.148897960574128
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3432.794189453125,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 9.979052876317224
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 271.8285827636719,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 2.6137363727276144
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165645.796875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 60.76514925715334
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90797.2265625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 39.086193096211794
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_1-2__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 46.14710235595703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 46.14710235595703,
+      "test_triangles_total_structural": 16.0,
+      "test_mse_by_total_triangles": 2.8841938972473145,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43.85768127441406,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 3.3736677903395433
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.727294921875,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 8.242431640625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2604.52099609375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 7.964896012519113
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 309.4871826171875,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 2.839331950616399
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 330.24041748046875,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 3.7527320168235083
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29888.3671875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 26.757714581468218
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3589.331787109375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 8.347283225835756
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3857.912353515625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 11.21486149277798
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368.4965515136719,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 3.543236072246845
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169682.421875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 62.24593612435803
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92907.9921875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 39.99483090292725
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 12463.14453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12463.14453125,
+      "test_triangles_total_structural": 1117.0,
+      "test_mse_by_total_triangles": 11.157694298343777,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42072.7109375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 3236.3623798076924
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42584.0234375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 14194.674479166666
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28543.068359375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 87.28767082377676
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38423.4375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 352.5086009174312
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38189.5703125,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 433.97238991477275
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41609.38671875,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 2600.586669921875
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25725.09765625,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 59.82580850290697
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28082.869140625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 81.63624750181685
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36649.375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 352.39783653846155
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55603.8046875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 20.397580589691856
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21517.14453125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 9.262653694037882
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 15786.73828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15786.73828125,
+      "test_triangles_total_structural": 1117.0,
+      "test_mse_by_total_triangles": 14.133158711951657,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52268.3125,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 4020.639423076923
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52655.11328125,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 17551.704427083332
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36552.74609375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 111.78209814602447
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48103.3984375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 441.31558199541286
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48053.41015625,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 546.0614790482955
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52096.13671875,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 3256.008544921875
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34235.71484375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 79.61794149709303
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36226.2109375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 105.3087527252907
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47368.984375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 455.4710036057692
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46466.40625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 17.045636922230376
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19910.078125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 8.57084723417994
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 11308.126953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11308.126953125,
+      "test_triangles_total_structural": 1117.0,
+      "test_mse_by_total_triangles": 10.123658865823634,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38404.08984375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 2954.1607572115386
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39002.1328125,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 13000.7109375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25120.841796875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 76.82214616781346
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35011.1484375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 321.2031966743119
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34366.19140625,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 390.52490234375
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38051.5859375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 2378.22412109375
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23092.138671875,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 53.70264807412791
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24513.4765625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 71.2601062863372
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33726.6640625,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 324.2948467548077
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58596.703125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 21.495489040719
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23031.548828125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 9.914571170092552
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 812.7072143554688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 812.7072143554688,
+      "test_triangles_total_structural": 430.0,
+      "test_mse_by_total_triangles": 1.8900167775708576,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3392.80810546875,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 260.98523888221155
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3546.278564453125,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 1182.0928548177083
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 855.4000854492188,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 2.6159024019853785
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2371.6162109375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 21.757946889334864
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2482.759033203125,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 28.21317083185369
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3240.50439453125,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 202.53152465820312
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15202.6162109375,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 13.61022042160922
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1994.1292724609375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 5.796887419944586
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2242.0068359375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 21.557758037860577
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127306.171875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 46.70072335840059
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61766.890625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 26.589277066293587
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1628.314208984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1628.314208984375,
+      "test_triangles_total_structural": 430.0,
+      "test_mse_by_total_triangles": 3.786777230196221,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5739.16552734375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 441.47427133413464
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5871.83740234375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 1957.2791341145833
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1891.3037109375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 5.7838033973623855
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4372.17822265625,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 40.11172681336009
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4376.4609375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 49.73251065340909
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5630.19921875,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 351.887451171875
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12139.75390625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 10.868177176589079
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2635.0263671875,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 7.659960369731104
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4195.6142578125,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 40.34244478665865
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114601.984375,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 42.040346432501835
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55447.640625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 23.868980036590617
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1913.3790283203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1913.3790283203125,
+      "test_triangles_total_structural": 430.0,
+      "test_mse_by_total_triangles": 4.449718670512355,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6407.24755859375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 492.86519681490387
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6662.77490234375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 2220.9249674479165
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2182.7470703125,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 6.675067493310397
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5053.92138671875,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 46.36625125430046
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4963.80126953125,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 56.40683260830966
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6387.30517578125,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 399.2065734863281
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12097.2578125,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 10.830132329901522
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2872.89990234375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 8.351453204487646
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4888.1171875,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 47.00112680288461
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112729.5390625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 41.353462605465886
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53512.3984375,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 23.03590117843306
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2608.31494140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2608.31494140625,
+      "test_triangles_total_structural": 344.0,
+      "test_mse_by_total_triangles": 7.5823108761809594,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4928.91259765625,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 379.14712289663464
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5085.5771484375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 1695.1923828125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1519.50341796875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 4.646799443329511
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3669.52783203125,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 33.66539295441514
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3824.114501953125,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 43.455846613103695
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4708.099609375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 294.2562255859375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13344.1689453125,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 11.946435940297672
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1241.7950439453125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 2.8878954510356105
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3524.868408203125,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 33.892965463491585
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119907.7265625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 43.98669352989729
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56514.046875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 24.3280442854068
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2205.131103515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2205.131103515625,
+      "test_triangles_total_structural": 344.0,
+      "test_mse_by_total_triangles": 6.410264835801235,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4749.10986328125,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 365.3161433293269
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4830.73193359375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 1610.2439778645833
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1474.6893310546875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 4.509753305977638
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3559.370361328125,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 32.65477395713876
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3594.8046875,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 40.85005326704545
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4715.92236328125,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 294.7451477050781
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12900.3046875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 11.549064178603402
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1330.4512939453125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 3.094072776617006
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3499.34423828125,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 33.64754075270433
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118613.5546875,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 43.511942291819516
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57744.39453125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 24.857681675096856
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2330.484619140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2330.484619140625,
+      "test_triangles_total_structural": 344.0,
+      "test_mse_by_total_triangles": 6.774664590525073,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5120.8974609375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 393.91518930288464
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5345.5888671875,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 1781.8629557291667
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1561.893310546875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 4.776432142345183
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3919.859375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 35.9620126146789
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3875.681396484375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 44.041834050958805
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5095.162109375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 318.4476318359375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13223.958984375,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 11.838817353961504
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1431.5164794921875,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 3.3291080918422966
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3801.175537109375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 36.549764779897835
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117863.5703125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 43.23681963041086
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56515.90625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 24.328844705122687
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 263.62127685546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 263.62127685546875,
+      "test_triangles_total_structural": 104.0,
+      "test_mse_by_total_triangles": 2.5348199697641225,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 495.57916259765625,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 38.12147404597356
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 539.7516479492188,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 179.9172159830729
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 720.4877319335938,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 2.20332639735044
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183.43527221679688,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 1.682892405658687
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 278.5744323730469,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 3.1656185496937144
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 456.3119812011719,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 28.519498825073242
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22384.619140625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 20.039945515331244
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1338.7471923828125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 3.113365563680959
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2090.08447265625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 6.075826955396075
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151044.609375,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 55.408880915260454
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77773.8359375,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 33.47991215561773
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 165.39035034179688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 165.39035034179688,
+      "test_triangles_total_structural": 104.0,
+      "test_mse_by_total_triangles": 1.5902918302095854,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 407.3539123535156,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 31.33491633488582
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 430.59527587890625,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 143.5317586263021
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 822.556396484375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 2.5154629861907494
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.03521728515625,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 1.459038690689507
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175.153076171875,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1.9903758655894885
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389.4059143066406,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 24.33786964416504
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22306.357421875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 19.96988130875112
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1539.6607666015625,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 3.580606433957122
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1972.9599609375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 5.735348723655523
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151006.4375,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 55.39487802641233
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79754.9765625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 34.33274927356866
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_1-2__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 107.10814666748047,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107.10814666748047,
+      "test_triangles_total_structural": 104.0,
+      "test_mse_by_total_triangles": 1.0298860256488507,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69.71131134033203,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 5.362408564640925
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93.46802520751953,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 31.15600840250651
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1423.848876953125,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 4.354277911171636
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.79733657836914,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 0.5210764823703591
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96.76861572265625,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1.0996433604847302
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.10612487792969,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 5.3191328048706055
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25894.353515625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 23.18205328166965
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2295.8408203125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 5.339164698401163
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2667.255859375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 7.753650753997093
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159719.84375,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 58.5912853081438
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85279.0234375,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 36.710728987300904
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 30067.083984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 30067.083984375,
+      "test_triangles_total_structural": 2726.0,
+      "test_mse_by_total_triangles": 11.029744675119222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185660.75,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 14281.596153846154
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186832.921875,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 62277.640625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156073.578125,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 477.28922974006116
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179559.8125,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 1647.3377293577983
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178331.484375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 2026.494140625
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185992.84375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 11624.552734375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94004.921875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 84.1583902193375
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149803.890625,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 348.38114098837207
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154240.484375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 448.3735010901163
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176000.578125,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1692.313251201923
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44408.453125,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 19.116854552303057
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 29202.25,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 29202.25,
+      "test_triangles_total_structural": 2726.0,
+      "test_mse_by_total_triangles": 10.712490829053559,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184161.5,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 14166.26923076923
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184693.6875,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 61564.5625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153602.96875,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 469.7338493883792
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177206.40625,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 1625.7468463302753
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176233.625,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 2002.6548295454545
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183911.9375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 11494.49609375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92218.7734375,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 82.55933163607878
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148733.890625,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 345.89276889534887
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151441.765625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 440.2376907703488
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174888.328125,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1681.6185396634614
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44792.19140625,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 19.28204537505381
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 27403.822265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27403.822265625,
+      "test_triangles_total_structural": 2726.0,
+      "test_mse_by_total_triangles": 10.052759451806676,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160378.53125,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 12336.810096153846
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161648.125,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 53882.708333333336
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131752.953125,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 402.91422974006116
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153906.8125,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 1411.989105504587
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151762.421875,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 1724.5729758522727
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159295.0,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 9955.9375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75735.3828125,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 67.80249132721576
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126389.0703125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 293.92807049418604
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128448.578125,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 373.39702943313955
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149842.5625,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 1440.7938701923076
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34747.91796875,
+          "test_triangles_total_structural": 2323.0,
+          "test_mse_by_total_triangles": 14.958208337817478
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 17637.845703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17637.845703125,
+      "test_triangles_total_structural": 2323.0,
+      "test_mse_by_total_triangles": 7.592701551065432,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79594.34375,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 6122.641826923077
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80285.2734375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 26761.7578125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60405.5390625,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 184.72641915137615
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74997.171875,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 688.0474483944954
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74844.859375,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 850.509765625
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79448.953125,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 4965.5595703125
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28872.025390625,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 25.84782935597583
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56619.05078125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 131.67221111918604
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60023.79296875,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 174.48777025799419
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73008.265625,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 702.0025540865385
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35181.78515625,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 12.906010695616288
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 18750.92578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18750.92578125,
+      "test_triangles_total_structural": 2323.0,
+      "test_mse_by_total_triangles": 8.071857848148944,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81413.3828125,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 6262.567908653846
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81841.0859375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 27280.361979166668
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61391.484375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 187.74154243119267
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76403.5859375,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 700.9503297018349
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76243.2265625,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 866.4003018465909
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81308.4375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 5081.77734375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29148.07421875,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 26.094963490376006
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58443.859375,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 135.91595203488373
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60766.49609375,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 176.64679097020348
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75436.609375,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 725.3520132211538
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33364.859375,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 12.239493534482758
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "bunn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 17952.205078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17952.205078125,
+      "test_triangles_total_structural": 2323.0,
+      "test_mse_by_total_triangles": 7.728026292778734,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62915.07421875,
+          "test_triangles_total_structural": 13.0,
+          "test_mse_by_total_triangles": 4839.62109375
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63675.9609375,
+          "test_triangles_total_structural": 3.0,
+          "test_mse_by_total_triangles": 21225.3203125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45432.12109375,
+          "test_triangles_total_structural": 327.0,
+          "test_mse_by_total_triangles": 138.93615013379204
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58663.21875,
+          "test_triangles_total_structural": 109.0,
+          "test_mse_by_total_triangles": 538.1946674311927
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57784.66796875,
+          "test_triangles_total_structural": 88.0,
+          "test_mse_by_total_triangles": 656.6439541903409
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62539.24609375,
+          "test_triangles_total_structural": 16.0,
+          "test_mse_by_total_triangles": 3908.702880859375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20400.408203125,
+          "test_triangles_total_structural": 1117.0,
+          "test_mse_by_total_triangles": 18.2635704593778
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42637.61328125,
+          "test_triangles_total_structural": 430.0,
+          "test_mse_by_total_triangles": 99.1572401889535
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44417.34765625,
+          "test_triangles_total_structural": 344.0,
+          "test_mse_by_total_triangles": 129.12019667514534
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56990.203125,
+          "test_triangles_total_structural": 104.0,
+          "test_mse_by_total_triangles": 547.9827223557693
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42028.53125,
+          "test_triangles_total_structural": 2726.0,
+          "test_mse_by_total_triangles": 15.41765636463683
+        }
+      },
+      "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/2026_tdl_challenge/outputs/bunn_full/results.json
+++ b/2026_tdl_challenge/outputs/bunn_full/results.json
@@ -2,7 +2,7 @@
   "metadata": {
     "study_id": "bunn_full",
     "model_config": "graph/bunn",
-    "generated_at_utc": "2026-05-16T06:06:54.792597+00:00",
+    "generated_at_utc": "2026-05-16T06:15:43.506502+00:00",
     "n_runs": 72,
     "train_seeds": [
       42,

--- a/2026_tdl_challenge/outputs/bunn_full/results.json
+++ b/2026_tdl_challenge/outputs/bunn_full/results.json
@@ -2,7 +2,7 @@
   "metadata": {
     "study_id": "bunn_full",
     "model_config": "graph/bunn",
-    "generated_at_utc": "2026-05-16T03:15:47.991764+00:00",
+    "generated_at_utc": "2026-05-16T05:57:57.368562+00:00",
     "n_runs": 72,
     "train_seeds": [
       42,
@@ -21,54 +21,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 3.014521360397339,
-      "test_best_rerun_accuracy": 0.09989142417907715,
+      "test_loss": 2.9346225261688232,
+      "test_best_rerun_accuracy": 0.09880564361810684,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09663408994674683,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09446254372596741,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
-        "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09663408994674683,
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
-        "h_hi__d_hi__pl_lo": {
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -83,54 +83,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.9218034744262695,
-      "test_best_rerun_accuracy": 0.11400651186704636,
+      "test_loss": 2.9061696529388428,
+      "test_best_rerun_accuracy": 0.09989142417907715,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         }
       },
@@ -145,54 +145,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.914597272872925,
-      "test_best_rerun_accuracy": 0.11074918508529663,
+      "test_loss": 2.926828622817993,
+      "test_best_rerun_accuracy": 0.09880564361810684,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -207,8 +207,8 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 3.017070770263672,
-      "test_best_rerun_accuracy": 0.09446254372596741,
+      "test_loss": 2.933964252471924,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -218,11 +218,11 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.0933767631649971,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
@@ -230,31 +230,31 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09011943638324738,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_accuracy": 0.11292073875665665,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -269,54 +269,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.926701307296753,
-      "test_best_rerun_accuracy": 0.10857763141393661,
+      "test_loss": 2.9056692123413086,
+      "test_best_rerun_accuracy": 0.10423452407121658,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         }
       },
@@ -331,54 +331,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.9184420108795166,
-      "test_best_rerun_accuracy": 0.11292073875665665,
+      "test_loss": 2.925989866256714,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         }
       },
@@ -393,54 +393,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 3.0145041942596436,
-      "test_best_rerun_accuracy": 0.09120520949363708,
+      "test_loss": 2.935696601867676,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09120520949363708,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         }
       },
@@ -455,54 +455,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.9294190406799316,
-      "test_best_rerun_accuracy": 0.1074918583035469,
+      "test_loss": 2.9063291549682617,
+      "test_best_rerun_accuracy": 0.10314875096082687,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.09771987050771713,
           "test_best_rerun_mse": null
         }
       },
@@ -517,54 +517,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.9151628017425537,
-      "test_best_rerun_accuracy": 0.11292073875665665,
+      "test_loss": 2.9260518550872803,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -579,38 +579,38 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 3.00780987739563,
-      "test_best_rerun_accuracy": 0.09446254372596741,
+      "test_loss": 2.936049222946167,
+      "test_best_rerun_accuracy": 0.10314875096082687,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.09880564361810684,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09446254372596741,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09663408994674683,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
@@ -618,15 +618,15 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         }
       },
@@ -641,54 +641,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.926323890686035,
-      "test_best_rerun_accuracy": 0.11509229242801666,
+      "test_loss": 2.9078376293182373,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         }
       },
@@ -703,54 +703,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.9109208583831787,
-      "test_best_rerun_accuracy": 0.11400651186704636,
+      "test_loss": 2.9272987842559814,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         }
       },
@@ -765,54 +765,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.9894351959228516,
-      "test_best_rerun_accuracy": 0.1074918583035469,
+      "test_loss": 2.924868106842041,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09880564361810684,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -827,54 +827,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.9030587673187256,
-      "test_best_rerun_accuracy": 0.12812159955501556,
+      "test_loss": 2.897615671157837,
+      "test_best_rerun_accuracy": 0.1064060777425766,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         }
       },
@@ -889,54 +889,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.894195318222046,
-      "test_best_rerun_accuracy": 0.12269272655248642,
+      "test_loss": 2.9193718433380127,
+      "test_best_rerun_accuracy": 0.10423452407121658,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         }
       },
@@ -951,30 +951,30 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.9931135177612305,
+      "test_loss": 2.9241905212402344,
       "test_best_rerun_accuracy": 0.10423452407121658,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10532030463218689,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
-        "h_lo__d_hi__pl_hi": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
@@ -982,23 +982,23 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.11292073875665665,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         }
       },
@@ -1013,54 +1013,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.909454345703125,
-      "test_best_rerun_accuracy": 0.11726384609937668,
+      "test_loss": 2.899684429168701,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         }
       },
@@ -1075,54 +1075,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.896246910095215,
-      "test_best_rerun_accuracy": 0.1205211728811264,
+      "test_loss": 2.9206252098083496,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -1137,8 +1137,8 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.993497610092163,
-      "test_best_rerun_accuracy": 0.09989142417907715,
+      "test_loss": 2.9274954795837402,
+      "test_best_rerun_accuracy": 0.10097719728946686,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -1148,31 +1148,31 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10097719728946686,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.0933767631649971,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
@@ -1180,11 +1180,11 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -1199,54 +1199,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.911760091781616,
-      "test_best_rerun_accuracy": 0.11726384609937668,
+      "test_loss": 2.901872396469116,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         }
       },
@@ -1261,54 +1261,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.89919376373291,
-      "test_best_rerun_accuracy": 0.12269272655248642,
+      "test_loss": 2.920147657394409,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -1323,14 +1323,14 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.991920232772827,
-      "test_best_rerun_accuracy": 0.10857763141393661,
+      "test_loss": 2.9272403717041016,
+      "test_best_rerun_accuracy": 0.1074918583035469,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
@@ -1338,39 +1338,39 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09880564361810684,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.11292073875665665,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         }
       },
@@ -1385,54 +1385,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.904486656188965,
-      "test_best_rerun_accuracy": 0.1194353997707367,
+      "test_loss": 2.9027609825134277,
+      "test_best_rerun_accuracy": 0.10314875096082687,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         }
       },
@@ -1447,54 +1447,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.8942389488220215,
-      "test_best_rerun_accuracy": 0.12377849966287613,
+      "test_loss": 2.9223968982696533,
+      "test_best_rerun_accuracy": 0.10206297785043716,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.09880564361810684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13572204113006592,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -1509,8 +1509,8 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2.9653916358947754,
-      "test_best_rerun_accuracy": 0.11834961920976639,
+      "test_loss": 2.915515422821045,
+      "test_best_rerun_accuracy": 0.11074918508529663,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
@@ -1520,31 +1520,31 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09880564361810684,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
@@ -1552,11 +1552,11 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         }
       },
@@ -1571,54 +1571,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2.8840227127075195,
-      "test_best_rerun_accuracy": 0.12595005333423615,
+      "test_loss": 2.8907883167266846,
+      "test_best_rerun_accuracy": 0.1074918583035469,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1313789337873459,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -1633,54 +1633,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2.8786516189575195,
-      "test_best_rerun_accuracy": 0.12595005333423615,
+      "test_loss": 2.9118335247039795,
+      "test_best_rerun_accuracy": 0.10423452407121658,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13572204113006592,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         }
       },
@@ -1695,54 +1695,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 2.9678187370300293,
-      "test_best_rerun_accuracy": 0.11509229242801666,
+      "test_loss": 2.913261651992798,
+      "test_best_rerun_accuracy": 0.10966341197490692,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1064060777425766,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09229099005460739,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.11074918508529663,
           "test_best_rerun_mse": null
         }
       },
@@ -1757,54 +1757,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 2.8914196491241455,
-      "test_best_rerun_accuracy": 0.1205211728811264,
+      "test_loss": 2.8900341987609863,
+      "test_best_rerun_accuracy": 0.10857763141393661,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         }
       },
@@ -1819,54 +1819,54 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 2.87847900390625,
-      "test_best_rerun_accuracy": 0.11834961920976639,
+      "test_loss": 2.909128427505493,
+      "test_best_rerun_accuracy": 0.10857763141393661,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10206297785043716,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         }
       },
@@ -1881,54 +1881,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 2.956035614013672,
-      "test_best_rerun_accuracy": 0.11834961920976639,
+      "test_loss": 2.913783550262451,
+      "test_best_rerun_accuracy": 0.1064060777425766,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.09554831683635712,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09989142417907715,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11400651186704636,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10532030463218689,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11834961920976639,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.11074918508529663,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.11074918508529663,
           "test_best_rerun_mse": null
         }
       },
@@ -1943,54 +1943,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 2.8809022903442383,
-      "test_best_rerun_accuracy": 0.1313789337873459,
+      "test_loss": 2.8891212940216064,
+      "test_best_rerun_accuracy": 0.10423452407121658,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1074918583035469,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11617806553840637,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1324647068977356,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -2005,54 +2005,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 2.867300510406494,
-      "test_best_rerun_accuracy": 0.12269272655248642,
+      "test_loss": 2.910036087036133,
+      "test_best_rerun_accuracy": 0.10857763141393661,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12920738756656647,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12595005333423615,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12920738756656647,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.13029316067695618,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13572204113006592,
+          "test_best_rerun_accuracy": 0.10857763141393661,
           "test_best_rerun_mse": null
         }
       },
@@ -2067,54 +2067,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 2.9625256061553955,
-      "test_best_rerun_accuracy": 0.1194353997707367,
+      "test_loss": 2.9138026237487793,
+      "test_best_rerun_accuracy": 0.1074918583035469,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10423452407121658,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.0933767631649971,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.09663408994674683,
-          "test_best_rerun_mse": null
-        },
-        "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.09771987050771713,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10423452407121658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10314875096082687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10206297785043716,
+          "test_best_rerun_mse": null
+        },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10857763141393661,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1205211728811264,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -2129,54 +2129,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 2.875361204147339,
-      "test_best_rerun_accuracy": 0.13029316067695618,
+      "test_loss": 2.888545513153076,
+      "test_best_rerun_accuracy": 0.10532030463218689,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.11183496564626694,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11292073875665665,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.10966341197490692,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11074918508529663,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11509229242801666,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11726384609937668,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.11074918508529663,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12812159955501556,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         }
       },
@@ -2191,54 +2191,54 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 2.867295026779175,
-      "test_best_rerun_accuracy": 0.1335504949092865,
+      "test_loss": 2.911616563796997,
+      "test_best_rerun_accuracy": 0.10857763141393661,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12269272655248642,
+          "test_best_rerun_accuracy": 0.10097719728946686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.10314875096082687,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12160694599151611,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1194353997707367,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.10532030463218689,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12920738756656647,
+          "test_best_rerun_accuracy": 0.09989142417907715,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12486428022384644,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10423452407121658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.1074918583035469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.12377849966287613,
+          "test_best_rerun_accuracy": 0.10966341197490692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12703582644462585,
+          "test_best_rerun_accuracy": 0.1064060777425766,
           "test_best_rerun_mse": null
         }
       },
@@ -2253,77 +2253,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 146.90553283691406,
+      "test_loss": 47.69805145263672,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 146.90553283691406,
+      "test_best_rerun_mse": 47.69805145263672,
       "test_triangles_total_structural": 13.0,
-      "test_mse_by_total_triangles": 11.300425602839542,
+      "test_mse_by_total_triangles": 3.6690808809720554,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 174.48585510253906,
+          "test_best_rerun_mse": 64.4527587890625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 58.16195170084635
+          "test_mse_by_total_triangles": 21.4842529296875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1219.4583740234375,
+          "test_best_rerun_mse": 1638.045654296875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.729230501600726
+          "test_mse_by_total_triangles": 5.00931392751338
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42.91153335571289,
+          "test_best_rerun_mse": 55.21993637084961,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.3936837922542467
+          "test_mse_by_total_triangles": 0.5066049208334826
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 105.74408721923828,
+          "test_best_rerun_mse": 80.57191467285156,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.2016373547640713
+          "test_mse_by_total_triangles": 0.9155899394642223
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 127.91765594482422,
+          "test_best_rerun_mse": 43.36471939086914,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 7.994853496551514
+          "test_mse_by_total_triangles": 2.7102949619293213
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24972.85546875,
+          "test_best_rerun_mse": 26246.3046875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 22.357077411593554
+          "test_mse_by_total_triangles": 23.49713938003581
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1959.8359375,
+          "test_best_rerun_mse": 2381.28466796875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.557757994186047
+          "test_mse_by_total_triangles": 5.537871320857558
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2557.40625,
+          "test_best_rerun_mse": 2843.069091796875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.434320494186046
+          "test_mse_by_total_triangles": 8.26473573196766
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 133.66624450683594,
+          "test_best_rerun_mse": 131.73480224609375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.2852523510272686
+          "test_mse_by_total_triangles": 1.2666807908278246
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 157923.5,
+          "test_best_rerun_mse": 160928.375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 57.932318415260454
+          "test_mse_by_total_triangles": 59.03462032281732
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 83141.71875,
+          "test_best_rerun_mse": 86230.625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 35.790666702539816
+          "test_mse_by_total_triangles": 37.12037236332329
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
@@ -2337,77 +2337,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 27.655567169189453,
+      "test_loss": 43.40519714355469,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 27.655567169189453,
+      "test_best_rerun_mse": 43.40519714355469,
       "test_triangles_total_structural": 13.0,
-      "test_mse_by_total_triangles": 2.127351320706881,
+      "test_mse_by_total_triangles": 3.338861318734976,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 39.581520080566406,
+          "test_best_rerun_mse": 53.552886962890625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 13.193840026855469
+          "test_mse_by_total_triangles": 17.850962320963543
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1771.7569580078125,
+          "test_best_rerun_mse": 1723.3055419921875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.418216996965787
+          "test_mse_by_total_triangles": 5.270047529028096
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 100.79743194580078,
+          "test_best_rerun_mse": 63.34309387207031,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.9247470820715668
+          "test_mse_by_total_triangles": 0.5811293015786267
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 109.27815246582031,
+          "test_best_rerun_mse": 115.101318359375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.2417971871115945
+          "test_mse_by_total_triangles": 1.3079695268110796
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.4259090423584,
+          "test_best_rerun_mse": 45.19928741455078,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 1.4016193151474
+          "test_mse_by_total_triangles": 2.824955463409424
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26639.55078125,
+          "test_best_rerun_mse": 26709.115234375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 23.849194969785138
+          "test_mse_by_total_triangles": 23.91147290454342
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2640.8740234375,
+          "test_best_rerun_mse": 2474.7275390625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 6.141567496366279
+          "test_mse_by_total_triangles": 5.755180323401163
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3038.257080078125,
+          "test_best_rerun_mse": 2951.1767578125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.832142674645713
+          "test_mse_by_total_triangles": 8.579002202943315
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 195.2026824951172,
+          "test_best_rerun_mse": 157.5531005859375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.8769488701453576
+          "test_mse_by_total_triangles": 1.5149336594801683
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 162118.046875,
+          "test_best_rerun_mse": 161512.859375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 59.471037004768895
+          "test_mse_by_total_triangles": 59.2490313187821
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 88349.015625,
+          "test_best_rerun_mse": 86729.046875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 38.03229256349548
+          "test_mse_by_total_triangles": 37.33493193069307
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
@@ -2421,77 +2421,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 35.436729431152344,
+      "test_loss": 13.749375343322754,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 35.436729431152344,
+      "test_best_rerun_mse": 13.749375343322754,
       "test_triangles_total_structural": 13.0,
-      "test_mse_by_total_triangles": 2.725902263934796,
+      "test_mse_by_total_triangles": 1.0576442571786733,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19.400245666503906,
+          "test_best_rerun_mse": 21.883607864379883,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 6.466748555501302
+          "test_mse_by_total_triangles": 7.294535954793294
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2540.875732421875,
+          "test_best_rerun_mse": 1964.2408447265625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 7.770262178660168
+          "test_mse_by_total_triangles": 6.0068527361668576
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 291.66009521484375,
+          "test_best_rerun_mse": 121.90777587890625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 2.675780690044438
+          "test_mse_by_total_triangles": 1.1184199621918005
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 298.8428039550781,
+          "test_best_rerun_mse": 120.49528503417969,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 3.3959409540349785
+          "test_mse_by_total_triangles": 1.3692646026611328
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 41.38544464111328,
+          "test_best_rerun_mse": 19.243982315063477,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 2.58659029006958
+          "test_mse_by_total_triangles": 1.2027488946914673
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29648.17578125,
+          "test_best_rerun_mse": 27076.78125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 26.542681988585496
+          "test_mse_by_total_triangles": 24.240627797672335
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3519.655029296875,
+          "test_best_rerun_mse": 2722.6943359375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 8.185244254178778
+          "test_mse_by_total_triangles": 6.331847292877907
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3771.662353515625,
+          "test_best_rerun_mse": 3069.570068359375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 10.964134748591933
+          "test_mse_by_total_triangles": 8.923168803370276
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 355.44866943359375,
+          "test_best_rerun_mse": 183.5992431640625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 3.417775667630709
+          "test_mse_by_total_triangles": 1.7653773381159856
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 169071.484375,
+          "test_best_rerun_mse": 162810.0,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 62.02182112068966
+          "test_mse_by_total_triangles": 59.724871606749815
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 92572.21875,
+          "test_best_rerun_mse": 88188.8125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 39.850287882049074
+          "test_mse_by_total_triangles": 37.963328669823504
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
@@ -2505,77 +2505,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 143.68934631347656,
+      "test_loss": 7.795704364776611,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 143.68934631347656,
+      "test_best_rerun_mse": 7.795704364776611,
       "test_triangles_total_structural": 3.0,
-      "test_mse_by_total_triangles": 47.89644877115885,
+      "test_mse_by_total_triangles": 2.5985681215922036,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 119.08289337158203,
+          "test_best_rerun_mse": 18.25130844116211,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 9.160222567044771
+          "test_mse_by_total_triangles": 1.403946803166316
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1286.806884765625,
+          "test_best_rerun_mse": 2443.1904296875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.9351892500477827
+          "test_mse_by_total_triangles": 7.47153036601682
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 41.10082244873047,
+          "test_best_rerun_mse": 254.099853515625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.3770717655846832
+          "test_mse_by_total_triangles": 2.33119131665711
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 98.55374145507812,
+          "test_best_rerun_mse": 237.39158630371094,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.1199288801713423
+          "test_mse_by_total_triangles": 2.69763166254217
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 101.71588134765625,
+          "test_best_rerun_mse": 21.87163543701172,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 6.357242584228516
+          "test_mse_by_total_triangles": 1.3669772148132324
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25299.265625,
+          "test_best_rerun_mse": 29132.44921875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 22.649297784243508
+          "test_mse_by_total_triangles": 26.080975128692927
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2052.28125,
+          "test_best_rerun_mse": 3329.256591796875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.772747093023256
+          "test_mse_by_total_triangles": 7.7424571902252906
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2628.27001953125,
+          "test_best_rerun_mse": 3678.248291015625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.64031982421875
+          "test_mse_by_total_triangles": 10.69258224132449
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 133.5175018310547,
+          "test_best_rerun_mse": 316.8338317871094,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.2838221329909105
+          "test_mse_by_total_triangles": 3.0464791517991285
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 158857.03125,
+          "test_best_rerun_mse": 168580.25,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 58.27477301907557
+          "test_mse_by_total_triangles": 61.84161775495231
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 83809.2421875,
+          "test_best_rerun_mse": 91736.953125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 36.078020743650455
+          "test_mse_by_total_triangles": 39.490724547998276
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
@@ -2589,77 +2589,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 12.124272346496582,
+      "test_loss": 6.170844554901123,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 12.124272346496582,
+      "test_best_rerun_mse": 6.170844554901123,
       "test_triangles_total_structural": 3.0,
-      "test_mse_by_total_triangles": 4.04142411549886,
+      "test_mse_by_total_triangles": 2.056948184967041,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19.09190559387207,
+          "test_best_rerun_mse": 13.539021492004395,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 1.4686081226055439
+          "test_mse_by_total_triangles": 1.0414631916926458
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2353.3388671875,
+          "test_best_rerun_mse": 2232.16796875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 7.196754945527523
+          "test_mse_by_total_triangles": 6.826201739296636
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 257.8009338378906,
+          "test_best_rerun_mse": 181.01718139648438,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 2.3651461819989965
+          "test_mse_by_total_triangles": 1.6607080862062786
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 260.83197021484375,
+          "test_best_rerun_mse": 203.01174926757812,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.9639996615323154
+          "test_mse_by_total_triangles": 2.3069516962224785
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29.8988037109375,
+          "test_best_rerun_mse": 16.437074661254883,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 1.8686752319335938
+          "test_mse_by_total_triangles": 1.0273171663284302
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28894.978515625,
+          "test_best_rerun_mse": 28586.142578125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 25.86837825928827
+          "test_mse_by_total_triangles": 25.59189129644136
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3381.36279296875,
+          "test_best_rerun_mse": 3082.302001953125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 7.863634402252907
+          "test_mse_by_total_triangles": 7.168144190588663
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3717.931884765625,
+          "test_best_rerun_mse": 3487.23046875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 10.807941525481468
+          "test_mse_by_total_triangles": 10.137297874273257
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 356.7107849121094,
+          "test_best_rerun_mse": 255.6205291748047,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 3.429911393385667
+          "test_mse_by_total_triangles": 2.4578897036038914
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 168312.046875,
+          "test_best_rerun_mse": 166565.234375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 61.74323069515774
+          "test_mse_by_total_triangles": 61.10243373991196
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 92634.3046875,
+          "test_best_rerun_mse": 90358.9296875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 39.87701450172191
+          "test_mse_by_total_triangles": 38.89751600839432
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
@@ -2673,77 +2673,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 24.46746253967285,
+      "test_loss": 8.582231521606445,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 24.46746253967285,
+      "test_best_rerun_mse": 8.582231521606445,
       "test_triangles_total_structural": 3.0,
-      "test_mse_by_total_triangles": 8.155820846557617,
+      "test_mse_by_total_triangles": 2.860743840535482,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44.236446380615234,
+          "test_best_rerun_mse": 14.909807205200195,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 3.4028035677396336
+          "test_mse_by_total_triangles": 1.1469082465538611
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2623.878662109375,
+          "test_best_rerun_mse": 2415.25048828125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 8.024093767918577
+          "test_mse_by_total_triangles": 7.386087120126147
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 312.4690246582031,
+          "test_best_rerun_mse": 243.48141479492188,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 2.8666882996165426
+          "test_mse_by_total_triangles": 2.2337744476598336
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 328.13421630859375,
+          "test_best_rerun_mse": 216.48162841796875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 3.7287979125976562
+          "test_mse_by_total_triangles": 2.460018504749645
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 48.78572082519531,
+          "test_best_rerun_mse": 17.690101623535156,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 3.049107551574707
+          "test_mse_by_total_triangles": 1.1056313514709473
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29905.87109375,
+          "test_best_rerun_mse": 28637.525390625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 26.77338504364369
+          "test_mse_by_total_triangles": 25.63789202383617
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3588.869873046875,
+          "test_best_rerun_mse": 3246.3291015625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 8.346209007085756
+          "test_mse_by_total_triangles": 7.549602561773256
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3854.202880859375,
+          "test_best_rerun_mse": 3529.74560546875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 11.204078142033067
+          "test_mse_by_total_triangles": 10.260888387990553
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 379.7357482910156,
+          "test_best_rerun_mse": 290.4015808105469,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 3.6513052720289965
+          "test_mse_by_total_triangles": 2.7923228924091044
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 169586.921875,
+          "test_best_rerun_mse": 166951.875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 62.210903108950845
+          "test_mse_by_total_triangles": 61.24426815847396
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 92996.4375,
+          "test_best_rerun_mse": 91188.265625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 40.03290464916057
+          "test_mse_by_total_triangles": 39.254526743435214
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
@@ -2757,77 +2757,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 508.7521057128906,
+      "test_loss": 1670.96533203125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 508.7521057128906,
+      "test_best_rerun_mse": 1670.96533203125,
       "test_triangles_total_structural": 327.0,
-      "test_mse_by_total_triangles": 1.555816837042479,
+      "test_mse_by_total_triangles": 5.109985724866208,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1716.5126953125,
+          "test_best_rerun_mse": 5463.966796875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 132.03943810096155
+          "test_mse_by_total_triangles": 420.30513822115387
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1819.7906494140625,
+          "test_best_rerun_mse": 5639.2421875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 606.5968831380209
+          "test_mse_by_total_triangles": 1879.7473958333333
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1005.2725830078125,
+          "test_best_rerun_mse": 4008.943603515625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 9.222684247778096
+          "test_mse_by_total_triangles": 36.77929911482225
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1179.88427734375,
+          "test_best_rerun_mse": 4235.53564453125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 13.40777587890625
+          "test_mse_by_total_triangles": 48.1310868696733
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1658.8094482421875,
+          "test_best_rerun_mse": 5386.263671875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 103.67559051513672
+          "test_mse_by_total_triangles": 336.6414794921875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18419.61328125,
+          "test_best_rerun_mse": 12701.01953125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 16.490253608997314
+          "test_mse_by_total_triangles": 11.370653116606983
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 782.8714599609375,
+          "test_best_rerun_mse": 1459.775146484375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 1.8206313022347385
+          "test_mse_by_total_triangles": 3.394825922056686
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1757.0545654296875,
+          "test_best_rerun_mse": 2546.99755859375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 5.107716759970022
+          "test_mse_by_total_triangles": 7.404062670330669
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 908.493408203125,
+          "test_best_rerun_mse": 4077.004638671875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 8.735513540414663
+          "test_mse_by_total_triangles": 39.20196767953726
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 138569.53125,
+          "test_best_rerun_mse": 116171.859375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 50.832549981658104
+          "test_mse_by_total_triangles": 42.61623601430668
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 69085.078125,
+          "test_best_rerun_mse": 55512.2890625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 29.7395945436935
+          "test_mse_by_total_triangles": 23.89680975570383
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
@@ -2841,77 +2841,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 718.6046142578125,
+      "test_loss": 607.85302734375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 718.6046142578125,
+      "test_best_rerun_mse": 607.85302734375,
       "test_triangles_total_structural": 327.0,
-      "test_mse_by_total_triangles": 2.1975676276997325,
+      "test_mse_by_total_triangles": 1.858877759461009,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2669.510986328125,
+          "test_best_rerun_mse": 2251.075927734375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 205.34699894831732
+          "test_mse_by_total_triangles": 173.15968674879807
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2796.398681640625,
+          "test_best_rerun_mse": 2367.77294921875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 932.1328938802084
+          "test_mse_by_total_triangles": 789.2576497395834
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1772.2760009765625,
+          "test_best_rerun_mse": 1364.9097900390625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 16.259412852995986
+          "test_mse_by_total_triangles": 12.522108165495986
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1804.156982421875,
+          "test_best_rerun_mse": 1596.2098388671875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 20.50178389115767
+          "test_mse_by_total_triangles": 18.138748168945312
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2580.171875,
+          "test_best_rerun_mse": 2248.0732421875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 161.2607421875
+          "test_mse_by_total_triangles": 140.50457763671875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15965.837890625,
+          "test_best_rerun_mse": 17172.234375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 14.293498559198747
+          "test_mse_by_total_triangles": 15.373531222023276
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 806.9767456054688,
+          "test_best_rerun_mse": 761.520751953125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 1.8766901060592296
+          "test_mse_by_total_triangles": 1.7709784929142443
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1557.9459228515625,
+          "test_best_rerun_mse": 1664.4208984375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 4.528912566428961
+          "test_mse_by_total_triangles": 4.838432844295058
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1658.366943359375,
+          "test_best_rerun_mse": 1537.681884765625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 15.945835993840145
+          "test_mse_by_total_triangles": 14.78540273813101
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 129512.6640625,
+          "test_best_rerun_mse": 132569.765625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 47.510148225421865
+          "test_mse_by_total_triangles": 48.63160881327953
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 65564.09375,
+          "test_best_rerun_mse": 66501.453125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 28.2238888291003
+          "test_mse_by_total_triangles": 28.627401259147653
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
@@ -2925,77 +2925,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 593.5123291015625,
+      "test_loss": 1033.7296142578125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 593.5123291015625,
+      "test_best_rerun_mse": 1033.7296142578125,
       "test_triangles_total_structural": 327.0,
-      "test_mse_by_total_triangles": 1.8150224131546253,
+      "test_mse_by_total_triangles": 3.1612526429902523,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2133.6552734375,
+          "test_best_rerun_mse": 3815.8564453125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 164.12732872596155
+          "test_mse_by_total_triangles": 293.5274188701923
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2271.693115234375,
+          "test_best_rerun_mse": 3978.76123046875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 757.2310384114584
+          "test_mse_by_total_triangles": 1326.2537434895833
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1371.1273193359375,
+          "test_best_rerun_mse": 2667.453369140625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 12.579149718678325
+          "test_mse_by_total_triangles": 24.472049258170873
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1413.61083984375,
+          "test_best_rerun_mse": 2886.759765625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 16.063759543678977
+          "test_mse_by_total_triangles": 32.80408824573863
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2139.496337890625,
+          "test_best_rerun_mse": 3821.508056640625,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 133.71852111816406
+          "test_mse_by_total_triangles": 238.84425354003906
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17463.591796875,
+          "test_best_rerun_mse": 14422.103515625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 15.634370453782452
+          "test_mse_by_total_triangles": 12.911462413272158
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 824.2676391601562,
+          "test_best_rerun_mse": 1009.4878540039062,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 1.916901486418968
+          "test_mse_by_total_triangles": 2.3476461721021074
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1513.7279052734375,
+          "test_best_rerun_mse": 2001.9451904296875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 4.4003718176553415
+          "test_mse_by_total_triangles": 5.819608111714208
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1348.9427490234375,
+          "test_best_rerun_mse": 2784.544677734375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 12.97060335599459
+          "test_mse_by_total_triangles": 26.77446805513822
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 133711.515625,
+          "test_best_rerun_mse": 123114.46875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 49.05044593727072
+          "test_mse_by_total_triangles": 45.16304796404989
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 67270.4453125,
+          "test_best_rerun_mse": 60566.7734375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 28.95843534761085
+          "test_mse_by_total_triangles": 26.072653223202757
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
@@ -3009,77 +3009,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 131.4573974609375,
+      "test_loss": 40.65708923339844,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 131.4573974609375,
+      "test_best_rerun_mse": 40.65708923339844,
       "test_triangles_total_structural": 109.0,
-      "test_mse_by_total_triangles": 1.206031169366399,
+      "test_mse_by_total_triangles": 0.37300081865503154,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 396.6576232910156,
+          "test_best_rerun_mse": 178.07400512695312,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 30.512124868539665
+          "test_mse_by_total_triangles": 13.69800039438101
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 440.6014709472656,
+          "test_best_rerun_mse": 211.64662170410156,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 146.86715698242188
+          "test_mse_by_total_triangles": 70.54887390136719
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 837.0330810546875,
+          "test_best_rerun_mse": 1237.4991455078125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 2.5597341928277904
+          "test_mse_by_total_triangles": 3.784401056598815
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 221.64662170410156,
+          "test_best_rerun_mse": 92.28705596923828,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.5187116102738814
+          "test_mse_by_total_triangles": 1.0487165451049805
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 366.7845458984375,
+          "test_best_rerun_mse": 168.87283325195312,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 22.924034118652344
+          "test_mse_by_total_triangles": 10.55455207824707
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22949.2890625,
+          "test_best_rerun_mse": 24520.142578125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 20.54546916965085
+          "test_mse_by_total_triangles": 21.951783865823636
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1466.3726806640625,
+          "test_best_rerun_mse": 1890.79150390625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.4101690248001453
+          "test_mse_by_total_triangles": 4.3971895439680235
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2193.11865234375,
+          "test_best_rerun_mse": 2421.018798828125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 6.375344919603925
+          "test_mse_by_total_triangles": 7.037845345430596
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 217.4273223876953,
+          "test_best_rerun_mse": 124.50513458251953,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 2.0906473306509166
+          "test_mse_by_total_triangles": 1.1971647556011493
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 152431.09375,
+          "test_best_rerun_mse": 156139.890625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 55.9174958730741
+          "test_mse_by_total_triangles": 57.278022973220835
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 79096.890625,
+          "test_best_rerun_mse": 82806.5078125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 34.04945786698235
+          "test_mse_by_total_triangles": 35.64636582544124
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
@@ -3093,77 +3093,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 141.25198364257812,
+      "test_loss": 44.530391693115234,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 141.25198364257812,
+      "test_best_rerun_mse": 44.530391693115234,
       "test_triangles_total_structural": 109.0,
-      "test_mse_by_total_triangles": 1.29588975818879,
+      "test_mse_by_total_triangles": 0.4085357036065618,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 369.7882995605469,
+          "test_best_rerun_mse": 202.42225646972656,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 28.44525381234976
+          "test_mse_by_total_triangles": 15.570942805363583
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 409.79095458984375,
+          "test_best_rerun_mse": 233.8235321044922,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 136.59698486328125
+          "test_mse_by_total_triangles": 77.94117736816406
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 960.1324462890625,
+          "test_best_rerun_mse": 1230.8720703125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 2.9361848510368884
+          "test_mse_by_total_triangles": 3.7641347715978593
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 152.4444580078125,
+          "test_best_rerun_mse": 135.58334350585938,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.7323233864524148
+          "test_mse_by_total_triangles": 1.5407198125665837
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 320.3896484375,
+          "test_best_rerun_mse": 203.65150451660156,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 20.02435302734375
+          "test_mse_by_total_triangles": 12.728219032287598
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22875.3515625,
+          "test_best_rerun_mse": 24592.458984375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 20.479276242166517
+          "test_mse_by_total_triangles": 22.01652550078335
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1615.56787109375,
+          "test_best_rerun_mse": 1864.2257080078125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.7571345839389534
+          "test_mse_by_total_triangles": 4.335408623273983
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2182.25634765625,
+          "test_best_rerun_mse": 2456.45263671875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 6.3437684524890985
+          "test_mse_by_total_triangles": 7.1408506881359015
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 179.93716430664062,
+          "test_best_rerun_mse": 164.52877807617188,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.730165041410006
+          "test_mse_by_total_triangles": 1.5820074815016527
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151797.625,
+          "test_best_rerun_mse": 155613.34375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 55.685115553925165
+          "test_mse_by_total_triangles": 57.08486564563463
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80969.3828125,
+          "test_best_rerun_mse": 82509.3828125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 34.85552424128282
+          "test_mse_by_total_triangles": 35.518460100086095
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
@@ -3177,77 +3177,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 64.11691284179688,
+      "test_loss": 81.41625213623047,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 64.11691284179688,
+      "test_best_rerun_mse": 81.41625213623047,
       "test_triangles_total_structural": 109.0,
-      "test_mse_by_total_triangles": 0.5882285581816227,
+      "test_mse_by_total_triangles": 0.7469380929929401,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 162.43740844726562,
+          "test_best_rerun_mse": 242.3984375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 12.495185265174278
+          "test_mse_by_total_triangles": 18.646033653846153
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 191.545166015625,
+          "test_best_rerun_mse": 283.1308898925781,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 63.848388671875
+          "test_mse_by_total_triangles": 94.37696329752605
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1307.5338134765625,
+          "test_best_rerun_mse": 1188.0439453125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 3.9985743531393347
+          "test_mse_by_total_triangles": 3.633161912270642
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 103.86161804199219,
+          "test_best_rerun_mse": 135.47471618652344,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.180245659568093
+          "test_mse_by_total_triangles": 1.5394854112104936
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 162.9203643798828,
+          "test_best_rerun_mse": 249.53802490234375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 10.182522773742676
+          "test_mse_by_total_triangles": 15.596126556396484
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24979.369140625,
+          "test_best_rerun_mse": 23814.568359375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 22.362908809870188
+          "test_mse_by_total_triangles": 21.320114914391226
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2048.4755859375,
+          "test_best_rerun_mse": 1786.638671875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 4.763896711482558
+          "test_mse_by_total_triangles": 4.154973655523256
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2468.251708984375,
+          "test_best_rerun_mse": 2280.202880859375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.175150316815044
+          "test_mse_by_total_triangles": 6.628496746684229
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 142.2845916748047,
+          "test_best_rerun_mse": 172.8159637451172,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1.3681210737961988
+          "test_mse_by_total_triangles": 1.6616919590876653
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 156630.140625,
+          "test_best_rerun_mse": 153745.265625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 57.45786523294204
+          "test_mse_by_total_triangles": 56.39958386830521
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 83618.890625,
+          "test_best_rerun_mse": 81773.5234375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 35.996078616013776
+          "test_mse_by_total_triangles": 35.201688952862675
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
@@ -3261,77 +3261,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 944.3739624023438,
+      "test_loss": 105.0186538696289,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 944.3739624023438,
+      "test_best_rerun_mse": 105.0186538696289,
       "test_triangles_total_structural": 88.0,
-      "test_mse_by_total_triangles": 10.731522300026633,
+      "test_mse_by_total_triangles": 1.1933937939730557,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1481.99072265625,
+          "test_best_rerun_mse": 218.2519073486328,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 113.99928635817308
+          "test_mse_by_total_triangles": 16.78860825758714
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1570.56982421875,
+          "test_best_rerun_mse": 257.5299377441406,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 523.5232747395834
+          "test_mse_by_total_triangles": 85.8433125813802
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 454.2861328125,
+          "test_best_rerun_mse": 1143.4588623046875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 1.3892542287844036
+          "test_mse_by_total_triangles": 3.4968160926748855
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 837.787353515625,
+          "test_best_rerun_mse": 49.85704803466797,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 7.68612250931766
+          "test_mse_by_total_triangles": 0.4574041104097979
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1398.5281982421875,
+          "test_best_rerun_mse": 210.49058532714844,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 87.40801239013672
+          "test_mse_by_total_triangles": 13.155661582946777
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18762.19921875,
+          "test_best_rerun_mse": 24102.6015625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 16.796955433079678
+          "test_mse_by_total_triangles": 21.577978122202328
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 839.607177734375,
+          "test_best_rerun_mse": 1789.410400390625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 1.952574831940407
+          "test_mse_by_total_triangles": 4.1614195357921515
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1609.4266357421875,
+          "test_best_rerun_mse": 2320.597900390625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 4.678565801576126
+          "test_mse_by_total_triangles": 6.745924129042515
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 813.3270263671875,
+          "test_best_rerun_mse": 129.01063537597656,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 7.8204521766075725
+          "test_mse_by_total_triangles": 1.2404868786151593
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 139766.328125,
+          "test_best_rerun_mse": 155028.484375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 51.27158038334556
+          "test_mse_by_total_triangles": 56.87031708547322
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 70180.140625,
+          "test_best_rerun_mse": 82047.90625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 30.21099467283685
+          "test_mse_by_total_triangles": 35.31980467068446
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
@@ -3345,77 +3345,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 669.4231567382812,
+      "test_loss": 468.1076354980469,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 669.4231567382812,
+      "test_best_rerun_mse": 468.1076354980469,
       "test_triangles_total_structural": 88.0,
-      "test_mse_by_total_triangles": 7.607081326571378,
+      "test_mse_by_total_triangles": 5.319404948841441,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1179.9173583984375,
+          "test_best_rerun_mse": 777.1082763671875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 90.76287372295673
+          "test_mse_by_total_triangles": 59.77755972055289
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1249.7540283203125,
+          "test_best_rerun_mse": 841.2628173828125,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 416.5846761067708
+          "test_mse_by_total_triangles": 280.4209391276042
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 550.9205932617188,
+          "test_best_rerun_mse": 691.5562744140625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 1.6847724564578554
+          "test_mse_by_total_triangles": 2.114850992091934
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 638.7086791992188,
+          "test_best_rerun_mse": 317.5474548339844,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 5.859712653203842
+          "test_mse_by_total_triangles": 2.9132794021466455
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1146.1614990234375,
+          "test_best_rerun_mse": 777.248779296875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 71.63509368896484
+          "test_mse_by_total_triangles": 48.57804870605469
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19165.951171875,
+          "test_best_rerun_mse": 21215.07421875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 17.158416447515666
+          "test_mse_by_total_triangles": 18.992904403536258
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 969.2962036132812,
+          "test_best_rerun_mse": 1138.0760498046875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 2.254177217705305
+          "test_mse_by_total_triangles": 2.646688487917878
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1535.16455078125,
+          "test_best_rerun_mse": 1834.15966796875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 4.462687647619913
+          "test_mse_by_total_triangles": 5.331859499909157
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 629.1400146484375,
+          "test_best_rerun_mse": 468.8193054199219,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 6.0494232177734375
+          "test_mse_by_total_triangles": 4.507877936730018
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 140568.0625,
+          "test_best_rerun_mse": 145661.46875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 51.56568690388848
+          "test_mse_by_total_triangles": 53.43414114086574
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 73106.59375,
+          "test_best_rerun_mse": 75553.5859375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 31.470767864829963
+          "test_mse_by_total_triangles": 32.524143752690485
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
@@ -3429,77 +3429,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 522.2561645507812,
+      "test_loss": 939.3889770507812,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 522.2561645507812,
+      "test_best_rerun_mse": 939.3889770507812,
       "test_triangles_total_structural": 88.0,
-      "test_mse_by_total_triangles": 5.934729142622515,
+      "test_mse_by_total_triangles": 10.674874739213424,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 934.7411499023438,
+          "test_best_rerun_mse": 1441.866943359375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 71.90316537710336
+          "test_mse_by_total_triangles": 110.912841796875
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1037.1622314453125,
+          "test_best_rerun_mse": 1541.6322021484375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 345.7207438151042
+          "test_mse_by_total_triangles": 513.8774007161459
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 622.4378662109375,
+          "test_best_rerun_mse": 568.173583984375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 1.903479713183295
+          "test_mse_by_total_triangles": 1.737533895976682
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 486.6128234863281,
+          "test_best_rerun_mse": 799.315185546875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 4.464337830149799
+          "test_mse_by_total_triangles": 7.3331668398795875
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 946.7542114257812,
+          "test_best_rerun_mse": 1450.1435546875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 59.17213821411133
+          "test_mse_by_total_triangles": 90.63397216796875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20657.099609375,
+          "test_best_rerun_mse": 18711.75,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 18.493374762197853
+          "test_mse_by_total_triangles": 16.751790510295436
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1094.197021484375,
+          "test_best_rerun_mse": 869.3226318359375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 2.5446442360101744
+          "test_mse_by_total_triangles": 2.0216805391533432
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1673.883056640625,
+          "test_best_rerun_mse": 1610.9373779296875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 4.865939118141352
+          "test_mse_by_total_triangles": 4.682957493981649
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 526.0240478515625,
+          "test_best_rerun_mse": 913.8004150390625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 5.057923537034255
+          "test_mse_by_total_triangles": 8.786542452298677
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 143761.53125,
+          "test_best_rerun_mse": 138339.46875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 52.73717213866471
+          "test_mse_by_total_triangles": 50.74815434702861
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74496.6796875,
+          "test_best_rerun_mse": 70931.4453125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 32.069169043263024
+          "test_mse_by_total_triangles": 30.53441468467499
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
@@ -3513,77 +3513,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 11.906838417053223,
+      "test_loss": 8.964803695678711,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 11.906838417053223,
+      "test_best_rerun_mse": 8.964803695678711,
       "test_triangles_total_structural": 16.0,
-      "test_mse_by_total_triangles": 0.7441774010658264,
+      "test_mse_by_total_triangles": 0.5603002309799194,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.471094131469727,
+          "test_best_rerun_mse": 10.362617492675781,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 0.7285457024207482
+          "test_mse_by_total_triangles": 0.7971244225135217
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6.247811794281006,
+          "test_best_rerun_mse": 16.25493049621582,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2.082603931427002
+          "test_mse_by_total_triangles": 5.418310165405273
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2085.582275390625,
+          "test_best_rerun_mse": 1938.250732421875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 6.377927447677752
+          "test_mse_by_total_triangles": 5.927372270403287
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 178.7725830078125,
+          "test_best_rerun_mse": 109.17376708984375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.6401154404386469
+          "test_mse_by_total_triangles": 1.001594193484805
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 189.71617126464844,
+          "test_best_rerun_mse": 118.5670166015625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.1558655825528232
+          "test_mse_by_total_triangles": 1.347352461381392
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28437.83984375,
+          "test_best_rerun_mse": 27383.37890625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 25.45912251007162
+          "test_mse_by_total_triangles": 24.515110927708147
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3048.911376953125,
+          "test_best_rerun_mse": 2735.539794921875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 7.090491574309593
+          "test_mse_by_total_triangles": 6.3617204533066865
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3449.79541015625,
+          "test_best_rerun_mse": 3152.800048828125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 10.028475029523982
+          "test_mse_by_total_triangles": 9.16511642101199
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 260.8478698730469,
+          "test_best_rerun_mse": 179.78933715820312,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 2.508152594933143
+          "test_mse_by_total_triangles": 1.728743626521184
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 167417.453125,
+          "test_best_rerun_mse": 163960.296875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 61.415059840425535
+          "test_mse_by_total_triangles": 60.14684404805576
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 89857.203125,
+          "test_best_rerun_mse": 88412.7421875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 38.68153384631942
+          "test_mse_by_total_triangles": 38.0597254358588
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
@@ -3597,77 +3597,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 11.786025047302246,
+      "test_loss": 38.601497650146484,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 11.786025047302246,
+      "test_best_rerun_mse": 38.601497650146484,
       "test_triangles_total_structural": 16.0,
-      "test_mse_by_total_triangles": 0.7366265654563904,
+      "test_mse_by_total_triangles": 2.4125936031341553,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.219371795654297,
+          "test_best_rerun_mse": 36.05458450317383,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 0.7091824458195612
+          "test_mse_by_total_triangles": 2.7734295771672177
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8.222160339355469,
+          "test_best_rerun_mse": 44.37975311279297,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2.7407201131184897
+          "test_mse_by_total_triangles": 14.793251037597656
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2119.21484375,
+          "test_best_rerun_mse": 1768.1513671875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 6.480779338685015
+          "test_mse_by_total_triangles": 5.407190725344036
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 181.10870361328125,
+          "test_best_rerun_mse": 71.3517837524414,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.6615477395713876
+          "test_mse_by_total_triangles": 0.6546035206646
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 189.55625915527344,
+          "test_best_rerun_mse": 123.2713851928711,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2.1540483994917436
+          "test_mse_by_total_triangles": 1.4008111953735352
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27959.619140625,
+          "test_best_rerun_mse": 26915.45703125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 25.030992963854075
+          "test_mse_by_total_triangles": 24.09620146038496
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3074.026123046875,
+          "test_best_rerun_mse": 2533.281982421875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 7.148897960574128
+          "test_mse_by_total_triangles": 5.891353447492732
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3432.794189453125,
+          "test_best_rerun_mse": 3017.791015625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 9.979052876317224
+          "test_mse_by_total_triangles": 8.772648301235465
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 271.8285827636719,
+          "test_best_rerun_mse": 162.75621032714844,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 2.6137363727276144
+          "test_mse_by_total_triangles": 1.5649635608379657
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 165645.796875,
+          "test_best_rerun_mse": 162062.921875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 60.76514925715334
+          "test_mse_by_total_triangles": 59.450815067865
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 90797.2265625,
+          "test_best_rerun_mse": 87091.5546875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 39.086193096211794
+          "test_mse_by_total_triangles": 37.49098350731812
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
@@ -3681,77 +3681,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 46.14710235595703,
+      "test_loss": 58.4522819519043,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 46.14710235595703,
+      "test_best_rerun_mse": 58.4522819519043,
       "test_triangles_total_structural": 16.0,
-      "test_mse_by_total_triangles": 2.8841938972473145,
+      "test_mse_by_total_triangles": 3.6532676219940186,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 43.85768127441406,
+          "test_best_rerun_mse": 50.63497543334961,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 3.3736677903395433
+          "test_mse_by_total_triangles": 3.8949981102576623
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24.727294921875,
+          "test_best_rerun_mse": 69.08403015136719,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 8.242431640625
+          "test_mse_by_total_triangles": 23.02801005045573
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2604.52099609375,
+          "test_best_rerun_mse": 1677.865966796875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 7.964896012519113
+          "test_mse_by_total_triangles": 5.131088583476682
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 309.4871826171875,
+          "test_best_rerun_mse": 73.78632354736328,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 2.839331950616399
+          "test_mse_by_total_triangles": 0.6769387481409476
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 330.24041748046875,
+          "test_best_rerun_mse": 90.1463394165039,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 3.7527320168235083
+          "test_mse_by_total_triangles": 1.0243902206420898
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29888.3671875,
+          "test_best_rerun_mse": 25994.541015625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 26.757714581468218
+          "test_mse_by_total_triangles": 23.27174665678156
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3589.331787109375,
+          "test_best_rerun_mse": 2384.660400390625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 8.347283225835756
+          "test_mse_by_total_triangles": 5.545721861373546
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3857.912353515625,
+          "test_best_rerun_mse": 2781.413330078125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 11.21486149277798
+          "test_mse_by_total_triangles": 8.085503866506178
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 368.4965515136719,
+          "test_best_rerun_mse": 145.2799072265625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 3.543236072246845
+          "test_mse_by_total_triangles": 1.3969221848707933
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 169682.421875,
+          "test_best_rerun_mse": 159889.828125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 62.24593612435803
+          "test_mse_by_total_triangles": 58.65364201210565
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 92907.9921875,
+          "test_best_rerun_mse": 86092.7578125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 39.99483090292725
+          "test_mse_by_total_triangles": 37.06102359556608
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
@@ -3765,77 +3765,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 12463.14453125,
+      "test_loss": 17320.4296875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 12463.14453125,
+      "test_best_rerun_mse": 17320.4296875,
       "test_triangles_total_structural": 1117.0,
-      "test_mse_by_total_triangles": 11.157694298343777,
+      "test_mse_by_total_triangles": 15.506203838406446,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42072.7109375,
+          "test_best_rerun_mse": 55621.92578125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 3236.3623798076924
+          "test_mse_by_total_triangles": 4278.6096754807695
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42584.0234375,
+          "test_best_rerun_mse": 56042.609375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 14194.674479166666
+          "test_mse_by_total_triangles": 18680.869791666668
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28543.068359375,
+          "test_best_rerun_mse": 39086.9453125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 87.28767082377676
+          "test_mse_by_total_triangles": 119.53194285168196
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38423.4375,
+          "test_best_rerun_mse": 50840.0859375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 352.5086009174312
+          "test_mse_by_total_triangles": 466.42280676605503
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38189.5703125,
+          "test_best_rerun_mse": 50993.390625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 433.97238991477275
+          "test_mse_by_total_triangles": 579.4703480113636
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 41609.38671875,
+          "test_best_rerun_mse": 55163.8515625,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 2600.586669921875
+          "test_mse_by_total_triangles": 3447.74072265625
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25725.09765625,
+          "test_best_rerun_mse": 36544.4765625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 59.82580850290697
+          "test_mse_by_total_triangles": 84.98715479651163
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28082.869140625,
+          "test_best_rerun_mse": 38679.171875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 81.63624750181685
+          "test_mse_by_total_triangles": 112.439453125
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 36649.375,
+          "test_best_rerun_mse": 50252.60546875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 352.39783653846155
+          "test_mse_by_total_triangles": 483.19812950721155
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55603.8046875,
+          "test_best_rerun_mse": 45357.36328125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 20.397580589691856
+          "test_mse_by_total_triangles": 16.638797975513572
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21517.14453125,
+          "test_best_rerun_mse": 18498.927734375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 9.262653694037882
+          "test_mse_by_total_triangles": 7.963378275667241
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
@@ -3849,77 +3849,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 15786.73828125,
+      "test_loss": 18351.25,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 15786.73828125,
+      "test_best_rerun_mse": 18351.25,
       "test_triangles_total_structural": 1117.0,
-      "test_mse_by_total_triangles": 14.133158711951657,
+      "test_mse_by_total_triangles": 16.42905102954342,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52268.3125,
+          "test_best_rerun_mse": 57076.296875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 4020.639423076923
+          "test_mse_by_total_triangles": 4390.484375
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52655.11328125,
+          "test_best_rerun_mse": 57631.07421875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 17551.704427083332
+          "test_mse_by_total_triangles": 19210.358072916668
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 36552.74609375,
+          "test_best_rerun_mse": 40287.46484375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 111.78209814602447
+          "test_mse_by_total_triangles": 123.2032564029052
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 48103.3984375,
+          "test_best_rerun_mse": 52213.953125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 441.31558199541286
+          "test_mse_by_total_triangles": 479.02709288990826
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 48053.41015625,
+          "test_best_rerun_mse": 53104.47265625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 546.0614790482955
+          "test_mse_by_total_triangles": 603.4599165482955
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52096.13671875,
+          "test_best_rerun_mse": 56861.5703125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 3256.008544921875
+          "test_mse_by_total_triangles": 3553.84814453125
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 34235.71484375,
+          "test_best_rerun_mse": 38070.6328125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 79.61794149709303
+          "test_mse_by_total_triangles": 88.53635537790697
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 36226.2109375,
+          "test_best_rerun_mse": 40572.328125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 105.3087527252907
+          "test_mse_by_total_triangles": 117.94281431686046
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 47368.984375,
+          "test_best_rerun_mse": 52223.90625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 455.4710036057692
+          "test_mse_by_total_triangles": 502.15294471153845
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 46466.40625,
+          "test_best_rerun_mse": 44626.4140625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 17.045636922230376
+          "test_mse_by_total_triangles": 16.37065813004402
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19910.078125,
+          "test_best_rerun_mse": 19011.26171875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 8.57084723417994
+          "test_mse_by_total_triangles": 8.183926697696943
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
@@ -3933,77 +3933,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 11308.126953125,
+      "test_loss": 20033.5,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 11308.126953125,
+      "test_best_rerun_mse": 20033.5,
       "test_triangles_total_structural": 1117.0,
-      "test_mse_by_total_triangles": 10.123658865823634,
+      "test_mse_by_total_triangles": 17.93509400179051,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38404.08984375,
+          "test_best_rerun_mse": 62027.0703125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 2954.1607572115386
+          "test_mse_by_total_triangles": 4771.313100961538
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 39002.1328125,
+          "test_best_rerun_mse": 62723.3046875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 13000.7109375
+          "test_mse_by_total_triangles": 20907.768229166668
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25120.841796875,
+          "test_best_rerun_mse": 44238.078125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 76.82214616781346
+          "test_mse_by_total_triangles": 135.28464258409787
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35011.1484375,
+          "test_best_rerun_mse": 57118.44921875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 321.2031966743119
+          "test_mse_by_total_triangles": 524.022469896789
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 34366.19140625,
+          "test_best_rerun_mse": 57285.75390625,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 390.52490234375
+          "test_mse_by_total_triangles": 650.9744762073864
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38051.5859375,
+          "test_best_rerun_mse": 61872.125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 2378.22412109375
+          "test_mse_by_total_triangles": 3867.0078125
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23092.138671875,
+          "test_best_rerun_mse": 41639.21484375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 53.70264807412791
+          "test_mse_by_total_triangles": 96.83538335755814
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24513.4765625,
+          "test_best_rerun_mse": 44038.53515625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 71.2601062863372
+          "test_mse_by_total_triangles": 128.01899754723837
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 33726.6640625,
+          "test_best_rerun_mse": 56277.984375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 324.2948467548077
+          "test_mse_by_total_triangles": 541.1344651442307
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 58596.703125,
+          "test_best_rerun_mse": 42436.109375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 21.495489040719
+          "test_mse_by_total_triangles": 15.567171450843727
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23031.548828125,
+          "test_best_rerun_mse": 18345.900390625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 9.914571170092552
+          "test_mse_by_total_triangles": 7.897503396739131
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
@@ -4017,77 +4017,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 812.7072143554688,
+      "test_loss": 2340.60302734375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 812.7072143554688,
+      "test_best_rerun_mse": 2340.60302734375,
       "test_triangles_total_structural": 430.0,
-      "test_mse_by_total_triangles": 1.8900167775708576,
+      "test_mse_by_total_triangles": 5.4432628542877906,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3392.80810546875,
+          "test_best_rerun_mse": 7581.5517578125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 260.98523888221155
+          "test_mse_by_total_triangles": 583.1962890625
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3546.278564453125,
+          "test_best_rerun_mse": 7788.39794921875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1182.0928548177083
+          "test_mse_by_total_triangles": 2596.1326497395835
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 855.4000854492188,
+          "test_best_rerun_mse": 2747.620361328125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 2.6159024019853785
+          "test_mse_by_total_triangles": 8.402508750238914
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2371.6162109375,
+          "test_best_rerun_mse": 5849.90673828125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 21.757946889334864
+          "test_mse_by_total_triangles": 53.66886915854358
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2482.759033203125,
+          "test_best_rerun_mse": 6110.95361328125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 28.21317083185369
+          "test_mse_by_total_triangles": 69.44265469637784
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3240.50439453125,
+          "test_best_rerun_mse": 7490.45654296875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 202.53152465820312
+          "test_mse_by_total_triangles": 468.1535339355469
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15202.6162109375,
+          "test_best_rerun_mse": 11090.1904296875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 13.61022042160922
+          "test_mse_by_total_triangles": 9.928550071340645
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1994.1292724609375,
+          "test_best_rerun_mse": 3574.423828125,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 5.796887419944586
+          "test_mse_by_total_triangles": 10.390766942223838
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2242.0068359375,
+          "test_best_rerun_mse": 5909.15869140625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 21.557758037860577
+          "test_mse_by_total_triangles": 56.81883357121394
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 127306.171875,
+          "test_best_rerun_mse": 108587.8046875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 46.70072335840059
+          "test_mse_by_total_triangles": 39.83411764031548
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 61766.890625,
+          "test_best_rerun_mse": 50608.671875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 26.589277066293587
+          "test_mse_by_total_triangles": 21.78591126775721
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
@@ -4101,77 +4101,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1628.314208984375,
+      "test_loss": 1638.6312255859375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1628.314208984375,
+      "test_best_rerun_mse": 1638.6312255859375,
       "test_triangles_total_structural": 430.0,
-      "test_mse_by_total_triangles": 3.786777230196221,
+      "test_mse_by_total_triangles": 3.8107702920603197,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5739.16552734375,
+          "test_best_rerun_mse": 5771.5703125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 441.47427133413464
+          "test_mse_by_total_triangles": 443.96694711538464
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5871.83740234375,
+          "test_best_rerun_mse": 5955.93359375,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1957.2791341145833
+          "test_mse_by_total_triangles": 1985.3111979166667
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1891.3037109375,
+          "test_best_rerun_mse": 1866.3240966796875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 5.7838033973623855
+          "test_mse_by_total_triangles": 5.707413139693234
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4372.17822265625,
+          "test_best_rerun_mse": 4276.8076171875,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 40.11172681336009
+          "test_mse_by_total_triangles": 39.23676713016055
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4376.4609375,
+          "test_best_rerun_mse": 4629.443359375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 49.73251065340909
+          "test_mse_by_total_triangles": 52.60731090198863
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5630.19921875,
+          "test_best_rerun_mse": 5762.6357421875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 351.887451171875
+          "test_mse_by_total_triangles": 360.16473388671875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12139.75390625,
+          "test_best_rerun_mse": 12714.34375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 10.868177176589079
+          "test_mse_by_total_triangles": 11.382581692032229
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2635.0263671875,
+          "test_best_rerun_mse": 2839.811279296875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.659960369731104
+          "test_mse_by_total_triangles": 8.25526534679324
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4195.6142578125,
+          "test_best_rerun_mse": 4514.18603515625,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 40.34244478665865
+          "test_mse_by_total_triangles": 43.40563495342548
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 114601.984375,
+          "test_best_rerun_mse": 114743.921875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 42.040346432501835
+          "test_mse_by_total_triangles": 42.09241448092443
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55447.640625,
+          "test_best_rerun_mse": 54733.96875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 23.868980036590617
+          "test_mse_by_total_triangles": 23.561760116229014
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
@@ -4185,77 +4185,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1913.3790283203125,
+      "test_loss": 1867.284912109375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1913.3790283203125,
+      "test_best_rerun_mse": 1867.284912109375,
       "test_triangles_total_structural": 430.0,
-      "test_mse_by_total_triangles": 4.449718670512355,
+      "test_mse_by_total_triangles": 4.342523051417151,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6407.24755859375,
+          "test_best_rerun_mse": 6328.271484375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 492.86519681490387
+          "test_mse_by_total_triangles": 486.7901141826923
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6662.77490234375,
+          "test_best_rerun_mse": 6539.7744140625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 2220.9249674479165
+          "test_mse_by_total_triangles": 2179.9248046875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2182.7470703125,
+          "test_best_rerun_mse": 2130.8740234375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 6.675067493310397
+          "test_mse_by_total_triangles": 6.516434322438838
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5053.92138671875,
+          "test_best_rerun_mse": 4814.78515625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 46.36625125430046
+          "test_mse_by_total_triangles": 44.17234088302752
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4963.80126953125,
+          "test_best_rerun_mse": 5092.94482421875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 56.40683260830966
+          "test_mse_by_total_triangles": 57.8743730024858
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6387.30517578125,
+          "test_best_rerun_mse": 6361.7353515625,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 399.2065734863281
+          "test_mse_by_total_triangles": 397.60845947265625
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12097.2578125,
+          "test_best_rerun_mse": 11929.1279296875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 10.830132329901522
+          "test_mse_by_total_triangles": 10.679613186828558
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2872.89990234375,
+          "test_best_rerun_mse": 3035.860107421875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 8.351453204487646
+          "test_mse_by_total_triangles": 8.825174730877544
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4888.1171875,
+          "test_best_rerun_mse": 4960.0263671875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 47.00112680288461
+          "test_mse_by_total_triangles": 47.69256122295673
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 112729.5390625,
+          "test_best_rerun_mse": 112356.5859375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 41.353462605465886
+          "test_mse_by_total_triangles": 41.2166492800807
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 53512.3984375,
+          "test_best_rerun_mse": 53577.4765625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 23.03590117843306
+          "test_mse_by_total_triangles": 23.063915868489023
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
@@ -4269,77 +4269,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2608.31494140625,
+      "test_loss": 4108.8876953125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2608.31494140625,
+      "test_best_rerun_mse": 4108.8876953125,
       "test_triangles_total_structural": 344.0,
-      "test_mse_by_total_triangles": 7.5823108761809594,
+      "test_mse_by_total_triangles": 11.944440974745639,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4928.91259765625,
+          "test_best_rerun_mse": 8632.736328125,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 379.14712289663464
+          "test_mse_by_total_triangles": 664.056640625
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5085.5771484375,
+          "test_best_rerun_mse": 8847.40625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1695.1923828125
+          "test_mse_by_total_triangles": 2949.1354166666665
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1519.50341796875,
+          "test_best_rerun_mse": 3329.6064453125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 4.646799443329511
+          "test_mse_by_total_triangles": 10.182282707377675
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3669.52783203125,
+          "test_best_rerun_mse": 6770.556640625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 33.66539295441514
+          "test_mse_by_total_triangles": 62.11519853784404
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3824.114501953125,
+          "test_best_rerun_mse": 7041.0966796875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 43.455846613103695
+          "test_mse_by_total_triangles": 80.01246226917614
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4708.099609375,
+          "test_best_rerun_mse": 8522.0126953125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 294.2562255859375
+          "test_mse_by_total_triangles": 532.6257934570312
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13344.1689453125,
+          "test_best_rerun_mse": 10508.076171875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 11.946435940297672
+          "test_mse_by_total_triangles": 9.407409285474484
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1241.7950439453125,
+          "test_best_rerun_mse": 2842.6005859375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 2.8878954510356105
+          "test_mse_by_total_triangles": 6.610699037063953
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3524.868408203125,
+          "test_best_rerun_mse": 6814.38818359375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 33.892965463491585
+          "test_mse_by_total_triangles": 65.52296330378606
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 119907.7265625,
+          "test_best_rerun_mse": 105243.6953125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 43.98669352989729
+          "test_mse_by_total_triangles": 38.60737172138665
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56514.046875,
+          "test_best_rerun_mse": 48513.68359375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 24.3280442854068
+          "test_mse_by_total_triangles": 20.884065257748603
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
@@ -4353,77 +4353,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2205.131103515625,
+      "test_loss": 3464.88134765625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2205.131103515625,
+      "test_best_rerun_mse": 3464.88134765625,
       "test_triangles_total_structural": 344.0,
-      "test_mse_by_total_triangles": 6.410264835801235,
+      "test_mse_by_total_triangles": 10.072329499000727,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4749.10986328125,
+          "test_best_rerun_mse": 7089.6591796875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 365.3161433293269
+          "test_mse_by_total_triangles": 545.3583984375
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4830.73193359375,
+          "test_best_rerun_mse": 7280.1953125,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1610.2439778645833
+          "test_mse_by_total_triangles": 2426.7317708333335
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1474.6893310546875,
+          "test_best_rerun_mse": 2533.70458984375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 4.509753305977638
+          "test_mse_by_total_triangles": 7.748332079032875
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3559.370361328125,
+          "test_best_rerun_mse": 5419.38330078125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 32.65477395713876
+          "test_mse_by_total_triangles": 49.71911285120413
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3594.8046875,
+          "test_best_rerun_mse": 5802.630859375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 40.85005326704545
+          "test_mse_by_total_triangles": 65.93898703835227
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4715.92236328125,
+          "test_best_rerun_mse": 7063.89306640625,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 294.7451477050781
+          "test_mse_by_total_triangles": 441.4933166503906
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12900.3046875,
+          "test_best_rerun_mse": 11707.9267578125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 11.549064178603402
+          "test_mse_by_total_triangles": 10.48158169902641
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1330.4512939453125,
+          "test_best_rerun_mse": 2200.927734375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.094072776617006
+          "test_mse_by_total_triangles": 5.118436591569767
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3499.34423828125,
+          "test_best_rerun_mse": 5668.0498046875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 33.64754075270433
+          "test_mse_by_total_triangles": 54.50047889122596
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 118613.5546875,
+          "test_best_rerun_mse": 109919.0234375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 43.511942291819516
+          "test_mse_by_total_triangles": 40.322459074651505
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 57744.39453125,
+          "test_best_rerun_mse": 51599.80078125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 24.857681675096856
+          "test_mse_by_total_triangles": 22.212570288958243
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
@@ -4437,77 +4437,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 2330.484619140625,
+      "test_loss": 3639.432861328125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2330.484619140625,
+      "test_best_rerun_mse": 3639.432861328125,
       "test_triangles_total_structural": 344.0,
-      "test_mse_by_total_triangles": 6.774664590525073,
+      "test_mse_by_total_triangles": 10.57974668990734,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5120.8974609375,
+          "test_best_rerun_mse": 7554.265625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 393.91518930288464
+          "test_mse_by_total_triangles": 581.0973557692307
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5345.5888671875,
+          "test_best_rerun_mse": 7783.478515625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 1781.8629557291667
+          "test_mse_by_total_triangles": 2594.4928385416665
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1561.893310546875,
+          "test_best_rerun_mse": 2756.464599609375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 4.776432142345183
+          "test_mse_by_total_triangles": 8.429555350487385
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3919.859375,
+          "test_best_rerun_mse": 5882.65234375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 35.9620126146789
+          "test_mse_by_total_triangles": 53.96928755733945
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3875.681396484375,
+          "test_best_rerun_mse": 6176.46044921875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 44.041834050958805
+          "test_mse_by_total_triangles": 70.18705055930398
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5095.162109375,
+          "test_best_rerun_mse": 7575.1123046875,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 318.4476318359375
+          "test_mse_by_total_triangles": 473.44451904296875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13223.958984375,
+          "test_best_rerun_mse": 11088.146484375,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 11.838817353961504
+          "test_mse_by_total_triangles": 9.926720218777977
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1431.5164794921875,
+          "test_best_rerun_mse": 2399.37939453125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.3291080918422966
+          "test_mse_by_total_triangles": 5.579952080305232
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3801.175537109375,
+          "test_best_rerun_mse": 6007.84375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 36.549764779897835
+          "test_mse_by_total_triangles": 57.76772836538461
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 117863.5703125,
+          "test_best_rerun_mse": 108218.765625,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 43.23681963041086
+          "test_mse_by_total_triangles": 39.69874014123258
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56515.90625,
+          "test_best_rerun_mse": 50833.609375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 24.328844705122687
+          "test_mse_by_total_triangles": 21.88274187473095
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
@@ -4521,77 +4521,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 263.62127685546875,
+      "test_loss": 116.66838836669922,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 263.62127685546875,
+      "test_best_rerun_mse": 116.66838836669922,
       "test_triangles_total_structural": 104.0,
-      "test_mse_by_total_triangles": 2.5348199697641225,
+      "test_mse_by_total_triangles": 1.1218114266028771,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 495.57916259765625,
+          "test_best_rerun_mse": 68.22390747070312,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 38.12147404597356
+          "test_mse_by_total_triangles": 5.247992882361779
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 539.7516479492188,
+          "test_best_rerun_mse": 89.37716674804688,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 179.9172159830729
+          "test_mse_by_total_triangles": 29.792388916015625
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 720.4877319335938,
+          "test_best_rerun_mse": 1519.6480712890625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 2.20332639735044
+          "test_mse_by_total_triangles": 4.647241808223432
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 183.43527221679688,
+          "test_best_rerun_mse": 43.37769317626953,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.682892405658687
+          "test_mse_by_total_triangles": 0.3979604878556838
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 278.5744323730469,
+          "test_best_rerun_mse": 75.37981414794922,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 3.1656185496937144
+          "test_mse_by_total_triangles": 0.8565887971357866
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 456.3119812011719,
+          "test_best_rerun_mse": 64.22402954101562,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 28.519498825073242
+          "test_mse_by_total_triangles": 4.014001846313477
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22384.619140625,
+          "test_best_rerun_mse": 25833.55078125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 20.039945515331244
+          "test_mse_by_total_triangles": 23.127619320725156
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1338.7471923828125,
+          "test_best_rerun_mse": 2261.90771484375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.113365563680959
+          "test_mse_by_total_triangles": 5.260250499636628
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2090.08447265625,
+          "test_best_rerun_mse": 2740.337890625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 6.075826955396075
+          "test_mse_by_total_triangles": 7.966098519258721
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151044.609375,
+          "test_best_rerun_mse": 159926.921875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 55.408880915260454
+          "test_mse_by_total_triangles": 58.66724940388848
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 77773.8359375,
+          "test_best_rerun_mse": 85411.921875,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 33.47991215561773
+          "test_mse_by_total_triangles": 36.76793881833836
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
@@ -4605,77 +4605,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 165.39035034179688,
+      "test_loss": 153.7852783203125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 165.39035034179688,
+      "test_best_rerun_mse": 153.7852783203125,
       "test_triangles_total_structural": 104.0,
-      "test_mse_by_total_triangles": 1.5902918302095854,
+      "test_mse_by_total_triangles": 1.478704599233774,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 407.3539123535156,
+          "test_best_rerun_mse": 238.8972930908203,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 31.33491633488582
+          "test_mse_by_total_triangles": 18.376714853140022
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 430.59527587890625,
+          "test_best_rerun_mse": 267.9529724121094,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 143.5317586263021
+          "test_mse_by_total_triangles": 89.31765747070312
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 822.556396484375,
+          "test_best_rerun_mse": 1121.768310546875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 2.5154629861907494
+          "test_mse_by_total_triangles": 3.4304841301127675
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 159.03521728515625,
+          "test_best_rerun_mse": 52.72783660888672,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1.459038690689507
+          "test_mse_by_total_triangles": 0.48374162026501577
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 175.153076171875,
+          "test_best_rerun_mse": 143.91319274902344,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.9903758655894885
+          "test_mse_by_total_triangles": 1.6353771903298118
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 389.4059143066406,
+          "test_best_rerun_mse": 237.8092498779297,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 24.33786964416504
+          "test_mse_by_total_triangles": 14.863078117370605
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22306.357421875,
+          "test_best_rerun_mse": 24152.50390625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 19.96988130875112
+          "test_mse_by_total_triangles": 21.622653452327665
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1539.6607666015625,
+          "test_best_rerun_mse": 1774.751708984375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 3.580606433957122
+          "test_mse_by_total_triangles": 4.127329555777616
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1972.9599609375,
+          "test_best_rerun_mse": 2330.008544921875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 5.735348723655523
+          "test_mse_by_total_triangles": 6.77328065384266
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151006.4375,
+          "test_best_rerun_mse": 154642.5,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 55.39487802641233
+          "test_mse_by_total_triangles": 56.72872340425532
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 79754.9765625,
+          "test_best_rerun_mse": 81689.375,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 34.33274927356866
+          "test_mse_by_total_triangles": 35.16546491605682
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
@@ -4689,77 +4689,77 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 107.10814666748047,
+      "test_loss": 206.7552032470703,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 107.10814666748047,
+      "test_best_rerun_mse": 206.7552032470703,
       "test_triangles_total_structural": 104.0,
-      "test_mse_by_total_triangles": 1.0298860256488507,
+      "test_mse_by_total_triangles": 1.988030800452599,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 69.71131134033203,
+          "test_best_rerun_mse": 341.1517639160156,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 5.362408564640925
+          "test_mse_by_total_triangles": 26.24244337815505
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 93.46802520751953,
+          "test_best_rerun_mse": 387.5005187988281,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 31.15600840250651
+          "test_mse_by_total_triangles": 129.16683959960938
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1423.848876953125,
+          "test_best_rerun_mse": 1002.9974365234375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 4.354277911171636
+          "test_mse_by_total_triangles": 3.0672704480839066
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56.79733657836914,
+          "test_best_rerun_mse": 117.27730560302734,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 0.5210764823703591
+          "test_mse_by_total_triangles": 1.0759385835140123
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 96.76861572265625,
+          "test_best_rerun_mse": 179.74188232421875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1.0996433604847302
+          "test_mse_by_total_triangles": 2.0425213900479404
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 85.10612487792969,
+          "test_best_rerun_mse": 356.9739074707031,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 5.3191328048706055
+          "test_mse_by_total_triangles": 22.310869216918945
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25894.353515625,
+          "test_best_rerun_mse": 22994.259765625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 23.18205328166965
+          "test_mse_by_total_triangles": 20.585729423119965
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2295.8408203125,
+          "test_best_rerun_mse": 1580.133544921875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 5.339164698401163
+          "test_mse_by_total_triangles": 3.674729174236919
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2667.255859375,
+          "test_best_rerun_mse": 2112.046875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 7.753650753997093
+          "test_mse_by_total_triangles": 6.139671148255814
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 159719.84375,
+          "test_best_rerun_mse": 151546.5,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 58.5912853081438
+          "test_mse_by_total_triangles": 55.592993396918565
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 85279.0234375,
+          "test_best_rerun_mse": 80168.15625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 36.710728987300904
+          "test_mse_by_total_triangles": 34.5106139690056
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
@@ -4773,77 +4773,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 30067.083984375,
+      "test_loss": 27809.431640625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 30067.083984375,
+      "test_best_rerun_mse": 27809.431640625,
       "test_triangles_total_structural": 2726.0,
-      "test_mse_by_total_triangles": 11.029744675119222,
+      "test_mse_by_total_triangles": 10.201552325981291,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 185660.75,
+          "test_best_rerun_mse": 111741.40625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 14281.596153846154
+          "test_mse_by_total_triangles": 8595.492788461539
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 186832.921875,
+          "test_best_rerun_mse": 112247.65625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 62277.640625
+          "test_mse_by_total_triangles": 37415.885416666664
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 156073.578125,
+          "test_best_rerun_mse": 87606.9609375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 477.28922974006116
+          "test_mse_by_total_triangles": 267.9111955275229
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 179559.8125,
+          "test_best_rerun_mse": 105134.8828125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1647.3377293577983
+          "test_mse_by_total_triangles": 964.5402092889908
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 178331.484375,
+          "test_best_rerun_mse": 104868.5546875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2026.494140625
+          "test_mse_by_total_triangles": 1191.6881214488637
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 185992.84375,
+          "test_best_rerun_mse": 111019.4609375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 11624.552734375
+          "test_mse_by_total_triangles": 6938.71630859375
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 94004.921875,
+          "test_best_rerun_mse": 45939.8203125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 84.1583902193375
+          "test_mse_by_total_triangles": 41.12786061996419
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 149803.890625,
+          "test_best_rerun_mse": 83720.71875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 348.38114098837207
+          "test_mse_by_total_triangles": 194.69934593023257
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 154240.484375,
+          "test_best_rerun_mse": 86278.1171875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 448.3735010901163
+          "test_mse_by_total_triangles": 250.80848019622093
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 176000.578125,
+          "test_best_rerun_mse": 103881.7734375,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1692.313251201923
+          "test_mse_by_total_triangles": 998.8632061298077
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44408.453125,
+          "test_best_rerun_mse": 21481.53515625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 19.116854552303057
+          "test_mse_by_total_triangles": 9.247324647546277
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
@@ -4857,77 +4857,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 29202.25,
+      "test_loss": 27226.091796875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 29202.25,
+      "test_best_rerun_mse": 27226.091796875,
       "test_triangles_total_structural": 2726.0,
-      "test_mse_by_total_triangles": 10.712490829053559,
+      "test_mse_by_total_triangles": 9.987561187408291,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 184161.5,
+          "test_best_rerun_mse": 128647.5390625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 14166.26923076923
+          "test_mse_by_total_triangles": 9895.96454326923
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 184693.6875,
+          "test_best_rerun_mse": 129486.796875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 61564.5625
+          "test_mse_by_total_triangles": 43162.265625
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 153602.96875,
+          "test_best_rerun_mse": 102479.8359375,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 469.7338493883792
+          "test_mse_by_total_triangles": 313.39399369266056
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 177206.40625,
+          "test_best_rerun_mse": 121522.5703125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1625.7468463302753
+          "test_mse_by_total_triangles": 1114.8859661697247
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 176233.625,
+          "test_best_rerun_mse": 122613.984375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 2002.6548295454545
+          "test_mse_by_total_triangles": 1393.340731534091
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 183911.9375,
+          "test_best_rerun_mse": 128227.0078125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 11494.49609375
+          "test_mse_by_total_triangles": 8014.18798828125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 92218.7734375,
+          "test_best_rerun_mse": 56392.66796875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 82.55933163607878
+          "test_mse_by_total_triangles": 50.48582629252462
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 148733.890625,
+          "test_best_rerun_mse": 98915.3671875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 345.89276889534887
+          "test_mse_by_total_triangles": 230.03573764534883
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151441.765625,
+          "test_best_rerun_mse": 102241.4609375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 440.2376907703488
+          "test_mse_by_total_triangles": 297.2135492369186
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 174888.328125,
+          "test_best_rerun_mse": 120988.7578125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1681.6185396634614
+          "test_mse_by_total_triangles": 1163.3534405048076
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44792.19140625,
+          "test_best_rerun_mse": 26781.001953125,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 19.28204537505381
+          "test_mse_by_total_triangles": 11.528627616498063
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
@@ -4941,77 +4941,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 27403.822265625,
+      "test_loss": 27167.458984375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 27403.822265625,
+      "test_best_rerun_mse": 27167.458984375,
       "test_triangles_total_structural": 2726.0,
-      "test_mse_by_total_triangles": 10.052759451806676,
+      "test_mse_by_total_triangles": 9.966052452081804,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 160378.53125,
+          "test_best_rerun_mse": 133552.109375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 12336.810096153846
+          "test_mse_by_total_triangles": 10273.239182692309
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 161648.125,
+          "test_best_rerun_mse": 134622.1875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 53882.708333333336
+          "test_mse_by_total_triangles": 44874.0625
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 131752.953125,
+          "test_best_rerun_mse": 106398.78125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 402.91422974006116
+          "test_mse_by_total_triangles": 325.3785359327217
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 153906.8125,
+          "test_best_rerun_mse": 126498.2734375,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 1411.989105504587
+          "test_mse_by_total_triangles": 1160.5346186926606
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151762.421875,
+          "test_best_rerun_mse": 126083.1484375,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 1724.5729758522727
+          "test_mse_by_total_triangles": 1432.7630504261363
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 159295.0,
+          "test_best_rerun_mse": 133149.34375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 9955.9375
+          "test_mse_by_total_triangles": 8321.833984375
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 75735.3828125,
+          "test_best_rerun_mse": 58653.3828125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 67.80249132721576
+          "test_mse_by_total_triangles": 52.50974289391227
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126389.0703125,
+          "test_best_rerun_mse": 102160.5625,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 293.92807049418604
+          "test_mse_by_total_triangles": 237.5827034883721
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 128448.578125,
+          "test_best_rerun_mse": 104976.2421875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 373.39702943313955
+          "test_mse_by_total_triangles": 305.16349473110466
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 149842.5625,
+          "test_best_rerun_mse": 124331.796875,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 1440.7938701923076
+          "test_mse_by_total_triangles": 1195.498046875
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 34747.91796875,
+          "test_best_rerun_mse": 27002.03515625,
           "test_triangles_total_structural": 2323.0,
-          "test_mse_by_total_triangles": 14.958208337817478
+          "test_mse_by_total_triangles": 11.623777510223848
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
@@ -5025,77 +5025,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 17637.845703125,
+      "test_loss": 24091.876953125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 17637.845703125,
+      "test_best_rerun_mse": 24091.876953125,
       "test_triangles_total_structural": 2323.0,
-      "test_mse_by_total_triangles": 7.592701551065432,
+      "test_mse_by_total_triangles": 10.37101892084589,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 79594.34375,
+          "test_best_rerun_mse": 123526.71875,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 6122.641826923077
+          "test_mse_by_total_triangles": 9502.055288461539
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80285.2734375,
+          "test_best_rerun_mse": 124051.6875,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 26761.7578125
+          "test_mse_by_total_triangles": 41350.5625
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 60405.5390625,
+          "test_best_rerun_mse": 98096.5390625,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 184.72641915137615
+          "test_mse_by_total_triangles": 299.98941609327215
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74997.171875,
+          "test_best_rerun_mse": 116593.1015625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 688.0474483944954
+          "test_mse_by_total_triangles": 1069.6614822247707
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74844.859375,
+          "test_best_rerun_mse": 116368.328125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 850.509765625
+          "test_mse_by_total_triangles": 1322.3673650568182
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 79448.953125,
+          "test_best_rerun_mse": 122868.109375,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 4965.5595703125
+          "test_mse_by_total_triangles": 7679.2568359375
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28872.025390625,
+          "test_best_rerun_mse": 52983.42578125,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 25.84782935597583
+          "test_mse_by_total_triangles": 47.43368467435094
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56619.05078125,
+          "test_best_rerun_mse": 93969.34375,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 131.67221111918604
+          "test_mse_by_total_triangles": 218.53335755813953
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 60023.79296875,
+          "test_best_rerun_mse": 96730.3515625,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 174.48777025799419
+          "test_mse_by_total_triangles": 281.1928824491279
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 73008.265625,
+          "test_best_rerun_mse": 115355.0,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 702.0025540865385
+          "test_mse_by_total_triangles": 1109.1826923076924
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35181.78515625,
+          "test_best_rerun_mse": 26802.162109375,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 12.906010695616288
+          "test_mse_by_total_triangles": 9.832047729044387
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
@@ -5109,77 +5109,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 18750.92578125,
+      "test_loss": 26871.220703125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 18750.92578125,
+      "test_best_rerun_mse": 26871.220703125,
       "test_triangles_total_structural": 2323.0,
-      "test_mse_by_total_triangles": 8.071857848148944,
+      "test_mse_by_total_triangles": 11.567464788258718,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 81413.3828125,
+          "test_best_rerun_mse": 128739.90625,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 6262.567908653846
+          "test_mse_by_total_triangles": 9903.069711538461
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 81841.0859375,
+          "test_best_rerun_mse": 129573.1640625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 27280.361979166668
+          "test_mse_by_total_triangles": 43191.0546875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 61391.484375,
+          "test_best_rerun_mse": 102569.1875,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 187.74154243119267
+          "test_mse_by_total_triangles": 313.6672400611621
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 76403.5859375,
+          "test_best_rerun_mse": 121628.203125,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 700.9503297018349
+          "test_mse_by_total_triangles": 1115.8550745412845
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 76243.2265625,
+          "test_best_rerun_mse": 122765.1875,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 866.4003018465909
+          "test_mse_by_total_triangles": 1395.0589488636363
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 81308.4375,
+          "test_best_rerun_mse": 128414.25,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 5081.77734375
+          "test_mse_by_total_triangles": 8025.890625
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29148.07421875,
+          "test_best_rerun_mse": 56480.7265625,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 26.094963490376006
+          "test_mse_by_total_triangles": 50.564661201880035
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 58443.859375,
+          "test_best_rerun_mse": 99051.0078125,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 135.91595203488373
+          "test_mse_by_total_triangles": 230.35118095930233
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 60766.49609375,
+          "test_best_rerun_mse": 102399.5859375,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 176.64679097020348
+          "test_mse_by_total_triangles": 297.67321493459303
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 75436.609375,
+          "test_best_rerun_mse": 121138.125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 725.3520132211538
+          "test_mse_by_total_triangles": 1164.7896634615386
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 33364.859375,
+          "test_best_rerun_mse": 27184.669921875,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 12.239493534482758
+          "test_mse_by_total_triangles": 9.972366075522745
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
@@ -5193,77 +5193,77 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 17952.205078125,
+      "test_loss": 32494.81640625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 17952.205078125,
+      "test_best_rerun_mse": 32494.81640625,
       "test_triangles_total_structural": 2323.0,
-      "test_mse_by_total_triangles": 7.728026292778734,
+      "test_mse_by_total_triangles": 13.98829806554025,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 62915.07421875,
+          "test_best_rerun_mse": 152634.359375,
           "test_triangles_total_structural": 13.0,
-          "test_mse_by_total_triangles": 4839.62109375
+          "test_mse_by_total_triangles": 11741.104567307691
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 63675.9609375,
+          "test_best_rerun_mse": 153829.640625,
           "test_triangles_total_structural": 3.0,
-          "test_mse_by_total_triangles": 21225.3203125
+          "test_mse_by_total_triangles": 51276.546875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 45432.12109375,
+          "test_best_rerun_mse": 123477.3125,
           "test_triangles_total_structural": 327.0,
-          "test_mse_by_total_triangles": 138.93615013379204
+          "test_mse_by_total_triangles": 377.6064602446483
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 58663.21875,
+          "test_best_rerun_mse": 145123.15625,
           "test_triangles_total_structural": 109.0,
-          "test_mse_by_total_triangles": 538.1946674311927
+          "test_mse_by_total_triangles": 1331.4051032110092
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 57784.66796875,
+          "test_best_rerun_mse": 144669.578125,
           "test_triangles_total_structural": 88.0,
-          "test_mse_by_total_triangles": 656.6439541903409
+          "test_mse_by_total_triangles": 1643.9724786931818
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 62539.24609375,
+          "test_best_rerun_mse": 152250.828125,
           "test_triangles_total_structural": 16.0,
-          "test_mse_by_total_triangles": 3908.702880859375
+          "test_mse_by_total_triangles": 9515.6767578125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20400.408203125,
+          "test_best_rerun_mse": 70612.546875,
           "test_triangles_total_structural": 1117.0,
-          "test_mse_by_total_triangles": 18.2635704593778
+          "test_mse_by_total_triangles": 63.21624608325873
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42637.61328125,
+          "test_best_rerun_mse": 118898.546875,
           "test_triangles_total_structural": 430.0,
-          "test_mse_by_total_triangles": 99.1572401889535
+          "test_mse_by_total_triangles": 276.50824854651165
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44417.34765625,
+          "test_best_rerun_mse": 121811.96875,
           "test_triangles_total_structural": 344.0,
-          "test_mse_by_total_triangles": 129.12019667514534
+          "test_mse_by_total_triangles": 354.1045603197674
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56990.203125,
+          "test_best_rerun_mse": 142723.3125,
           "test_triangles_total_structural": 104.0,
-          "test_mse_by_total_triangles": 547.9827223557693
+          "test_mse_by_total_triangles": 1372.3395432692307
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42028.53125,
+          "test_best_rerun_mse": 27388.703125,
           "test_triangles_total_structural": 2726.0,
-          "test_mse_by_total_triangles": 15.41765636463683
+          "test_mse_by_total_triangles": 10.047213178650036
         }
       },
       "output_dir": "C:\\tb_topobench\\logs\\train\\runs\\notebook_gu_grid_bunn_full__triangle_counting__11__h_hi__d_hi__pl_hi__s44"

--- a/configs/model/graph/bunn.yaml
+++ b/configs/model/graph/bunn.yaml
@@ -21,6 +21,9 @@ backbone:
   taylor_degree: 3
   dropout: 0.1
   act: gelu
+  angle_hidden_channels: 16
+  residual: false
+  norm: null
 
 backbone_wrapper:
   _target_: topobench.nn.wrappers.GNNWrapper

--- a/configs/model/graph/bunn.yaml
+++ b/configs/model/graph/bunn.yaml
@@ -22,6 +22,7 @@ backbone:
   dropout: 0.1
   act: gelu
   angle_hidden_channels: 16
+  include_reflections: true
   residual: false
   norm: null
 

--- a/configs/model/graph/bunn.yaml
+++ b/configs/model/graph/bunn.yaml
@@ -1,0 +1,41 @@
+_target_: topobench.model.TBModel
+
+model_name: bunn
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.BuNN
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_layers: 2
+  num_bundles: 8
+  bundle_dim: 2
+  t: 1.0
+  taylor_degree: 3
+  dropout: 0.1
+  act: gelu
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+compile: false

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -16,7 +16,7 @@ class TestBuNNLayer:
     """Test the BuNN diffusion layer."""
 
     def test_bundle_maps_are_orthogonal(self):
-        """Node-wise bundle maps should be valid 2D rotations."""
+        """Node-wise bundle maps should cover both O(2) components."""
         layer = BuNNLayer(
             hidden_channels=16,
             num_bundles=4,
@@ -26,11 +26,20 @@ class TestBuNNLayer:
         x = torch.randn(5, 16)
 
         maps = layer._compute_bundle_maps(x)
-        identity = torch.eye(2).expand(5, 4, 2, 2)
+        identity = torch.eye(2, dtype=maps.dtype, device=maps.device).expand(
+            5, 4, 2, 2
+        )
         product = maps @ maps.transpose(-1, -2)
+        determinants = torch.linalg.det(maps)
+        expected_determinants = maps.new_tensor([1.0, 1.0, -1.0, -1.0])
 
         assert maps.shape == (5, 4, 2, 2)
         assert torch.allclose(product, identity, atol=1e-5)
+        assert torch.allclose(
+            determinants,
+            expected_determinants.expand_as(determinants),
+            atol=1e-5,
+        )
 
     def test_invalid_bundle_dimension_raises(self):
         """Only 2D bundles are supported by the direct parameterization."""
@@ -41,6 +50,11 @@ class TestBuNNLayer:
         """The hidden width must split cleanly into bundle channels."""
         with pytest.raises(ValueError, match="divisible"):
             BuNNLayer(hidden_channels=18, num_bundles=4, bundle_dim=2)
+
+    def test_reflection_parameterization_requires_even_bundles(self):
+        """The paper-style O(2) split needs matched rotations/reflections."""
+        with pytest.raises(ValueError, match="even"):
+            BuNNLayer(hidden_channels=18, num_bundles=3, bundle_dim=2)
 
     def test_random_walk_laplacian_handles_edgeless_graph(self):
         """Isolated nodes should have a zero random-walk Laplacian."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -404,6 +404,15 @@ class TestBuNN:
         assert out.shape == x.shape
         assert torch.isfinite(out).all()
 
+    def test_forward_rejects_unexpected_kwargs(self):
+        """Forward-only graph attributes should not be silently ignored."""
+        model = BuNN(in_channels=8, hidden_channels=16, num_layers=1)
+        x = torch.randn(3, 8)
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+
+        with pytest.raises(ValueError, match="unexpected.*edge_attr"):
+            model(x=x, edge_index=edge_index, edge_attr=torch.empty(0, 1))
+
     def test_forward_requires_input_width(self, simple_graph_0):
         """The full encoder should reject mismatched node feature widths."""
         edge_index = _undirected_edge_index(simple_graph_0)
@@ -456,6 +465,11 @@ class TestBuNN:
         """At least one BuNN layer is required."""
         with pytest.raises(ValueError, match="num_layers"):
             BuNN(in_channels=8, hidden_channels=16, num_layers=0)
+
+    def test_unexpected_model_init_kwargs_raise(self):
+        """Constructor config typos should not be silently ignored."""
+        with pytest.raises(ValueError, match="unexpected.*typo_param"):
+            BuNN(in_channels=8, hidden_channels=16, typo_param=1)
 
     def test_non_integer_num_layers_raises(self):
         """Layer count should not be silently coerced from a float."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -78,6 +78,30 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match=r"\[2, num_edges\]"):
             BuNNLayer._random_walk_laplacian(x, edge_index)
 
+    def test_random_walk_laplacian_requires_2d_node_features(self):
+        """Node features should be a matrix indexed by graph nodes."""
+        x = torch.randn(3)
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+
+        with pytest.raises(ValueError, match=r"\[num_nodes, num_features\]"):
+            BuNNLayer._random_walk_laplacian(x, edge_index)
+
+    def test_random_walk_laplacian_requires_long_edge_index(self):
+        """PyG edge indices should use integer node ids."""
+        x = torch.randn(3, 8)
+        edge_index = torch.tensor([[0.0], [1.0]])
+
+        with pytest.raises(ValueError, match="torch.long"):
+            BuNNLayer._random_walk_laplacian(x, edge_index)
+
+    def test_random_walk_laplacian_rejects_out_of_range_nodes(self):
+        """Invalid node ids should not be interpreted as tensor indices."""
+        x = torch.randn(3, 8)
+        edge_index = torch.tensor([[0, -1], [1, 3]])
+
+        with pytest.raises(ValueError, match=r"\[0, num_nodes\)"):
+            BuNNLayer._random_walk_laplacian(x, edge_index)
+
     def test_random_walk_laplacian_symmetrizes_edges(self):
         """A one-way edge should be treated as an undirected graph edge."""
         x = torch.tensor([[0.0], [2.0]])

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -56,6 +56,21 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="hidden_channels"):
             BuNNLayer(hidden_channels=0, num_bundles=4, bundle_dim=2)
 
+    def test_non_integer_hidden_channels_raises(self):
+        """Feature widths should not be accepted as floats."""
+        with pytest.raises(ValueError, match="hidden_channels.*integer"):
+            BuNNLayer(hidden_channels=16.0, num_bundles=4, bundle_dim=2)
+
+    def test_non_integer_angle_hidden_channels_raises(self):
+        """Angle-network widths should be explicit integers."""
+        with pytest.raises(ValueError, match="angle_hidden_channels.*integer"):
+            BuNNLayer(
+                hidden_channels=16,
+                num_bundles=4,
+                bundle_dim=2,
+                angle_hidden_channels=8.0,
+            )
+
     def test_invalid_diffusion_time_raises(self):
         """Diffusion time is a non-negative heat-equation parameter."""
         with pytest.raises(ValueError, match="finite and non-negative"):
@@ -269,6 +284,11 @@ class TestBuNN:
         """At least one BuNN layer is required."""
         with pytest.raises(ValueError, match="num_layers"):
             BuNN(in_channels=8, hidden_channels=16, num_layers=0)
+
+    def test_non_integer_num_layers_raises(self):
+        """Layer count should not be silently coerced from a float."""
+        with pytest.raises(ValueError, match="num_layers.*integer"):
+            BuNN(in_channels=8, hidden_channels=16, num_layers=2.0)
 
     def test_invalid_input_width_raises(self):
         """The graph encoder needs a positive input feature width."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -51,10 +51,32 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="divisible"):
             BuNNLayer(hidden_channels=18, num_bundles=4, bundle_dim=2)
 
+    def test_invalid_hidden_channels_raises(self):
+        """A BuNN layer needs a positive feature width."""
+        with pytest.raises(ValueError, match="hidden_channels"):
+            BuNNLayer(hidden_channels=0, num_bundles=4, bundle_dim=2)
+
     def test_invalid_diffusion_time_raises(self):
         """Diffusion time is a non-negative heat-equation parameter."""
-        with pytest.raises(ValueError, match="non-negative"):
+        with pytest.raises(ValueError, match="finite and non-negative"):
             BuNNLayer(hidden_channels=16, num_bundles=4, bundle_dim=2, t=-0.1)
+
+    def test_non_finite_diffusion_time_raises(self):
+        """The heat kernel needs a finite diffusion time."""
+        with pytest.raises(ValueError, match="finite and non-negative"):
+            BuNNLayer(
+                hidden_channels=16, num_bundles=4, bundle_dim=2, t=float("inf")
+            )
+
+    def test_non_integer_taylor_degree_raises(self):
+        """Taylor approximation degree should not be silently truncated."""
+        with pytest.raises(ValueError, match="integer"):
+            BuNNLayer(
+                hidden_channels=16,
+                num_bundles=4,
+                bundle_dim=2,
+                taylor_degree=2.5,
+            )
 
     def test_reflection_parameterization_requires_even_bundles(self):
         """The paper-style O(2) split needs matched rotations/reflections."""
@@ -247,3 +269,8 @@ class TestBuNN:
         """At least one BuNN layer is required."""
         with pytest.raises(ValueError, match="num_layers"):
             BuNN(in_channels=8, hidden_channels=16, num_layers=0)
+
+    def test_invalid_input_width_raises(self):
+        """The graph encoder needs a positive input feature width."""
+        with pytest.raises(ValueError, match="in_channels"):
+            BuNN(in_channels=0, hidden_channels=16)

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -260,6 +260,15 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="numeric"):
             BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
 
+    def test_complex_edge_weights_are_rejected(self):
+        """Diffusion weights should be real-valued graph scalars."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0], [1]])
+        edge_weight = torch.tensor([1.0 + 1.0j])
+
+        with pytest.raises(ValueError, match="real-valued"):
+            BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
+
     def test_non_contiguous_edge_weights_are_accepted(self):
         """Flattening edge weights should not require contiguous storage."""
         x = torch.tensor([[0.0], [2.0], [4.0]])

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -288,6 +288,16 @@ class TestBuNNLayer:
 
         assert torch.allclose(out, torch.tensor([[-2.0], [0.0], [2.0]]))
 
+    def test_weighted_laplacian_uses_random_walk_average(self):
+        """Non-uniform weights should change the neighbor average."""
+        x = torch.tensor([[0.0], [2.0], [10.0]])
+        edge_index = torch.tensor([[0, 1], [1, 2]])
+        edge_weight = torch.tensor([1.0, 3.0])
+
+        out = BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
+
+        assert torch.allclose(out, torch.tensor([[-2.0], [-5.5], [8.0]]))
+
     def test_edge_weights_must_be_non_negative(self):
         """Random-walk diffusion uses non-negative edge weights."""
         x = torch.tensor([[0.0], [2.0]])

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -5,6 +5,7 @@ import torch
 from torch_geometric.utils import to_undirected
 
 from topobench.nn.backbones.graph.bunn import BuNN, BuNNLayer
+from topobench.nn.wrappers.graph.gnn_wrapper import GNNWrapper
 
 
 def _undirected_edge_index(data):
@@ -364,12 +365,20 @@ class TestBuNN:
 
         assert model.in_channels == 8
         assert model.hidden_channels == 16
+        assert model.out_channels == 16
         assert model.num_layers == 3
         assert model.num_bundles == 4
         assert model.t == 0.5
         assert model.taylor_degree == 2
         assert len(model.layers) == 3
         assert model.layers[0].angle_network[0].out_features == 8
+
+    def test_wrapper_repr_uses_output_channels(self):
+        """TopoBench wrappers expect graph backbones to expose out_channels."""
+        model = BuNN(in_channels=8, hidden_channels=16, num_layers=1)
+        wrapper = GNNWrapper(model, out_channels=16, num_cell_dimensions=1)
+
+        assert "out_channels=16" in repr(wrapper)
 
     def test_forward_shape(self, simple_graph_0):
         """BuNN returns one hidden vector per node."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -138,6 +138,16 @@ class TestBuNNLayer:
                 dropout=True,
             )
 
+    def test_non_string_activation_raises(self):
+        """Activation names should fail clearly before dictionary lookup."""
+        with pytest.raises(ValueError, match="act.*string"):
+            BuNNLayer(
+                hidden_channels=16,
+                num_bundles=4,
+                bundle_dim=2,
+                act=["gelu"],
+            )
+
     def test_reflection_parameterization_requires_even_bundles(self):
         """The paper-style O(2) split needs matched rotations/reflections."""
         with pytest.raises(ValueError, match="even"):
@@ -483,6 +493,11 @@ class TestBuNN:
         """The full encoder should reject invalid dropout probabilities."""
         with pytest.raises(ValueError, match="dropout.*finite probability"):
             BuNN(in_channels=8, hidden_channels=16, dropout=float("nan"))
+
+    def test_non_string_model_activation_raises(self):
+        """The top-level encoder should validate activation config values."""
+        with pytest.raises(ValueError, match="act.*string"):
+            BuNN(in_channels=8, hidden_channels=16, act=["gelu"])
 
     def test_invalid_input_width_raises(self):
         """The graph encoder needs a positive input feature width."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -70,6 +70,14 @@ class TestBuNNLayer:
 
         assert torch.equal(out, torch.zeros_like(x))
 
+    def test_random_walk_laplacian_requires_coo_edge_index(self):
+        """The Laplacian expects PyG COO connectivity."""
+        x = torch.randn(3, 8)
+        edge_index = torch.empty(0, dtype=torch.long)
+
+        with pytest.raises(ValueError, match=r"\[2, num_edges\]"):
+            BuNNLayer._random_walk_laplacian(x, edge_index)
+
     def test_random_walk_laplacian_symmetrizes_edges(self):
         """A one-way edge should be treated as an undirected graph edge."""
         x = torch.tensor([[0.0], [2.0]])
@@ -95,6 +103,15 @@ class TestBuNNLayer:
         edge_weight = torch.tensor([1.0, 1.0])
 
         with pytest.raises(ValueError, match="one scalar per edge"):
+            BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
+
+    def test_edge_weights_must_be_non_negative(self):
+        """Random-walk diffusion uses non-negative edge weights."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0], [1]])
+        edge_weight = torch.tensor([-1.0])
+
+        with pytest.raises(ValueError, match="non-negative"):
             BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
 
     def test_zero_time_identity_update_recovers_input(self):

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -201,6 +201,14 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="torch.long"):
             BuNNLayer._random_walk_laplacian(x, edge_index)
 
+    def test_random_walk_laplacian_requires_edge_index_device_match(self):
+        """Connectivity should live on the same device as node features."""
+        x = torch.randn(3, 8)
+        edge_index = torch.empty(2, 0, dtype=torch.long, device="meta")
+
+        with pytest.raises(ValueError, match="same device"):
+            BuNNLayer._random_walk_laplacian(x, edge_index)
+
     def test_random_walk_laplacian_requires_tensor_edge_index(self):
         """Connectivity should fail clearly before tensor operations."""
         x = torch.randn(3, 8)

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -241,6 +241,16 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="edge_weight.*torch.Tensor"):
             BuNNLayer._random_walk_laplacian(x, edge_index, [1.0])
 
+    def test_non_contiguous_edge_weights_are_accepted(self):
+        """Flattening edge weights should not require contiguous storage."""
+        x = torch.tensor([[0.0], [2.0], [4.0]])
+        edge_index = torch.tensor([[0, 1], [1, 2]])
+        edge_weight = torch.ones(1, 2).transpose(0, 1)
+
+        out = BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
+
+        assert torch.allclose(out, torch.tensor([[-2.0], [0.0], [2.0]]))
+
     def test_edge_weights_must_be_non_negative(self):
         """Random-walk diffusion uses non-negative edge weights."""
         x = torch.tensor([[0.0], [2.0]])

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -344,6 +344,32 @@ class TestBuNN:
         with pytest.raises(ValueError, match="num_layers.*integer"):
             BuNN(in_channels=8, hidden_channels=16, num_layers=2.0)
 
+    def test_non_integer_model_num_bundles_raises(self):
+        """The top-level encoder should validate bundle count directly."""
+        with pytest.raises(ValueError, match="num_bundles.*integer"):
+            BuNN(in_channels=8, hidden_channels=16, num_bundles=4.0)
+
+    def test_invalid_model_bundle_dimension_raises(self):
+        """The full encoder should report unsupported bundle dimensions."""
+        with pytest.raises(ValueError, match="bundle_dim=2"):
+            BuNN(
+                in_channels=8, hidden_channels=16, num_bundles=2, bundle_dim=4
+            )
+
+    def test_invalid_model_hidden_width_raises(self):
+        """Top-level hidden width should split into bundle channels."""
+        with pytest.raises(ValueError, match="divisible"):
+            BuNN(in_channels=8, hidden_channels=18, num_bundles=4)
+
+    def test_non_integer_model_angle_hidden_channels_raises(self):
+        """The top-level encoder should validate angle-network width."""
+        with pytest.raises(ValueError, match="angle_hidden_channels.*integer"):
+            BuNN(
+                in_channels=8,
+                hidden_channels=16,
+                angle_hidden_channels=8.0,
+            )
+
     def test_non_integer_model_taylor_degree_raises(self):
         """The full encoder should validate Taylor degree before building."""
         with pytest.raises(ValueError, match="taylor_degree.*integer"):

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -51,6 +51,11 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="divisible"):
             BuNNLayer(hidden_channels=18, num_bundles=4, bundle_dim=2)
 
+    def test_invalid_diffusion_time_raises(self):
+        """Diffusion time is a non-negative heat-equation parameter."""
+        with pytest.raises(ValueError, match="non-negative"):
+            BuNNLayer(hidden_channels=16, num_bundles=4, bundle_dim=2, t=-0.1)
+
     def test_reflection_parameterization_requires_even_bundles(self):
         """The paper-style O(2) split needs matched rotations/reflections."""
         with pytest.raises(ValueError, match="even"):
@@ -73,6 +78,24 @@ class TestBuNNLayer:
         out = BuNNLayer._random_walk_laplacian(x, edge_index)
 
         assert torch.allclose(out, torch.tensor([[-2.0], [2.0]]))
+
+    def test_random_walk_laplacian_ignores_self_loops(self):
+        """Self-loops are not part of the paper's simple graph Laplacian."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0, 0], [0, 1]])
+
+        out = BuNNLayer._random_walk_laplacian(x, edge_index)
+
+        assert torch.allclose(out, torch.tensor([[-2.0], [2.0]]))
+
+    def test_edge_weight_length_must_match_edges(self):
+        """Weighted Laplacians need one scalar weight per edge."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0], [1]])
+        edge_weight = torch.tensor([1.0, 1.0])
+
+        with pytest.raises(ValueError, match="one scalar per edge"):
+            BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
 
     def test_zero_time_identity_update_recovers_input(self):
         """Synchronization and desynchronization should cancel for identity W."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -1,0 +1,139 @@
+"""Unit tests for the Bundle Neural Network graph backbone."""
+
+import pytest
+import torch
+from torch_geometric.utils import to_undirected
+
+from topobench.nn.backbones.graph.bunn import BuNN, BuNNLayer
+
+
+def _undirected_edge_index(data):
+    """Return an undirected edge index for stable diffusion tests."""
+    return to_undirected(data.edge_index, num_nodes=data.num_nodes)
+
+
+class TestBuNNLayer:
+    """Test the BuNN diffusion layer."""
+
+    def test_bundle_maps_are_orthogonal(self):
+        """Node-wise bundle maps should be valid 2D rotations."""
+        layer = BuNNLayer(
+            hidden_channels=16,
+            num_bundles=4,
+            bundle_dim=2,
+            dropout=0.0,
+        )
+        x = torch.randn(5, 16)
+
+        maps = layer._compute_bundle_maps(x)
+        identity = torch.eye(2).expand(5, 4, 2, 2)
+        product = maps @ maps.transpose(-1, -2)
+
+        assert maps.shape == (5, 4, 2, 2)
+        assert torch.allclose(product, identity, atol=1e-5)
+
+    def test_invalid_bundle_dimension_raises(self):
+        """Only 2D bundles are supported by the direct parameterization."""
+        with pytest.raises(ValueError, match="bundle_dim=2"):
+            BuNNLayer(hidden_channels=16, num_bundles=2, bundle_dim=4)
+
+    def test_invalid_hidden_width_raises(self):
+        """The hidden width must split cleanly into bundle channels."""
+        with pytest.raises(ValueError, match="divisible"):
+            BuNNLayer(hidden_channels=18, num_bundles=4, bundle_dim=2)
+
+    def test_random_walk_laplacian_handles_edgeless_graph(self):
+        """Isolated nodes should have a zero random-walk Laplacian."""
+        x = torch.randn(3, 8)
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+
+        out = BuNNLayer._random_walk_laplacian(x, edge_index)
+
+        assert torch.equal(out, torch.zeros_like(x))
+
+
+class TestBuNN:
+    """Test the full BuNN graph encoder."""
+
+    def test_initialization(self):
+        """BuNN stores its main architectural parameters."""
+        model = BuNN(
+            in_channels=8,
+            hidden_channels=16,
+            num_layers=3,
+            num_bundles=4,
+            t=0.5,
+            taylor_degree=2,
+        )
+
+        assert model.in_channels == 8
+        assert model.hidden_channels == 16
+        assert model.num_layers == 3
+        assert model.num_bundles == 4
+        assert model.t == 0.5
+        assert model.taylor_degree == 2
+        assert len(model.layers) == 3
+
+    def test_forward_shape(self, simple_graph_0):
+        """BuNN returns one hidden vector per node."""
+        edge_index = _undirected_edge_index(simple_graph_0)
+        x = torch.randn(simple_graph_0.num_nodes, 8)
+        model = BuNN(
+            in_channels=8,
+            hidden_channels=16,
+            num_layers=2,
+            num_bundles=4,
+            taylor_degree=2,
+            dropout=0.0,
+        )
+
+        out = model(x=x, edge_index=edge_index)
+
+        assert out.shape == (simple_graph_0.num_nodes, 16)
+        assert torch.isfinite(out).all()
+
+    def test_forward_with_edge_weights(self, simple_graph_0):
+        """BuNN accepts scalar edge weights from the graph wrapper."""
+        edge_index = _undirected_edge_index(simple_graph_0)
+        edge_weight = torch.ones(edge_index.shape[1])
+        x = torch.randn(simple_graph_0.num_nodes, 16)
+        model = BuNN(
+            in_channels=16,
+            hidden_channels=16,
+            num_layers=1,
+            num_bundles=4,
+            dropout=0.0,
+        )
+
+        out = model(
+            x=x,
+            edge_index=edge_index,
+            edge_weight=edge_weight,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+
+        assert out.shape == x.shape
+        assert torch.isfinite(out).all()
+
+    def test_forward_backward(self, simple_graph_0):
+        """Gradients should flow through bundle maps and diffusion."""
+        edge_index = _undirected_edge_index(simple_graph_0)
+        x = torch.randn(simple_graph_0.num_nodes, 8, requires_grad=True)
+        model = BuNN(
+            in_channels=8,
+            hidden_channels=16,
+            num_layers=1,
+            num_bundles=4,
+            dropout=0.0,
+        )
+
+        loss = model(x=x, edge_index=edge_index).sum()
+        loss.backward()
+
+        assert x.grad is not None
+        assert torch.isfinite(x.grad).all()
+
+    def test_invalid_num_layers_raises(self):
+        """At least one BuNN layer is required."""
+        with pytest.raises(ValueError, match="num_layers"):
+            BuNN(in_channels=8, hidden_channels=16, num_layers=0)

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -103,6 +103,11 @@ class TestBuNNLayer:
                 hidden_channels=16, num_bundles=4, bundle_dim=2, t=float("inf")
             )
 
+    def test_non_numeric_diffusion_time_raises(self):
+        """The heat diffusion time should not accept boolean coercion."""
+        with pytest.raises(ValueError, match="t.*numeric scalar"):
+            BuNNLayer(hidden_channels=16, num_bundles=4, bundle_dim=2, t=True)
+
     def test_non_integer_taylor_degree_raises(self):
         """Taylor approximation degree should not be silently truncated."""
         with pytest.raises(ValueError, match="integer"):
@@ -111,6 +116,26 @@ class TestBuNNLayer:
                 num_bundles=4,
                 bundle_dim=2,
                 taylor_degree=2.5,
+            )
+
+    def test_invalid_dropout_raises(self):
+        """Dropout should be a finite probability."""
+        with pytest.raises(ValueError, match="dropout.*finite probability"):
+            BuNNLayer(
+                hidden_channels=16,
+                num_bundles=4,
+                bundle_dim=2,
+                dropout=float("nan"),
+            )
+
+    def test_non_numeric_dropout_raises(self):
+        """Dropout should not accept boolean probability coercion."""
+        with pytest.raises(ValueError, match="dropout.*probability"):
+            BuNNLayer(
+                hidden_channels=16,
+                num_bundles=4,
+                bundle_dim=2,
+                dropout=True,
             )
 
     def test_reflection_parameterization_requires_even_bundles(self):
@@ -318,6 +343,21 @@ class TestBuNN:
         """Layer count should not be silently coerced from a float."""
         with pytest.raises(ValueError, match="num_layers.*integer"):
             BuNN(in_channels=8, hidden_channels=16, num_layers=2.0)
+
+    def test_non_integer_model_taylor_degree_raises(self):
+        """The full encoder should validate Taylor degree before building."""
+        with pytest.raises(ValueError, match="taylor_degree.*integer"):
+            BuNN(in_channels=8, hidden_channels=16, taylor_degree=2.5)
+
+    def test_non_numeric_model_diffusion_time_raises(self):
+        """The top-level diffusion time should not accept booleans."""
+        with pytest.raises(ValueError, match="t.*numeric scalar"):
+            BuNN(in_channels=8, hidden_channels=16, t=True)
+
+    def test_invalid_model_dropout_raises(self):
+        """The full encoder should reject invalid dropout probabilities."""
+        with pytest.raises(ValueError, match="dropout.*finite probability"):
+            BuNN(in_channels=8, hidden_channels=16, dropout=float("nan"))
 
     def test_invalid_input_width_raises(self):
         """The graph encoder needs a positive input feature width."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -229,6 +229,17 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="finite"):
             BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
 
+    def test_forward_requires_hidden_width(self):
+        """Layer input features should match the configured hidden width."""
+        layer = BuNNLayer(hidden_channels=16, num_bundles=4, bundle_dim=2)
+        x = torch.randn(3, 15)
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+
+        with pytest.raises(
+            ValueError, match=r"\[num_nodes, hidden_channels\]"
+        ):
+            layer(x, edge_index)
+
     def test_zero_time_identity_update_recovers_input(self):
         """Synchronization and desynchronization should cancel for identity W."""
         layer = BuNNLayer(
@@ -315,6 +326,21 @@ class TestBuNN:
 
         assert out.shape == x.shape
         assert torch.isfinite(out).all()
+
+    def test_forward_requires_input_width(self, simple_graph_0):
+        """The full encoder should reject mismatched node feature widths."""
+        edge_index = _undirected_edge_index(simple_graph_0)
+        x = torch.randn(simple_graph_0.num_nodes, 7)
+        model = BuNN(
+            in_channels=8,
+            hidden_channels=16,
+            num_layers=1,
+            num_bundles=4,
+            dropout=0.0,
+        )
+
+        with pytest.raises(ValueError, match=r"\[num_nodes, in_channels\]"):
+            model(x=x, edge_index=edge_index)
 
     def test_forward_backward(self, simple_graph_0):
         """Gradients should flow through bundle maps and diffusion."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -241,6 +241,15 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match="edge_weight.*torch.Tensor"):
             BuNNLayer._random_walk_laplacian(x, edge_index, [1.0])
 
+    def test_boolean_edge_weights_are_rejected(self):
+        """Boolean edge weights should not be coerced into numeric weights."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0], [1]])
+        edge_weight = torch.tensor([True])
+
+        with pytest.raises(ValueError, match="numeric"):
+            BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
+
     def test_non_contiguous_edge_weights_are_accepted(self):
         """Flattening edge weights should not require contiguous storage."""
         x = torch.tensor([[0.0], [2.0], [4.0]])

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -71,6 +71,26 @@ class TestBuNNLayer:
                 angle_hidden_channels=8.0,
             )
 
+    def test_non_boolean_include_reflections_raises(self):
+        """Reflection mode should not be inferred from truthy strings."""
+        with pytest.raises(ValueError, match="include_reflections.*boolean"):
+            BuNNLayer(
+                hidden_channels=16,
+                num_bundles=4,
+                bundle_dim=2,
+                include_reflections="false",
+            )
+
+    def test_non_boolean_residual_raises(self):
+        """Residual mode should be an explicit boolean config value."""
+        with pytest.raises(ValueError, match="residual.*boolean"):
+            BuNNLayer(
+                hidden_channels=16,
+                num_bundles=4,
+                bundle_dim=2,
+                residual="false",
+            )
+
     def test_invalid_diffusion_time_raises(self):
         """Diffusion time is a non-negative heat-equation parameter."""
         with pytest.raises(ValueError, match="finite and non-negative"):
@@ -173,6 +193,15 @@ class TestBuNNLayer:
         edge_weight = torch.tensor([-1.0])
 
         with pytest.raises(ValueError, match="non-negative"):
+            BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
+
+    def test_edge_weights_must_be_finite(self):
+        """Invalid weights should not silently poison heat diffusion."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0], [1]])
+        edge_weight = torch.tensor([float("nan")])
+
+        with pytest.raises(ValueError, match="finite"):
             BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
 
     def test_zero_time_identity_update_recovers_input(self):
@@ -294,3 +323,14 @@ class TestBuNN:
         """The graph encoder needs a positive input feature width."""
         with pytest.raises(ValueError, match="in_channels"):
             BuNN(in_channels=0, hidden_channels=16)
+
+    def test_non_boolean_model_flags_raise(self):
+        """Top-level boolean flags should not accept truthy strings."""
+        with pytest.raises(ValueError, match="include_reflections.*boolean"):
+            BuNN(
+                in_channels=8,
+                hidden_channels=16,
+                include_reflections="false",
+            )
+        with pytest.raises(ValueError, match="residual.*boolean"):
+            BuNN(in_channels=8, hidden_channels=16, residual="false")

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -175,6 +175,14 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match=r"\[num_nodes, num_features\]"):
             BuNNLayer._random_walk_laplacian([[0.0], [1.0]], edge_index)
 
+    def test_random_walk_laplacian_requires_float_node_features(self):
+        """Heat diffusion should operate on real-valued node signals."""
+        x = torch.tensor([[0], [2]])
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+
+        with pytest.raises(ValueError, match="floating point"):
+            BuNNLayer._random_walk_laplacian(x, edge_index)
+
     def test_random_walk_laplacian_requires_long_edge_index(self):
         """PyG edge indices should use integer node ids."""
         x = torch.randn(3, 8)
@@ -260,6 +268,15 @@ class TestBuNNLayer:
         with pytest.raises(
             ValueError, match=r"\[num_nodes, hidden_channels\]"
         ):
+            layer(x, edge_index)
+
+    def test_forward_requires_float_hidden_features(self):
+        """Layer input features should be real-valued signals."""
+        layer = BuNNLayer(hidden_channels=16, num_bundles=4, bundle_dim=2)
+        x = torch.ones(3, 16, dtype=torch.long)
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+
+        with pytest.raises(ValueError, match="floating point"):
             layer(x, edge_index)
 
     def test_zero_time_identity_update_recovers_input(self):
@@ -362,6 +379,21 @@ class TestBuNN:
         )
 
         with pytest.raises(ValueError, match=r"\[num_nodes, in_channels\]"):
+            model(x=x, edge_index=edge_index)
+
+    def test_forward_requires_float_input_features(self, simple_graph_0):
+        """The full encoder should reject integer node features clearly."""
+        edge_index = _undirected_edge_index(simple_graph_0)
+        x = torch.ones(simple_graph_0.num_nodes, 8, dtype=torch.long)
+        model = BuNN(
+            in_channels=8,
+            hidden_channels=16,
+            num_layers=1,
+            num_bundles=4,
+            dropout=0.0,
+        )
+
+        with pytest.raises(ValueError, match="floating point"):
             model(x=x, edge_index=edge_index)
 
     def test_forward_backward(self, simple_graph_0):

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -51,6 +51,37 @@ class TestBuNNLayer:
 
         assert torch.equal(out, torch.zeros_like(x))
 
+    def test_random_walk_laplacian_symmetrizes_edges(self):
+        """A one-way edge should be treated as an undirected graph edge."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0], [1]])
+
+        out = BuNNLayer._random_walk_laplacian(x, edge_index)
+
+        assert torch.allclose(out, torch.tensor([[-2.0], [2.0]]))
+
+    def test_zero_time_identity_update_recovers_input(self):
+        """Synchronization and desynchronization should cancel for identity W."""
+        layer = BuNNLayer(
+            hidden_channels=8,
+            num_bundles=2,
+            bundle_dim=2,
+            t=0.0,
+            act="identity",
+            dropout=0.0,
+            residual=False,
+            norm=None,
+        )
+        with torch.no_grad():
+            layer.channel_mixer.weight.copy_(torch.eye(8))
+            layer.channel_mixer.bias.zero_()
+        x = torch.randn(4, 8)
+        edge_index = torch.tensor([[0, 1], [1, 2]])
+
+        out = layer(x, edge_index)
+
+        assert torch.allclose(out, x, atol=1e-5)
+
 
 class TestBuNN:
     """Test the full BuNN graph encoder."""
@@ -73,6 +104,7 @@ class TestBuNN:
         assert model.t == 0.5
         assert model.taylor_degree == 2
         assert len(model.layers) == 3
+        assert model.layers[0].angle_network[0].out_features == 8
 
     def test_forward_shape(self, simple_graph_0):
         """BuNN returns one hidden vector per node."""

--- a/test/nn/backbones/graph/test_bunn.py
+++ b/test/nn/backbones/graph/test_bunn.py
@@ -168,6 +168,13 @@ class TestBuNNLayer:
         with pytest.raises(ValueError, match=r"\[num_nodes, num_features\]"):
             BuNNLayer._random_walk_laplacian(x, edge_index)
 
+    def test_random_walk_laplacian_requires_tensor_node_features(self):
+        """Node features should fail clearly before tensor operations."""
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+
+        with pytest.raises(ValueError, match=r"\[num_nodes, num_features\]"):
+            BuNNLayer._random_walk_laplacian([[0.0], [1.0]], edge_index)
+
     def test_random_walk_laplacian_requires_long_edge_index(self):
         """PyG edge indices should use integer node ids."""
         x = torch.randn(3, 8)
@@ -175,6 +182,13 @@ class TestBuNNLayer:
 
         with pytest.raises(ValueError, match="torch.long"):
             BuNNLayer._random_walk_laplacian(x, edge_index)
+
+    def test_random_walk_laplacian_requires_tensor_edge_index(self):
+        """Connectivity should fail clearly before tensor operations."""
+        x = torch.randn(3, 8)
+
+        with pytest.raises(ValueError, match=r"\[2, num_edges\]"):
+            BuNNLayer._random_walk_laplacian(x, [[0], [1]])
 
     def test_random_walk_laplacian_rejects_out_of_range_nodes(self):
         """Invalid node ids should not be interpreted as tensor indices."""
@@ -210,6 +224,14 @@ class TestBuNNLayer:
 
         with pytest.raises(ValueError, match="one scalar per edge"):
             BuNNLayer._random_walk_laplacian(x, edge_index, edge_weight)
+
+    def test_edge_weight_must_be_tensor(self):
+        """Edge weights should fail clearly before tensor conversion."""
+        x = torch.tensor([[0.0], [2.0]])
+        edge_index = torch.tensor([[0], [1]])
+
+        with pytest.raises(ValueError, match="edge_weight.*torch.Tensor"):
+            BuNNLayer._random_walk_laplacian(x, edge_index, [1.0])
 
     def test_edge_weights_must_be_non_negative(self):
         """Random-walk diffusion uses non-negative edge weights."""

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -5,7 +5,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS   = ["graph/bunn"]                                               # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -92,6 +92,11 @@ def _require_node_feature_matrix(
         or x.shape[1] != expected_channels
     ):
         raise ValueError(f"x must have shape [num_nodes, {channel_name}].")
+    if not torch.is_floating_point(x):
+        raise ValueError(
+            "x must be a floating point tensor with shape "
+            f"[num_nodes, {channel_name}]."
+        )
 
 
 class BuNNLayer(nn.Module):
@@ -266,6 +271,11 @@ class BuNNLayer(nn.Module):
         """
         if not isinstance(x, torch.Tensor) or x.dim() != 2:
             raise ValueError("x must have shape [num_nodes, num_features].")
+        if not torch.is_floating_point(x):
+            raise ValueError(
+                "x must be a floating point tensor with shape "
+                "[num_nodes, num_features]."
+            )
         if (
             not isinstance(edge_index, torch.Tensor)
             or edge_index.dim() != 2

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -20,6 +20,7 @@ def _get_activation(name: str) -> nn.Module:
     activations = {
         "elu": nn.ELU,
         "gelu": nn.GELU,
+        "identity": nn.Identity,
         "relu": nn.ReLU,
         "tanh": nn.Tanh,
     }
@@ -60,11 +61,18 @@ class BuNNLayer(nn.Module):
     dropout : float, optional
         Dropout probability applied after the layer activation. Default is 0.0.
     act : str, optional
-        Activation name. One of ``relu``, ``gelu``, ``elu``, or ``tanh``.
-        Default is ``gelu``.
+        Activation name. One of ``relu``, ``gelu``, ``elu``, ``tanh``, or
+        ``identity``. Default is ``gelu``.
     angle_hidden_channels : int or None, optional
-        Hidden width of the angle network. If ``None``, ``hidden_channels`` is
-        used. Default is ``None``.
+        Hidden width of the angle network. If ``None``, twice the number of
+        bundles is used, matching the compact angle-network width described
+        for the paper's LRGB experiments. Default is ``None``.
+    residual : bool, optional
+        Whether to add a residual connection around the BuNN layer. Default is
+        ``False``, matching the core Equations (1)--(4).
+    norm : str or None, optional
+        Optional normalization applied after the layer. Use ``layer_norm`` for
+        ``torch.nn.LayerNorm``. Default is ``None``.
     """
 
     def __init__(
@@ -77,6 +85,8 @@ class BuNNLayer(nn.Module):
         dropout: float = 0.0,
         act: str = "gelu",
         angle_hidden_channels: int | None = None,
+        residual: bool = False,
+        norm: str | None = None,
     ) -> None:
         super().__init__()
 
@@ -101,7 +111,10 @@ class BuNNLayer(nn.Module):
         self.t = float(t)
         self.taylor_degree = int(taylor_degree)
 
-        angle_hidden_channels = angle_hidden_channels or hidden_channels
+        self.residual = residual
+        self.norm_name = norm
+
+        angle_hidden_channels = angle_hidden_channels or 2 * num_bundles
         self.angle_network = nn.Sequential(
             nn.Linear(hidden_channels, angle_hidden_channels),
             nn.GELU(),
@@ -110,7 +123,12 @@ class BuNNLayer(nn.Module):
         self.channel_mixer = nn.Linear(hidden_channels, hidden_channels)
         self.activation = _get_activation(act)
         self.dropout = nn.Dropout(dropout)
-        self.norm = nn.LayerNorm(hidden_channels)
+        if norm is None:
+            self.norm = nn.Identity()
+        elif norm == "layer_norm":
+            self.norm = nn.LayerNorm(hidden_channels)
+        else:
+            raise ValueError("Unsupported norm. Use None or 'layer_norm'.")
 
     def _compute_bundle_maps(self, x: torch.Tensor) -> torch.Tensor:
         """Compute one 2D rotation matrix per node and bundle."""
@@ -241,7 +259,9 @@ class BuNNLayer(nn.Module):
         out = self._from_bundle_fields(desynchronized)
         out = self.activation(out)
         out = self.dropout(out)
-        return self.norm(out + residual)
+        if self.residual:
+            out = out + residual
+        return self.norm(out)
 
     def reset_parameters(self) -> None:
         """Reset learnable parameters."""
@@ -281,7 +301,14 @@ class BuNN(nn.Module):
     act : str, optional
         Activation name. Default is ``gelu``.
     angle_hidden_channels : int or None, optional
-        Hidden width of each angle network. Default is ``None``.
+        Hidden width of each angle network. If ``None``, twice the number of
+        bundles is used. Default is ``None``.
+    residual : bool, optional
+        Whether to add residual connections around BuNN layers. Default is
+        ``False``.
+    norm : str or None, optional
+        Optional layer normalization mode. Use ``layer_norm`` to enable
+        ``torch.nn.LayerNorm``. Default is ``None``.
     """
 
     def __init__(
@@ -296,6 +323,8 @@ class BuNN(nn.Module):
         dropout: float = 0.0,
         act: str = "gelu",
         angle_hidden_channels: int | None = None,
+        residual: bool = False,
+        norm: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -328,6 +357,8 @@ class BuNN(nn.Module):
                     dropout=dropout,
                     act=act,
                     angle_hidden_channels=angle_hidden_channels,
+                    residual=residual,
+                    norm=norm,
                 )
                 for _ in range(num_layers)
             ]

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -1,0 +1,389 @@
+"""Bundle Neural Network backbone for graph data.
+
+This module implements a compact BuNN-style encoder from Bamberger et al.,
+"Bundle Neural Networks for message diffusion on graphs", arXiv:2405.15540.
+The implementation follows the flat vector bundle formulation in the paper:
+node-wise orthogonal maps synchronize features to a global frame, a learnable
+channel update is applied, and a truncated Taylor heat-kernel approximation
+diffuses the synchronized features over the graph before returning them to
+local frames.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+def _get_activation(name: str) -> nn.Module:
+    """Return an activation module from a small supported set."""
+    activations = {
+        "elu": nn.ELU,
+        "gelu": nn.GELU,
+        "relu": nn.ReLU,
+        "tanh": nn.Tanh,
+    }
+    if name not in activations:
+        supported = ", ".join(sorted(activations))
+        raise ValueError(
+            f"Unsupported activation '{name}'. Use one of {supported}."
+        )
+    return activations[name]()
+
+
+class BuNNLayer(nn.Module):
+    r"""Single flat-bundle heat diffusion layer.
+
+    The layer approximates the BuNN update described in Equations (1)--(4) and
+    Algorithm 1 of Bamberger et al. (2024). For scalability and compatibility
+    with arbitrary PyG mini-batches, it uses multiple two-dimensional flat
+    bundles and the truncated Taylor approximation of the random-walk graph
+    heat kernel.
+
+    Parameters
+    ----------
+    hidden_channels : int
+        Width of the node representation. It must be divisible by
+        ``num_bundles * bundle_dim``.
+    num_bundles : int, optional
+        Number of independent flat vector bundles. Default is 8.
+    bundle_dim : int, optional
+        Dimension of each bundle. Only 2D bundles are currently supported,
+        matching the direct angle parameterization used in the BuNN paper's
+        experiments. Default is 2.
+    t : float, optional
+        Heat diffusion time. Larger values mix information over a larger graph
+        scale. Default is 1.0.
+    taylor_degree : int, optional
+        Degree of the truncated Taylor approximation to the heat kernel.
+        Default is 3.
+    dropout : float, optional
+        Dropout probability applied after the layer activation. Default is 0.0.
+    act : str, optional
+        Activation name. One of ``relu``, ``gelu``, ``elu``, or ``tanh``.
+        Default is ``gelu``.
+    angle_hidden_channels : int or None, optional
+        Hidden width of the angle network. If ``None``, ``hidden_channels`` is
+        used. Default is ``None``.
+    """
+
+    def __init__(
+        self,
+        hidden_channels: int,
+        num_bundles: int = 8,
+        bundle_dim: int = 2,
+        t: float = 1.0,
+        taylor_degree: int = 3,
+        dropout: float = 0.0,
+        act: str = "gelu",
+        angle_hidden_channels: int | None = None,
+    ) -> None:
+        super().__init__()
+
+        if bundle_dim != 2:
+            raise ValueError("BuNNLayer currently supports bundle_dim=2 only.")
+        if num_bundles <= 0:
+            raise ValueError("num_bundles must be a positive integer.")
+        if taylor_degree < 0:
+            raise ValueError("taylor_degree must be non-negative.")
+
+        bundle_width = num_bundles * bundle_dim
+        if hidden_channels % bundle_width != 0:
+            raise ValueError(
+                "hidden_channels must be divisible by "
+                "num_bundles * bundle_dim."
+            )
+
+        self.hidden_channels = hidden_channels
+        self.num_bundles = num_bundles
+        self.bundle_dim = bundle_dim
+        self.channels_per_bundle = hidden_channels // bundle_width
+        self.t = float(t)
+        self.taylor_degree = int(taylor_degree)
+
+        angle_hidden_channels = angle_hidden_channels or hidden_channels
+        self.angle_network = nn.Sequential(
+            nn.Linear(hidden_channels, angle_hidden_channels),
+            nn.GELU(),
+            nn.Linear(angle_hidden_channels, num_bundles),
+        )
+        self.channel_mixer = nn.Linear(hidden_channels, hidden_channels)
+        self.activation = _get_activation(act)
+        self.dropout = nn.Dropout(dropout)
+        self.norm = nn.LayerNorm(hidden_channels)
+
+    def _compute_bundle_maps(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute one 2D rotation matrix per node and bundle."""
+        angles = self.angle_network(x)
+        cos = torch.cos(angles)
+        sin = torch.sin(angles)
+        return torch.stack((cos, -sin, sin, cos), dim=-1).reshape(
+            x.shape[0], self.num_bundles, 2, 2
+        )
+
+    def _to_bundle_fields(self, x: torch.Tensor) -> torch.Tensor:
+        """Reshape node features into bundle and vector-field channels."""
+        return x.reshape(
+            x.shape[0],
+            self.num_bundles,
+            self.channels_per_bundle,
+            self.bundle_dim,
+        )
+
+    def _from_bundle_fields(self, x: torch.Tensor) -> torch.Tensor:
+        """Flatten bundle and vector-field channels back to node features."""
+        return x.reshape(x.shape[0], self.hidden_channels)
+
+    @staticmethod
+    def _random_walk_laplacian(
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply the random-walk graph Laplacian to node features.
+
+        BuNN is derived for undirected graphs, so the COO edge list is
+        symmetrized before computing random-walk neighbor averages. Duplicate
+        reverse edges do not change the normalized average.
+        """
+        if edge_index.numel() == 0:
+            return torch.zeros_like(x)
+
+        source, target = edge_index
+        if edge_weight is None:
+            edge_weight = x.new_ones(source.shape[0])
+        else:
+            edge_weight = edge_weight.to(dtype=x.dtype, device=x.device).view(
+                -1
+            )
+
+        source, target = (
+            torch.cat((source, target), dim=0),
+            torch.cat((target, source), dim=0),
+        )
+        edge_weight = torch.cat((edge_weight, edge_weight), dim=0)
+
+        weighted_messages = x[source] * edge_weight.unsqueeze(-1)
+        aggregated = torch.zeros_like(x)
+        aggregated.index_add_(0, target, weighted_messages)
+
+        degree = x.new_zeros(x.shape[0])
+        degree.index_add_(0, target, edge_weight)
+
+        laplacian = torch.zeros_like(x)
+        non_isolated = degree > 0
+        laplacian[non_isolated] = x[non_isolated] - aggregated[
+            non_isolated
+        ] / degree[non_isolated].unsqueeze(-1)
+        return laplacian
+
+    def _heat_kernel_taylor(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Approximate ``exp(-t L_rw) x`` with a Taylor polynomial."""
+        if self.t == 0.0 or self.taylor_degree == 0:
+            return x
+
+        output = x
+        term = x
+        coefficient = 1.0
+        for degree in range(1, self.taylor_degree + 1):
+            term = self._random_walk_laplacian(
+                term, edge_index=edge_index, edge_weight=edge_weight
+            )
+            coefficient *= -self.t / degree
+            output = output + coefficient * term
+        return output
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        r"""Apply one BuNN layer.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``[num_nodes, hidden_channels]``.
+        edge_index : torch.Tensor
+            Graph connectivity in PyG COO format.
+        edge_weight : torch.Tensor or None, optional
+            Optional scalar edge weights. Default is ``None``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of shape ``[num_nodes, hidden_channels]``.
+        """
+        residual = x
+        bundle_maps = self._compute_bundle_maps(x)
+        fields = self._to_bundle_fields(x)
+
+        synchronized = torch.einsum("nbij,nbcj->nbci", bundle_maps, fields)
+        synchronized = self.channel_mixer(
+            self._from_bundle_fields(synchronized)
+        )
+        synchronized = self._to_bundle_fields(synchronized)
+
+        diffused = self._heat_kernel_taylor(
+            self._from_bundle_fields(synchronized),
+            edge_index=edge_index,
+            edge_weight=edge_weight,
+        )
+        diffused = self._to_bundle_fields(diffused)
+
+        desynchronized = torch.einsum("nbji,nbcj->nbci", bundle_maps, diffused)
+        out = self._from_bundle_fields(desynchronized)
+        out = self.activation(out)
+        out = self.dropout(out)
+        return self.norm(out + residual)
+
+    def reset_parameters(self) -> None:
+        """Reset learnable parameters."""
+        for module in self.modules():
+            if module is self:
+                continue
+            if hasattr(module, "reset_parameters"):
+                module.reset_parameters()
+
+
+class BuNN(nn.Module):
+    r"""Bundle Neural Network graph encoder.
+
+    BuNN performs global message diffusion through flat vector bundles while
+    staying compatible with TopoBench's standard graph wrapper. The backbone
+    accepts the same call pattern as PyG graph models and returns node
+    embeddings for downstream TopoBench readouts.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input feature dimension.
+    hidden_channels : int
+        Hidden and output feature dimension.
+    num_layers : int, optional
+        Number of BuNN layers. Default is 2.
+    num_bundles : int, optional
+        Number of parallel 2D bundles. Default is 8.
+    bundle_dim : int, optional
+        Bundle dimension. Only 2 is currently supported. Default is 2.
+    t : float, optional
+        Heat diffusion time used in each layer. Default is 1.0.
+    taylor_degree : int, optional
+        Taylor approximation degree for the heat kernel. Default is 3.
+    dropout : float, optional
+        Dropout probability. Default is 0.0.
+    act : str, optional
+        Activation name. Default is ``gelu``.
+    angle_hidden_channels : int or None, optional
+        Hidden width of each angle network. Default is ``None``.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_layers: int = 2,
+        num_bundles: int = 8,
+        bundle_dim: int = 2,
+        t: float = 1.0,
+        taylor_degree: int = 3,
+        dropout: float = 0.0,
+        act: str = "gelu",
+        angle_hidden_channels: int | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        del kwargs
+
+        if num_layers <= 0:
+            raise ValueError("num_layers must be a positive integer.")
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.num_layers = num_layers
+        self.num_bundles = num_bundles
+        self.bundle_dim = bundle_dim
+        self.t = float(t)
+        self.taylor_degree = int(taylor_degree)
+
+        if in_channels == hidden_channels:
+            self.input_projection = nn.Identity()
+        else:
+            self.input_projection = nn.Linear(in_channels, hidden_channels)
+
+        self.layers = nn.ModuleList(
+            [
+                BuNNLayer(
+                    hidden_channels=hidden_channels,
+                    num_bundles=num_bundles,
+                    bundle_dim=bundle_dim,
+                    t=t,
+                    taylor_degree=taylor_degree,
+                    dropout=dropout,
+                    act=act,
+                    angle_hidden_channels=angle_hidden_channels,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""Compute node embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            Graph connectivity in PyG COO format.
+        batch : torch.Tensor or None, optional
+            Batch assignment vector. It is accepted for wrapper compatibility
+            but not used by the diffusion operator. Default is ``None``.
+        edge_weight : torch.Tensor or None, optional
+            Optional scalar edge weights. Default is ``None``.
+        **kwargs
+            Additional keyword arguments accepted for PyG compatibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``[num_nodes, hidden_channels]``.
+        """
+        del batch, kwargs
+
+        x = self.input_projection(x)
+        for layer in self.layers:
+            x = layer(x, edge_index=edge_index, edge_weight=edge_weight)
+        return x
+
+    def reset_parameters(self) -> None:
+        """Reset learnable parameters."""
+        if hasattr(self.input_projection, "reset_parameters"):
+            self.input_projection.reset_parameters()
+        for layer in self.layers:
+            layer.reset_parameters()
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"in_channels={self.in_channels}, "
+            f"hidden_channels={self.hidden_channels}, "
+            f"num_layers={self.num_layers}, "
+            f"num_bundles={self.num_bundles}, "
+            f"bundle_dim={self.bundle_dim}, "
+            f"t={self.t}, "
+            f"taylor_degree={self.taylor_degree})"
+        )

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -264,9 +264,13 @@ class BuNNLayer(nn.Module):
         symmetrized before computing random-walk neighbor averages. Duplicate
         reverse edges do not change the normalized average.
         """
-        if x.dim() != 2:
+        if not isinstance(x, torch.Tensor) or x.dim() != 2:
             raise ValueError("x must have shape [num_nodes, num_features].")
-        if edge_index.dim() != 2 or edge_index.shape[0] != 2:
+        if (
+            not isinstance(edge_index, torch.Tensor)
+            or edge_index.dim() != 2
+            or edge_index.shape[0] != 2
+        ):
             raise ValueError("edge_index must have shape [2, num_edges].")
         if edge_index.dtype != torch.long:
             raise ValueError("edge_index must be a torch.long tensor.")
@@ -280,6 +284,8 @@ class BuNNLayer(nn.Module):
         if edge_weight is None:
             edge_weight = x.new_ones(source.shape[0])
         else:
+            if not isinstance(edge_weight, torch.Tensor):
+                raise ValueError("edge_weight must be a torch.Tensor.")
             edge_weight = edge_weight.to(dtype=x.dtype, device=x.device).view(
                 -1
             )

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -296,6 +296,8 @@ class BuNNLayer(nn.Module):
         else:
             if not isinstance(edge_weight, torch.Tensor):
                 raise ValueError("edge_weight must be a torch.Tensor.")
+            if edge_weight.dtype == torch.bool:
+                raise ValueError("edge_weight must be numeric, not boolean.")
             edge_weight = edge_weight.to(
                 dtype=x.dtype, device=x.device
             ).reshape(-1)

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -300,6 +300,8 @@ class BuNNLayer(nn.Module):
                 raise ValueError("edge_weight must be a torch.Tensor.")
             if edge_weight.dtype == torch.bool:
                 raise ValueError("edge_weight must be numeric, not boolean.")
+            if edge_weight.is_complex():
+                raise ValueError("edge_weight must be real-valued.")
             edge_weight = edge_weight.to(
                 dtype=x.dtype, device=x.device
             ).reshape(-1)

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -191,8 +191,8 @@ class BuNNLayer(nn.Module):
         symmetrized before computing random-walk neighbor averages. Duplicate
         reverse edges do not change the normalized average.
         """
-        if edge_index.numel() == 0:
-            return torch.zeros_like(x)
+        if edge_index.dim() != 2 or edge_index.shape[0] != 2:
+            raise ValueError("edge_index must have shape [2, num_edges].")
 
         source, target = edge_index
         if edge_weight is None:
@@ -205,6 +205,11 @@ class BuNNLayer(nn.Module):
                 raise ValueError(
                     "edge_weight must have one scalar per edge_index column."
                 )
+            if (edge_weight < 0).any():
+                raise ValueError("edge_weight must be non-negative.")
+
+        if source.numel() == 0:
+            return torch.zeros_like(x)
 
         non_loop = source != target
         source = source[non_loop]

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -20,6 +20,8 @@ import torch.nn as nn
 
 def _get_activation(name: str) -> nn.Module:
     """Return an activation module from a small supported set."""
+    if not isinstance(name, str):
+        raise ValueError("act must be a string activation name.")
     activations = {
         "elu": nn.ELU,
         "gelu": nn.GELU,

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -55,6 +55,13 @@ def _require_non_negative_int(name: str, value: int) -> int:
     return value
 
 
+def _require_bool(name: str, value: bool) -> bool:
+    """Validate boolean feature flags from configs and CLI overrides."""
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean.")
+    return value
+
+
 class BuNNLayer(nn.Module):
     r"""Single flat-bundle heat diffusion layer.
 
@@ -129,6 +136,10 @@ class BuNNLayer(nn.Module):
             angle_hidden_channels = _require_positive_int(
                 "angle_hidden_channels", angle_hidden_channels
             )
+        include_reflections = _require_bool(
+            "include_reflections", include_reflections
+        )
+        residual = _require_bool("residual", residual)
 
         if bundle_dim != 2:
             raise ValueError("BuNNLayer currently supports bundle_dim=2 only.")
@@ -245,6 +256,8 @@ class BuNNLayer(nn.Module):
                 raise ValueError(
                     "edge_weight must have one scalar per edge_index column."
                 )
+            if not torch.isfinite(edge_weight).all():
+                raise ValueError("edge_weight must be finite.")
             if (edge_weight < 0).any():
                 raise ValueError("edge_weight must be non-negative.")
 
@@ -422,6 +435,10 @@ class BuNN(nn.Module):
             "hidden_channels", hidden_channels
         )
         num_layers = _require_positive_int("num_layers", num_layers)
+        include_reflections = _require_bool(
+            "include_reflections", include_reflections
+        )
+        residual = _require_bool("residual", residual)
 
         self.in_channels = in_channels
         self.hidden_channels = hidden_channels

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -101,6 +101,15 @@ def _require_node_feature_matrix(
         )
 
 
+def _reject_unexpected_kwargs(context: str, kwargs: dict) -> None:
+    """Fail fast on misspelled or unsupported integration arguments."""
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise ValueError(
+            f"{context} got unexpected keyword argument(s): {unexpected}."
+        )
+
+
 class BuNNLayer(nn.Module):
     r"""Single flat-bundle heat diffusion layer.
 
@@ -484,7 +493,7 @@ class BuNN(nn.Module):
         **kwargs,
     ) -> None:
         super().__init__()
-        del kwargs
+        _reject_unexpected_kwargs("BuNN", kwargs)
 
         in_channels = _require_positive_int("in_channels", in_channels)
         hidden_channels = _require_positive_int(
@@ -573,14 +582,16 @@ class BuNN(nn.Module):
         edge_weight : torch.Tensor or None, optional
             Optional scalar edge weights. Default is ``None``.
         **kwargs
-            Additional keyword arguments accepted for PyG compatibility.
+            Unsupported keyword arguments raise ``ValueError`` to avoid silent
+            configuration mistakes.
 
         Returns
         -------
         torch.Tensor
             Node embeddings of shape ``[num_nodes, hidden_channels]``.
         """
-        del batch, kwargs
+        del batch
+        _reject_unexpected_kwargs("BuNN.forward", kwargs)
 
         _require_node_feature_matrix(x, self.in_channels, "in_channels")
         x = self.input_projection(x)

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -531,6 +531,7 @@ class BuNN(nn.Module):
 
         self.in_channels = in_channels
         self.hidden_channels = hidden_channels
+        self.out_channels = hidden_channels
         self.num_layers = num_layers
         self.num_bundles = num_bundles
         self.bundle_dim = bundle_dim

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -454,15 +454,32 @@ class BuNN(nn.Module):
             "hidden_channels", hidden_channels
         )
         num_layers = _require_positive_int("num_layers", num_layers)
+        num_bundles = _require_positive_int("num_bundles", num_bundles)
+        bundle_dim = _require_positive_int("bundle_dim", bundle_dim)
         taylor_degree = _require_non_negative_int(
             "taylor_degree", taylor_degree
         )
+        if angle_hidden_channels is not None:
+            angle_hidden_channels = _require_positive_int(
+                "angle_hidden_channels", angle_hidden_channels
+            )
         include_reflections = _require_bool(
             "include_reflections", include_reflections
         )
         residual = _require_bool("residual", residual)
         diffusion_time = _require_non_negative_float("t", t)
         dropout = _require_probability("dropout", dropout)
+        if bundle_dim != 2:
+            raise ValueError("BuNN currently supports bundle_dim=2 only.")
+        if include_reflections and num_bundles % 2 != 0:
+            raise ValueError(
+                "num_bundles must be even when include_reflections=True."
+            )
+        if hidden_channels % (num_bundles * bundle_dim) != 0:
+            raise ValueError(
+                "hidden_channels must be divisible by "
+                "num_bundles * bundle_dim."
+            )
 
         self.in_channels = in_channels
         self.hidden_channels = hidden_channels

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -295,6 +295,8 @@ class BuNNLayer(nn.Module):
             raise ValueError("edge_index must have shape [2, num_edges].")
         if edge_index.dtype != torch.long:
             raise ValueError("edge_index must be a torch.long tensor.")
+        if edge_index.device != x.device:
+            raise ValueError("edge_index must be on the same device as x.")
 
         source, target = edge_index
         if source.numel() > 0 and (

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -11,6 +11,8 @@ local frames.
 
 from __future__ import annotations
 
+import math
+
 import torch
 import torch.nn as nn
 
@@ -96,15 +98,21 @@ class BuNNLayer(nn.Module):
 
         if bundle_dim != 2:
             raise ValueError("BuNNLayer currently supports bundle_dim=2 only.")
+        if hidden_channels <= 0:
+            raise ValueError("hidden_channels must be a positive integer.")
         if num_bundles <= 0:
             raise ValueError("num_bundles must be a positive integer.")
         if include_reflections and num_bundles % 2 != 0:
             raise ValueError(
                 "num_bundles must be even when include_reflections=True."
             )
-        if t < 0:
-            raise ValueError("t must be non-negative.")
-        if taylor_degree < 0:
+        diffusion_time = float(t)
+        if not math.isfinite(diffusion_time) or diffusion_time < 0:
+            raise ValueError("t must be finite and non-negative.")
+        taylor_degree_int = int(taylor_degree)
+        if taylor_degree_int != taylor_degree:
+            raise ValueError("taylor_degree must be an integer.")
+        if taylor_degree_int < 0:
             raise ValueError("taylor_degree must be non-negative.")
         if angle_hidden_channels is not None and angle_hidden_channels <= 0:
             raise ValueError("angle_hidden_channels must be positive.")
@@ -120,8 +128,8 @@ class BuNNLayer(nn.Module):
         self.num_bundles = num_bundles
         self.bundle_dim = bundle_dim
         self.channels_per_bundle = hidden_channels // bundle_width
-        self.t = float(t)
-        self.taylor_degree = int(taylor_degree)
+        self.t = diffusion_time
+        self.taylor_degree = taylor_degree_int
 
         self.include_reflections = include_reflections
         self.residual = residual
@@ -386,6 +394,10 @@ class BuNN(nn.Module):
         super().__init__()
         del kwargs
 
+        if in_channels <= 0:
+            raise ValueError("in_channels must be a positive integer.")
+        if hidden_channels <= 0:
+            raise ValueError("hidden_channels must be a positive integer.")
         if num_layers <= 0:
             raise ValueError("num_layers must be a positive integer.")
 

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -82,6 +82,18 @@ def _require_probability(name: str, value: float) -> float:
     return value
 
 
+def _require_node_feature_matrix(
+    x: torch.Tensor, expected_channels: int, channel_name: str
+) -> None:
+    """Validate node-feature matrices before learnable projections."""
+    if (
+        not isinstance(x, torch.Tensor)
+        or x.dim() != 2
+        or x.shape[1] != expected_channels
+    ):
+        raise ValueError(f"x must have shape [num_nodes, {channel_name}].")
+
+
 class BuNNLayer(nn.Module):
     r"""Single flat-bundle heat diffusion layer.
 
@@ -353,6 +365,9 @@ class BuNNLayer(nn.Module):
         torch.Tensor
             Updated node features of shape ``[num_nodes, hidden_channels]``.
         """
+        _require_node_feature_matrix(
+            x, self.hidden_channels, "hidden_channels"
+        )
         residual = x
         bundle_maps = self._compute_bundle_maps(x)
         fields = self._to_bundle_fields(x)
@@ -545,6 +560,7 @@ class BuNN(nn.Module):
         """
         del batch, kwargs
 
+        _require_node_feature_matrix(x, self.in_channels, "in_channels")
         x = self.input_projection(x)
         for layer in self.layers:
             x = layer(x, edge_index=edge_index, edge_weight=edge_weight)

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -12,6 +12,7 @@ local frames.
 from __future__ import annotations
 
 import math
+from numbers import Integral
 
 import torch
 import torch.nn as nn
@@ -32,6 +33,26 @@ def _get_activation(name: str) -> nn.Module:
             f"Unsupported activation '{name}'. Use one of {supported}."
         )
     return activations[name]()
+
+
+def _require_positive_int(name: str, value: int) -> int:
+    """Validate positive integer hyperparameters before module construction."""
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return value
+
+
+def _require_non_negative_int(name: str, value: int) -> int:
+    """Validate non-negative integer hyperparameters."""
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer.")
+    value = int(value)
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative.")
+    return value
 
 
 class BuNNLayer(nn.Module):
@@ -96,12 +117,21 @@ class BuNNLayer(nn.Module):
     ) -> None:
         super().__init__()
 
+        hidden_channels = _require_positive_int(
+            "hidden_channels", hidden_channels
+        )
+        num_bundles = _require_positive_int("num_bundles", num_bundles)
+        bundle_dim = _require_positive_int("bundle_dim", bundle_dim)
+        taylor_degree = _require_non_negative_int(
+            "taylor_degree", taylor_degree
+        )
+        if angle_hidden_channels is not None:
+            angle_hidden_channels = _require_positive_int(
+                "angle_hidden_channels", angle_hidden_channels
+            )
+
         if bundle_dim != 2:
             raise ValueError("BuNNLayer currently supports bundle_dim=2 only.")
-        if hidden_channels <= 0:
-            raise ValueError("hidden_channels must be a positive integer.")
-        if num_bundles <= 0:
-            raise ValueError("num_bundles must be a positive integer.")
         if include_reflections and num_bundles % 2 != 0:
             raise ValueError(
                 "num_bundles must be even when include_reflections=True."
@@ -109,13 +139,6 @@ class BuNNLayer(nn.Module):
         diffusion_time = float(t)
         if not math.isfinite(diffusion_time) or diffusion_time < 0:
             raise ValueError("t must be finite and non-negative.")
-        taylor_degree_int = int(taylor_degree)
-        if taylor_degree_int != taylor_degree:
-            raise ValueError("taylor_degree must be an integer.")
-        if taylor_degree_int < 0:
-            raise ValueError("taylor_degree must be non-negative.")
-        if angle_hidden_channels is not None and angle_hidden_channels <= 0:
-            raise ValueError("angle_hidden_channels must be positive.")
 
         bundle_width = num_bundles * bundle_dim
         if hidden_channels % bundle_width != 0:
@@ -129,7 +152,7 @@ class BuNNLayer(nn.Module):
         self.bundle_dim = bundle_dim
         self.channels_per_bundle = hidden_channels // bundle_width
         self.t = diffusion_time
-        self.taylor_degree = taylor_degree_int
+        self.taylor_degree = taylor_degree
 
         self.include_reflections = include_reflections
         self.residual = residual
@@ -394,12 +417,11 @@ class BuNN(nn.Module):
         super().__init__()
         del kwargs
 
-        if in_channels <= 0:
-            raise ValueError("in_channels must be a positive integer.")
-        if hidden_channels <= 0:
-            raise ValueError("hidden_channels must be a positive integer.")
-        if num_layers <= 0:
-            raise ValueError("num_layers must be a positive integer.")
+        in_channels = _require_positive_int("in_channels", in_channels)
+        hidden_channels = _require_positive_int(
+            "hidden_channels", hidden_channels
+        )
+        num_layers = _require_positive_int("num_layers", num_layers)
 
         self.in_channels = in_channels
         self.hidden_channels = hidden_channels

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -67,6 +67,9 @@ class BuNNLayer(nn.Module):
         Hidden width of the angle network. If ``None``, twice the number of
         bundles is used, matching the compact angle-network width described
         for the paper's LRGB experiments. Default is ``None``.
+    include_reflections : bool, optional
+        Whether to parameterize half of the 2D bundles as determinant -1
+        orthogonal maps. Default is ``True``, following Appendix E.
     residual : bool, optional
         Whether to add a residual connection around the BuNN layer. Default is
         ``False``, matching the core Equations (1)--(4).
@@ -85,6 +88,7 @@ class BuNNLayer(nn.Module):
         dropout: float = 0.0,
         act: str = "gelu",
         angle_hidden_channels: int | None = None,
+        include_reflections: bool = True,
         residual: bool = False,
         norm: str | None = None,
     ) -> None:
@@ -94,8 +98,14 @@ class BuNNLayer(nn.Module):
             raise ValueError("BuNNLayer currently supports bundle_dim=2 only.")
         if num_bundles <= 0:
             raise ValueError("num_bundles must be a positive integer.")
+        if include_reflections and num_bundles % 2 != 0:
+            raise ValueError(
+                "num_bundles must be even when include_reflections=True."
+            )
         if taylor_degree < 0:
             raise ValueError("taylor_degree must be non-negative.")
+        if angle_hidden_channels is not None and angle_hidden_channels <= 0:
+            raise ValueError("angle_hidden_channels must be positive.")
 
         bundle_width = num_bundles * bundle_dim
         if hidden_channels % bundle_width != 0:
@@ -111,6 +121,7 @@ class BuNNLayer(nn.Module):
         self.t = float(t)
         self.taylor_degree = int(taylor_degree)
 
+        self.include_reflections = include_reflections
         self.residual = residual
         self.norm_name = norm
 
@@ -131,13 +142,27 @@ class BuNNLayer(nn.Module):
             raise ValueError("Unsupported norm. Use None or 'layer_norm'.")
 
     def _compute_bundle_maps(self, x: torch.Tensor) -> torch.Tensor:
-        """Compute one 2D rotation matrix per node and bundle."""
+        """Compute one 2D orthogonal matrix per node and bundle."""
         angles = self.angle_network(x)
         cos = torch.cos(angles)
         sin = torch.sin(angles)
-        return torch.stack((cos, -sin, sin, cos), dim=-1).reshape(
+        maps = torch.stack((cos, -sin, sin, cos), dim=-1).reshape(
             x.shape[0], self.num_bundles, 2, 2
         )
+        if not self.include_reflections:
+            return maps
+
+        reflection_start = self.num_bundles // 2
+        reflection_maps = torch.stack(
+            (
+                cos[:, reflection_start:],
+                sin[:, reflection_start:],
+                sin[:, reflection_start:],
+                -cos[:, reflection_start:],
+            ),
+            dim=-1,
+        ).reshape(x.shape[0], self.num_bundles - reflection_start, 2, 2)
+        return torch.cat((maps[:, :reflection_start], reflection_maps), dim=1)
 
     def _to_bundle_fields(self, x: torch.Tensor) -> torch.Tensor:
         """Reshape node features into bundle and vector-field channels."""
@@ -303,6 +328,9 @@ class BuNN(nn.Module):
     angle_hidden_channels : int or None, optional
         Hidden width of each angle network. If ``None``, twice the number of
         bundles is used. Default is ``None``.
+    include_reflections : bool, optional
+        Whether to parameterize half of the 2D bundles as determinant -1
+        orthogonal maps. Default is ``True``.
     residual : bool, optional
         Whether to add residual connections around BuNN layers. Default is
         ``False``.
@@ -323,6 +351,7 @@ class BuNN(nn.Module):
         dropout: float = 0.0,
         act: str = "gelu",
         angle_hidden_channels: int | None = None,
+        include_reflections: bool = True,
         residual: bool = False,
         norm: str | None = None,
         **kwargs,
@@ -340,6 +369,7 @@ class BuNN(nn.Module):
         self.bundle_dim = bundle_dim
         self.t = float(t)
         self.taylor_degree = int(taylor_degree)
+        self.include_reflections = include_reflections
 
         if in_channels == hidden_channels:
             self.input_projection = nn.Identity()
@@ -357,6 +387,7 @@ class BuNN(nn.Module):
                     dropout=dropout,
                     act=act,
                     angle_hidden_channels=angle_hidden_channels,
+                    include_reflections=include_reflections,
                     residual=residual,
                     norm=norm,
                 )
@@ -415,6 +446,7 @@ class BuNN(nn.Module):
             f"num_layers={self.num_layers}, "
             f"num_bundles={self.num_bundles}, "
             f"bundle_dim={self.bundle_dim}, "
+            f"include_reflections={self.include_reflections}, "
             f"t={self.t}, "
             f"taylor_degree={self.taylor_degree})"
         )

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -12,7 +12,7 @@ local frames.
 from __future__ import annotations
 
 import math
-from numbers import Integral
+from numbers import Integral, Real
 
 import torch
 import torch.nn as nn
@@ -59,6 +59,26 @@ def _require_bool(name: str, value: bool) -> bool:
     """Validate boolean feature flags from configs and CLI overrides."""
     if not isinstance(value, bool):
         raise ValueError(f"{name} must be a boolean.")
+    return value
+
+
+def _require_non_negative_float(name: str, value: float) -> float:
+    """Validate finite non-negative scalar hyperparameters."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a numeric scalar.")
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be finite and non-negative.")
+    return value
+
+
+def _require_probability(name: str, value: float) -> float:
+    """Validate probability-valued regularization hyperparameters."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a probability in [0, 1].")
+    value = float(value)
+    if not math.isfinite(value) or value < 0 or value > 1:
+        raise ValueError(f"{name} must be a finite probability in [0, 1].")
     return value
 
 
@@ -140,6 +160,8 @@ class BuNNLayer(nn.Module):
             "include_reflections", include_reflections
         )
         residual = _require_bool("residual", residual)
+        diffusion_time = _require_non_negative_float("t", t)
+        dropout = _require_probability("dropout", dropout)
 
         if bundle_dim != 2:
             raise ValueError("BuNNLayer currently supports bundle_dim=2 only.")
@@ -147,9 +169,6 @@ class BuNNLayer(nn.Module):
             raise ValueError(
                 "num_bundles must be even when include_reflections=True."
             )
-        diffusion_time = float(t)
-        if not math.isfinite(diffusion_time) or diffusion_time < 0:
-            raise ValueError("t must be finite and non-negative.")
 
         bundle_width = num_bundles * bundle_dim
         if hidden_channels % bundle_width != 0:
@@ -435,18 +454,23 @@ class BuNN(nn.Module):
             "hidden_channels", hidden_channels
         )
         num_layers = _require_positive_int("num_layers", num_layers)
+        taylor_degree = _require_non_negative_int(
+            "taylor_degree", taylor_degree
+        )
         include_reflections = _require_bool(
             "include_reflections", include_reflections
         )
         residual = _require_bool("residual", residual)
+        diffusion_time = _require_non_negative_float("t", t)
+        dropout = _require_probability("dropout", dropout)
 
         self.in_channels = in_channels
         self.hidden_channels = hidden_channels
         self.num_layers = num_layers
         self.num_bundles = num_bundles
         self.bundle_dim = bundle_dim
-        self.t = float(t)
-        self.taylor_degree = int(taylor_degree)
+        self.t = diffusion_time
+        self.taylor_degree = taylor_degree
         self.include_reflections = include_reflections
 
         if in_channels == hidden_channels:
@@ -460,7 +484,7 @@ class BuNN(nn.Module):
                     hidden_channels=hidden_channels,
                     num_bundles=num_bundles,
                     bundle_dim=bundle_dim,
-                    t=t,
+                    t=diffusion_time,
                     taylor_degree=taylor_degree,
                     dropout=dropout,
                     act=act,

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -191,10 +191,19 @@ class BuNNLayer(nn.Module):
         symmetrized before computing random-walk neighbor averages. Duplicate
         reverse edges do not change the normalized average.
         """
+        if x.dim() != 2:
+            raise ValueError("x must have shape [num_nodes, num_features].")
         if edge_index.dim() != 2 or edge_index.shape[0] != 2:
             raise ValueError("edge_index must have shape [2, num_edges].")
+        if edge_index.dtype != torch.long:
+            raise ValueError("edge_index must be a torch.long tensor.")
 
         source, target = edge_index
+        if source.numel() > 0 and (
+            (edge_index < 0).any() or edge_index.max() >= x.shape[0]
+        ):
+            raise ValueError("edge_index values must be in [0, num_nodes).")
+
         if edge_weight is None:
             edge_weight = x.new_ones(source.shape[0])
         else:

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -102,6 +102,8 @@ class BuNNLayer(nn.Module):
             raise ValueError(
                 "num_bundles must be even when include_reflections=True."
             )
+        if t < 0:
+            raise ValueError("t must be non-negative.")
         if taylor_degree < 0:
             raise ValueError("taylor_degree must be non-negative.")
         if angle_hidden_channels is not None and angle_hidden_channels <= 0:
@@ -199,6 +201,17 @@ class BuNNLayer(nn.Module):
             edge_weight = edge_weight.to(dtype=x.dtype, device=x.device).view(
                 -1
             )
+            if edge_weight.shape[0] != source.shape[0]:
+                raise ValueError(
+                    "edge_weight must have one scalar per edge_index column."
+                )
+
+        non_loop = source != target
+        source = source[non_loop]
+        target = target[non_loop]
+        edge_weight = edge_weight[non_loop]
+        if source.numel() == 0:
+            return torch.zeros_like(x)
 
         source, target = (
             torch.cat((source, target), dim=0),

--- a/topobench/nn/backbones/graph/bunn.py
+++ b/topobench/nn/backbones/graph/bunn.py
@@ -296,9 +296,9 @@ class BuNNLayer(nn.Module):
         else:
             if not isinstance(edge_weight, torch.Tensor):
                 raise ValueError("edge_weight must be a torch.Tensor.")
-            edge_weight = edge_weight.to(dtype=x.dtype, device=x.device).view(
-                -1
-            )
+            edge_weight = edge_weight.to(
+                dtype=x.dtype, device=x.device
+            ).reshape(-1)
             if edge_weight.shape[0] != source.shape[0]:
                 raise ValueError(
                     "edge_weight must have one scalar per edge_index column."


### PR DESCRIPTION
## Summary
- Adds a graph BuNN backbone for the challenge track with learned O(2) bundle maps, random-walk heat-kernel Taylor diffusion, residual/norm/dropout channel updates, and a real Hydra config.
- Review-driven hardening covers tensor shapes, tensor input types, floating node-feature tensors, node-feature widths, node ids, edge-index device placement, bundle shape constraints, scalar/integer/probability hyperparameters, boolean flags, activation config values, finite real-valued non-negative edge weights, non-contiguous edge-weight tensors, boolean edge-weight rejection, unexpected constructor/forward keyword arguments, TopoBench wrapper output-channel introspection, and weighted random-walk Laplacian coverage.
- The full challenge result artifact remains tracked at `2026_tdl_challenge/outputs/bunn_full/results.json`.

## Validation
- `.venv\Scripts\python.exe -m ruff check topobench\nn\backbones\graph\bunn.py test\nn\backbones\graph\test_bunn.py` -> passed
- `.venv\Scripts\python.exe -m pytest test\nn\backbones\graph\test_bunn.py -q` -> 59 passed
- `.venv\Scripts\python.exe -m pytest test\nn\backbones\graph\test_bunn.py test\pipeline\test_pipeline.py -q` -> 60 passed
- Full challenge grid: 72 runs, community accuracy mean `0.1034`, triangle normalized MSE `6.7543`

The full grid result above was generated before the invalid-input validation commits; the valid-input computation path is unchanged by these hardening patches.

## Submission Info
- Track: Track1
- Team name: yeahkitory
- Model: Bundle Neural Networks (BuNN)