### PR TITLE
ci(leaderboard): rename auto-PR branch to avoid ref collision

### DIFF
--- a/.github/workflows/update_leaderboard.yml
+++ b/.github/workflows/update_leaderboard.yml
@@ -53,7 +53,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: leaderboard/refresh-tdl-challenge-2026
+          branch: bot/refresh-tdl-challenge-2026-leaderboard
           base: main
           add-paths: docs/_static/leaderboard/data/leaderboard.json
           commit-message: "docs(leaderboard): refresh TDL Challenge 2026 results [skip ci]"


### PR DESCRIPTION
The previous branch name `leaderboard/refresh-tdl-challenge-2026` collided with the existing `leaderboard` branch on the remote, causing the push from `peter-evans/create-pull-request` to be rejected with a `directory file conflict`. Git stores refs as files, so `refs/heads/leaderboard` (a file) prevents creating `refs/heads/leaderboard/...` (which would require `leaderboard` to be a directory).

Rename the auto-PR branch to `bot/refresh-tdl-challenge-2026-leaderboard` so it no longer nests under the existing `leaderboard` ref.

<!--
Thank you for opening this pull request!
-->

## Checklist

- [ ] My pull request has a clear and explanatory title.
- [ ] My pull request passes the Linting test.
- [ ] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [ ] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [ ] I linked to issues and PRs that are relevant to this PR.


## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->
