### PR TITLE
Track: Track2; Team name: TJPaik; Model: Directed Simplicial Neural Networks (Dir-SNN)

### DIFF
--- a/2026_tdl_challenge/outputs/dirsnn/results.json
+++ b/2026_tdl_challenge/outputs/dirsnn/results.json
@@ -1,0 +1,5697 @@
+{
+  "metadata": {
+    "study_id": "2026-05-22_09-01-19",
+    "model_config": "simplicial/dirsnn",
+    "generated_at_utc": "2026-05-22T05:43:06.183572+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.342477321624756,
+      "test_best_rerun_accuracy": 0.28638550639152527,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2925739288330078,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24684849381446838,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28050270676612854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27549850940704346,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2874933183193207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2198410928249359,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25429749488830566,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.261861115694046,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2708381116390228,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2176636904478073,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20887768268585205,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3159525866555697,
+        "AvgTime/train_epoch_std": 0.34718442268233474,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.305121898651123,
+      "test_best_rerun_accuracy": 0.28989991545677185,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28951790928840637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2778668999671936,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2870731055736542,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2806173264980316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2883719205856323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24833829700946808,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2704178988933563,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27385589480400085,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2800443172454834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23661088943481445,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22709909081459045,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5129985453477546,
+        "AvgTime/train_epoch_std": 0.10551794043429319,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.264768362045288,
+      "test_best_rerun_accuracy": 0.3010925352573395,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29941171407699585,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2882191240787506,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2986477315425873,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.296890527009964,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3015127182006836,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26678889989852905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29245930910110474,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2860035002231598,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24745969474315643,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2498663067817688,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5437107628042046,
+        "AvgTime/train_epoch_std": 0.18726354180210258,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.5363402366638184,
+      "test_best_rerun_accuracy": 0.23294369876384735,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21082589030265808,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12716785073280334,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16387806832790375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20085568726062775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21922989189624786,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12758804857730865,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14271526038646698,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1937122792005539,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1995568871498108,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15073725581169128,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12464664876461029,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3684364954630532,
+        "AvgTime/train_epoch_std": 0.21228840130289758,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.5532031059265137,
+      "test_best_rerun_accuracy": 0.24150049686431885,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2102910876274109,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11906944960355759,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15830086171627045,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20055007934570312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22400489449501038,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12499044835567474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13805486261844635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1976468861103058,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2024218738079071,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14943845570087433,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12460844963788986,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.315548292795817,
+        "AvgTime/train_epoch_std": 0.19755093555675893,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.5032856464385986,
+      "test_best_rerun_accuracy": 0.241424098610878,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21392008662223816,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13052944839000702,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1757582724094391,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20257468521595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22904729843139648,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12892505526542664,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15054626762866974,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20158147811889648,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20719687640666962,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1489800661802292,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1256016492843628,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.355012740407671,
+        "AvgTime/train_epoch_std": 0.14888119046021395,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2308859825134277,
+      "test_best_rerun_accuracy": 0.30892351269721985,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30147451162338257,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3013599216938019,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3050653338432312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29685232043266296,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2975781261920929,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30445411801338196,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3011307120323181,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2916189134120941,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28187790513038635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2819543182849884,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.872435020021171,
+        "AvgTime/train_epoch_std": 0.15649602133713666,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.236459255218506,
+      "test_best_rerun_accuracy": 0.30892351269721985,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29983192682266235,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29883870482444763,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3001375198364258,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2989533245563507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30487433075904846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29883870482444763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29765450954437256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2998701333999634,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29807472229003906,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.813386833458616,
+        "AvgTime/train_epoch_std": 0.2129444493474885,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.249866008758545,
+      "test_best_rerun_accuracy": 0.3068225085735321,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30074870586395264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30021393299102783,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30197110772132874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29505690932273865,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2976163327693939,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2902437150478363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29440751671791077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2867293059825897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29249751567840576,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2607533037662506,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2588050961494446,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.7992416463914465,
+        "AvgTime/train_epoch_std": 0.21807751112844453,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.5000195503234863,
+      "test_best_rerun_accuracy": 0.24214988946914673,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24268469214439392,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25609290599823,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19451448321342468,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2293146848678589,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24677209556102753,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17682787775993347,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2157536894083023,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2253800928592682,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24016349017620087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18565207719802856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1798456758260727,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5256625413894653,
+        "AvgTime/train_epoch_std": 0.2724866671722525,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.4659385681152344,
+      "test_best_rerun_accuracy": 0.24692489206790924,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2426465004682541,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2511269152164459,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19768507778644562,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2327144891023636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2475360929965973,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19042707979679108,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22339369356632233,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22507448494434357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24123309552669525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19226068258285522,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1938650757074356,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3585184812545776,
+        "AvgTime/train_epoch_std": 0.13925002041224546,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.4741568565368652,
+      "test_best_rerun_accuracy": 0.2474215030670166,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24344870448112488,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2593398988246918,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19191688299179077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2321796864271164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2529987096786499,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18125906586647034,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22453969717025757,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2279776930809021,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24073649942874908,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19260448217391968,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18259607255458832,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4661884858058047,
+        "AvgTime/train_epoch_std": 0.2140739764036895,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.4435105323791504,
+      "test_best_rerun_accuracy": 0.2672854959964752,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23512110114097595,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24807089567184448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1629994660615921,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20994728803634644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2546030879020691,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2332874983549118,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24023990333080292,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30647870898246765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2690427005290985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3040721118450165,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2604859173297882,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5420031547546387,
+        "AvgTime/train_epoch_std": 0.1130656165992717,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.504371166229248,
+      "test_best_rerun_accuracy": 0.2762625217437744,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2468867003917694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2633126974105835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17262586951255798,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2169760912656784,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2688899040222168,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2338222861289978,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2440216988325119,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3110245168209076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27943310141563416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30510351061820984,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2555581033229828,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4511928775093774,
+        "AvgTime/train_epoch_std": 0.14264873753995147,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.411794424057007,
+      "test_best_rerun_accuracy": 0.2845137119293213,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25105050206184387,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2626633048057556,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18504087626934052,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22958208620548248,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2718695104122162,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2507830858230591,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2624723017215729,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3288257420063019,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2880663275718689,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3241271376609802,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27889829874038696,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4278601656357446,
+        "AvgTime/train_epoch_std": 0.1516629474508985,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.4838311672210693,
+      "test_best_rerun_accuracy": 0.26747649908065796,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23072808980941772,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2592635154724121,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14252425730228424,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19497287273406982,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24612270295619965,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1741538643836975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21460768580436707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2611353099346161,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2712201178073883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21999388933181763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20375888049602509,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3510215818212274,
+        "AvgTime/train_epoch_std": 0.18740753191233284,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.400041341781616,
+      "test_best_rerun_accuracy": 0.27278631925582886,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2415768951177597,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26571929454803467,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15757505595684052,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21747268736362457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2513943016529083,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18099167943000793,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22637328505516052,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26419129967689514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27397051453590393,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21663229167461395,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20628008246421814,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.300051707141804,
+        "AvgTime/train_epoch_std": 0.18665714999943003,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.3838257789611816,
+      "test_best_rerun_accuracy": 0.2736267149448395,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24486209452152252,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16590265929698944,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23279088735580444,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25276950001716614,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19417068362236023,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23332569003105164,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2687753140926361,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2708381116390228,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22793948650360107,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21571548283100128,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.643759808540344,
+        "AvgTime/train_epoch_std": 0.5436003860839701,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.295358657836914,
+      "test_best_rerun_accuracy": 0.33283674716949463,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.254182904958725,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2558636963367462,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23282909393310547,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2532660961151123,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2698449194431305,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3125525116920471,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3478875458240509,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3001375198364258,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40923675894737244,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3666437566280365,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8632021511302277,
+        "AvgTime/train_epoch_std": 0.2127315134031772,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.3506500720977783,
+      "test_best_rerun_accuracy": 0.3161815404891968,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2529987096786499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25551989674568176,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22568568587303162,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2509359121322632,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2936435043811798,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2638857066631317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2952861189842224,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3319963216781616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2868439257144928,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3865077495574951,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34781113266944885,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.945701421693314,
+        "AvgTime/train_epoch_std": 0.20608416764223192,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.3335933685302734,
+      "test_best_rerun_accuracy": 0.3266865313053131,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25414469838142395,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2509740889072418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23309649527072906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2525402903556824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2952861189842224,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3089617192745209,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34276872873306274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2954389154911041,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.407021164894104,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3654213547706604,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.835749077796936,
+        "AvgTime/train_epoch_std": 4.937310373938719,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.04887056350708,
+      "test_best_rerun_accuracy": 0.40148216485977173,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24203529953956604,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2455115020275116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2002444863319397,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23661088943481445,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3200015425682068,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3120177388191223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32687753438949585,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3935365676879883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4023607671260834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47177019715309143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5211246013641357,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8800908584220735,
+        "AvgTime/train_epoch_std": 0.2120510315835529,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.279015302658081,
+      "test_best_rerun_accuracy": 0.31515011191368103,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2759568989276886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22461609542369843,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26705631613731384,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29792192578315735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28554511070251465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2898235023021698,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32894033193588257,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3047979176044464,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3507143259048462,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3398655354976654,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.925191756657192,
+        "AvgTime/train_epoch_std": 0.2248598542298853,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.339836597442627,
+      "test_best_rerun_accuracy": 0.30922913551330566,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2600657045841217,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2663305103778839,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2131560891866684,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2544502913951874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2913133203983307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28054091334342957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32630452513694763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30770111083984375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3501795530319214,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3467797338962555,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.938192623311823,
+        "AvgTime/train_epoch_std": 0.2593104910555619,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.8287712335586548,
+      "test_best_rerun_accuracy": 0.49938881397247314,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19978608191013336,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20100848376750946,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14225685596466064,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1621972620487213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33489954471588135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3242417275905609,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3057147264480591,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3394453227519989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4889602065086365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5430132150650024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5423638224601746,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.906181780497233,
+        "AvgTime/train_epoch_std": 0.12092480159879224,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.8970363140106201,
+      "test_best_rerun_accuracy": 0.5071433782577515,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19485828280448914,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20058828592300415,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14290626347064972,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15100465714931488,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33772632479667664,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3228665292263031,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30579110980033875,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32427993416786194,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48620977997779846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5393841862678528,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.531209409236908,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.799758302063501,
+        "AvgTime/train_epoch_std": 0.1698277213343729,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.8567367792129517,
+      "test_best_rerun_accuracy": 0.5117655992507935,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19757047295570374,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20184887945652008,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1344640552997589,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15310566127300262,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3412407338619232,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3277943432331085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3112919330596924,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3352433443069458,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4994269907474518,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5563068389892578,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5514172315597534,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.719706885449521,
+        "AvgTime/train_epoch_std": 0.22448740255951014,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6919724941253662,
+      "test_best_rerun_accuracy": 0.5299488306045532,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19531667232513428,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20838108658790588,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13637405633926392,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16861486434936523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3353961408138275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3474291265010834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28867751359939575,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36198335886001587,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5064939856529236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5501184463500977,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6039804220199585,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.471101741942148,
+        "AvgTime/train_epoch_std": 0.12399680745378729,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6409190893173218,
+      "test_best_rerun_accuracy": 0.5336542129516602,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2013522833585739,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2039116770029068,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.139468252658844,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16601726412773132,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33543434739112854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34639772772789,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2927267253398895,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3652685582637787,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5104668140411377,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5616165995597839,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6089464426040649,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4872424683328402,
+        "AvgTime/train_epoch_std": 0.14897871455515557,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6482412815093994,
+      "test_best_rerun_accuracy": 0.5356405973434448,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1984872817993164,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20624187588691711,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13564825057983398,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16437466442584991,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3327603340148926,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.347199946641922,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28734052181243896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35652074217796326,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5138666033744812,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5550844073295593,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5980212688446045,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.589475258913907,
+        "AvgTime/train_epoch_std": 0.21790065138835107,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.480058193206787,
+      "test_best_rerun_accuracy": 0.6021468639373779,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18156467378139496,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18370386958122253,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14813965559005737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15356406569480896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32878753542900085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3022385239601135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3439147472381592,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38028115034103394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5021392107009888,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4796012043952942,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6329360604286194,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.1906430674534216,
+        "AvgTime/train_epoch_std": 0.2195979313955804,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.6000745296478271,
+      "test_best_rerun_accuracy": 0.5876308083534241,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18614867329597473,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18794406950473785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14768126606941223,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1515776664018631,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32554054260253906,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2971579134464264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3398655354976654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36045533418655396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4916723966598511,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46497058868408203,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6073802709579468,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.052788734436035,
+        "AvgTime/train_epoch_std": 0.2525799719415217,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.5479077100753784,
+      "test_best_rerun_accuracy": 0.5912980437278748,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1831308752298355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1808006763458252,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1453128606081009,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14901825785636902,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3227137327194214,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2981511056423187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34059134125709534,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3669111430644989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4926655888557434,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4694017767906189,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6218580603599548,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0163098408625677,
+        "AvgTime/train_epoch_std": 0.192097679195359,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.2091197967529297,
+      "test_best_rerun_accuracy": 0.6700282692909241,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18859347701072693,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1912674754858017,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14023225009441376,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16704866290092468,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3217587172985077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32538771629333496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31885552406311035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4034685492515564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4868209958076477,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5077928304672241,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5890824198722839,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.047153870264689,
+        "AvgTime/train_epoch_std": 0.17396554453822516,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.3180286884307861,
+      "test_best_rerun_accuracy": 0.6512720584869385,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17980746924877167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18385668098926544,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13373824954032898,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15570326149463654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3142715394496918,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3182443380355835,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3017801344394684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38341355323791504,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48414698243141174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4998854100704193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5740698575973511,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.9336438179016113,
+        "AvgTime/train_epoch_std": 0.23341170278989326,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.2172813415527344,
+      "test_best_rerun_accuracy": 0.6678508520126343,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18943387269973755,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19061808288097382,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14072886109352112,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16357246041297913,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3231339156627655,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3262663185596466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3237069249153137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4027809500694275,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4917106032371521,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5058445930480957,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5896936655044556,
+          "test_best_rerun_mse": null
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.7547379194521437,
+        "AvgTime/train_epoch_std": 0.0815972906125486,
+        "model/params/total": 110446,
+        "model/params/trainable": 110446,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 10.204398155212402,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9.97625732421875,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.007187505276814662,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.2613868713378906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.006638878270199424
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3470.665771484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2632283482354475
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.88548278808594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02928395105766294
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3374.527587890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4508386890969439
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.115379333496094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03464195106519524
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110601.4921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.5683051316064462
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7606.28173828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5333250412481595
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34575.52734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7722859881977548
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2419.91650390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.43020737847222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 662115.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.489737339230569
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215200.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.581132057810394
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5738532909980187,
+        "AvgTime/train_epoch_std": 0.04027213431328264,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 10.774212837219238,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11.126656532287598,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.00801632315006311,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.7374060153961182,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.009144242186295358
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3691.1474609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.27995050898274554
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96.3211669921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03246416143990141
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3543.537109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.47341845148630596
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.83161544799805,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03957825168220902
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113816.7734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.642967988052666
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7881.19189453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5526007498619584
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35139.58203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8011985253600902
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2483.344482421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4414834635416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668187.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.5584199631234235
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218228.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6315071014926863
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1142974495887756,
+        "AvgTime/train_epoch_std": 0.09660268936913015,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 12.645509719848633,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12.546174049377441,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.00903903029494052,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.307722806930542,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.006882751615423905
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3522.205810546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.26713733868387374
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97.25257873535156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03277808518212051
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3548.864990234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4741302592163494
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.969573974609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.037106713276864746
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114716.9765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.663871831750418
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7862.07568359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5512603900991271
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35146.51171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8015537300092266
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2473.23388671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.43968602430555553
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668402.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.56085978417022
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218212.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.631248127901752
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.128329486846924,
+        "AvgTime/train_epoch_std": 0.05832462537668406,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.3081381916999817,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.31007301807403564,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0016319632530212402,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.85900115966797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05681484233405473
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8850.91015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6712863220515738
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.85470581054688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05252939191457596
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6302.50146484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8420175637733801
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89.40376281738281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07720532194938066
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155213.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.604251811257663
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11917.41796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8356063643773665
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43040.48828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2061862874186273
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3153.745849609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5606659288194444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 729155.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.248086179202064
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244693.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.071910413858519
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9251926048942234,
+        "AvgTime/train_epoch_std": 0.22018143345370364,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.4112239480018616,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.42299172282218933,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.002226272225379944,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73.9575424194336,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05328353200247377
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8490.64453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6439624217861206
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.04617309570312,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05326800576194915
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6146.6513671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8211959074398798
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87.06036376953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07518166128629641
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153319.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5602729367917516
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11654.525390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8171732849968447
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42864.31640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1971560001153314
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3150.374267578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5600665364583334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 727991.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.23492203318892
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244156.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.062973484848484
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.741341961754693,
+        "AvgTime/train_epoch_std": 0.05127931431875007,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.27277523279190063,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.27966779470443726,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0014719357616023014,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.76780700683594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.061792368160544626
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8983.9189453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6813742089732651
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.34149169921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.055052744084670965
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6363.36865234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8501494525509352
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92.48614501953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07986713732256584
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156439.328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.632717075167193
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12026.1513671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.843230358097567
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43608.73828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.235313869560203
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3238.78759765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5757844618055555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 734378.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.307165056615725
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247756.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.122883748939144
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0784563422203064,
+        "AvgTime/train_epoch_std": 0.2416846279358619,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 378.66522216796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 385.5989990234375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.029245278651758626,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123.6851577758789,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08911034421893294
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.38890075683594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.0967836881938733
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.02388000488281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01281559824903364
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1860.5460205078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.24856994261961424
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209.5789337158203,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.18098353516046659
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71987.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.671642061814973
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4461.40625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3128177149067452
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28453.953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4585039276744067
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2121.97705078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3772403645833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 596827.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.751215315091117
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 187937.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.127444908308788
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1815678344832525,
+        "AvgTime/train_epoch_std": 0.262898491579261,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 387.1382751464844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 394.55487060546875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.029924525643190654,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183.14312744140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13194749815663276
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 294.12896728515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5480471962376645
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89.81241607666016,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.030270446941914445
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1985.000244140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.26519709340556114
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 295.2898864746094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2549999019642568
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72102.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6742998066830763
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4649.337890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3259948037179218
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29102.529296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4917489003472757
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2323.8515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.41312916666666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 600349.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.791047815119397
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189135.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1473840547151917
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9958416938781738,
+        "AvgTime/train_epoch_std": 0.06779997573954312,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 639.341064453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 660.5391235351562,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.05009777197839638,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212.04339599609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15276901728825198
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 412.2167053222656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.169561606959293
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108.25251007080078,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03648551064064738
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2017.9471435546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.26959881677417336
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 421.4264831542969,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.36392615125586947
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74364.8515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7268449647617499
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5015.43310546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.35166407975520614
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29505.154296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.512386811055154
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2544.94873046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4524353298611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 603994.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.832284396457133
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 192109.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.196876092057311
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0089989602565765,
+        "AvgTime/train_epoch_std": 0.04547272680621796,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 11.803399085998535,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12.061229705810547,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.004065126291139382,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103.55518341064453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07460748084340384
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.18247985839844,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.0483288413599918
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2542.71728515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.19284924422876373
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3251.3046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.434376043754175
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156.0255126953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13473705759526122
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103863.453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4118394279444546
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5458.2841796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3827151998098093
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34788.46875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7832010226049515
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2364.877197265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4204226128472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 655974.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.420279147766479
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204793.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.407950489241675
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3616381689559582,
+        "AvgTime/train_epoch_std": 0.18392320190791794,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 10.422069549560547,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10.5987548828125,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.003572212633236434,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70.94097900390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05111021542068173
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.83885192871094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.746520273309005
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2822.218505859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.21404766824872012
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3370.068115234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4502429011669172
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.94825744628906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10530937603306482
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106771.9765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4793789838960616
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5629.32666015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3947080816264374
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35069.5859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.797610638038854
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2320.130615234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.41246766493055553
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 656938.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.431176685180367
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206018.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4283282786680647
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2862469439810895,
+        "AvgTime/train_epoch_std": 0.1264629268896518,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 12.19298267364502,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12.322755813598633,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.004153271255004595,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107.97911834716797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07779475385242648
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206.76878356933594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.0882567556280838
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2621.285400390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.19880814564964921
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3399.566162109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.45418385599323646
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164.3838348388672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14195495236517028
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107317.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.492043818502694
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5643.82373046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.39572456390890126
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35768.21484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.833421233469168
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2457.94140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4369673611111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 661635.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.484311901179824
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207862.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.459008328757093
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.316800594329834,
+        "AvgTime/train_epoch_std": 0.05273835769616293,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 503.96875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 520.1087036132812,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.06948680074993738,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109.4693374633789,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07886839874883206
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.508882522583008,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1079414869609632
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1249.2552490234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.09474821759753034
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94.51726531982422,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03185617300971494
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.98493576049805,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04230132621804667
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30499.119140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7082277340847344
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2385.191162109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.16724100140999684
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15983.6298828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8192951910816803
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1145.299560546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2036088107638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 446834.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.054519501600624
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136855.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2773887973640856
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9293341934680939,
+        "AvgTime/train_epoch_std": 0.16782526303084885,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 683.6021118164062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 706.9229125976562,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.09444527890416249,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.80260467529297,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.053892366480758624
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.821006774902344,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09905793039422287
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1115.6746826171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.08461696493114808
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89.49679565429688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.030164069987966592
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.52437973022461,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.018587547262715554
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36455.3671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8465392714912688
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2196.82568359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.15403349345069065
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17500.052734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.897024590413399
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1130.426513671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.20096471354166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 466658.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.2787578617241495
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139097.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.314697115304611
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0070855696996053,
+        "AvgTime/train_epoch_std": 0.17082144587109555,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 592.7628784179688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 624.4166870117188,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.08342240307437793,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.80908966064453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0380468945681877
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.418086051940918,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07588466343126798
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1143.8890380859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.08675684778808779
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71.3869400024414,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.024060310078342233
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.276708602905273,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02010078463117899
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31586.44921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7334768999338195
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2187.659423828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.15339078837667403
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16633.912109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8526276133771593
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1077.247314453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19151063368055554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 456958.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.169034846102508
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136057.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2641164008287156
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9264134378994213,
+        "AvgTime/train_epoch_std": 0.16237682451376415,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 25.993793487548828,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 22.538742065429688,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.019463507828523047,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71.16769409179688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.051273554821179304
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.712486267089844,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.02480255930047286
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2680.048828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.20326498506825938
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43.36056137084961,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.014614277509554975
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2139.107177734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.28578586208876083
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88741.2421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0606827556079326
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4980.28076171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.349199324198482
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29722.283203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5235164899853915
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1904.0845947265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3385039279513889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 614709.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.953487155413278
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 192865.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2094563322683176
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8640788048505783,
+        "AvgTime/train_epoch_std": 0.20330605054257747,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 22.284801483154297,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 22.33067512512207,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.019283829987152046,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39.7210807800293,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02861749335736981
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.8673925399780273,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.020354697578831724
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3066.603759765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2325827652457812
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62.913761138916016,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02120450324870779
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2388.325927734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3190816202717936
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90935.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.111640523407022
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5489.970703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3849369445466975
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30264.029296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5512855244694757
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2017.910400390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3587396267361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 619181.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.004080743866158
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195190.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2481463627211156
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8560639072108913,
+        "AvgTime/train_epoch_std": 0.2270847848222068,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 26.107192993164062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 25.34513282775879,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.02188698862500759,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128.79531860351562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09279201628495362
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.63133430480957,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.029638601604260895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2112.346435546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16020830000355518
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.20283889770508,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.016583363295485366
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2175.394287109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.29063383929316966
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85706.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9902169590609327
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4812.70849609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3374497613303709
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29494.447265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5118379858334614
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1874.90869140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3333171006944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612675.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.9304774724839655
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 190778.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1747216293911102
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.009482741355896,
+        "AvgTime/train_epoch_std": 0.21715718555008973,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 6545.58984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6251.552734375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.14516888199830486,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 781.037109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5627068511347262
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.10443115234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5689706902754934
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3042.3662109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.23074449836461888
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262.3623046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08842679632204246
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1592.4658203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21275428461088844
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 372.03118896484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.32127045679174765
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 600.2036743164062,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.04208411683609636
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6486.09814453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.332466971373789
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 844.951171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.15021354166666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254683.203125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.8809339403074556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61721.98046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0271076576098714
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.193132479985555,
+        "AvgTime/train_epoch_std": 0.1620631394540739,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 6227.37646484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6279.42919921875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.14581620841581716,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 979.286376953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7055377355570065
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 496.2987976074219,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.6120989347759047
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3419.745361328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2593663527742226
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172.99481201171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.058306306711061254
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1552.35205078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.20739506356462925
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 471.02447509765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.40675688695825235
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 973.4139404296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.06825227460592397
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5983.74267578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.30671703704860576
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1086.7098388671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19319286024305554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 277919.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.1437832992093027
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74262.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.235789214217962
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2721964200337728,
+        "AvgTime/train_epoch_std": 0.4005031649731885,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 6741.359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6188.125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.14369601058889095,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 500.9801025390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3609366732990364
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.24069213867188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.1381089059930098
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2002.06787109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.15184435882394767
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 418.1714172363281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1409408214480378
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 862.9212646484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.11528674210399967
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.75759887695312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1871827278730165
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 763.0505981445312,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.05350235578071317
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6281.98681640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.32200455258630634
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752.8304443359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1338365234375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276472.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.127408713505198
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70689.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.176330073802273
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2172074010295253,
+        "AvgTime/train_epoch_std": 0.16023126750917036,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 670.9794311523438,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 609.0438232421875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.04270395619423556,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 654.625732421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4716323720618696
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 294.5061340332031,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5500322843852796
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2619.6611328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1986849550862723
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112.96220397949219,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.038072869558305425
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1076.2745361328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.14379085319075652
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.79495239257812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.18030652192796037
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20481.01953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.47559491759358163
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15992.7021484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.819760220843585
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1172.078369140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.20836948784722223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 423028.59375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.785228937366379
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113690.9453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8919166177841014
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9694636397891574,
+        "AvgTime/train_epoch_std": 0.05360914279485434,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 560.236328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 569.5383911132812,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.03993397778104622,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 686.8009033203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.49481333092241536
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 661.7021484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.482642886513158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3114.0087890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2361781409982935
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.6259536743164,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03391505010930786
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1079.124755859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1441716440693888
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 478.0623474121094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.41283449690164886
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22721.5859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5276236749373027
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16488.5390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8451760245271414
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1325.480224609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.23564092881944446
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 426004.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.818895427756977
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113327.9765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.885876500798762
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2271321850853996,
+        "AvgTime/train_epoch_std": 0.21326339868393307,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 612.521484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 576.9708251953125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.040455113251669644,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 598.7774658203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.43139586874662283
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 297.19390869140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.564178466796875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2512.64208984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1905682282778726
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129.6917724609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.043711416400720425
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1020.4879150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.13633773080014194
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 223.038330078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.19260650265813903
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22753.279296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5283596344249257
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16859.248046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8641779715451843
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1183.6895751953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.21043370225694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 427828.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.839529625691436
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114393.3203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9036047511773417
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.275193979000223,
+        "AvgTime/train_epoch_std": 0.20819421019916878,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 7325.28271484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7760.56005859375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.3977938417445154,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3430.628662109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.471634482787734
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256.2211608886719,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.3485324257298519
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18272.125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.3858266970041715
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1958.8870849609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6602248348368512
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3314.624755859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4428356387253674
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 701.769775390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6060188043096935
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13633.53515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3165877567399684
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1414.6424560546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.09918962670415703
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1002.8284301757812,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.17828060980902777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236592.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.6762995175503095
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58892.79296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9800275068435591
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.086171719763014,
+        "AvgTime/train_epoch_std": 0.18691320129259212,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 4560.27734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4788.18701171875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.24543477429487673,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3022.95654296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.1779225813895895
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 430.0647277832031,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.2634985672800165
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13914.9716796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0553637982318922
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2190.68017578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7383485594139704
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3087.581298828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4125025115334836
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612.018310546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5285132215430699
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9045.0048828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.21003633853828024
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1462.2061767578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.10252462324763795
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 688.679931640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.12243198784722223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222413.890625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.5159088563170933
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57002.734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.948575281230759
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0833421897888185,
+        "AvgTime/train_epoch_std": 0.15125815620077968,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 5882.1708984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6146.6123046875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.3150654725863704,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1800.9210205078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.297493530625225
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 219.47988891601562,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.1551573100842927
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11453.724609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8686935615756541
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1139.908447265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.38419563440027804
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3141.68603515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4197309332206079
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 670.7903442382812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5792662730900529
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8187.33642578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.19012020308799113
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1061.10546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.07440088828705652
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759.8292846679688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13508076171875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199086.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.252037543974752
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54830.24609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9124231789684323
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9362340340247521,
+        "AvgTime/train_epoch_std": 0.15975040984252345,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 878.8555908203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 927.1289672851562,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.1648229275173611,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257.2041015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.18530554867615273
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.2741584777832,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2646008340935958
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1797.0189208984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.13629267507762136
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 459.47796630859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1548628130463747
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1221.3031005859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.16316674690526886
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.335819244384766,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.054694144425202734
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46601.328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.082141188115363
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1581.6458740234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.11089930402632432
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18173.5390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9315464176790199
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 457082.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.170445997307784
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113096.8515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8820303789542876
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7682966102253308,
+        "AvgTime/train_epoch_std": 0.05891345999995182,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 888.20849609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 939.51123046875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.16702421875,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222.79620361328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1605159968395398
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.75049591064453,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18816050479286595
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1971.5814208984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1495321517556646
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 293.37872314453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09888059425161147
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1115.80908203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1490726896501336
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.810665130615234,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.030924581287232498
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38592.56640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.896167713316227
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 990.3029174804688,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.06943646876177736
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17563.751953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9002897100376749
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 447604.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.063222543352601
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110315.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8357512002229877
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9048966339656286,
+        "AvgTime/train_epoch_std": 0.2576984905656883,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 821.763671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 854.8343505859375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.15197055121527778,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.32681274414062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12847753079549037
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.338470458984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17546563399465462
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2011.2979736328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.15254440452277682
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 335.8417053222656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11319235096807065
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 934.328857421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.12482683465890114
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54.869285583496094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04738280274913307
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36380.8203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8448081997143786
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1050.620849609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0736657446087067
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16750.220703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8585894050502332
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 433709.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.906048861463978
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110517.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8391061562910822
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7229144191741943,
+        "AvgTime/train_epoch_std": 0.0428593871471292,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 151385.09375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 93542.296875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 1.058134869574562,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48057.39453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 34.62348309167867
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14934.6396484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 78.60336657072368
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215454.703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 16.340895193401593
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13996.76953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.717482147371082
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42600.76171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 5.691484531563126
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19264.50390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 16.636013735967186
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120710.3046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.803044414998607
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17710.720703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.241811856901206
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24002.48828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2303289907863038
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14177.75,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.520488888888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29361.642578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4886033744050888
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.559237012863159,
+        "AvgTime/train_epoch_std": 0.21236916126175914,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 146645.171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 87195.3046875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.9863387519371515,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48629.8984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 35.035949882925074
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18538.302734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 97.57001439144737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125039.6796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.48347968809253
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13790.1279296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.647835500400236
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49664.6875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.635228790915163
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22121.0,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 19.102763385146805
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80580.890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.871189174832807
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14981.3271484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0504366251884378
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28320.796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4516785522066737
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17148.9375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.0487
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25595.59765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.42593309796898143
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8173387611613556,
+        "AvgTime/train_epoch_std": 0.10797517106892388,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 139704.59375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 76578.234375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.8662402223340837,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46592.80859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 33.568305903278095
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19658.30078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 103.46474095394737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171703.234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 13.022619216913158
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49877.375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 16.81070947084597
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34696.234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 4.635435454241817
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21653.56640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 18.69910743199482
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56257.30078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3063649633394483
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29700.380859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.0824835829038704
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14655.0703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7511953617561126
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16603.115234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.9516649305555553
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23156.298828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.38534103519752716
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8250668965853176,
+        "AvgTime/train_epoch_std": 0.051275304799685915,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 13544.275390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 14199.4130859375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.23629063428248714,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13652.212890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.835888249729827
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1536.26171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.085587993421052
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74451.671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.646694871065605
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2575.313232421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8679855855820273
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16955.634765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.265281865814963
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1988.72119140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.717375812958765
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53200.84765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.235390294822822
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3365.4013671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.23596980558038844
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5903.98583984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.30262882976286587
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2067.386962890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.36753546006944443
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95508.65625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.080377999049806
+        }
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 11985.001953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12511.1650390625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.20819671241346746,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21159.01953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 15.244250382744957
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2882.609130859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 15.171627004523026
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109219.0234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.283581603147516
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4008.584228515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.3510563628296681
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24865.828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 3.3220879258517035
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3719.8837890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.2123348782923142
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80507.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.869479510147687
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5514.49755859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.38665667918901625
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8183.50830078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4194734891988954
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3732.793212890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6636076822916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93859.0390625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.0617178044014344
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5321378548940023,
+        "AvgTime/train_epoch_std": 0.18231201209615266,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "dirsnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 18049.16015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18912.712890625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.3147240592186278,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18974.25,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 13.670208933717579
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1258.667236328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.624564401726974
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126583.3046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.600554014979142
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1752.3525390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5906142699907314
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16120.931640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.153765082247829
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1631.6502685546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.4090244115325454
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73930.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.716754967896619
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2437.551513671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.17091232040891005
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6260.79150390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3209181149165129
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2840.083984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5049038194444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96642.5859375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.0932048226587332
+        }
+      },
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2511938015619912,
+        "AvgTime/train_epoch_std": 0.09102711375834233,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/2026_tdl_challenge/outputs/dirsnn/results.json
+++ b/2026_tdl_challenge/outputs/dirsnn/results.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "study_id": "2026-05-22_09-01-19",
+    "study_id": "2026-05-26_09-23-26",
     "model_config": "simplicial/dirsnn",
-    "generated_at_utc": "2026-05-22T05:43:06.183572+00:00",
+    "generated_at_utc": "2026-05-26T04:12:32.630368+00:00",
     "n_runs": 72,
     "train_seeds": [
       42,
@@ -21,60 +21,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.342477321624756,
-      "test_best_rerun_accuracy": 0.28638550639152527,
+      "test_loss": 2.3524298667907715,
+      "test_best_rerun_accuracy": 0.27958589792251587,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2925739288330078,
+          "test_best_rerun_accuracy": 0.2838261127471924,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24684849381446838,
+          "test_best_rerun_accuracy": 0.24975170195102692,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.28050270676612854,
+          "test_best_rerun_accuracy": 0.2758041024208069,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.27549850940704346,
+          "test_best_rerun_accuracy": 0.27305370569229126,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2874933183193207,
+          "test_best_rerun_accuracy": 0.2807319164276123,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2198410928249359,
+          "test_best_rerun_accuracy": 0.22167469561100006,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.25429749488830566,
+          "test_best_rerun_accuracy": 0.2543357014656067,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.261861115694046,
+          "test_best_rerun_accuracy": 0.2635801136493683,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2708381116390228,
+          "test_best_rerun_accuracy": 0.27102911472320557,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2176636904478073,
+          "test_best_rerun_accuracy": 0.2209106832742691,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.20887768268585205,
+          "test_best_rerun_accuracy": 0.21487508714199066,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__00__h_lo__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.3159525866555697,
-        "AvgTime/train_epoch_std": 0.34718442268233474,
+        "AvgTime/train_epoch_mean": 1.6974943209502658,
+        "AvgTime/train_epoch_std": 0.03419461911082665,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -89,60 +90,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.305121898651123,
-      "test_best_rerun_accuracy": 0.28989991545677185,
+      "test_loss": 2.296513557434082,
+      "test_best_rerun_accuracy": 0.2908167243003845,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28951790928840637,
+          "test_best_rerun_accuracy": 0.29605013132095337,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2778668999671936,
+          "test_best_rerun_accuracy": 0.2704943120479584,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2870731055736542,
+          "test_best_rerun_accuracy": 0.29234471917152405,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2806173264980316,
+          "test_best_rerun_accuracy": 0.28772252798080444,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2883719205856323,
+          "test_best_rerun_accuracy": 0.29154253005981445,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24833829700946808,
+          "test_best_rerun_accuracy": 0.2499808967113495,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2704178988933563,
+          "test_best_rerun_accuracy": 0.27836352586746216,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.27385589480400085,
+          "test_best_rerun_accuracy": 0.27809610962867737,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2800443172454834,
+          "test_best_rerun_accuracy": 0.28527772426605225,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23661088943481445,
+          "test_best_rerun_accuracy": 0.23959049582481384,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22709909081459045,
+          "test_best_rerun_accuracy": 0.2330200970172882,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__00__h_lo__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.5129985453477546,
-        "AvgTime/train_epoch_std": 0.10551794043429319,
+        "AvgTime/train_epoch_mean": 1.904802672717036,
+        "AvgTime/train_epoch_std": 0.04988563722158083,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -157,60 +159,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.264768362045288,
-      "test_best_rerun_accuracy": 0.3010925352573395,
+      "test_loss": 2.2977116107940674,
+      "test_best_rerun_accuracy": 0.2926885187625885,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29941171407699585,
+          "test_best_rerun_accuracy": 0.29627931118011475,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2882191240787506,
+          "test_best_rerun_accuracy": 0.27087631821632385,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2986477315425873,
+          "test_best_rerun_accuracy": 0.29261210560798645,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.296890527009964,
+          "test_best_rerun_accuracy": 0.28810450434684753,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3015127182006836,
+          "test_best_rerun_accuracy": 0.29005271196365356,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.26678889989852905,
+          "test_best_rerun_accuracy": 0.24738329648971558,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.29245930910110474,
+          "test_best_rerun_accuracy": 0.2792039215564728,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2860035002231598,
+          "test_best_rerun_accuracy": 0.2765299081802368,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_accuracy": 0.2867293059825897,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24745969474315643,
+          "test_best_rerun_accuracy": 0.24230270087718964,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2498663067817688,
+          "test_best_rerun_accuracy": 0.23500649631023407,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__00__h_lo__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.5437107628042046,
-        "AvgTime/train_epoch_std": 0.18726354180210258,
+        "AvgTime/train_epoch_mean": 1.9135501861572266,
+        "AvgTime/train_epoch_std": 0.0383678348337783,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -225,60 +228,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.5363402366638184,
-      "test_best_rerun_accuracy": 0.23294369876384735,
+      "test_loss": 2.4891769886016846,
+      "test_best_rerun_accuracy": 0.23974329233169556,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.21082589030265808,
+          "test_best_rerun_accuracy": 0.21835128962993622,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12716785073280334,
+          "test_best_rerun_accuracy": 0.1454656571149826,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.16387806832790375,
+          "test_best_rerun_accuracy": 0.1969974786043167,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.20085568726062775,
+          "test_best_rerun_accuracy": 0.20601268112659454,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.21922989189624786,
+          "test_best_rerun_accuracy": 0.230575293302536,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12758804857730865,
+          "test_best_rerun_accuracy": 0.14676445722579956,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.14271526038646698,
+          "test_best_rerun_accuracy": 0.1727786660194397,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1937122792005539,
+          "test_best_rerun_accuracy": 0.20207807421684265,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1995568871498108,
+          "test_best_rerun_accuracy": 0.212086483836174,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.15073725581169128,
+          "test_best_rerun_accuracy": 0.16319046914577484,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12464664876461029,
+          "test_best_rerun_accuracy": 0.14577126502990723,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__01__h_lo__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.3684364954630532,
-        "AvgTime/train_epoch_std": 0.21228840130289758,
+        "AvgTime/train_epoch_mean": 1.8836950338803804,
+        "AvgTime/train_epoch_std": 0.019210267553952887,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -293,60 +297,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.5532031059265137,
-      "test_best_rerun_accuracy": 0.24150049686431885,
+      "test_loss": 2.521503448486328,
+      "test_best_rerun_accuracy": 0.24016349017620087,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2102910876274109,
+          "test_best_rerun_accuracy": 0.2142638862133026,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.11906944960355759,
+          "test_best_rerun_accuracy": 0.12884865701198578,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15830086171627045,
+          "test_best_rerun_accuracy": 0.16872946918010712,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.20055007934570312,
+          "test_best_rerun_accuracy": 0.20276568830013275,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.22400489449501038,
+          "test_best_rerun_accuracy": 0.22694629430770874,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12499044835567474,
+          "test_best_rerun_accuracy": 0.13068224489688873,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13805486261844635,
+          "test_best_rerun_accuracy": 0.14638246595859528,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1976468861103058,
+          "test_best_rerun_accuracy": 0.19516387581825256,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2024218738079071,
+          "test_best_rerun_accuracy": 0.2052868753671646,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.14943845570087433,
+          "test_best_rerun_accuracy": 0.15146306157112122,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12460844963788986,
+          "test_best_rerun_accuracy": 0.1262892484664917,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__01__h_lo__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.315548292795817,
-        "AvgTime/train_epoch_std": 0.19755093555675893,
+        "AvgTime/train_epoch_mean": 1.8765929034261992,
+        "AvgTime/train_epoch_std": 0.020550240735468316,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -361,60 +366,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.5032856464385986,
-      "test_best_rerun_accuracy": 0.241424098610878,
+      "test_loss": 2.5624923706054688,
+      "test_best_rerun_accuracy": 0.24188250303268433,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.21392008662223816,
+          "test_best_rerun_accuracy": 0.21254488825798035,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.13052944839000702,
+          "test_best_rerun_accuracy": 0.12090304493904114,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1757582724094391,
+          "test_best_rerun_accuracy": 0.15788066387176514,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.20257468521595,
+          "test_best_rerun_accuracy": 0.2013522833585739,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.22904729843139648,
+          "test_best_rerun_accuracy": 0.22450149059295654,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.12892505526542664,
+          "test_best_rerun_accuracy": 0.12048284709453583,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15054626762866974,
+          "test_best_rerun_accuracy": 0.13923905789852142,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.20158147811889648,
+          "test_best_rerun_accuracy": 0.19420887529850006,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20719687640666962,
+          "test_best_rerun_accuracy": 0.19608068466186523,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1489800661802292,
+          "test_best_rerun_accuracy": 0.1494002640247345,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1256016492843628,
+          "test_best_rerun_accuracy": 0.12136144936084747,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__01__h_lo__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.355012740407671,
-        "AvgTime/train_epoch_std": 0.14888119046021395,
+        "AvgTime/train_epoch_mean": 1.9033115143869437,
+        "AvgTime/train_epoch_std": 0.060517260752303695,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -429,60 +435,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.2308859825134277,
-      "test_best_rerun_accuracy": 0.30892351269721985,
+      "test_loss": 2.231623411178589,
+      "test_best_rerun_accuracy": 0.308312326669693,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30147451162338257,
+          "test_best_rerun_accuracy": 0.2979601323604584,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3013599216938019,
+          "test_best_rerun_accuracy": 0.2966613173484802,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3050653338432312,
+          "test_best_rerun_accuracy": 0.3028497099876404,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29685232043266296,
+          "test_best_rerun_accuracy": 0.2966231107711792,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2975781261920929,
+          "test_best_rerun_accuracy": 0.29436931014060974,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.30445411801338196,
+          "test_best_rerun_accuracy": 0.3002903163433075,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3011307120323181,
+          "test_best_rerun_accuracy": 0.29857131838798523,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2916189134120941,
+          "test_best_rerun_accuracy": 0.28867751359939575,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_accuracy": 0.29085493087768555,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.28187790513038635,
+          "test_best_rerun_accuracy": 0.27618610858917236,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2819543182849884,
+          "test_best_rerun_accuracy": 0.27588051557540894,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__02__h_lo__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.872435020021171,
-        "AvgTime/train_epoch_std": 0.15649602133713666,
+        "AvgTime/train_epoch_mean": 2.172043862968984,
+        "AvgTime/train_epoch_std": 0.020326621995027255,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -497,60 +504,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.236459255218506,
-      "test_best_rerun_accuracy": 0.30892351269721985,
+      "test_loss": 2.211885690689087,
+      "test_best_rerun_accuracy": 0.31507372856140137,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29983192682266235,
+          "test_best_rerun_accuracy": 0.30567651987075806,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29883870482444763,
+          "test_best_rerun_accuracy": 0.30242952704429626,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_accuracy": 0.30827412009239197,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3001375198364258,
+          "test_best_rerun_accuracy": 0.3015127182006836,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2989533245563507,
+          "test_best_rerun_accuracy": 0.3016273081302643,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.30487433075904846,
+          "test_best_rerun_accuracy": 0.29956451058387756,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_accuracy": 0.3032699227333069,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29883870482444763,
+          "test_best_rerun_accuracy": 0.29196271300315857,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29765450954437256,
+          "test_best_rerun_accuracy": 0.29601192474365234,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2998701333999634,
+          "test_best_rerun_accuracy": 0.2697302997112274,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.29807472229003906,
+          "test_best_rerun_accuracy": 0.2744289040565491,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__02__h_lo__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.813386833458616,
-        "AvgTime/train_epoch_std": 0.2129444493474885,
+        "AvgTime/train_epoch_mean": 2.1694472987635605,
+        "AvgTime/train_epoch_std": 0.035932922573815806,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -565,60 +573,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.249866008758545,
-      "test_best_rerun_accuracy": 0.3068225085735321,
+      "test_loss": 2.233675479888916,
+      "test_best_rerun_accuracy": 0.30961111187934875,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30074870586395264,
+          "test_best_rerun_accuracy": 0.29792192578315735,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.30021393299102783,
+          "test_best_rerun_accuracy": 0.2956681251525879,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30197110772132874,
+          "test_best_rerun_accuracy": 0.3028497099876404,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29505690932273865,
+          "test_best_rerun_accuracy": 0.29738712310791016,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2976163327693939,
+          "test_best_rerun_accuracy": 0.29478952288627625,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2902437150478363,
+          "test_best_rerun_accuracy": 0.30365192890167236,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.29440751671791077,
+          "test_best_rerun_accuracy": 0.2966613173484802,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2867293059825897,
+          "test_best_rerun_accuracy": 0.2886011302471161,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29249751567840576,
+          "test_best_rerun_accuracy": 0.290396511554718,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2607533037662506,
+          "test_best_rerun_accuracy": 0.27496370673179626,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2588050961494446,
+          "test_best_rerun_accuracy": 0.273244708776474,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__02__h_lo__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.7992416463914465,
-        "AvgTime/train_epoch_std": 0.21807751112844453,
+        "AvgTime/train_epoch_mean": 2.186675705909729,
+        "AvgTime/train_epoch_std": 0.020620262472321266,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -633,60 +642,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.5000195503234863,
-      "test_best_rerun_accuracy": 0.24214988946914673,
+      "test_loss": 2.475196599960327,
+      "test_best_rerun_accuracy": 0.24341049790382385,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.24268469214439392,
+          "test_best_rerun_accuracy": 0.2399342954158783,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.25609290599823,
+          "test_best_rerun_accuracy": 0.2467339038848877,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19451448321342468,
+          "test_best_rerun_accuracy": 0.19810527563095093,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2293146848678589,
+          "test_best_rerun_accuracy": 0.22984948754310608,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.24677209556102753,
+          "test_best_rerun_accuracy": 0.24379250407218933,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.17682787775993347,
+          "test_best_rerun_accuracy": 0.1901978701353073,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2157536894083023,
+          "test_best_rerun_accuracy": 0.2255328893661499,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2253800928592682,
+          "test_best_rerun_accuracy": 0.22366109490394592,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.24016349017620087,
+          "test_best_rerun_accuracy": 0.23630529642105103,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18565207719802856,
+          "test_best_rerun_accuracy": 0.19138208031654358,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1798456758260727,
+          "test_best_rerun_accuracy": 0.19226068258285522,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__03__h_lo__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.5256625413894653,
-        "AvgTime/train_epoch_std": 0.2724866671722525,
+        "AvgTime/train_epoch_mean": 2.0639452384068417,
+        "AvgTime/train_epoch_std": 0.028010883092946984,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -701,60 +711,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.4659385681152344,
-      "test_best_rerun_accuracy": 0.24692489206790924,
+      "test_loss": 2.5091309547424316,
+      "test_best_rerun_accuracy": 0.24234089255332947,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2426465004682541,
+          "test_best_rerun_accuracy": 0.24283750355243683,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2511269152164459,
+          "test_best_rerun_accuracy": 0.2581174969673157,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19768507778644562,
+          "test_best_rerun_accuracy": 0.18152646720409393,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2327144891023636,
+          "test_best_rerun_accuracy": 0.23099549114704132,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2475360929965973,
+          "test_best_rerun_accuracy": 0.2533807158470154,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19042707979679108,
+          "test_best_rerun_accuracy": 0.17274047434329987,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22339369356632233,
+          "test_best_rerun_accuracy": 0.2157536894083023,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.22507448494434357,
+          "test_best_rerun_accuracy": 0.2263350933790207,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.24123309552669525,
+          "test_best_rerun_accuracy": 0.2359996885061264,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19226068258285522,
+          "test_best_rerun_accuracy": 0.1870654821395874,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1938650757074356,
+          "test_best_rerun_accuracy": 0.1771334707736969,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__03__h_lo__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.3585184812545776,
-        "AvgTime/train_epoch_std": 0.13925002041224546,
+        "AvgTime/train_epoch_mean": 2.1005151653289795,
+        "AvgTime/train_epoch_std": 0.02037966987165162,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -769,60 +780,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.4741568565368652,
-      "test_best_rerun_accuracy": 0.2474215030670166,
+      "test_loss": 2.452746868133545,
+      "test_best_rerun_accuracy": 0.2520436942577362,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.24344870448112488,
+          "test_best_rerun_accuracy": 0.2466192990541458,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2593398988246918,
+          "test_best_rerun_accuracy": 0.2584230899810791,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19191688299179077,
+          "test_best_rerun_accuracy": 0.1979524791240692,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2321796864271164,
+          "test_best_rerun_accuracy": 0.23412789404392242,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2529987096786499,
+          "test_best_rerun_accuracy": 0.2532278895378113,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18125906586647034,
+          "test_best_rerun_accuracy": 0.1867980808019638,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22453969717025757,
+          "test_best_rerun_accuracy": 0.226755291223526,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2279776930809021,
+          "test_best_rerun_accuracy": 0.22805409133434296,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.24073649942874908,
+          "test_best_rerun_accuracy": 0.23978149890899658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19260448217391968,
+          "test_best_rerun_accuracy": 0.1904652714729309,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.18259607255458832,
+          "test_best_rerun_accuracy": 0.1896630823612213,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__03__h_lo__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.4661884858058047,
-        "AvgTime/train_epoch_std": 0.2140739764036895,
+        "AvgTime/train_epoch_mean": 2.1236403442564464,
+        "AvgTime/train_epoch_std": 0.04843469913607975,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -837,60 +849,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.4435105323791504,
-      "test_best_rerun_accuracy": 0.2672854959964752,
+      "test_loss": 2.472949504852295,
+      "test_best_rerun_accuracy": 0.27496370673179626,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.23512110114097595,
+          "test_best_rerun_accuracy": 0.23638169467449188,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.24807089567184448,
+          "test_best_rerun_accuracy": 0.2559783160686493,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1629994660615921,
+          "test_best_rerun_accuracy": 0.16727787256240845,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.20994728803634644,
+          "test_best_rerun_accuracy": 0.20979447662830353,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2546030879020691,
+          "test_best_rerun_accuracy": 0.26216670870780945,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2332874983549118,
+          "test_best_rerun_accuracy": 0.22847428917884827,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.24023990333080292,
+          "test_best_rerun_accuracy": 0.2382916957139969,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30647870898246765,
+          "test_best_rerun_accuracy": 0.3079303205013275,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2690427005290985,
+          "test_best_rerun_accuracy": 0.2758423089981079,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3040721118450165,
+          "test_best_rerun_accuracy": 0.3034609258174896,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2604859173297882,
+          "test_best_rerun_accuracy": 0.25861409306526184,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__04__h_mid__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.5420031547546387,
-        "AvgTime/train_epoch_std": 0.1130656165992717,
+        "AvgTime/train_epoch_mean": 1.9567255427440007,
+        "AvgTime/train_epoch_std": 0.024530038398848243,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -905,60 +918,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.504371166229248,
-      "test_best_rerun_accuracy": 0.2762625217437744,
+      "test_loss": 2.429100751876831,
+      "test_best_rerun_accuracy": 0.28516310453414917,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2468867003917694,
+          "test_best_rerun_accuracy": 0.2489113062620163,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2633126974105835,
+          "test_best_rerun_accuracy": 0.2621285021305084,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.17262586951255798,
+          "test_best_rerun_accuracy": 0.1817556768655777,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2169760912656784,
+          "test_best_rerun_accuracy": 0.22828328609466553,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2688899040222168,
+          "test_best_rerun_accuracy": 0.27358850836753845,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2338222861289978,
+          "test_best_rerun_accuracy": 0.2456642985343933,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2440216988325119,
+          "test_best_rerun_accuracy": 0.25403010845184326,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3110245168209076,
+          "test_best_rerun_accuracy": 0.3200015425682068,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.27943310141563416,
+          "test_best_rerun_accuracy": 0.2843991219997406,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.30510351061820984,
+          "test_best_rerun_accuracy": 0.3162197172641754,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2555581033229828,
+          "test_best_rerun_accuracy": 0.273244708776474,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__04__h_mid__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.4511928775093774,
-        "AvgTime/train_epoch_std": 0.14264873753995147,
+        "AvgTime/train_epoch_mean": 1.9583034335442309,
+        "AvgTime/train_epoch_std": 0.023245114642268527,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -973,60 +987,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.411794424057007,
-      "test_best_rerun_accuracy": 0.2845137119293213,
+      "test_loss": 2.4359967708587646,
+      "test_best_rerun_accuracy": 0.291160523891449,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.25105050206184387,
+          "test_best_rerun_accuracy": 0.25616928935050964,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2626633048057556,
+          "test_best_rerun_accuracy": 0.27110549807548523,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18504087626934052,
+          "test_best_rerun_accuracy": 0.18465887010097504,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22958208620548248,
+          "test_best_rerun_accuracy": 0.22996409237384796,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2718695104122162,
+          "test_best_rerun_accuracy": 0.2797769010066986,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2507830858230591,
+          "test_best_rerun_accuracy": 0.24948430061340332,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2624723017215729,
+          "test_best_rerun_accuracy": 0.2607150971889496,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3288257420063019,
+          "test_best_rerun_accuracy": 0.3271067440509796,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2880663275718689,
+          "test_best_rerun_accuracy": 0.2917335033416748,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3241271376609802,
+          "test_best_rerun_accuracy": 0.3256933391094208,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.27889829874038696,
+          "test_best_rerun_accuracy": 0.2821834981441498,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__04__h_mid__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.4278601656357446,
-        "AvgTime/train_epoch_std": 0.1516629474508985,
+        "AvgTime/train_epoch_mean": 1.9575362273624966,
+        "AvgTime/train_epoch_std": 0.022386558194275125,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1041,60 +1056,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.4838311672210693,
-      "test_best_rerun_accuracy": 0.26747649908065796,
+      "test_loss": 2.46330189704895,
+      "test_best_rerun_accuracy": 0.2687753140926361,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.23072808980941772,
+          "test_best_rerun_accuracy": 0.2285124957561493,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2592635154724121,
+          "test_best_rerun_accuracy": 0.2594926953315735,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.14252425730228424,
+          "test_best_rerun_accuracy": 0.13637405633926392,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.19497287273406982,
+          "test_best_rerun_accuracy": 0.19688287377357483,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.24612270295619965,
+          "test_best_rerun_accuracy": 0.2456642985343933,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1741538643836975,
+          "test_best_rerun_accuracy": 0.17056307196617126,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.21460768580436707,
+          "test_best_rerun_accuracy": 0.21227748692035675,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2611353099346161,
+          "test_best_rerun_accuracy": 0.25983649492263794,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2712201178073883,
+          "test_best_rerun_accuracy": 0.2630453109741211,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.21999388933181763,
+          "test_best_rerun_accuracy": 0.2131560891866684,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.20375888049602509,
+          "test_best_rerun_accuracy": 0.19504927098751068,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__05__h_mid__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.3510215818212274,
-        "AvgTime/train_epoch_std": 0.18740753191233284,
+        "AvgTime/train_epoch_mean": 1.8767898042323226,
+        "AvgTime/train_epoch_std": 0.027107712511365494,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1109,60 +1125,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.400041341781616,
-      "test_best_rerun_accuracy": 0.27278631925582886,
+      "test_loss": 2.3841662406921387,
+      "test_best_rerun_accuracy": 0.2760715186595917,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2415768951177597,
+          "test_best_rerun_accuracy": 0.24440370500087738,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.26571929454803467,
+          "test_best_rerun_accuracy": 0.2664833068847656,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.15757505595684052,
+          "test_best_rerun_accuracy": 0.15937046706676483,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.21747268736362457,
+          "test_best_rerun_accuracy": 0.2225532829761505,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2513943016529083,
+          "test_best_rerun_accuracy": 0.25960731506347656,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18099167943000793,
+          "test_best_rerun_accuracy": 0.1896248757839203,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22637328505516052,
+          "test_best_rerun_accuracy": 0.23321110010147095,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.26419129967689514,
+          "test_best_rerun_accuracy": 0.27209872007369995,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.27397051453590393,
+          "test_best_rerun_accuracy": 0.27534571290016174,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.21663229167461395,
+          "test_best_rerun_accuracy": 0.2309572994709015,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.20628008246421814,
+          "test_best_rerun_accuracy": 0.22419588267803192,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__05__h_mid__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.300051707141804,
-        "AvgTime/train_epoch_std": 0.18665714999943003,
+        "AvgTime/train_epoch_mean": 1.8699591305791115,
+        "AvgTime/train_epoch_std": 0.02669552145371013,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1177,60 +1194,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.3838257789611816,
-      "test_best_rerun_accuracy": 0.2736267149448395,
+      "test_loss": 2.370652198791504,
+      "test_best_rerun_accuracy": 0.27725571393966675,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.24486209452152252,
+          "test_best_rerun_accuracy": 0.24409809708595276,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_accuracy": 0.2702651023864746,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.16590265929698944,
+          "test_best_rerun_accuracy": 0.1589120626449585,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.23279088735580444,
+          "test_best_rerun_accuracy": 0.23053708672523499,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.25276950001716614,
+          "test_best_rerun_accuracy": 0.26079151034355164,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19417068362236023,
+          "test_best_rerun_accuracy": 0.19313926994800568,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.23332569003105164,
+          "test_best_rerun_accuracy": 0.23848269879817963,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2687753140926361,
+          "test_best_rerun_accuracy": 0.27332112193107605,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2708381116390228,
+          "test_best_rerun_accuracy": 0.282794713973999,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22793948650360107,
+          "test_best_rerun_accuracy": 0.2335548996925354,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.21571548283100128,
+          "test_best_rerun_accuracy": 0.22339369356632233,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__05__h_mid__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.643759808540344,
-        "AvgTime/train_epoch_std": 0.5436003860839701,
+        "AvgTime/train_epoch_mean": 1.8709415769577027,
+        "AvgTime/train_epoch_std": 0.02635625773225153,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1245,60 +1263,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.295358657836914,
-      "test_best_rerun_accuracy": 0.33283674716949463,
+      "test_loss": 2.3494811058044434,
+      "test_best_rerun_accuracy": 0.32752692699432373,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.254182904958725,
+          "test_best_rerun_accuracy": 0.24772709608078003,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2558636963367462,
+          "test_best_rerun_accuracy": 0.25429749488830566,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23282909393310547,
+          "test_best_rerun_accuracy": 0.22671708464622498,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2532660961151123,
+          "test_best_rerun_accuracy": 0.251508891582489,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_accuracy": 0.2935289144515991,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2698449194431305,
+          "test_best_rerun_accuracy": 0.2668271064758301,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3125525116920471,
+          "test_best_rerun_accuracy": 0.30991673469543457,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3478875458240509,
+          "test_best_rerun_accuracy": 0.34536632895469666,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3001375198364258,
+          "test_best_rerun_accuracy": 0.29616472125053406,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.40923675894737244,
+          "test_best_rerun_accuracy": 0.4082435667514801,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3666437566280365,
+          "test_best_rerun_accuracy": 0.36274734139442444,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__06__h_mid__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.8632021511302277,
-        "AvgTime/train_epoch_std": 0.2127315134031772,
+        "AvgTime/train_epoch_mean": 2.3282102697035847,
+        "AvgTime/train_epoch_std": 0.034250659735100726,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1313,60 +1332,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.3506500720977783,
-      "test_best_rerun_accuracy": 0.3161815404891968,
+      "test_loss": 2.383068323135376,
+      "test_best_rerun_accuracy": 0.31694552302360535,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2529987096786499,
+          "test_best_rerun_accuracy": 0.24978989362716675,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.25551989674568176,
+          "test_best_rerun_accuracy": 0.2538008987903595,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22568568587303162,
+          "test_best_rerun_accuracy": 0.2285124957561493,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2509359121322632,
+          "test_best_rerun_accuracy": 0.25047749280929565,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2936435043811798,
+          "test_best_rerun_accuracy": 0.29138970375061035,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2638857066631317,
+          "test_best_rerun_accuracy": 0.26636871695518494,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2952861189842224,
+          "test_best_rerun_accuracy": 0.2974635064601898,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3319963216781616,
+          "test_best_rerun_accuracy": 0.3345557451248169,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2868439257144928,
+          "test_best_rerun_accuracy": 0.28909772634506226,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3865077495574951,
+          "test_best_rerun_accuracy": 0.3903277516365051,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.34781113266944885,
+          "test_best_rerun_accuracy": 0.35136374831199646,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__06__h_mid__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.945701421693314,
-        "AvgTime/train_epoch_std": 0.20608416764223192,
+        "AvgTime/train_epoch_mean": 2.279517645738563,
+        "AvgTime/train_epoch_std": 0.017654357703037735,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1381,60 +1401,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2.3335933685302734,
-      "test_best_rerun_accuracy": 0.3266865313053131,
+      "test_loss": 2.324577808380127,
+      "test_best_rerun_accuracy": 0.32836732268333435,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.25414469838142395,
+          "test_best_rerun_accuracy": 0.2513178884983063,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2509740889072418,
+          "test_best_rerun_accuracy": 0.25594010949134827,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23309649527072906,
+          "test_best_rerun_accuracy": 0.2332874983549118,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2525402903556824,
+          "test_best_rerun_accuracy": 0.2513560950756073,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2952861189842224,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2667125165462494,
-          "test_best_rerun_mse": null
-        },
-        "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3089617192745209,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.34276872873306274,
-          "test_best_rerun_mse": null
-        },
-        "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": 0.2954389154911041,
           "test_best_rerun_mse": null
         },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26755291223526,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30785393714904785,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3402857482433319,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2938727140426636,
+          "test_best_rerun_mse": null
+        },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.407021164894104,
+          "test_best_rerun_accuracy": 0.3972037732601166,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3654213547706604,
+          "test_best_rerun_accuracy": 0.35487812757492065,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__06__h_mid__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.835749077796936,
-        "AvgTime/train_epoch_std": 4.937310373938719,
+        "AvgTime/train_epoch_mean": 2.3357149887084963,
+        "AvgTime/train_epoch_std": 0.018295256619109704,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1449,60 +1470,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.04887056350708,
-      "test_best_rerun_accuracy": 0.40148216485977173,
+      "test_loss": 2.187541961669922,
+      "test_best_rerun_accuracy": 0.3574375510215759,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.24203529953956604,
+          "test_best_rerun_accuracy": 0.24467109143733978,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2455115020275116,
+          "test_best_rerun_accuracy": 0.2527312934398651,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2002444863319397,
+          "test_best_rerun_accuracy": 0.20368248224258423,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.23661088943481445,
+          "test_best_rerun_accuracy": 0.24310488998889923,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3200015425682068,
+          "test_best_rerun_accuracy": 0.3002903163433075,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3120177388191223,
+          "test_best_rerun_accuracy": 0.2895943224430084,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.32687753438949585,
+          "test_best_rerun_accuracy": 0.3078921139240265,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3935365676879883,
+          "test_best_rerun_accuracy": 0.35690274834632874,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4023607671260834,
+          "test_best_rerun_accuracy": 0.34483152627944946,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.47177019715309143,
+          "test_best_rerun_accuracy": 0.40732675790786743,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5211246013641357,
+          "test_best_rerun_accuracy": 0.4239819645881653,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__07__h_mid__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.8800908584220735,
-        "AvgTime/train_epoch_std": 0.2120510315835529,
+        "AvgTime/train_epoch_mean": 2.1019140829642615,
+        "AvgTime/train_epoch_std": 0.021386793435318047,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1517,60 +1539,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.279015302658081,
-      "test_best_rerun_accuracy": 0.31515011191368103,
+      "test_loss": 2.2779953479766846,
+      "test_best_rerun_accuracy": 0.31167393922805786,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_accuracy": 0.26514631509780884,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2759568989276886,
+          "test_best_rerun_accuracy": 0.2773320972919464,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22461609542369843,
+          "test_best_rerun_accuracy": 0.2218656837940216,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.26705631613731384,
+          "test_best_rerun_accuracy": 0.26720911264419556,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29792192578315735,
+          "test_best_rerun_accuracy": 0.2936435043811798,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28554511070251465,
+          "test_best_rerun_accuracy": 0.28367331624031067,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2898235023021698,
+          "test_best_rerun_accuracy": 0.27981510758399963,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.32894033193588257,
+          "test_best_rerun_accuracy": 0.31923753023147583,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3047979176044464,
+          "test_best_rerun_accuracy": 0.2981511056423187,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3507143259048462,
+          "test_best_rerun_accuracy": 0.34307435154914856,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3398655354976654,
+          "test_best_rerun_accuracy": 0.33207273483276367,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__07__h_mid__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.925191756657192,
-        "AvgTime/train_epoch_std": 0.2248598542298853,
+        "AvgTime/train_epoch_mean": 2.162944487162999,
+        "AvgTime/train_epoch_std": 0.03253852235872642,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1585,60 +1608,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 2.339836597442627,
-      "test_best_rerun_accuracy": 0.30922913551330566,
+      "test_loss": 2.279813051223755,
+      "test_best_rerun_accuracy": 0.3255787193775177,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2600657045841217,
+          "test_best_rerun_accuracy": 0.25376269221305847,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2663305103778839,
+          "test_best_rerun_accuracy": 0.2635801136493683,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2131560891866684,
+          "test_best_rerun_accuracy": 0.21120788156986237,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2544502913951874,
+          "test_best_rerun_accuracy": 0.25616928935050964,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2913133203983307,
+          "test_best_rerun_accuracy": 0.29669952392578125,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28054091334342957,
+          "test_best_rerun_accuracy": 0.28527772426605225,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_accuracy": 0.29074031114578247,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.32630452513694763,
+          "test_best_rerun_accuracy": 0.3373061418533325,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.30770111083984375,
+          "test_best_rerun_accuracy": 0.31843534111976624,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3501795530319214,
+          "test_best_rerun_accuracy": 0.36656734347343445,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3467797338962555,
+          "test_best_rerun_accuracy": 0.3602261543273926,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__07__h_mid__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.938192623311823,
-        "AvgTime/train_epoch_std": 0.2593104910555619,
+        "AvgTime/train_epoch_mean": 2.1438928127288817,
+        "AvgTime/train_epoch_std": 0.03989970988386137,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1653,60 +1677,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.8287712335586548,
-      "test_best_rerun_accuracy": 0.49938881397247314,
+      "test_loss": 1.8207248449325562,
+      "test_best_rerun_accuracy": 0.5033615827560425,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19978608191013336,
+          "test_best_rerun_accuracy": 0.1957750767469406,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20100848376750946,
+          "test_best_rerun_accuracy": 0.1995568871498108,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.14225685596466064,
+          "test_best_rerun_accuracy": 0.13939185440540314,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1621972620487213,
+          "test_best_rerun_accuracy": 0.1628466695547104,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.33489954471588135,
+          "test_best_rerun_accuracy": 0.3360837399959564,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3242417275905609,
+          "test_best_rerun_accuracy": 0.32894033193588257,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3057147264480591,
+          "test_best_rerun_accuracy": 0.30754831433296204,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3394453227519989,
+          "test_best_rerun_accuracy": 0.34059134125709534,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4889602065086365,
+          "test_best_rerun_accuracy": 0.4933531880378723,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5430132150650024,
+          "test_best_rerun_accuracy": 0.5488960146903992,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5423638224601746,
+          "test_best_rerun_accuracy": 0.5466040372848511,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__08__h_hi__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.906181780497233,
-        "AvgTime/train_epoch_std": 0.12092480159879224,
+        "AvgTime/train_epoch_mean": 2.0420400423881335,
+        "AvgTime/train_epoch_std": 0.021256007108260654,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1721,18 +1746,18 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.8970363140106201,
-      "test_best_rerun_accuracy": 0.5071433782577515,
+      "test_loss": 1.829690933227539,
+      "test_best_rerun_accuracy": 0.49652379751205444,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19485828280448914,
+          "test_best_rerun_accuracy": 0.19554588198661804,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20058828592300415,
+          "test_best_rerun_accuracy": 0.2009320855140686,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
@@ -1740,41 +1765,42 @@
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15100465714931488,
+          "test_best_rerun_accuracy": 0.15119566023349762,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.33772632479667664,
+          "test_best_rerun_accuracy": 0.33298954367637634,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3228665292263031,
+          "test_best_rerun_accuracy": 0.3122469186782837,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.30579110980033875,
+          "test_best_rerun_accuracy": 0.306440532207489,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.32427993416786194,
+          "test_best_rerun_accuracy": 0.32725954055786133,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.48620977997779846,
+          "test_best_rerun_accuracy": 0.47249600291252136,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5393841862678528,
+          "test_best_rerun_accuracy": 0.535067617893219,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.531209409236908,
+          "test_best_rerun_accuracy": 0.5229200124740601,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__08__h_hi__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.799758302063501,
-        "AvgTime/train_epoch_std": 0.1698277213343729,
+        "AvgTime/train_epoch_mean": 2.0588959323035345,
+        "AvgTime/train_epoch_std": 0.03429542838244544,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1789,60 +1815,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.8567367792129517,
-      "test_best_rerun_accuracy": 0.5117655992507935,
+      "test_loss": 1.8392730951309204,
+      "test_best_rerun_accuracy": 0.5121093988418579,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19757047295570374,
+          "test_best_rerun_accuracy": 0.19906027615070343,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20184887945652008,
+          "test_best_rerun_accuracy": 0.20352968573570251,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1344640552997589,
+          "test_best_rerun_accuracy": 0.14630605280399323,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15310566127300262,
+          "test_best_rerun_accuracy": 0.15658186376094818,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3412407338619232,
+          "test_best_rerun_accuracy": 0.34131714701652527,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3277943432331085,
+          "test_best_rerun_accuracy": 0.32767972350120544,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3112919330596924,
+          "test_best_rerun_accuracy": 0.3095347285270691,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3352433443069458,
+          "test_best_rerun_accuracy": 0.3386049270629883,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4994269907474518,
+          "test_best_rerun_accuracy": 0.49163419008255005,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5563068389892578,
+          "test_best_rerun_accuracy": 0.5475208163261414,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5514172315597534,
+          "test_best_rerun_accuracy": 0.5407594442367554,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__08__h_hi__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.719706885449521,
-        "AvgTime/train_epoch_std": 0.22448740255951014,
+        "AvgTime/train_epoch_mean": 2.0374231067570774,
+        "AvgTime/train_epoch_std": 0.02313345796831479,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1857,60 +1884,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.6919724941253662,
-      "test_best_rerun_accuracy": 0.5299488306045532,
+      "test_loss": 1.6413443088531494,
+      "test_best_rerun_accuracy": 0.5352967977523804,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19531667232513428,
+          "test_best_rerun_accuracy": 0.19329208135604858,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20838108658790588,
+          "test_best_rerun_accuracy": 0.2013140767812729,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.13637405633926392,
+          "test_best_rerun_accuracy": 0.1396210491657257,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.16861486434936523,
+          "test_best_rerun_accuracy": 0.1659790724515915,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3353961408138275,
+          "test_best_rerun_accuracy": 0.3327985405921936,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3474291265010834,
+          "test_best_rerun_accuracy": 0.3480403423309326,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.28867751359939575,
+          "test_best_rerun_accuracy": 0.28565970063209534,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.36198335886001587,
+          "test_best_rerun_accuracy": 0.36316755414009094,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5064939856529236,
+          "test_best_rerun_accuracy": 0.5091680288314819,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5501184463500977,
+          "test_best_rerun_accuracy": 0.5486668348312378,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6039804220199585,
+          "test_best_rerun_accuracy": 0.6076858639717102,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__09__h_hi__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.471101741942148,
-        "AvgTime/train_epoch_std": 0.12399680745378729,
+        "AvgTime/train_epoch_mean": 1.9127590289482703,
+        "AvgTime/train_epoch_std": 0.021584096015164828,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1925,30 +1953,30 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.6409190893173218,
-      "test_best_rerun_accuracy": 0.5336542129516602,
+      "test_loss": 1.672583818435669,
+      "test_best_rerun_accuracy": 0.5294139981269836,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2013522833585739,
+          "test_best_rerun_accuracy": 0.1979142725467682,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2039116770029068,
+          "test_best_rerun_accuracy": 0.20578348636627197,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.139468252658844,
+          "test_best_rerun_accuracy": 0.13912445306777954,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.16601726412773132,
+          "test_best_rerun_accuracy": 0.1647566705942154,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.33543434739112854,
+          "test_best_rerun_accuracy": 0.33478492498397827,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
@@ -1956,29 +1984,30 @@
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2927267253398895,
+          "test_best_rerun_accuracy": 0.28607991337776184,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3652685582637787,
+          "test_best_rerun_accuracy": 0.3541141450405121,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5104668140411377,
+          "test_best_rerun_accuracy": 0.5079073905944824,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5616165995597839,
+          "test_best_rerun_accuracy": 0.5472152233123779,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6089464426040649,
+          "test_best_rerun_accuracy": 0.6050882339477539,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__09__h_hi__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.4872424683328402,
-        "AvgTime/train_epoch_std": 0.14897871455515557,
+        "AvgTime/train_epoch_mean": 1.9101027821841305,
+        "AvgTime/train_epoch_std": 0.02367626663342166,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -1993,60 +2022,61 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.6482412815093994,
-      "test_best_rerun_accuracy": 0.5356405973434448,
+      "test_loss": 1.671792984008789,
+      "test_best_rerun_accuracy": 0.5317060351371765,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1984872817993164,
+          "test_best_rerun_accuracy": 0.19936588406562805,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20624187588691711,
+          "test_best_rerun_accuracy": 0.2060890793800354,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.13564825057983398,
+          "test_best_rerun_accuracy": 0.1420658528804779,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.16437466442584991,
+          "test_best_rerun_accuracy": 0.1680418699979782,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3327603340148926,
+          "test_best_rerun_accuracy": 0.3326839208602905,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.347199946641922,
+          "test_best_rerun_accuracy": 0.3503323495388031,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.28734052181243896,
+          "test_best_rerun_accuracy": 0.2850485146045685,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.35652074217796326,
+          "test_best_rerun_accuracy": 0.35839253664016724,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5138666033744812,
+          "test_best_rerun_accuracy": 0.5094354152679443,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5550844073295593,
+          "test_best_rerun_accuracy": 0.5507296323776245,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5980212688446045,
+          "test_best_rerun_accuracy": 0.6032546162605286,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__09__h_hi__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.589475258913907,
-        "AvgTime/train_epoch_std": 0.21790065138835107,
+        "AvgTime/train_epoch_mean": 1.9120197491567643,
+        "AvgTime/train_epoch_std": 0.024522705190121674,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -2061,60 +2091,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.480058193206787,
-      "test_best_rerun_accuracy": 0.6021468639373779,
+      "test_loss": 1.5049099922180176,
+      "test_best_rerun_accuracy": 0.603636622428894,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.18156467378139496,
+          "test_best_rerun_accuracy": 0.17843227088451385,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18370386958122253,
+          "test_best_rerun_accuracy": 0.17900526523590088,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.14813965559005737,
+          "test_best_rerun_accuracy": 0.14187484979629517,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15356406569480896,
+          "test_best_rerun_accuracy": 0.15031705796718597,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.32878753542900085,
+          "test_best_rerun_accuracy": 0.3246237337589264,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3022385239601135,
+          "test_best_rerun_accuracy": 0.2976163327693939,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3439147472381592,
+          "test_best_rerun_accuracy": 0.3447933495044708,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.38028115034103394,
+          "test_best_rerun_accuracy": 0.3765757381916046,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5021392107009888,
+          "test_best_rerun_accuracy": 0.5011460185050964,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4796012043952942,
+          "test_best_rerun_accuracy": 0.4779967963695526,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6329360604286194,
+          "test_best_rerun_accuracy": 0.6337764263153076,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__10__h_hi__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.1906430674534216,
-        "AvgTime/train_epoch_std": 0.2195979313955804,
+        "AvgTime/train_epoch_mean": 2.572456178994014,
+        "AvgTime/train_epoch_std": 0.016573616522359755,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -2129,60 +2160,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.6000745296478271,
-      "test_best_rerun_accuracy": 0.5876308083534241,
+      "test_loss": 1.5677236318588257,
+      "test_best_rerun_accuracy": 0.5863320231437683,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.18614867329597473,
+          "test_best_rerun_accuracy": 0.18400947749614716,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18794406950473785,
+          "test_best_rerun_accuracy": 0.18523187935352325,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.14768126606941223,
+          "test_best_rerun_accuracy": 0.14225685596466064,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1515776664018631,
+          "test_best_rerun_accuracy": 0.15299105644226074,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.32554054260253906,
+          "test_best_rerun_accuracy": 0.327374130487442,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2971579134464264,
+          "test_best_rerun_accuracy": 0.2970433235168457,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3398655354976654,
+          "test_best_rerun_accuracy": 0.33841392397880554,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.36045533418655396,
+          "test_best_rerun_accuracy": 0.35843074321746826,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4916723966598511,
+          "test_best_rerun_accuracy": 0.4934678077697754,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.46497058868408203,
+          "test_best_rerun_accuracy": 0.46432119607925415,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6073802709579468,
+          "test_best_rerun_accuracy": 0.612002432346344,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__10__h_hi__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.052788734436035,
-        "AvgTime/train_epoch_std": 0.2525799719415217,
+        "AvgTime/train_epoch_mean": 2.580966340644019,
+        "AvgTime/train_epoch_std": 0.025791544998804313,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -2197,42 +2229,42 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.5479077100753784,
-      "test_best_rerun_accuracy": 0.5912980437278748,
+      "test_loss": 1.508474588394165,
+      "test_best_rerun_accuracy": 0.5896172523498535,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1831308752298355,
+          "test_best_rerun_accuracy": 0.1853082776069641,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1808006763458252,
+          "test_best_rerun_accuracy": 0.18320727348327637,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1453128606081009,
+          "test_best_rerun_accuracy": 0.14554205536842346,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.14901825785636902,
+          "test_best_rerun_accuracy": 0.1477576643228531,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3227137327194214,
+          "test_best_rerun_accuracy": 0.3242035210132599,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2981511056423187,
+          "test_best_rerun_accuracy": 0.2952861189842224,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.34059134125709534,
+          "test_best_rerun_accuracy": 0.34234854578971863,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3669111430644989,
+          "test_best_rerun_accuracy": 0.36003515124320984,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
@@ -2240,17 +2272,18 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4694017767906189,
+          "test_best_rerun_accuracy": 0.46718618273735046,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6218580603599548,
+          "test_best_rerun_accuracy": 0.6186492443084717,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__10__h_hi__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.0163098408625677,
-        "AvgTime/train_epoch_std": 0.192097679195359,
+        "AvgTime/train_epoch_mean": 2.560531212733342,
+        "AvgTime/train_epoch_std": 0.01677916528792496,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -2265,60 +2298,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 1.2091197967529297,
-      "test_best_rerun_accuracy": 0.6700282692909241,
+      "test_loss": 1.1745903491973877,
+      "test_best_rerun_accuracy": 0.6676216721534729,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.18859347701072693,
+          "test_best_rerun_accuracy": 0.1843532770872116,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1912674754858017,
+          "test_best_rerun_accuracy": 0.1874474734067917,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.14023225009441376,
+          "test_best_rerun_accuracy": 0.13939185440540314,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.16704866290092468,
+          "test_best_rerun_accuracy": 0.16418366134166718,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3217587172985077,
+          "test_best_rerun_accuracy": 0.3238215148448944,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.32538771629333496,
+          "test_best_rerun_accuracy": 0.32065093517303467,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.31885552406311035,
+          "test_best_rerun_accuracy": 0.3221789300441742,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4034685492515564,
+          "test_best_rerun_accuracy": 0.40598976612091064,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4868209958076477,
+          "test_best_rerun_accuracy": 0.48089998960494995,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5077928304672241,
+          "test_best_rerun_accuracy": 0.4974023997783661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5890824198722839,
+          "test_best_rerun_accuracy": 0.5907632112503052,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__11__h_hi__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.047153870264689,
-        "AvgTime/train_epoch_std": 0.17396554453822516,
+        "AvgTime/train_epoch_mean": 2.2924389979418587,
+        "AvgTime/train_epoch_std": 0.015410440519144721,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -2333,60 +2367,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 1.3180286884307861,
-      "test_best_rerun_accuracy": 0.6512720584869385,
+      "test_loss": 1.3145172595977783,
+      "test_best_rerun_accuracy": 0.6489800810813904,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.17980746924877167,
+          "test_best_rerun_accuracy": 0.18232867121696472,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18385668098926544,
+          "test_best_rerun_accuracy": 0.18355107307434082,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.13373824954032898,
+          "test_best_rerun_accuracy": 0.1324012577533722,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15570326149463654,
+          "test_best_rerun_accuracy": 0.1570020616054535,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3142715394496918,
+          "test_best_rerun_accuracy": 0.3174039125442505,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3182443380355835,
+          "test_best_rerun_accuracy": 0.3202689290046692,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3017801344394684,
+          "test_best_rerun_accuracy": 0.30418673157691956,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.38341355323791504,
+          "test_best_rerun_accuracy": 0.3819619417190552,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.48414698243141174,
+          "test_best_rerun_accuracy": 0.48280999064445496,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4998854100704193,
+          "test_best_rerun_accuracy": 0.4970203936100006,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5740698575973511,
+          "test_best_rerun_accuracy": 0.5724272131919861,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__11__h_hi__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.9336438179016113,
-        "AvgTime/train_epoch_std": 0.23341170278989326,
+        "AvgTime/train_epoch_mean": 2.298521000605363,
+        "AvgTime/train_epoch_std": 0.024634696680590297,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -2401,60 +2436,61 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 1.2172813415527344,
-      "test_best_rerun_accuracy": 0.6678508520126343,
+      "test_loss": 1.203606128692627,
+      "test_best_rerun_accuracy": 0.655512273311615,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.18943387269973755,
+          "test_best_rerun_accuracy": 0.18721827864646912,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.19061808288097382,
+          "test_best_rerun_accuracy": 0.1867980808019638,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.14072886109352112,
+          "test_best_rerun_accuracy": 0.13969746232032776,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.16357246041297913,
+          "test_best_rerun_accuracy": 0.1654442697763443,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3231339156627655,
+          "test_best_rerun_accuracy": 0.3217969238758087,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3262663185596466,
+          "test_best_rerun_accuracy": 0.3174421191215515,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3237069249153137,
+          "test_best_rerun_accuracy": 0.32523491978645325,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4027809500694275,
+          "test_best_rerun_accuracy": 0.40178775787353516,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4917106032371521,
+          "test_best_rerun_accuracy": 0.48662999272346497,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5058445930480957,
+          "test_best_rerun_accuracy": 0.49667659401893616,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5896936655044556,
+          "test_best_rerun_accuracy": 0.5864466428756714,
           "test_best_rerun_mse": null
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__community_detection__11__h_hi__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.7547379194521437,
-        "AvgTime/train_epoch_std": 0.0815972906125486,
+        "AvgTime/train_epoch_mean": 2.2976918292768076,
+        "AvgTime/train_epoch_std": 0.01448290756112649,
         "model/params/total": 110446,
         "model/params/trainable": 110446,
         "model/params/non_trainable": 0
@@ -2469,82 +2505,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 10.204398155212402,
+      "test_loss": 17.773818969726562,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 9.97625732421875,
+      "test_best_rerun_mse": 16.350086212158203,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.007187505276814662,
+      "test_mse_by_total_triangles": 0.011779601017405045,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.2613868713378906,
+          "test_best_rerun_mse": 3.5079362392425537,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.006638878270199424
+          "test_mse_by_total_triangles": 0.018462822311802914
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3470.665771484375,
+          "test_best_rerun_mse": 3826.443359375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.2632283482354475
+          "test_mse_by_total_triangles": 0.2902118588832006
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86.88548278808594,
+          "test_best_rerun_mse": 131.36183166503906,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.02928395105766294
+          "test_mse_by_total_triangles": 0.04427429446074792
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3374.527587890625,
+          "test_best_rerun_mse": 3559.156982421875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4508386890969439
+          "test_mse_by_total_triangles": 0.475505274872662
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 40.115379333496094,
+          "test_best_rerun_mse": 50.18569564819336,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.03464195106519524
+          "test_mse_by_total_triangles": 0.04333825185508926
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 110601.4921875,
+          "test_best_rerun_mse": 114403.1875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.5683051316064462
+          "test_mse_by_total_triangles": 2.6565852568270483
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7606.28173828125,
+          "test_best_rerun_mse": 8046.03076171875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.5333250412481595
+          "test_mse_by_total_triangles": 0.5641586566904186
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 34575.52734375,
+          "test_best_rerun_mse": 35247.875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.7722859881977548
+          "test_mse_by_total_triangles": 1.8067494489722693
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2419.91650390625,
+          "test_best_rerun_mse": 2509.583984375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.43020737847222223
+          "test_mse_by_total_triangles": 0.4461482638888889
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 662115.25,
+          "test_best_rerun_mse": 668131.1875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.489737339230569
+          "test_mse_by_total_triangles": 7.557788621426875
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 215200.96875,
+          "test_best_rerun_mse": 218532.28125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.581132057810394
+          "test_mse_by_total_triangles": 3.636568007089012
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.5738532909980187,
-        "AvgTime/train_epoch_std": 0.04027213431328264,
+        "AvgTime/train_epoch_mean": 1.509551763534546,
+        "AvgTime/train_epoch_std": 0.018278826043789134,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -2559,82 +2596,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 10.774212837219238,
+      "test_loss": 13.82002067565918,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 11.126656532287598,
+      "test_best_rerun_mse": 14.175479888916016,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.00801632315006311,
+      "test_mse_by_total_triangles": 0.010212881764348715,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.7374060153961182,
+          "test_best_rerun_mse": 2.9341347217559814,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.009144242186295358
+          "test_mse_by_total_triangles": 0.015442814325031482
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3691.1474609375,
+          "test_best_rerun_mse": 3615.186767578125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.27995050898274554
+          "test_mse_by_total_triangles": 0.2741893642455916
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 96.3211669921875,
+          "test_best_rerun_mse": 90.78960418701172,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03246416143990141
+          "test_mse_by_total_triangles": 0.030599799186724543
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3543.537109375,
+          "test_best_rerun_mse": 3591.1767578125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.47341845148630596
+          "test_mse_by_total_triangles": 0.4797831339762859
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 45.83161544799805,
+          "test_best_rerun_mse": 45.4864501953125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.03957825168220902
+          "test_mse_by_total_triangles": 0.0392801815158139
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 113816.7734375,
+          "test_best_rerun_mse": 114856.078125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.642967988052666
+          "test_mse_by_total_triangles": 2.6671019441993313
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7881.19189453125,
+          "test_best_rerun_mse": 7779.994140625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.5526007498619584
+          "test_mse_by_total_triangles": 0.5455051283568223
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35139.58203125,
+          "test_best_rerun_mse": 35510.328125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.8011985253600902
+          "test_mse_by_total_triangles": 1.8202023745450817
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2483.344482421875,
+          "test_best_rerun_mse": 2489.156494140625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.4414834635416667
+          "test_mse_by_total_triangles": 0.44251671006944443
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 668187.0,
+          "test_best_rerun_mse": 671566.0625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.5584199631234235
+          "test_mse_by_total_triangles": 7.596643354863523
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 218228.15625,
+          "test_best_rerun_mse": 219298.8125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.6315071014926863
+          "test_mse_by_total_triangles": 3.6493237565107415
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.1142974495887756,
-        "AvgTime/train_epoch_std": 0.09660268936913015,
+        "AvgTime/train_epoch_mean": 1.568298625946045,
+        "AvgTime/train_epoch_std": 0.029342083047591082,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -2649,82 +2687,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 12.645509719848633,
+      "test_loss": 9.253644943237305,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 12.546174049377441,
+      "test_best_rerun_mse": 9.081782341003418,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.00903903029494052,
+      "test_mse_by_total_triangles": 0.0065430708508670155,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.307722806930542,
+          "test_best_rerun_mse": 0.899366557598114,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.006882751615423905
+          "test_mse_by_total_triangles": 0.004733508197884811
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3522.205810546875,
+          "test_best_rerun_mse": 3456.438232421875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.26713733868387374
+          "test_mse_by_total_triangles": 0.2621492781510713
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 97.25257873535156,
+          "test_best_rerun_mse": 79.5461654663086,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03277808518212051
+          "test_mse_by_total_triangles": 0.026810301808664845
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3548.864990234375,
+          "test_best_rerun_mse": 3614.964599609375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4741302592163494
+          "test_mse_by_total_triangles": 0.4829612023526219
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42.969573974609375,
+          "test_best_rerun_mse": 41.63644790649414,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.037106713276864746
+          "test_mse_by_total_triangles": 0.03595548178453725
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 114716.9765625,
+          "test_best_rerun_mse": 115262.8828125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.663871831750418
+          "test_mse_by_total_triangles": 2.676548458399127
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7862.07568359375,
+          "test_best_rerun_mse": 7698.7001953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.5512603900991271
+          "test_mse_by_total_triangles": 0.5398050901214767
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35146.51171875,
+          "test_best_rerun_mse": 35576.63671875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.8015537300092266
+          "test_mse_by_total_triangles": 1.8236012465400584
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2473.23388671875,
+          "test_best_rerun_mse": 2489.942626953125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.43968602430555553
+          "test_mse_by_total_triangles": 0.4426564670138889
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 668402.6875,
+          "test_best_rerun_mse": 671298.6875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.56085978417022
+          "test_mse_by_total_triangles": 7.5936188534325755
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 218212.59375,
+          "test_best_rerun_mse": 218552.78125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.631248127901752
+          "test_mse_by_total_triangles": 3.6369091449919293
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.128329486846924,
-        "AvgTime/train_epoch_std": 0.05832462537668406,
+        "AvgTime/train_epoch_mean": 1.5519384729101302,
+        "AvgTime/train_epoch_std": 0.02210813860786259,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -2739,82 +2778,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.3081381916999817,
+      "test_loss": 0.29736092686653137,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.31007301807403564,
+      "test_best_rerun_mse": 0.29672926664352417,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.0016319632530212402,
+      "test_mse_by_total_triangles": 0.0015617329823343377,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 78.85900115966797,
+          "test_best_rerun_mse": 83.8833236694336,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.05681484233405473
+          "test_mse_by_total_triangles": 0.060434671231580396
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8850.91015625,
+          "test_best_rerun_mse": 9025.849609375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.6712863220515738
+          "test_mse_by_total_triangles": 0.6845543882726584
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 155.85470581054688,
+          "test_best_rerun_mse": 160.57508850097656,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.05252939191457596
+          "test_mse_by_total_triangles": 0.054120353387589
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6302.50146484375,
+          "test_best_rerun_mse": 6381.85400390625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.8420175637733801
+          "test_mse_by_total_triangles": 0.8526191053982966
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 89.40376281738281,
+          "test_best_rerun_mse": 91.45682525634766,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.07720532194938066
+          "test_mse_by_total_triangles": 0.0789782601522864
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 155213.5,
+          "test_best_rerun_mse": 156195.0,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.604251811257663
+          "test_mse_by_total_triangles": 3.6270434701839123
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11917.41796875,
+          "test_best_rerun_mse": 12049.2529296875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.8356063643773665
+          "test_mse_by_total_triangles": 0.8448501563376455
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 43040.48828125,
+          "test_best_rerun_mse": 43226.48046875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.2061862874186273
+          "test_mse_by_total_triangles": 2.2157199481649497
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3153.745849609375,
+          "test_best_rerun_mse": 3177.562744140625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.5606659288194444
+          "test_mse_by_total_triangles": 0.5649000434027778
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 729155.5625,
+          "test_best_rerun_mse": 730522.375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 8.248086179202064
+          "test_mse_by_total_triangles": 8.26354733436648
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 244693.3125,
+          "test_best_rerun_mse": 245493.921875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 4.071910413858519
+          "test_mse_by_total_triangles": 4.085233253041119
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9251926048942234,
-        "AvgTime/train_epoch_std": 0.22018143345370364,
+        "AvgTime/train_epoch_mean": 1.5225905922223937,
+        "AvgTime/train_epoch_std": 0.05579716922361043,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -2829,82 +2869,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.4112239480018616,
+      "test_loss": 0.41114673018455505,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.42299172282218933,
+      "test_best_rerun_mse": 0.4233161211013794,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.002226272225379944,
+      "test_mse_by_total_triangles": 0.0022279795847441023,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 73.9575424194336,
+          "test_best_rerun_mse": 74.08531188964844,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.05328353200247377
+          "test_mse_by_total_triangles": 0.05337558493490521
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8490.64453125,
+          "test_best_rerun_mse": 8488.087890625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.6439624217861206
+          "test_mse_by_total_triangles": 0.6437685165434206
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 158.04617309570312,
+          "test_best_rerun_mse": 157.882080078125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.05326800576194915
+          "test_mse_by_total_triangles": 0.053212699722994604
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6146.6513671875,
+          "test_best_rerun_mse": 6146.52001953125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.8211959074398798
+          "test_mse_by_total_triangles": 0.8211783593228122
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 87.06036376953125,
+          "test_best_rerun_mse": 87.04308319091797,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.07518166128629641
+          "test_mse_by_total_triangles": 0.07516673850683762
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 153319.59375,
+          "test_best_rerun_mse": 153301.6875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.5602729367917516
+          "test_mse_by_total_triangles": 3.559857131246517
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11654.525390625,
+          "test_best_rerun_mse": 11652.37890625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.8171732849968447
+          "test_mse_by_total_triangles": 0.8170227812543823
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42864.31640625,
+          "test_best_rerun_mse": 42862.87890625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.1971560001153314
+          "test_mse_by_total_triangles": 2.197082316174586
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3150.374267578125,
+          "test_best_rerun_mse": 3150.47119140625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.5600665364583334
+          "test_mse_by_total_triangles": 0.5600837673611111
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 727991.8125,
+          "test_best_rerun_mse": 727981.0625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 8.23492203318892
+          "test_mse_by_total_triangles": 8.23480043098085
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 244156.265625,
+          "test_best_rerun_mse": 244149.515625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 4.062973484848484
+          "test_mse_by_total_triangles": 4.062861158953622
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.741341961754693,
-        "AvgTime/train_epoch_std": 0.05127931431875007,
+        "AvgTime/train_epoch_mean": 1.5123972098032634,
+        "AvgTime/train_epoch_std": 0.023279685920329432,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -2919,82 +2960,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.27277523279190063,
+      "test_loss": 0.2678527235984802,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.27966779470443726,
+      "test_best_rerun_mse": 0.2748469412326813,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.0014719357616023014,
+      "test_mse_by_total_triangles": 0.0014465628485930593,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 85.76780700683594,
+          "test_best_rerun_mse": 85.87569427490234,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.061792368160544626
+          "test_mse_by_total_triangles": 0.061870096739843186
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8983.9189453125,
+          "test_best_rerun_mse": 8988.7470703125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.6813742089732651
+          "test_mse_by_total_triangles": 0.68174039213595
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 163.34149169921875,
+          "test_best_rerun_mse": 163.11587524414062,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.055052744084670965
+          "test_mse_by_total_triangles": 0.054976702138234114
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6363.36865234375,
+          "test_best_rerun_mse": 6370.43505859375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.8501494525509352
+          "test_mse_by_total_triangles": 0.8510935282022378
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 92.48614501953125,
+          "test_best_rerun_mse": 92.49531555175781,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.07986713732256584
+          "test_mse_by_total_triangles": 0.07987505660773558
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 156439.328125,
+          "test_best_rerun_mse": 156514.578125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.632717075167193
+          "test_mse_by_total_triangles": 3.634464474386959
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12026.1513671875,
+          "test_best_rerun_mse": 12024.15625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.843230358097567
+          "test_mse_by_total_triangles": 0.8430904676763428
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 43608.73828125,
+          "test_best_rerun_mse": 43629.7890625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.235313869560203
+          "test_mse_by_total_triangles": 2.236392898790302
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3238.78759765625,
+          "test_best_rerun_mse": 3238.36376953125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.5757844618055555
+          "test_mse_by_total_triangles": 0.5757091145833333
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 734378.3125,
+          "test_best_rerun_mse": 734462.875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 8.307165056615725
+          "test_mse_by_total_triangles": 8.308121613519903
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 247756.453125,
+          "test_best_rerun_mse": 247724.75,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 4.122883748939144
+          "test_mse_by_total_triangles": 4.122356181252393
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.0784563422203064,
-        "AvgTime/train_epoch_std": 0.2416846279358619,
+        "AvgTime/train_epoch_mean": 1.5078101732112743,
+        "AvgTime/train_epoch_std": 0.02080331501826689,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3009,82 +3051,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 378.66522216796875,
+      "test_loss": 353.5852355957031,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 385.5989990234375,
+      "test_best_rerun_mse": 351.22601318359375,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.029245278651758626,
+      "test_mse_by_total_triangles": 0.026638302099627892,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 123.6851577758789,
+          "test_best_rerun_mse": 127.94507598876953,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.08911034421893294
+          "test_mse_by_total_triangles": 0.09217944955963223
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 208.38890075683594,
+          "test_best_rerun_mse": 169.9383087158203,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.0967836881938733
+          "test_mse_by_total_triangles": 0.8944121511358963
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38.02388000488281,
+          "test_best_rerun_mse": 37.6472053527832,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.01281559824903364
+          "test_mse_by_total_triangles": 0.01268864352975504
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1860.5460205078125,
+          "test_best_rerun_mse": 1804.127685546875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.24856994261961424
+          "test_mse_by_total_triangles": 0.24103242291875418
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 209.5789337158203,
+          "test_best_rerun_mse": 179.3152313232422,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.18098353516046659
+          "test_mse_by_total_triangles": 0.15484907713578772
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71987.59375,
+          "test_best_rerun_mse": 70523.2109375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.671642061814973
+          "test_mse_by_total_triangles": 1.6376372593697752
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4461.40625,
+          "test_best_rerun_mse": 4307.69873046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.3128177149067452
+          "test_mse_by_total_triangles": 0.30204029802753823
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28453.953125,
+          "test_best_rerun_mse": 27865.048828125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.4585039276744067
+          "test_mse_by_total_triangles": 1.428317639454867
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2121.97705078125,
+          "test_best_rerun_mse": 2035.6029052734375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.3772403645833333
+          "test_mse_by_total_triangles": 0.3618849609375
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 596827.6875,
+          "test_best_rerun_mse": 593214.5,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.751215315091117
+          "test_mse_by_total_triangles": 6.710343540377589
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 187937.546875,
+          "test_best_rerun_mse": 186038.953125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.127444908308788
+          "test_mse_by_total_triangles": 3.0958506502421246
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.1815678344832525,
-        "AvgTime/train_epoch_std": 0.262898491579261,
+        "AvgTime/train_epoch_mean": 1.817377746105194,
+        "AvgTime/train_epoch_std": 0.018502073245315387,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3099,82 +3142,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 387.1382751464844,
+      "test_loss": 459.78887939453125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 394.55487060546875,
+      "test_best_rerun_mse": 466.90374755859375,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.029924525643190654,
+      "test_mse_by_total_triangles": 0.035411736636980946,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 183.14312744140625,
+          "test_best_rerun_mse": 136.1577911376953,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.13194749815663276
+          "test_mse_by_total_triangles": 0.09809639130957876
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 294.12896728515625,
+          "test_best_rerun_mse": 203.71041870117188,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.5480471962376645
+          "test_mse_by_total_triangles": 1.0721600984272204
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 89.81241607666016,
+          "test_best_rerun_mse": 48.42829132080078,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.030270446941914445
+          "test_mse_by_total_triangles": 0.016322309174519982
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1985.000244140625,
+          "test_best_rerun_mse": 1971.74169921875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.26519709340556114
+          "test_mse_by_total_triangles": 0.26342574471860386
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 295.2898864746094,
+          "test_best_rerun_mse": 213.6786651611328,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.2549999019642568
+          "test_mse_by_total_triangles": 0.1845238904672995
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 72102.046875,
+          "test_best_rerun_mse": 72268.234375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.6742998066830763
+          "test_mse_by_total_triangles": 1.6781588885147687
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4649.337890625,
+          "test_best_rerun_mse": 4607.32421875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.3259948037179218
+          "test_mse_by_total_triangles": 0.3230489565804235
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29102.529296875,
+          "test_best_rerun_mse": 28943.20703125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.4917489003472757
+          "test_mse_by_total_triangles": 1.4835822969526884
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2323.8515625,
+          "test_best_rerun_mse": 2211.06103515625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.41312916666666666
+          "test_mse_by_total_triangles": 0.39307751736111113
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 600349.0,
+          "test_best_rerun_mse": 599200.8125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.791047815119397
+          "test_mse_by_total_triangles": 6.778059709512121
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 189135.75,
+          "test_best_rerun_mse": 189331.421875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.1473840547151917
+          "test_mse_by_total_triangles": 3.15064020559799
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9958416938781738,
-        "AvgTime/train_epoch_std": 0.06779997573954312,
+        "AvgTime/train_epoch_mean": 1.8057901859283447,
+        "AvgTime/train_epoch_std": 0.015357465258987606,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3189,82 +3233,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 639.341064453125,
+      "test_loss": 646.0679931640625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 660.5391235351562,
+      "test_best_rerun_mse": 667.1400756835938,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.05009777197839638,
+      "test_mse_by_total_triangles": 0.0505984130211296,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 212.04339599609375,
+          "test_best_rerun_mse": 220.50997924804688,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.15276901728825198
+          "test_mse_by_total_triangles": 0.15886886112971677
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 412.2167053222656,
+          "test_best_rerun_mse": 428.7188415527344,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 2.169561606959293
+          "test_mse_by_total_triangles": 2.2564149555407074
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 108.25251007080078,
+          "test_best_rerun_mse": 114.19477844238281,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03648551064064738
+          "test_mse_by_total_triangles": 0.03848829741907071
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2017.9471435546875,
+          "test_best_rerun_mse": 2024.4130859375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.26959881677417336
+          "test_mse_by_total_triangles": 0.27046267013193054
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 421.4264831542969,
+          "test_best_rerun_mse": 437.2146301269531,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.36392615125586947
+          "test_mse_by_total_triangles": 0.37756012964331015
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74364.8515625,
+          "test_best_rerun_mse": 74350.4375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.7268449647617499
+          "test_mse_by_total_triangles": 1.7265102521827977
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5015.43310546875,
+          "test_best_rerun_mse": 5017.228515625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.35166407975520614
+          "test_mse_by_total_triangles": 0.3517899674396999
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29505.154296875,
+          "test_best_rerun_mse": 29546.5390625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.512386811055154
+          "test_mse_by_total_triangles": 1.514508127659029
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2544.94873046875,
+          "test_best_rerun_mse": 2564.885986328125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.4524353298611111
+          "test_mse_by_total_triangles": 0.45597973090277777
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 603994.4375,
+          "test_best_rerun_mse": 604010.125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.832284396457133
+          "test_mse_by_total_triangles": 6.832461850842166
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 192109.875,
+          "test_best_rerun_mse": 192092.40625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.196876092057311
+          "test_mse_by_total_triangles": 3.1965853968016242
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.0089989602565765,
-        "AvgTime/train_epoch_std": 0.04547272680621796,
+        "AvgTime/train_epoch_mean": 1.8043332397937775,
+        "AvgTime/train_epoch_std": 0.014015475381324777,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3279,82 +3324,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 11.803399085998535,
+      "test_loss": 13.249578475952148,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 12.061229705810547,
+      "test_best_rerun_mse": 13.205219268798828,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.004065126291139382,
+      "test_mse_by_total_triangles": 0.00445069742797399,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 103.55518341064453,
+          "test_best_rerun_mse": 102.05594635009766,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.07460748084340384
+          "test_mse_by_total_triangles": 0.07352733886894644
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 199.18247985839844,
+          "test_best_rerun_mse": 187.26901245117188,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.0483288413599918
+          "test_mse_by_total_triangles": 0.9856263813219572
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2542.71728515625,
+          "test_best_rerun_mse": 2568.96044921875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.19284924422876373
+          "test_mse_by_total_triangles": 0.1948396245141259
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3251.3046875,
+          "test_best_rerun_mse": 3561.7470703125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.434376043754175
+          "test_mse_by_total_triangles": 0.475851311998998
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 156.0255126953125,
+          "test_best_rerun_mse": 143.53436279296875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.13473705759526122
+          "test_mse_by_total_triangles": 0.12395022693693329
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 103863.453125,
+          "test_best_rerun_mse": 109335.1796875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.4118394279444546
+          "test_mse_by_total_triangles": 2.5388997698193387
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5458.2841796875,
+          "test_best_rerun_mse": 5912.05126953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.3827151998098093
+          "test_mse_by_total_triangles": 0.41453171150829127
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 34788.46875,
+          "test_best_rerun_mse": 35977.23828125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.7832010226049515
+          "test_mse_by_total_triangles": 1.8441354390922138
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2364.877197265625,
+          "test_best_rerun_mse": 2438.413330078125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.4204226128472222
+          "test_mse_by_total_triangles": 0.433495703125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 655974.9375,
+          "test_best_rerun_mse": 665786.375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.420279147766479
+          "test_mse_by_total_triangles": 7.531264493286427
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 204793.96875,
+          "test_best_rerun_mse": 209662.671875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.407950489241675
+          "test_mse_by_total_triangles": 3.4889699611435607
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.3616381689559582,
-        "AvgTime/train_epoch_std": 0.18392320190791794,
+        "AvgTime/train_epoch_mean": 1.7364071882688081,
+        "AvgTime/train_epoch_std": 0.04973837889563672,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3369,82 +3415,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 10.422069549560547,
+      "test_loss": 12.171700477600098,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 10.5987548828125,
+      "test_best_rerun_mse": 12.547347068786621,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.003572212633236434,
+      "test_mse_by_total_triangles": 0.004228967667268831,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 70.94097900390625,
+          "test_best_rerun_mse": 78.35623931884766,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.05111021542068173
+          "test_mse_by_total_triangles": 0.05645262198764241
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 141.83885192871094,
+          "test_best_rerun_mse": 148.4351043701172,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.746520273309005
+          "test_mse_by_total_triangles": 0.7812373914216694
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2822.218505859375,
+          "test_best_rerun_mse": 2769.9599609375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.21404766824872012
+          "test_mse_by_total_triangles": 0.2100841836130072
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3370.068115234375,
+          "test_best_rerun_mse": 3368.22216796875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4502429011669172
+          "test_mse_by_total_triangles": 0.4499962816257515
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 121.94825744628906,
+          "test_best_rerun_mse": 128.03082275390625,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.10530937603306482
+          "test_mse_by_total_triangles": 0.11056202310354599
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 106771.9765625,
+          "test_best_rerun_mse": 106877.0703125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.4793789838960616
+          "test_mse_by_total_triangles": 2.481819392357886
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5629.32666015625,
+          "test_best_rerun_mse": 5645.541015625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.3947080816264374
+          "test_mse_by_total_triangles": 0.3958449737501753
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35069.5859375,
+          "test_best_rerun_mse": 35093.265625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.797610638038854
+          "test_mse_by_total_triangles": 1.7988244207801527
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2320.130615234375,
+          "test_best_rerun_mse": 2336.021484375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.41246766493055553
+          "test_mse_by_total_triangles": 0.4152927083333333
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 656938.3125,
+          "test_best_rerun_mse": 657272.5625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.431176685180367
+          "test_mse_by_total_triangles": 7.434957665463842
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 206018.53125,
+          "test_best_rerun_mse": 206627.59375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.4283282786680647
+          "test_mse_by_total_triangles": 3.438463610570283
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.2862469439810895,
-        "AvgTime/train_epoch_std": 0.1264629268896518,
+        "AvgTime/train_epoch_mean": 1.729501485824585,
+        "AvgTime/train_epoch_std": 0.0230525437793974,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3459,82 +3506,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 12.19298267364502,
+      "test_loss": 11.460241317749023,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 12.322755813598633,
+      "test_best_rerun_mse": 11.521909713745117,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.004153271255004595,
+      "test_mse_by_total_triangles": 0.00388335345930068,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 107.97911834716797,
+          "test_best_rerun_mse": 95.53227996826172,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.07779475385242648
+          "test_mse_by_total_triangles": 0.06882729104341623
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 206.76878356933594,
+          "test_best_rerun_mse": 174.7046356201172,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.0882567556280838
+          "test_mse_by_total_triangles": 0.919498082211143
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2621.285400390625,
+          "test_best_rerun_mse": 2720.837646484375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.19880814564964921
+          "test_mse_by_total_triangles": 0.2063585624940747
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3399.566162109375,
+          "test_best_rerun_mse": 3348.96240234375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.45418385599323646
+          "test_mse_by_total_triangles": 0.44742316664579157
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 164.3838348388672,
+          "test_best_rerun_mse": 146.49693298339844,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.14195495236517028
+          "test_mse_by_total_triangles": 0.12650857770587084
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 107317.375,
+          "test_best_rerun_mse": 106522.4921875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.492043818502694
+          "test_mse_by_total_triangles": 2.4735856443316924
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5643.82373046875,
+          "test_best_rerun_mse": 5627.98681640625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.39572456390890126
+          "test_mse_by_total_triangles": 0.39461413661521877
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35768.21484375,
+          "test_best_rerun_mse": 35427.3203125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.833421233469168
+          "test_mse_by_total_triangles": 1.8159475274232406
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2457.94140625,
+          "test_best_rerun_mse": 2385.652587890625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.4369673611111111
+          "test_mse_by_total_triangles": 0.424116015625
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 661635.625,
+          "test_best_rerun_mse": 661015.8125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.484311901179824
+          "test_mse_by_total_triangles": 7.477300685497099
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 207862.1875,
+          "test_best_rerun_mse": 207075.5,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.459008328757093
+          "test_mse_by_total_triangles": 3.445917161732648
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.316800594329834,
-        "AvgTime/train_epoch_std": 0.05273835769616293,
+        "AvgTime/train_epoch_mean": 1.7042284445329146,
+        "AvgTime/train_epoch_std": 0.017512490170759315,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3549,82 +3597,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 503.96875,
+      "test_loss": 560.8211669921875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 520.1087036132812,
+      "test_best_rerun_mse": 580.6119384765625,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.06948680074993738,
+      "test_mse_by_total_triangles": 0.07757006526072979,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 109.4693374633789,
+          "test_best_rerun_mse": 97.00016021728516,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.07886839874883206
+          "test_mse_by_total_triangles": 0.06988484165510458
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20.508882522583008,
+          "test_best_rerun_mse": 11.935657501220703,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.1079414869609632
+          "test_mse_by_total_triangles": 0.06281925000642476
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1249.2552490234375,
+          "test_best_rerun_mse": 1118.1707763671875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.09474821759753034
+          "test_mse_by_total_triangles": 0.08480627807107982
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 94.51726531982422,
+          "test_best_rerun_mse": 85.37681579589844,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03185617300971494
+          "test_mse_by_total_triangles": 0.02877546875493712
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 48.98493576049805,
+          "test_best_rerun_mse": 37.479373931884766,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.04230132621804667
+          "test_mse_by_total_triangles": 0.03236560788591085
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 30499.119140625,
+          "test_best_rerun_mse": 32534.19921875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.7082277340847344
+          "test_mse_by_total_triangles": 0.7554848416020342
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2385.191162109375,
+          "test_best_rerun_mse": 2473.729248046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.16724100140999684
+          "test_mse_by_total_triangles": 0.17344897265789336
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15983.6298828125,
+          "test_best_rerun_mse": 17023.71484375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.8192951910816803
+          "test_mse_by_total_triangles": 0.8726082753472756
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1145.299560546875,
+          "test_best_rerun_mse": 1202.1915283203125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.2036088107638889
+          "test_mse_by_total_triangles": 0.21372293836805556
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 446834.6875,
+          "test_best_rerun_mse": 460559.40625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.054519501600624
+          "test_mse_by_total_triangles": 5.2097712323111205
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 136855.125,
+          "test_best_rerun_mse": 141538.171875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.2773887973640856
+          "test_mse_by_total_triangles": 2.355318787129949
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9293341934680939,
-        "AvgTime/train_epoch_std": 0.16782526303084885,
+        "AvgTime/train_epoch_mean": 1.576195044395251,
+        "AvgTime/train_epoch_std": 0.02817426102452655,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3639,82 +3688,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 683.6021118164062,
+      "test_loss": 674.4276733398438,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 706.9229125976562,
+      "test_best_rerun_mse": 697.7672729492188,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.09444527890416249,
+      "test_mse_by_total_triangles": 0.09322208055433784,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74.80260467529297,
+          "test_best_rerun_mse": 96.91741180419922,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.053892366480758624
+          "test_mse_by_total_triangles": 0.06982522464279482
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.821006774902344,
+          "test_best_rerun_mse": 20.856847763061523,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.09905793039422287
+          "test_mse_by_total_triangles": 0.1097728829634817
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1115.6746826171875,
+          "test_best_rerun_mse": 1092.4779052734375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.08461696493114808
+          "test_mse_by_total_triangles": 0.0828576340745876
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 89.49679565429688,
+          "test_best_rerun_mse": 107.72506713867188,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.030164069987966592
+          "test_mse_by_total_triangles": 0.03630774086237677
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21.52437973022461,
+          "test_best_rerun_mse": 24.971080780029297,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.018587547262715554
+          "test_mse_by_total_triangles": 0.02156397303974896
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 36455.3671875,
+          "test_best_rerun_mse": 34491.96484375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.8465392714912688
+          "test_mse_by_total_triangles": 0.8009466107131247
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2196.82568359375,
+          "test_best_rerun_mse": 2080.827392578125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.15403349345069065
+          "test_mse_by_total_triangles": 0.14590011166583403
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17500.052734375,
+          "test_best_rerun_mse": 17157.34765625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.897024590413399
+          "test_mse_by_total_triangles": 0.8794580786431904
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1130.426513671875,
+          "test_best_rerun_mse": 1155.82373046875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.20096471354166667
+          "test_mse_by_total_triangles": 0.20547977430555556
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 466658.03125,
+          "test_best_rerun_mse": 458757.28125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.2787578617241495
+          "test_mse_by_total_triangles": 5.1893858947094555
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 139097.09375,
+          "test_best_rerun_mse": 136604.59375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.314697115304611
+          "test_mse_by_total_triangles": 2.27321973857188
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.0070855696996053,
-        "AvgTime/train_epoch_std": 0.17082144587109555,
+        "AvgTime/train_epoch_mean": 1.5648568272590637,
+        "AvgTime/train_epoch_std": 0.018084002021957427,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3729,82 +3779,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 592.7628784179688,
+      "test_loss": 706.4010620117188,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 624.4166870117188,
+      "test_best_rerun_mse": 731.2543334960938,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.08342240307437793,
+      "test_mse_by_total_triangles": 0.09769596973895708,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52.80908966064453,
+          "test_best_rerun_mse": 147.64320373535156,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.0380468945681877
+          "test_mse_by_total_triangles": 0.10637118424737144
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14.418086051940918,
+          "test_best_rerun_mse": 32.097774505615234,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.07588466343126798
+          "test_mse_by_total_triangles": 0.16893565529271176
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1143.8890380859375,
+          "test_best_rerun_mse": 1175.41748046875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.08675684778808779
+          "test_mse_by_total_triangles": 0.0891480834636898
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71.3869400024414,
+          "test_best_rerun_mse": 159.28370666503906,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.024060310078342233
+          "test_mse_by_total_triangles": 0.053685105043828465
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23.276708602905273,
+          "test_best_rerun_mse": 42.47596740722656,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.02010078463117899
+          "test_mse_by_total_triangles": 0.03668045544665506
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 31586.44921875,
+          "test_best_rerun_mse": 33380.875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.7334768999338195
+          "test_mse_by_total_triangles": 0.7751457133568642
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2187.659423828125,
+          "test_best_rerun_mse": 2233.651123046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.15339078837667403
+          "test_mse_by_total_triangles": 0.15661556044361766
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16633.912109375,
+          "test_best_rerun_mse": 16904.455078125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.8526276133771593
+          "test_mse_by_total_triangles": 0.8664952113447639
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1077.247314453125,
+          "test_best_rerun_mse": 1172.9788818359375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.19151063368055554
+          "test_mse_by_total_triangles": 0.20852957899305555
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 456958.1875,
+          "test_best_rerun_mse": 458325.21875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.169034846102508
+          "test_mse_by_total_triangles": 5.184498475730462
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 136057.546875,
+          "test_best_rerun_mse": 138498.765625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.2641164008287156
+          "test_mse_by_total_triangles": 2.3047404127768627
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9264134378994213,
-        "AvgTime/train_epoch_std": 0.16237682451376415,
+        "AvgTime/train_epoch_mean": 1.5653613408406575,
+        "AvgTime/train_epoch_std": 0.02188673288808037,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3819,82 +3870,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 25.993793487548828,
+      "test_loss": 28.825387954711914,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 22.538742065429688,
+      "test_best_rerun_mse": 24.225263595581055,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.019463507828523047,
+      "test_mse_by_total_triangles": 0.020919916749206437,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71.16769409179688,
+          "test_best_rerun_mse": 93.52259063720703,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.051273554821179304
+          "test_mse_by_total_triangles": 0.06737938806715205
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4.712486267089844,
+          "test_best_rerun_mse": 5.964328765869141,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.02480255930047286
+          "test_mse_by_total_triangles": 0.03139120403089021
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2680.048828125,
+          "test_best_rerun_mse": 2244.340087890625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.20326498506825938
+          "test_mse_by_total_triangles": 0.17021919513770384
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 43.36056137084961,
+          "test_best_rerun_mse": 37.61042785644531,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.014614277509554975
+          "test_mse_by_total_triangles": 0.01267624801363172
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2139.107177734375,
+          "test_best_rerun_mse": 2181.177490234375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.28578586208876083
+          "test_mse_by_total_triangles": 0.2914064783212258
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 88741.2421875,
+          "test_best_rerun_mse": 88610.7734375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.0606827556079326
+          "test_mse_by_total_triangles": 2.0576531078743265
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4980.28076171875,
+          "test_best_rerun_mse": 4800.2001953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.349199324198482
+          "test_mse_by_total_triangles": 0.33657272439436964
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29722.283203125,
+          "test_best_rerun_mse": 29775.79296875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.5235164899853915
+          "test_mse_by_total_triangles": 1.5262593146112051
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1904.0845947265625,
+          "test_best_rerun_mse": 1876.71142578125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.3385039279513889
+          "test_mse_by_total_triangles": 0.33363758680555555
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 614709.125,
+          "test_best_rerun_mse": 614666.9375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.953487155413278
+          "test_mse_by_total_triangles": 6.953009937445562
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 192865.859375,
+          "test_best_rerun_mse": 192136.140625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.2094563322683176
+          "test_mse_by_total_triangles": 3.197313174995424
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.8640788048505783,
-        "AvgTime/train_epoch_std": 0.20330605054257747,
+        "AvgTime/train_epoch_mean": 1.4988766728025493,
+        "AvgTime/train_epoch_std": 0.0749926131325798,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3909,82 +3961,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 22.284801483154297,
+      "test_loss": 24.35521697998047,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 22.33067512512207,
+      "test_best_rerun_mse": 24.220691680908203,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.019283829987152046,
+      "test_mse_by_total_triangles": 0.02091596863636287,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 39.7210807800293,
+          "test_best_rerun_mse": 48.696861267089844,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.02861749335736981
+          "test_mse_by_total_triangles": 0.035084193996462426
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3.8673925399780273,
+          "test_best_rerun_mse": 4.389904975891113,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.020354697578831724
+          "test_mse_by_total_triangles": 0.023104763031005858
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3066.603759765625,
+          "test_best_rerun_mse": 2675.17822265625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.2325827652457812
+          "test_mse_by_total_triangles": 0.20289558002701935
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 62.913761138916016,
+          "test_best_rerun_mse": 47.39038848876953,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.02120450324870779
+          "test_mse_by_total_triangles": 0.015972493592440018
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2388.325927734375,
+          "test_best_rerun_mse": 2530.924072265625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.3190816202717936
+          "test_mse_by_total_triangles": 0.3381328085859218
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 90935.6875,
+          "test_best_rerun_mse": 94692.3203125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.111640523407022
+          "test_mse_by_total_triangles": 2.1988742409553224
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5489.970703125,
+          "test_best_rerun_mse": 5557.890625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.3849369445466975
+          "test_mse_by_total_triangles": 0.38969924449586313
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 30264.029296875,
+          "test_best_rerun_mse": 31301.56640625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.5512855244694757
+          "test_mse_by_total_triangles": 1.604468009956943
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2017.910400390625,
+          "test_best_rerun_mse": 2077.5263671875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.3587396267361111
+          "test_mse_by_total_triangles": 0.36933802083333334
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 619181.75,
+          "test_best_rerun_mse": 629779.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.004080743866158
+          "test_mse_by_total_triangles": 7.123962139293916
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 195190.859375,
+          "test_best_rerun_mse": 199371.625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.2481463627211156
+          "test_mse_by_total_triangles": 3.3177179538382173
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.8560639072108913,
-        "AvgTime/train_epoch_std": 0.2270847848222068,
+        "AvgTime/train_epoch_mean": 1.4847408433755238,
+        "AvgTime/train_epoch_std": 0.021831376136016743,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -3999,82 +4052,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 26.107192993164062,
+      "test_loss": 25.328540802001953,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 25.34513282775879,
+      "test_best_rerun_mse": 23.95280647277832,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.02188698862500759,
+      "test_mse_by_total_triangles": 0.020684634259739484,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 128.79531860351562,
+          "test_best_rerun_mse": 115.90579223632812,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.09279201628495362
+          "test_mse_by_total_triangles": 0.08350561400311825
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5.63133430480957,
+          "test_best_rerun_mse": 4.338724136352539,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.029638601604260895
+          "test_mse_by_total_triangles": 0.022835390191329154
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2112.346435546875,
+          "test_best_rerun_mse": 2107.63037109375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.16020830000355518
+          "test_mse_by_total_triangles": 0.15985061593430033
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 49.20283889770508,
+          "test_best_rerun_mse": 44.8409423828125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.016583363295485366
+          "test_mse_by_total_triangles": 0.015113226283388102
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2175.394287109375,
+          "test_best_rerun_mse": 2231.763427734375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.29063383929316966
+          "test_mse_by_total_triangles": 0.29816478660445894
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 85706.703125,
+          "test_best_rerun_mse": 86698.4921875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.9902169590609327
+          "test_mse_by_total_triangles": 2.0132475429012633
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4812.70849609375,
+          "test_best_rerun_mse": 4794.2685546875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.3374497613303709
+          "test_mse_by_total_triangles": 0.3361568191479105
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29494.447265625,
+          "test_best_rerun_mse": 29651.673828125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.5118379858334614
+          "test_mse_by_total_triangles": 1.5198971668524783
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1874.90869140625,
+          "test_best_rerun_mse": 1881.8782958984375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.3333171006944444
+          "test_mse_by_total_triangles": 0.33455614149305557
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 612675.0,
+          "test_best_rerun_mse": 612833.25,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.9304774724839655
+          "test_mse_by_total_triangles": 6.932267570105087
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 190778.546875,
+          "test_best_rerun_mse": 190915.09375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.1747216293911102
+          "test_mse_by_total_triangles": 3.176993888639276
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.009482741355896,
-        "AvgTime/train_epoch_std": 0.21715718555008973,
+        "AvgTime/train_epoch_mean": 1.4844607664988592,
+        "AvgTime/train_epoch_std": 0.020575717216992525,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4089,82 +4143,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 6545.58984375,
+      "test_loss": 6764.2490234375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 6251.552734375,
+      "test_best_rerun_mse": 6149.849609375,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.14516888199830486,
+      "test_mse_by_total_triangles": 0.14280720809434794,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 781.037109375,
+          "test_best_rerun_mse": 814.7398681640625,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.5627068511347262
+          "test_mse_by_total_triangles": 0.5869883776398145
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 298.10443115234375,
+          "test_best_rerun_mse": 289.0301513671875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.5689706902754934
+          "test_mse_by_total_triangles": 1.5212113229851973
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3042.3662109375,
+          "test_best_rerun_mse": 3068.2353515625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.23074449836461888
+          "test_mse_by_total_triangles": 0.23270651130546074
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 262.3623046875,
+          "test_best_rerun_mse": 460.28839111328125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.08842679632204246
+          "test_mse_by_total_triangles": 0.1551359592562458
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1592.4658203125,
+          "test_best_rerun_mse": 1446.0350341796875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.21275428461088844
+          "test_mse_by_total_triangles": 0.19319105333061956
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 372.03118896484375,
+          "test_best_rerun_mse": 400.6950988769531,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.32127045679174765
+          "test_mse_by_total_triangles": 0.34602340144814603
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 600.2036743164062,
+          "test_best_rerun_mse": 644.445068359375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.04208411683609636
+          "test_mse_by_total_triangles": 0.045186163817092624
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6486.09814453125,
+          "test_best_rerun_mse": 6108.55224609375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.332466971373789
+          "test_mse_by_total_triangles": 0.3131145751239812
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 844.951171875,
+          "test_best_rerun_mse": 897.642822265625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.15021354166666667
+          "test_mse_by_total_triangles": 0.15958094618055554
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 254683.203125,
+          "test_best_rerun_mse": 254496.265625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.8809339403074556
+          "test_mse_by_total_triangles": 2.8788193344682873
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 61721.98046875,
+          "test_best_rerun_mse": 62013.765625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.0271076576098714
+          "test_mse_by_total_triangles": 1.0319632174296507
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.193132479985555,
-        "AvgTime/train_epoch_std": 0.1620631394540739,
+        "AvgTime/train_epoch_mean": 1.951985627412796,
+        "AvgTime/train_epoch_std": 0.012892514159365426,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4179,82 +4234,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 6227.37646484375,
+      "test_loss": 6017.1025390625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 6279.42919921875,
+      "test_best_rerun_mse": 5994.6806640625,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.14581620841581716,
+      "test_mse_by_total_triangles": 0.13920399089872051,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 979.286376953125,
+          "test_best_rerun_mse": 882.3169555664062,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.7055377355570065
+          "test_mse_by_total_triangles": 0.6356750400334339
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 496.2987976074219,
+          "test_best_rerun_mse": 171.69796752929688,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 2.6120989347759047
+          "test_mse_by_total_triangles": 0.9036735133120888
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3419.745361328125,
+          "test_best_rerun_mse": 4131.02978515625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.2593663527742226
+          "test_mse_by_total_triangles": 0.31331283922307546
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 172.99481201171875,
+          "test_best_rerun_mse": 679.052978515625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.058306306711061254
+          "test_mse_by_total_triangles": 0.22886854685393496
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1552.35205078125,
+          "test_best_rerun_mse": 1575.214111328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.20739506356462925
+          "test_mse_by_total_triangles": 0.2104494470712258
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 471.02447509765625,
+          "test_best_rerun_mse": 233.34585571289062,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.40675688695825235
+          "test_mse_by_total_triangles": 0.20150764742045824
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 973.4139404296875,
+          "test_best_rerun_mse": 746.5198364257812,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.06825227460592397
+          "test_mse_by_total_triangles": 0.0523432783919353
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5983.74267578125,
+          "test_best_rerun_mse": 5555.97265625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.30671703704860576
+          "test_mse_by_total_triangles": 0.28479023303347173
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1086.7098388671875,
+          "test_best_rerun_mse": 645.2376708984375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.19319286024305554
+          "test_mse_by_total_triangles": 0.11470891927083333
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 277919.875,
+          "test_best_rerun_mse": 271554.1875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.1437832992093027
+          "test_mse_by_total_triangles": 3.071775703313236
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74262.28125,
+          "test_best_rerun_mse": 67807.0546875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.235789214217962
+          "test_mse_by_total_triangles": 1.128368606784484
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.2721964200337728,
-        "AvgTime/train_epoch_std": 0.4005031649731885,
+        "AvgTime/train_epoch_mean": 1.9209736453162298,
+        "AvgTime/train_epoch_std": 0.07241526685083927,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4269,82 +4325,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 6741.359375,
+      "test_loss": 5083.2451171875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 6188.125,
+      "test_best_rerun_mse": 5127.091796875,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.14369601058889095,
+      "test_mse_by_total_triangles": 0.1190574911033578,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 500.9801025390625,
+          "test_best_rerun_mse": 651.8108520507812,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.3609366732990364
+          "test_mse_by_total_triangles": 0.4696043602671335
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 216.24069213867188,
+          "test_best_rerun_mse": 563.3274536132812,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.1381089059930098
+          "test_mse_by_total_triangles": 2.9648813348067433
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2002.06787109375,
+          "test_best_rerun_mse": 1833.6666259765625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.15184435882394767
+          "test_mse_by_total_triangles": 0.13907217489393725
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 418.1714172363281,
+          "test_best_rerun_mse": 158.5806121826172,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.1409408214480378
+          "test_mse_by_total_triangles": 0.053448133529699085
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 862.9212646484375,
+          "test_best_rerun_mse": 1018.630615234375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.11528674210399967
+          "test_mse_by_total_triangles": 0.1360895945536907
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 216.75759887695312,
+          "test_best_rerun_mse": 547.8063354492188,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.1871827278730165
+          "test_mse_by_total_triangles": 0.47306246584561207
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 763.0505981445312,
+          "test_best_rerun_mse": 626.9188232421875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.05350235578071317
+          "test_mse_by_total_triangles": 0.04395728672291316
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6281.98681640625,
+          "test_best_rerun_mse": 6285.642578125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.32200455258630634
+          "test_mse_by_total_triangles": 0.3221919410592547
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 752.8304443359375,
+          "test_best_rerun_mse": 1058.699951171875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.1338365234375
+          "test_mse_by_total_triangles": 0.1882133246527778
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 276472.3125,
+          "test_best_rerun_mse": 274337.1875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.127408713505198
+          "test_mse_by_total_triangles": 3.103256535411694
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 70689.203125,
+          "test_best_rerun_mse": 70078.3828125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.176330073802273
+          "test_mse_by_total_triangles": 1.1661654903649343
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.2172074010295253,
-        "AvgTime/train_epoch_std": 0.16023126750917036,
+        "AvgTime/train_epoch_mean": 1.9474797171931113,
+        "AvgTime/train_epoch_std": 0.04636329916668802,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4359,82 +4416,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 670.9794311523438,
+      "test_loss": 679.0528564453125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 609.0438232421875,
+      "test_best_rerun_mse": 633.147216796875,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.04270395619423556,
+      "test_mse_by_total_triangles": 0.04439399921447728,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 654.625732421875,
+          "test_best_rerun_mse": 600.1466674804688,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.4716323720618696
+          "test_mse_by_total_triangles": 0.4323823252741129
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 294.5061340332031,
+          "test_best_rerun_mse": 261.5605773925781,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.5500322843852796
+          "test_mse_by_total_triangles": 1.3766346178556743
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2619.6611328125,
+          "test_best_rerun_mse": 2307.911376953125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.1986849550862723
+          "test_mse_by_total_triangles": 0.17504068084589497
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 112.96220397949219,
+          "test_best_rerun_mse": 147.668212890625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.038072869558305425
+          "test_mse_by_total_triangles": 0.04977020993954331
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1076.2745361328125,
+          "test_best_rerun_mse": 989.9683227539062,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.14379085319075652
+          "test_mse_by_total_triangles": 0.13226029696110972
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 208.79495239257812,
+          "test_best_rerun_mse": 191.91966247558594,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.18030652192796037
+          "test_mse_by_total_triangles": 0.16573373270775987
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20481.01953125,
+          "test_best_rerun_mse": 21461.150390625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.47559491759358163
+          "test_mse_by_total_triangles": 0.49835478336023126
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15992.7021484375,
+          "test_best_rerun_mse": 16417.51171875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.819760220843585
+          "test_mse_by_total_triangles": 0.8415352769875442
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1172.078369140625,
+          "test_best_rerun_mse": 1156.611572265625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.20836948784722223
+          "test_mse_by_total_triangles": 0.20561983506944445
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 423028.59375,
+          "test_best_rerun_mse": 428227.90625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.785228937366379
+          "test_mse_by_total_triangles": 4.844042693686866
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 113690.9453125,
+          "test_best_rerun_mse": 114351.015625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.8919166177841014
+          "test_mse_by_total_triangles": 1.902900764232107
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9694636397891574,
-        "AvgTime/train_epoch_std": 0.05360914279485434,
+        "AvgTime/train_epoch_mean": 1.7435894111792247,
+        "AvgTime/train_epoch_std": 0.0157298017631647,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4449,82 +4507,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 560.236328125,
+      "test_loss": 512.7718505859375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 569.5383911132812,
+      "test_best_rerun_mse": 513.889892578125,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.03993397778104622,
+      "test_mse_by_total_triangles": 0.036032105776057005,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 686.8009033203125,
+          "test_best_rerun_mse": 612.777099609375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.49481333092241536
+          "test_mse_by_total_triangles": 0.44148206023730185
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 661.7021484375,
+          "test_best_rerun_mse": 518.600341796875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 3.482642886513158
+          "test_mse_by_total_triangles": 2.729475483141447
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3114.0087890625,
+          "test_best_rerun_mse": 2873.367919921875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.2361781409982935
+          "test_mse_by_total_triangles": 0.21792703222767348
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 100.6259536743164,
+          "test_best_rerun_mse": 84.15560150146484,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03391505010930786
+          "test_mse_by_total_triangles": 0.028363869734231495
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1079.124755859375,
+          "test_best_rerun_mse": 1059.3006591796875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.1441716440693888
+          "test_mse_by_total_triangles": 0.14152313415894288
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 478.0623474121094,
+          "test_best_rerun_mse": 403.5762023925781,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.41283449690164886
+          "test_mse_by_total_triangles": 0.3485114010298602
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22721.5859375,
+          "test_best_rerun_mse": 21867.07421875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.5276236749373027
+          "test_mse_by_total_triangles": 0.5077808429024243
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16488.5390625,
+          "test_best_rerun_mse": 16155.158203125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.8451760245271414
+          "test_mse_by_total_triangles": 0.8280874572312779
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1325.480224609375,
+          "test_best_rerun_mse": 1244.1370849609375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.23564092881944446
+          "test_mse_by_total_triangles": 0.22117992621527777
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 426004.8125,
+          "test_best_rerun_mse": 425706.8125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.818895427756977
+          "test_mse_by_total_triangles": 4.815524501430947
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 113327.9765625,
+          "test_best_rerun_mse": 112581.2109375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.885876500798762
+          "test_mse_by_total_triangles": 1.8734496686386102
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.2271321850853996,
-        "AvgTime/train_epoch_std": 0.21326339868393307,
+        "AvgTime/train_epoch_mean": 1.7651659029501456,
+        "AvgTime/train_epoch_std": 0.017938767958655136,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4539,82 +4598,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 612.521484375,
+      "test_loss": 606.9447021484375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 576.9708251953125,
+      "test_best_rerun_mse": 569.634765625,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.040455113251669644,
+      "test_mse_by_total_triangles": 0.03994073521420558,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 598.7774658203125,
+          "test_best_rerun_mse": 570.8294067382812,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.43139586874662283
+          "test_mse_by_total_triangles": 0.41126037949443894
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 297.19390869140625,
+          "test_best_rerun_mse": 228.2942657470703,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.564178466796875
+          "test_mse_by_total_triangles": 1.2015487670898437
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2512.64208984375,
+          "test_best_rerun_mse": 2478.066162109375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.1905682282778726
+          "test_mse_by_total_triangles": 0.1879458598490235
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 129.6917724609375,
+          "test_best_rerun_mse": 133.91004943847656,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.043711416400720425
+          "test_mse_by_total_triangles": 0.045133147771646974
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1020.4879150390625,
+          "test_best_rerun_mse": 928.2572021484375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.13633773080014194
+          "test_mse_by_total_triangles": 0.12401565826966433
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 223.038330078125,
+          "test_best_rerun_mse": 177.09317016601562,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.19260650265813903
+          "test_mse_by_total_triangles": 0.15293019876167152
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22753.279296875,
+          "test_best_rerun_mse": 22978.443359375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.5283596344249257
+          "test_mse_by_total_triangles": 0.5335882258818271
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16859.248046875,
+          "test_best_rerun_mse": 16741.134765625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.8641779715451843
+          "test_mse_by_total_triangles": 0.858123674489979
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1183.6895751953125,
+          "test_best_rerun_mse": 1134.101318359375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.21043370225694444
+          "test_mse_by_total_triangles": 0.20161801215277778
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 427828.9375,
+          "test_best_rerun_mse": 427245.78125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.839529625691436
+          "test_mse_by_total_triangles": 4.832933059398437
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 114393.3203125,
+          "test_best_rerun_mse": 114058.8125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.9036047511773417
+          "test_mse_by_total_triangles": 1.89803824904731
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.275193979000223,
-        "AvgTime/train_epoch_std": 0.20819421019916878,
+        "AvgTime/train_epoch_mean": 1.7407696575954044,
+        "AvgTime/train_epoch_std": 0.022137733287144717,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4629,82 +4689,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 7325.28271484375,
+      "test_loss": 7277.9375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 7760.56005859375,
+      "test_best_rerun_mse": 7616.3857421875,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.3977938417445154,
+      "test_mse_by_total_triangles": 0.3904036978926393,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3430.628662109375,
+          "test_best_rerun_mse": 3067.19970703125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 2.471634482787734
+          "test_mse_by_total_triangles": 2.2097980598207854
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 256.2211608886719,
+          "test_best_rerun_mse": 285.9851379394531,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.3485324257298519
+          "test_mse_by_total_triangles": 1.5051849365234375
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18272.125,
+          "test_best_rerun_mse": 19811.62890625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 1.3858266970041715
+          "test_mse_by_total_triangles": 1.502588464637846
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1958.8870849609375,
+          "test_best_rerun_mse": 1730.87646484375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.6602248348368512
+          "test_mse_by_total_triangles": 0.583375957143158
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3314.624755859375,
+          "test_best_rerun_mse": 4352.8564453125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4428356387253674
+          "test_mse_by_total_triangles": 0.5815439472695391
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 701.769775390625,
+          "test_best_rerun_mse": 1247.8455810546875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.6060188043096935
+          "test_mse_by_total_triangles": 1.0775868575601792
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13633.53515625,
+          "test_best_rerun_mse": 15224.7099609375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.3165877567399684
+          "test_mse_by_total_triangles": 0.3535368279987344
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1414.6424560546875,
+          "test_best_rerun_mse": 1801.421875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.09918962670415703
+          "test_mse_by_total_triangles": 0.126309204529519
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1002.8284301757812,
+          "test_best_rerun_mse": 1454.23828125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.17828060980902777
+          "test_mse_by_total_triangles": 0.25853125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 236592.90625,
+          "test_best_rerun_mse": 220209.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.6762995175503095
+          "test_mse_by_total_triangles": 2.4909745709987217
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 58892.79296875,
+          "test_best_rerun_mse": 51938.88671875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.9800275068435591
+          "test_mse_by_total_triangles": 0.8643084339066114
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.086171719763014,
-        "AvgTime/train_epoch_std": 0.18691320129259212,
+        "AvgTime/train_epoch_mean": 1.6579567909240722,
+        "AvgTime/train_epoch_std": 0.02968724087687177,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4719,82 +4780,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 4560.27734375,
+      "test_loss": 5194.45849609375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 4788.18701171875,
+      "test_best_rerun_mse": 5457.99072265625,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.24543477429487673,
+      "test_mse_by_total_triangles": 0.2797678365193629,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3022.95654296875,
+          "test_best_rerun_mse": 3729.722412109375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 2.1779225813895895
+          "test_mse_by_total_triangles": 2.6871198934505585
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 430.0647277832031,
+          "test_best_rerun_mse": 280.6649475097656,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 2.2634985672800165
+          "test_mse_by_total_triangles": 1.4771839342619244
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13914.9716796875,
+          "test_best_rerun_mse": 24060.802734375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 1.0553637982318922
+          "test_mse_by_total_triangles": 1.824861792519909
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2190.68017578125,
+          "test_best_rerun_mse": 1463.7406005859375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.7383485594139704
+          "test_mse_by_total_triangles": 0.493340276570926
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3087.581298828125,
+          "test_best_rerun_mse": 4090.848388671875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4125025115334836
+          "test_mse_by_total_triangles": 0.546539530884686
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 612.018310546875,
+          "test_best_rerun_mse": 506.9618835449219,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.5285132215430699
+          "test_mse_by_total_triangles": 0.437790918432575
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9045.0048828125,
+          "test_best_rerun_mse": 15790.9384765625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.21003633853828024
+          "test_mse_by_total_triangles": 0.36668536310055966
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1462.2061767578125,
+          "test_best_rerun_mse": 1533.442138671875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.10252462324763795
+          "test_mse_by_total_triangles": 0.10751943196409164
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 688.679931640625,
+          "test_best_rerun_mse": 1014.356689453125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.12243198784722223
+          "test_mse_by_total_triangles": 0.180330078125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 222413.890625,
+          "test_best_rerun_mse": 214041.8125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.5159088563170933
+          "test_mse_by_total_triangles": 2.4212053041186383
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 57002.734375,
+          "test_best_rerun_mse": 52097.08984375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.948575281230759
+          "test_mse_by_total_triangles": 0.8669410720674621
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.0833421897888185,
-        "AvgTime/train_epoch_std": 0.15125815620077968,
+        "AvgTime/train_epoch_mean": 1.6385710672898726,
+        "AvgTime/train_epoch_std": 0.01897997700246597,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4809,82 +4871,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 5882.1708984375,
+      "test_loss": 6048.87548828125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 6146.6123046875,
+      "test_best_rerun_mse": 6298.70361328125,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.3150654725863704,
+      "test_mse_by_total_triangles": 0.32286142873962015,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1800.9210205078125,
+          "test_best_rerun_mse": 1939.9293212890625,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 1.297493530625225
+          "test_mse_by_total_triangles": 1.3976436032341948
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 219.47988891601562,
+          "test_best_rerun_mse": 373.5536804199219,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.1551573100842927
+          "test_mse_by_total_triangles": 1.966072002210115
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11453.724609375,
+          "test_best_rerun_mse": 10898.5205078125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.8686935615756541
+          "test_mse_by_total_triangles": 0.8265847939182783
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1139.908447265625,
+          "test_best_rerun_mse": 1302.1541748046875,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.38419563440027804
+          "test_mse_by_total_triangles": 0.438879061275594
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3141.68603515625,
+          "test_best_rerun_mse": 3408.825927734375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4197309332206079
+          "test_mse_by_total_triangles": 0.455420965629175
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 670.7903442382812,
+          "test_best_rerun_mse": 734.5104370117188,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.5792662730900529
+          "test_mse_by_total_triangles": 0.6342922599410352
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8187.33642578125,
+          "test_best_rerun_mse": 9481.712890625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.19012020308799113
+          "test_mse_by_total_triangles": 0.22017724527737786
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1061.10546875,
+          "test_best_rerun_mse": 1219.047607421875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.07440088828705652
+          "test_mse_by_total_triangles": 0.08547522138703373
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 759.8292846679688,
+          "test_best_rerun_mse": 661.5387573242188,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.13508076171875
+          "test_mse_by_total_triangles": 0.11760689019097222
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 199086.875,
+          "test_best_rerun_mse": 194348.453125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.252037543974752
+          "test_mse_by_total_triangles": 2.198437305577865
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 54830.24609375,
+          "test_best_rerun_mse": 47982.28515625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.9124231789684323
+          "test_mse_by_total_triangles": 0.7984671285549065
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9362340340247521,
-        "AvgTime/train_epoch_std": 0.15975040984252345,
+        "AvgTime/train_epoch_mean": 1.6620219349861145,
+        "AvgTime/train_epoch_std": 0.057443464202118766,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4899,82 +4962,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 878.8555908203125,
+      "test_loss": 909.8043823242188,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 927.1289672851562,
+      "test_best_rerun_mse": 965.3555297851562,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.1648229275173611,
+      "test_mse_by_total_triangles": 0.17161876085069444,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 257.2041015625,
+          "test_best_rerun_mse": 326.3340759277344,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.18530554867615273
+          "test_mse_by_total_triangles": 0.2351110057116242
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 50.2741584777832,
+          "test_best_rerun_mse": 35.111026763916016,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.2646008340935958
+          "test_mse_by_total_triangles": 0.18479487770482114
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1797.0189208984375,
+          "test_best_rerun_mse": 2216.4267578125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.13629267507762136
+          "test_mse_by_total_triangles": 0.16810214317880168
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 459.47796630859375,
+          "test_best_rerun_mse": 423.11224365234375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.1548628130463747
+          "test_mse_by_total_triangles": 0.1426060814466949
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1221.3031005859375,
+          "test_best_rerun_mse": 1375.4468994140625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.16316674690526886
+          "test_mse_by_total_triangles": 0.18376044080348197
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 63.335819244384766,
+          "test_best_rerun_mse": 47.04166030883789,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.054694144425202734
+          "test_mse_by_total_triangles": 0.04062319543077538
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 46601.328125,
+          "test_best_rerun_mse": 45222.9609375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.082141188115363
+          "test_mse_by_total_triangles": 1.0501337761819618
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1581.6458740234375,
+          "test_best_rerun_mse": 1403.45263671875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.11089930402632432
+          "test_mse_by_total_triangles": 0.09840503693161899
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18173.5390625,
+          "test_best_rerun_mse": 18000.263671875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.9315464176790199
+          "test_mse_by_total_triangles": 0.9226645995117638
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 457082.9375,
+          "test_best_rerun_mse": 456937.96875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.170445997307784
+          "test_mse_by_total_triangles": 5.168806134972795
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 113096.8515625,
+          "test_best_rerun_mse": 112309.0,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.8820303789542876
+          "test_mse_by_total_triangles": 1.868919840913251
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.7682966102253308,
-        "AvgTime/train_epoch_std": 0.05891345999995182,
+        "AvgTime/train_epoch_mean": 1.5439387321472169,
+        "AvgTime/train_epoch_std": 0.02011353769759716,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -4989,82 +5053,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 888.20849609375,
+      "test_loss": 919.71337890625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 939.51123046875,
+      "test_best_rerun_mse": 971.6712646484375,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.16702421875,
+      "test_mse_by_total_triangles": 0.17274155815972222,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 222.79620361328125,
+          "test_best_rerun_mse": 349.9826965332031,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.1605159968395398
+          "test_mse_by_total_triangles": 0.2521489168106651
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35.75049591064453,
+          "test_best_rerun_mse": 44.54586410522461,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.18816050479286595
+          "test_mse_by_total_triangles": 0.2344519163432874
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1971.5814208984375,
+          "test_best_rerun_mse": 2289.133056640625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.1495321517556646
+          "test_mse_by_total_triangles": 0.17361646239215964
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 293.37872314453125,
+          "test_best_rerun_mse": 416.845458984375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.09888059425161147
+          "test_mse_by_total_triangles": 0.14049391944198686
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1115.80908203125,
+          "test_best_rerun_mse": 1308.427734375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.1490726896501336
+          "test_mse_by_total_triangles": 0.17480664453907815
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35.810665130615234,
+          "test_best_rerun_mse": 49.03630065917969,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.030924581287232498
+          "test_mse_by_total_triangles": 0.042345682779947914
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38592.56640625,
+          "test_best_rerun_mse": 37791.26171875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.896167713316227
+          "test_mse_by_total_triangles": 0.8775604151669608
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 990.3029174804688,
+          "test_best_rerun_mse": 1029.921630859375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.06943646876177736
+          "test_mse_by_total_triangles": 0.07221439004763533
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17563.751953125,
+          "test_best_rerun_mse": 17461.83984375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.9002897100376749
+          "test_mse_by_total_triangles": 0.8950658590266031
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 447604.0625,
+          "test_best_rerun_mse": 448671.90625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.063222543352601
+          "test_mse_by_total_triangles": 5.075301813852471
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 110315.796875,
+          "test_best_rerun_mse": 113271.828125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.8357512002229877
+          "test_mse_by_total_triangles": 1.8849421417635996
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9048966339656286,
-        "AvgTime/train_epoch_std": 0.2576984905656883,
+        "AvgTime/train_epoch_mean": 1.5174132486184437,
+        "AvgTime/train_epoch_std": 0.029717770979886888,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -5079,82 +5144,83 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 821.763671875,
+      "test_loss": 809.4652709960938,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 854.8343505859375,
+      "test_best_rerun_mse": 847.4739379882812,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.15197055121527778,
+      "test_mse_by_total_triangles": 0.1506620334201389,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 178.32681274414062,
+          "test_best_rerun_mse": 261.2123107910156,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.12847753079549037
+          "test_mse_by_total_triangles": 0.1881933074863225
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 33.338470458984375,
+          "test_best_rerun_mse": 65.77201843261719,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.17546563399465462
+          "test_mse_by_total_triangles": 0.34616851806640625
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2011.2979736328125,
+          "test_best_rerun_mse": 1747.97412109375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.15254440452277682
+          "test_mse_by_total_triangles": 0.13257293296122488
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 335.8417053222656,
+          "test_best_rerun_mse": 424.3948669433594,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.11319235096807065
+          "test_mse_by_total_triangles": 0.14303837780362635
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 934.328857421875,
+          "test_best_rerun_mse": 1002.1353149414062,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.12482683465890114
+          "test_mse_by_total_triangles": 0.13388581361942636
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 54.869285583496094,
+          "test_best_rerun_mse": 96.02670288085938,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.04738280274913307
+          "test_mse_by_total_triangles": 0.08292461388675249
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 36380.8203125,
+          "test_best_rerun_mse": 31093.099609375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.8448081997143786
+          "test_mse_by_total_triangles": 0.7220207042860626
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1050.620849609375,
+          "test_best_rerun_mse": 804.4086303710938,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.0736657446087067
+          "test_mse_by_total_triangles": 0.05640223183081572
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16750.220703125,
+          "test_best_rerun_mse": 15452.6552734375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.8585894050502332
+          "test_mse_by_total_triangles": 0.792078285582936
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 433709.4375,
+          "test_best_rerun_mse": 416633.0,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.906048861463978
+          "test_mse_by_total_triangles": 4.71288304695542
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 110517.40625,
+          "test_best_rerun_mse": 105955.4609375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.8391061562910822
+          "test_mse_by_total_triangles": 1.7631914022847919
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.7229144191741943,
-        "AvgTime/train_epoch_std": 0.0428593871471292,
+        "AvgTime/train_epoch_mean": 1.5137105408836813,
+        "AvgTime/train_epoch_std": 0.02409021154564643,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -5169,82 +5235,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 151385.09375,
+      "test_loss": 168419.78125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 93542.296875,
+      "test_best_rerun_mse": 103321.96875,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 1.058134869574562,
+      "test_mse_by_total_triangles": 1.1687608876395597,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 48057.39453125,
+          "test_best_rerun_mse": 54383.03125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 34.62348309167867
+          "test_mse_by_total_triangles": 39.18085824927954
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14934.6396484375,
+          "test_best_rerun_mse": 15161.748046875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 78.60336657072368
+          "test_mse_by_total_triangles": 79.79867393092105
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 215454.703125,
+          "test_best_rerun_mse": 216057.09375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 16.340895193401593
+          "test_mse_by_total_triangles": 16.38658276450512
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13996.76953125,
+          "test_best_rerun_mse": 12176.3798828125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 4.717482147371082
+          "test_mse_by_total_triangles": 4.1039365968360295
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42600.76171875,
+          "test_best_rerun_mse": 47968.6328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 5.691484531563126
+          "test_mse_by_total_triangles": 6.408634978289913
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19264.50390625,
+          "test_best_rerun_mse": 20012.26171875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 16.636013735967186
+          "test_mse_by_total_triangles": 17.28174587111399
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 120710.3046875,
+          "test_best_rerun_mse": 109573.6640625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.803044414998607
+          "test_mse_by_total_triangles": 2.5444376756107188
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17710.720703125,
+          "test_best_rerun_mse": 15073.0751953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 1.241811856901206
+          "test_mse_by_total_triangles": 1.0568696673196256
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24002.48828125,
+          "test_best_rerun_mse": 29131.02734375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.2303289907863038
+          "test_mse_by_total_triangles": 1.4932096644497412
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14177.75,
+          "test_best_rerun_mse": 15081.376953125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 2.520488888888889
+          "test_mse_by_total_triangles": 2.6811336805555555
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29361.642578125,
+          "test_best_rerun_mse": 31214.08984375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.4886033744050888
+          "test_mse_by_total_triangles": 0.519429714671426
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.559237012863159,
-        "AvgTime/train_epoch_std": 0.21236916126175914,
+        "AvgTime/train_epoch_mean": 2.223341245651245,
+        "AvgTime/train_epoch_std": 0.019446387376177095,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -5259,82 +5326,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 146645.171875,
+      "test_loss": 150787.84375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 87195.3046875,
+      "test_best_rerun_mse": 86415.5625,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.9863387519371515,
+      "test_mse_by_total_triangles": 0.9775184382882934,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 48629.8984375,
+          "test_best_rerun_mse": 44501.078125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 35.035949882925074
+          "test_mse_by_total_triangles": 32.061295479106626
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18538.302734375,
+          "test_best_rerun_mse": 16231.8466796875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 97.57001439144737
+          "test_mse_by_total_triangles": 85.43077199835527
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 125039.6796875,
+          "test_best_rerun_mse": 112962.640625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 9.48347968809253
+          "test_mse_by_total_triangles": 8.567511613576034
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13790.1279296875,
+          "test_best_rerun_mse": 10943.212890625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 4.647835500400236
+          "test_mse_by_total_triangles": 3.6883090295331984
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 49664.6875,
+          "test_best_rerun_mse": 43543.5,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 6.635228790915163
+          "test_mse_by_total_triangles": 5.817434869739479
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22121.0,
+          "test_best_rerun_mse": 18270.017578125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 19.102763385146805
+          "test_mse_by_total_triangles": 15.777217252266839
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80580.890625,
+          "test_best_rerun_mse": 64043.02734375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.871189174832807
+          "test_mse_by_total_triangles": 1.48715928255039
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14981.3271484375,
+          "test_best_rerun_mse": 11364.052734375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 1.0504366251884378
+          "test_mse_by_total_triangles": 0.7968063900136727
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28320.796875,
+          "test_best_rerun_mse": 22004.71484375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.4516785522066737
+          "test_mse_by_total_triangles": 1.1279263336793275
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17148.9375,
+          "test_best_rerun_mse": 14273.8466796875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 3.0487
+          "test_mse_by_total_triangles": 2.5375727430555557
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25595.59765625,
+          "test_best_rerun_mse": 24695.5625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.42593309796898143
+          "test_mse_by_total_triangles": 0.4109557269565507
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.8173387611613556,
-        "AvgTime/train_epoch_std": 0.10797517106892388,
+        "AvgTime/train_epoch_mean": 2.4391850864186004,
+        "AvgTime/train_epoch_std": 0.16513499520449937,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -5349,82 +5417,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 139704.59375,
+      "test_loss": 105236.046875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 76578.234375,
+      "test_best_rerun_mse": 59617.97265625,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.8662402223340837,
+      "test_mse_by_total_triangles": 0.6743885688975487,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 46592.80859375,
+          "test_best_rerun_mse": 27740.552734375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 33.568305903278095
+          "test_mse_by_total_triangles": 19.985989001711093
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19658.30078125,
+          "test_best_rerun_mse": 7611.630859375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 103.46474095394737
+          "test_mse_by_total_triangles": 40.0612150493421
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 171703.234375,
+          "test_best_rerun_mse": 142694.84375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 13.022619216913158
+          "test_mse_by_total_triangles": 10.822513746681835
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 49877.375,
+          "test_best_rerun_mse": 28627.77734375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 16.81070947084597
+          "test_mse_by_total_triangles": 9.64872846098753
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 34696.234375,
+          "test_best_rerun_mse": 19995.517578125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 4.635435454241817
+          "test_mse_by_total_triangles": 2.6714118340848363
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21653.56640625,
+          "test_best_rerun_mse": 9252.865234375,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 18.69910743199482
+          "test_mse_by_total_triangles": 7.990384485643351
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56257.30078125,
+          "test_best_rerun_mse": 44071.59375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.3063649633394483
+          "test_mse_by_total_triangles": 1.0233975884729705
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29700.380859375,
+          "test_best_rerun_mse": 16571.275390625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 2.0824835829038704
+          "test_mse_by_total_triangles": 1.1619180613255504
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14655.0703125,
+          "test_best_rerun_mse": 8582.5478515625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.7511953617561126
+          "test_mse_by_total_triangles": 0.43992761553962273
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16603.115234375,
+          "test_best_rerun_mse": 8058.78857421875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 2.9516649305555553
+          "test_mse_by_total_triangles": 1.4326735243055555
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23156.298828125,
+          "test_best_rerun_mse": 19408.8359375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.38534103519752716
+          "test_mse_by_total_triangles": 0.32297997998934985
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.8250668965853176,
-        "AvgTime/train_epoch_std": 0.051275304799685915,
+        "AvgTime/train_epoch_mean": 2.2998632265596974,
+        "AvgTime/train_epoch_std": 0.059193429248981015,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -5439,78 +5508,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 13544.275390625,
+      "test_loss": 13429.384765625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 14199.4130859375,
+      "test_best_rerun_mse": 14027.4697265625,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.23629063428248714,
+      "test_mse_by_total_triangles": 0.23342934662211073,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13652.212890625,
+          "test_best_rerun_mse": 13192.6953125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 9.835888249729827
+          "test_mse_by_total_triangles": 9.504823712175792
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1536.26171875,
+          "test_best_rerun_mse": 1660.2935791015625,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 8.085587993421052
+          "test_mse_by_total_triangles": 8.738387258429276
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74451.671875,
+          "test_best_rerun_mse": 74197.9296875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 5.646694871065605
+          "test_mse_by_total_triangles": 5.627450109025408
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2575.313232421875,
+          "test_best_rerun_mse": 2571.51171875,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.8679855855820273
+          "test_mse_by_total_triangles": 0.8667043204415235
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16955.634765625,
+          "test_best_rerun_mse": 15836.9248046875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 2.265281865814963
+          "test_mse_by_total_triangles": 2.1158216171927187
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1988.72119140625,
+          "test_best_rerun_mse": 2126.254150390625,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 1.717375812958765
+          "test_mse_by_total_triangles": 1.8361434804754966
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 53200.84765625,
+          "test_best_rerun_mse": 51761.609375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.235390294822822
+          "test_mse_by_total_triangles": 1.201969379876463
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3365.4013671875,
+          "test_best_rerun_mse": 3967.157470703125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.23596980558038844
+          "test_mse_by_total_triangles": 0.27816277315265214
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5903.98583984375,
+          "test_best_rerun_mse": 5702.04296875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.30262882976286587
+          "test_mse_by_total_triangles": 0.29227756259931315
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2067.386962890625,
+          "test_best_rerun_mse": 2102.566162109375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.36753546006944443
+          "test_mse_by_total_triangles": 0.3737895399305556
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 95508.65625,
+          "test_best_rerun_mse": 101131.078125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.080377999049806
+          "test_mse_by_total_triangles": 1.1439778980916937
         }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9296613890549232,
+        "AvgTime/train_epoch_std": 0.01658946227326415,
+        "model/params/total": 109211,
+        "model/params/trainable": 109211,
+        "model/params/non_trainable": 0
       }
     },
     {
@@ -5522,82 +5599,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 11985.001953125,
+      "test_loss": 18983.70703125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 12511.1650390625,
+      "test_best_rerun_mse": 18542.224609375,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.20819671241346746,
+      "test_mse_by_total_triangles": 0.3085588106663838,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21159.01953125,
+          "test_best_rerun_mse": 16556.21875,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 15.244250382744957
+          "test_mse_by_total_triangles": 11.928111491354468
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2882.609130859375,
+          "test_best_rerun_mse": 1264.6876220703125,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 15.171627004523026
+          "test_mse_by_total_triangles": 6.656250642475329
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 109219.0234375,
+          "test_best_rerun_mse": 91653.1640625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 8.283581603147516
+          "test_mse_by_total_triangles": 6.951320748009101
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4008.584228515625,
+          "test_best_rerun_mse": 4714.005859375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 1.3510563628296681
+          "test_mse_by_total_triangles": 1.5888122208881024
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24865.828125,
+          "test_best_rerun_mse": 16656.603515625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 3.3220879258517035
+          "test_mse_by_total_triangles": 2.225331131012024
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3719.8837890625,
+          "test_best_rerun_mse": 2047.874755859375,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 3.2123348782923142
+          "test_mse_by_total_triangles": 1.7684583383932426
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80507.265625,
+          "test_best_rerun_mse": 70332.0625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.869479510147687
+          "test_mse_by_total_triangles": 1.6331985533159947
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5514.49755859375,
+          "test_best_rerun_mse": 6384.86279296875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.38665667918901625
+          "test_mse_by_total_triangles": 0.4476835502011464
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8183.50830078125,
+          "test_best_rerun_mse": 6588.47314453125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.4194734891988954
+          "test_mse_by_total_triangles": 0.3377145494146932
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3732.793212890625,
+          "test_best_rerun_mse": 2586.863525390625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.6636076822916667
+          "test_mse_by_total_triangles": 0.4598868489583333
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 93859.0390625,
+          "test_best_rerun_mse": 116986.7734375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.0617178044014344
+          "test_mse_by_total_triangles": 1.3233348804622016
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.5321378548940023,
-        "AvgTime/train_epoch_std": 0.18231201209615266,
+        "AvgTime/train_epoch_mean": 1.9321708986836095,
+        "AvgTime/train_epoch_std": 0.0203568892990528,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0
@@ -5612,82 +5690,83 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 18049.16015625,
+      "test_loss": 18150.4765625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 18912.712890625,
+      "test_best_rerun_mse": 18915.66015625,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.3147240592186278,
+      "test_mse_by_total_triangles": 0.31477310429251326,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18974.25,
+          "test_best_rerun_mse": 23664.876953125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 13.670208933717579
+          "test_mse_by_total_triangles": 17.049623165075648
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1258.667236328125,
+          "test_best_rerun_mse": 1935.7718505859375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 6.624564401726974
+          "test_mse_by_total_triangles": 10.188272897820724
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126583.3046875,
+          "test_best_rerun_mse": 140814.9375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 9.600554014979142
+          "test_mse_by_total_triangles": 10.679934584755404
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1752.3525390625,
+          "test_best_rerun_mse": 1888.74560546875,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.5906142699907314
+          "test_mse_by_total_triangles": 0.6365842957427537
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16120.931640625,
+          "test_best_rerun_mse": 19058.943359375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 2.153765082247829
+          "test_mse_by_total_triangles": 2.546285017952572
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1631.6502685546875,
+          "test_best_rerun_mse": 2498.49072265625,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 1.4090244115325454
+          "test_mse_by_total_triangles": 2.157591297630613
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 73930.3359375,
+          "test_best_rerun_mse": 76559.4765625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.716754967896619
+          "test_mse_by_total_triangles": 1.7778069051295746
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2437.551513671875,
+          "test_best_rerun_mse": 2663.1328125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.17091232040891005
+          "test_mse_by_total_triangles": 0.1867292674589819
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6260.79150390625,
+          "test_best_rerun_mse": 7888.97607421875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.3209181149165129
+          "test_mse_by_total_triangles": 0.40437624041307857
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2840.083984375,
+          "test_best_rerun_mse": 4301.13427734375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.5049038194444444
+          "test_mse_by_total_triangles": 0.76464609375
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 96642.5859375,
+          "test_best_rerun_mse": 101132.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.0932048226587332
+          "test_mse_by_total_triangles": 1.1439953960838434
         }
       },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/dirsnn/logs/train/runs/notebook_gu_grid_2026-05-26_09-23-26__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.2511938015619912,
-        "AvgTime/train_epoch_std": 0.09102711375834233,
+        "AvgTime/train_epoch_mean": 1.9260065290662978,
+        "AvgTime/train_epoch_std": 0.023871034381474983,
         "model/params/total": 109211,
         "model/params/trainable": 109211,
         "model/params/non_trainable": 0

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -124,7 +124,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "expected_hash = \"a357310044dd2dbaaf8ecf89b2818f197f3696a07f3bacaa828d66d1b54e8170\""
+        "expected_hash = \"f87b2cfd0c61cabaa50ee2c05d8fa7b5e1d78e14e8c3a50dfdd933a5b389bfde\""
       ]
     },
     {

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -104,7 +104,7 @@
       "outputs": [],
       "source": [
         "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-        "MODEL_CONFIG = \"graph/gin\""
+        "MODEL_CONFIG = \"simplicial/dirsnn\""
       ]
     },
     {
@@ -124,7 +124,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "expected_hash = \"f87b2cfd0c61cabaa50ee2c05d8fa7b5e1d78e14e8c3a50dfdd933a5b389bfde\""
+        "expected_hash = \"a357310044dd2dbaaf8ecf89b2818f197f3696a07f3bacaa828d66d1b54e8170\""
       ]
     },
     {

--- a/configs/model/simplicial/dirsnn.yaml
+++ b/configs/model/simplicial/dirsnn.yaml
@@ -1,0 +1,44 @@
+_target_: topobench.model.TBModel
+
+model_name: dirsnn
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 32
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+
+backbone:
+  _target_: topobench.nn.backbones.simplicial.dirsnn.DirSNN
+  edge_channels: ${model.feature_encoder.out_channels}
+  n_hid: ${model.feature_encoder.out_channels}
+  n_layers: 2
+  conv_order: 1
+  n_adjs: 10  # 4 directed lower + 6 directed upper edge adjacencies
+              # (see DirectedSimplicialLifting / DirSNNWrapper)
+  aggr_norm: False
+  update_func: "relu"
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.DirSNNWrapper
+  _partial_: true
+  wrapper_name: DirSNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/simplicial/dirsnn_official_lower.yaml
+++ b/configs/model/simplicial/dirsnn_official_lower.yaml
@@ -1,0 +1,52 @@
+_target_: topobench.model.TBModel
+
+model_name: dirsnn_official_lower
+model_domain: simplicial
+
+# Official-experimental variant of Dir-SNN: uses only the four *lower*
+# directed edge adjacencies (Eq. (3) of arXiv:2409.08389), matching the
+# narrower setup actually used in the upstream reference repository
+# (`compute_lower_adj` of `repos/DirSNN/compute_adj.py`). The paper's
+# general formulation (Eqs. (6)-(10)) is a template over all 10 directed
+# adjacencies; the paper's published experiments use only these four
+# lower ones. See `DirSNNWrapper(adj_subset="lower")`.
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 32
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+
+backbone:
+  _target_: topobench.nn.backbones.simplicial.dirsnn.DirSNN
+  edge_channels: ${model.feature_encoder.out_channels}
+  n_hid: ${model.feature_encoder.out_channels}
+  n_layers: 2
+  conv_order: 1
+  n_adjs: 4  # 4 directed lower edge adjacencies only (official setup)
+  aggr_norm: False
+  update_func: "relu"
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.DirSNNWrapper
+  _partial_: true
+  wrapper_name: DirSNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  adj_subset: "lower"
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/transforms/liftings/graph2simplicial/directed_simplicial.yaml
+++ b/configs/transforms/liftings/graph2simplicial/directed_simplicial.yaml
@@ -1,0 +1,9 @@
+transform_type: 'lifting'
+transform_name: "DirectedSimplicialLifting"
+complex_dim: 2  # locked: paper defines edge adjacencies only up to triangles
+preserve_edge_attr: ${oc.select:dataset.parameters.preserve_edge_attr_if_lifted,False}
+signed: True  # signed incidences keep the orientation information
+feature_lifting: ProjectionSum
+neighborhoods: ${oc.select:model.backbone.neighborhoods,null}
+directed_input: False  # locked: directed-input path is guarded (NotImplementedError) until canonical orientation is threaded through incidence_1
+spectral_normalize: False  # opt-in: divides each directed adjacency by its largest eigenvalue, mirroring upstream utils.py/train.py normalization. Default off keeps raw binary adjacencies.

--- a/configs/transforms/model_defaults/dirsnn.yaml
+++ b/configs/transforms/model_defaults/dirsnn.yaml
@@ -1,0 +1,9 @@
+# Default transform pipeline for the Dir-SNN model.
+#
+# Dir-SNN (Lecha et al. 2024, arXiv:2409.08389) operates on edge
+# signals propagated through ten directed edge adjacencies, so we must
+# replace the default undirected clique lifting with
+# DirectedSimplicialLifting.
+defaults:
+  - data_manipulations: identity
+  - /transforms/liftings/graph2simplicial@graph2simplicial_lifting: directed_simplicial

--- a/configs/transforms/model_defaults/dirsnn_official_lower.yaml
+++ b/configs/transforms/model_defaults/dirsnn_official_lower.yaml
@@ -1,0 +1,20 @@
+# Default transform pipeline for the Dir-SNN (official-experimental
+# lower-only) model.
+#
+# Same as the default Dir-SNN model_defaults: we need the directed
+# simplicial lifting on the batch so the four ``dir_lower_adj_*``
+# tensors are available. The wrapper restricts itself to the four
+# lower adjacencies via ``adj_subset="lower"`` -- the six upper
+# adjacencies are still produced by the lifting but are ignored.
+#
+# Reference-parity mode: this official-experimental config opts into
+# spectral normalization of the directed adjacencies, mirroring
+# ``repos/DirSNN/utils.py:16-20`` applied to the four lower
+# adjacencies in ``repos/DirSNN/train.py:29-33`` before they are fed
+# to the model.
+defaults:
+  - data_manipulations: identity
+  - /transforms/liftings/graph2simplicial@graph2simplicial_lifting: directed_simplicial
+
+graph2simplicial_lifting:
+  spectral_normalize: True

--- a/test/nn/backbones/simplicial/test_dirsnn.py
+++ b/test/nn/backbones/simplicial/test_dirsnn.py
@@ -1,0 +1,417 @@
+"""Unit tests for DirSNN backbone."""
+
+import pytest
+import torch
+
+from topobench.nn.backbones.simplicial.dirsnn import DirSNN, DirSNNLayer
+from topobench.nn.wrappers.simplicial.dirsnn_wrapper import DIRSNN_ADJ_KEYS
+from topobench.transforms.liftings.graph2simplicial import (
+    DirectedSimplicialLifting,
+    SimplicialCliqueLifting,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def random_edge_data():
+    """Return a small synthetic edge-level test bench.
+
+    Returns
+    -------
+    dict
+        Dictionary with edge features and two dense adjacency
+        matrices, sized so that downstream tests stay cheap.
+    """
+    torch.manual_seed(0)
+    n_edges = 6
+    edge_channels = 4
+    x_1 = torch.randn(n_edges, edge_channels)
+    adj_a = (torch.rand(n_edges, n_edges) > 0.6).float()
+    adj_b = (torch.rand(n_edges, n_edges) > 0.6).float()
+    return {
+        "x_1": x_1,
+        "n_edges": n_edges,
+        "edge_channels": edge_channels,
+        "adjs": (adj_a, adj_b),
+    }
+
+
+# ---------------------------------------------------------------------------
+# DirSNN (the outer module)
+# ---------------------------------------------------------------------------
+
+
+def test_dirsnn_construction(random_edge_data):
+    """Build a vanilla DirSNN and inspect its structure.
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    """
+    d = random_edge_data
+    model = DirSNN(
+        edge_channels=d["edge_channels"],
+        n_layers=2,
+        n_hid=8,
+        conv_order=1,
+        n_adjs=len(d["adjs"]),
+    )
+    assert isinstance(model, DirSNN)
+    assert len(model.layers) == 2
+    assert hasattr(model, "in_linear_1")
+    assert all(isinstance(layer, DirSNNLayer) for layer in model.layers)
+
+
+def test_dirsnn_forward_shape(random_edge_data):
+    """The forward pass preserves the number of edges.
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    """
+    d = random_edge_data
+    n_hid = 10
+    model = DirSNN(
+        edge_channels=d["edge_channels"],
+        n_layers=2,
+        n_hid=n_hid,
+        conv_order=2,
+        n_adjs=len(d["adjs"]),
+        update_func="relu",
+    )
+    out = model(d["x_1"], d["adjs"])
+    assert out.shape == (d["n_edges"], n_hid)
+    assert torch.isfinite(out).all()
+
+
+@pytest.mark.parametrize(
+    "update_func", ["relu", "sigmoid", "leaky_relu", None]
+)
+def test_dirsnn_update_funcs(random_edge_data, update_func):
+    """All advertised update activations run end-to-end.
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    update_func : str or None
+        Activation tag passed through to the layer.
+    """
+    d = random_edge_data
+    model = DirSNN(
+        edge_channels=d["edge_channels"],
+        n_layers=1,
+        n_hid=6,
+        conv_order=1,
+        n_adjs=len(d["adjs"]),
+        update_func=update_func,
+    )
+    out = model(d["x_1"], d["adjs"])
+    assert out.shape == (d["n_edges"], 6)
+
+
+def test_dirsnn_aggr_norm(random_edge_data):
+    """Aggregation normalisation does not crash and produces finite output.
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    """
+    d = random_edge_data
+    model = DirSNN(
+        edge_channels=d["edge_channels"],
+        n_layers=1,
+        n_hid=5,
+        conv_order=2,
+        n_adjs=len(d["adjs"]),
+        aggr_norm=True,
+        update_func="relu",
+    )
+    out = model(d["x_1"], d["adjs"])
+    assert torch.isfinite(out).all()
+
+
+def test_dirsnn_backprop(random_edge_data):
+    """Check that gradients flow through the network parameters.
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    """
+    d = random_edge_data
+    model = DirSNN(
+        edge_channels=d["edge_channels"],
+        n_layers=1,
+        n_hid=4,
+        conv_order=1,
+        n_adjs=len(d["adjs"]),
+        update_func="relu",
+    )
+    out = model(d["x_1"], d["adjs"])
+    loss = out.pow(2).mean()
+    loss.backward()
+    for p in model.parameters():
+        assert p.grad is not None
+        assert torch.isfinite(p.grad).all()
+
+
+def test_dirsnn_backprop_sparse(random_edge_data):
+    """Check that gradients flow through ``torch.sparse.mm`` adjacencies.
+
+    Mirrors :func:`test_dirsnn_backprop` but converts every adjacency
+    to a sparse COO tensor before the forward pass so the sparse
+    propagation path is exercised end-to-end. This catches silent
+    dtype / device / autograd issues that the dense path would not
+    surface (e.g. ``torch.sparse.mm`` requiring a coalesced operand
+    or a specific dtype combination).
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    """
+    d = random_edge_data
+    sparse_adjs = tuple(a.to_sparse().coalesce() for a in d["adjs"])
+    assert all(a.is_sparse for a in sparse_adjs)
+    model = DirSNN(
+        edge_channels=d["edge_channels"],
+        n_layers=1,
+        n_hid=4,
+        conv_order=2,  # >1 exercises repeated sparse.mm propagation
+        n_adjs=len(sparse_adjs),
+        update_func="relu",
+    )
+    out = model(d["x_1"], sparse_adjs)
+    loss = out.pow(2).mean()
+    loss.backward()
+    # Every learnable parameter must have a finite gradient, and at
+    # least one of them must be non-zero (otherwise the sparse path
+    # silently zeros out the propagation).
+    any_nonzero = False
+    for p in model.parameters():
+        assert p.grad is not None
+        assert torch.isfinite(p.grad).all()
+        if p.grad.abs().sum().item() > 0:
+            any_nonzero = True
+    assert any_nonzero, (
+        "All gradients are zero through the sparse path -- something "
+        "in torch.sparse.mm propagation is silently dropping signal."
+    )
+
+
+# ---------------------------------------------------------------------------
+# DirSNNLayer (the inner layer)
+# ---------------------------------------------------------------------------
+
+
+def test_layer_invalid_init_raises():
+    """Construction rejects unknown initialisation tags."""
+    with pytest.raises(AssertionError):
+        DirSNNLayer(
+            in_channels_1=3,
+            out_channels_1=3,
+            conv_order=1,
+            n_adjs=1,
+            initialization="not_a_thing",
+        )
+
+
+def test_layer_invalid_conv_order_raises():
+    """Convolution order must be strictly positive."""
+    with pytest.raises(AssertionError):
+        DirSNNLayer(
+            in_channels_1=3,
+            out_channels_1=3,
+            conv_order=0,
+            n_adjs=1,
+        )
+
+
+def test_layer_xavier_uniform_init():
+    """Selecting Xavier-uniform initialisation works and changes weights.
+
+    The default initialisation is Xavier-normal; explicitly switching to
+    Xavier-uniform must yield finite weights of the expected shape.
+    """
+    layer = DirSNNLayer(
+        in_channels_1=3,
+        out_channels_1=4,
+        conv_order=2,
+        n_adjs=2,
+        initialization="xavier_uniform",
+    )
+    # conv_order * n_adjs + 1
+    assert layer.weight_1.shape == (3, 4, 5)
+    assert torch.isfinite(layer.weight_1).all()
+
+
+def test_layer_reset_parameters_bad_init_raises():
+    """``reset_parameters`` rejects unknown initialisations at call time.
+
+    The init-time assertion guards normal construction; here we mutate
+    the attribute so the runtime branch in ``reset_parameters`` is
+    exercised directly.
+    """
+    layer = DirSNNLayer(
+        in_channels_1=2,
+        out_channels_1=2,
+        conv_order=1,
+        n_adjs=1,
+    )
+    layer.initialization = "unknown"
+    with pytest.raises(RuntimeError):
+        layer.reset_parameters()
+
+
+def test_layer_wrong_n_adjs_raises(random_edge_data):
+    """Mismatched ``n_adjs`` between init and forward must raise.
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    """
+    d = random_edge_data
+    layer = DirSNNLayer(
+        in_channels_1=d["edge_channels"],
+        out_channels_1=d["edge_channels"],
+        conv_order=1,
+        n_adjs=1,
+    )
+    with pytest.raises(AssertionError):
+        layer(d["x_1"], d["adjs"])  # 2 adjacencies but layer expects 1
+
+
+def test_layer_update_unknown_raises():
+    """``update`` raises :class:`ValueError` for an unknown activation tag.
+
+    The reference Dir-SNN code silently returned ``None`` here, which
+    propagated to ``forward`` and produced opaque downstream crashes
+    (e.g. ``NoneType has no attribute 'shape'`` deeper in the call
+    stack). Surfacing the misconfiguration early is much friendlier.
+    """
+    layer = DirSNNLayer(
+        in_channels_1=2,
+        out_channels_1=2,
+        conv_order=1,
+        n_adjs=1,
+        update_func="not_an_activation",
+    )
+    with pytest.raises(ValueError, match="Unknown update_func"):
+        layer.update(torch.zeros(3, 2))
+
+
+def test_layer_sparse_adjacency(random_edge_data):
+    """The layer handles sparse adjacencies via ``torch.sparse.mm``.
+
+    Parameters
+    ----------
+    random_edge_data : dict
+        Synthetic edge-level data fixture.
+    """
+    d = random_edge_data
+    sparse_adjs = tuple(a.to_sparse() for a in d["adjs"])
+    layer = DirSNNLayer(
+        in_channels_1=d["edge_channels"],
+        out_channels_1=5,
+        conv_order=2,
+        n_adjs=2,
+        aggr_norm=True,
+        update_func="relu",
+    )
+    out = layer(d["x_1"], sparse_adjs)
+    assert out.shape == (d["n_edges"], 5)
+    assert torch.isfinite(out).all()
+
+
+def test_layer_dense_aggr_norm_handles_isolated_rows():
+    """``aggr_norm_func`` zeroes out empty rows safely."""
+    layer = DirSNNLayer(
+        in_channels_1=2,
+        out_channels_1=2,
+        conv_order=1,
+        n_adjs=1,
+        aggr_norm=True,
+    )
+    # row 1 has no neighbours -> inverse degree is +inf and must be
+    # mapped to 0.
+    adj = torch.tensor([[1.0, 1.0], [0.0, 0.0]])
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    out = layer.aggr_norm_func(adj, x)
+    assert torch.isfinite(out).all()
+    assert torch.equal(out[1], torch.zeros(2))
+
+
+# ---------------------------------------------------------------------------
+# Integration with a TopoBench-lifted simplicial complex
+# ---------------------------------------------------------------------------
+
+
+def test_dirsnn_on_lifted_graph(simple_graph_1):
+    """End-to-end test on a clique-lifted simple graph.
+
+    Sanity-checks that the backbone can still run on plain Hodge
+    Laplacians produced by the standard :class:`SimplicialCliqueLifting`
+    -- this exercises the ``n_adjs`` configurability of the backbone
+    independently of the new directed lifting.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph fixture from ``test/conftest.py``.
+    """
+    lifting = SimplicialCliqueLifting(complex_dim=3, signed=True)
+    data = lifting(simple_graph_1)
+
+    edge_channels = data.x_1.shape[1]
+    out_dim = 8
+    model = DirSNN(
+        edge_channels=edge_channels,
+        n_layers=2,
+        n_hid=out_dim,
+        conv_order=1,
+        n_adjs=2,
+        update_func="relu",
+    )
+    adjs = (data.down_laplacian_1, data.up_laplacian_1)
+    out = model(data.x_1, adjs)
+    assert out.shape == (data.x_1.shape[0], out_dim)
+    assert torch.isfinite(out).all()
+
+
+def test_dirsnn_on_directed_lifted_graph(simple_graph_1):
+    """Run Dir-SNN end-to-end on a :class:`DirectedSimplicialLifting`.
+
+    This is the production configuration: ten directed edge adjacencies
+    feed the backbone via :data:`DIRSNN_ADJ_KEYS`.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph fixture from ``test/conftest.py``.
+    """
+    lifting = DirectedSimplicialLifting(signed=True)
+    data = lifting(simple_graph_1)
+
+    edge_channels = data.x_1.shape[1]
+    out_dim = 6
+    model = DirSNN(
+        edge_channels=edge_channels,
+        n_layers=2,
+        n_hid=out_dim,
+        conv_order=1,
+        n_adjs=10,
+        update_func="relu",
+    )
+    adjs = tuple(getattr(data, key) for key in DIRSNN_ADJ_KEYS)
+    assert len(adjs) == 10
+    out = model(data.x_1, adjs)
+    assert out.shape == (data.x_1.shape[0], out_dim)
+    assert torch.isfinite(out).all()

--- a/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
+++ b/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
@@ -158,6 +158,32 @@ def test_wrapper_adj_subset_invalid_raises(directed_lifted):
         )
 
 
+def test_wrapper_n_adjs_mismatch_raises(directed_lifted):
+    """Construction rejects a backbone/subset adjacency-count mismatch.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture (only used to size the backbone).
+    """
+    edge_channels = directed_lifted.x_1.shape[1]
+    backbone = DirSNN(
+        edge_channels=edge_channels,
+        n_layers=1,
+        n_hid=edge_channels,
+        conv_order=1,
+        n_adjs=10,
+        update_func="relu",
+    )
+    with pytest.raises(ValueError, match="backbone.n_adjs=4"):
+        DirSNNWrapper(
+            backbone,
+            adj_subset="lower",
+            out_channels=edge_channels,
+            num_cell_dimensions=2,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Hydra config wiring for the new official-lower variant
 # ---------------------------------------------------------------------------

--- a/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
+++ b/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
@@ -1,0 +1,236 @@
+"""Unit tests for :class:`DirSNNWrapper` and its ``adj_subset`` knob."""
+
+import os
+
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+
+from topobench.nn.backbones.simplicial.dirsnn import DirSNN
+from topobench.nn.wrappers.simplicial.dirsnn_wrapper import (
+    DIRSNN_ADJ_KEYS,
+    DirSNNWrapper,
+)
+from topobench.transforms.liftings.graph2simplicial import (
+    DirectedSimplicialLifting,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def directed_lifted(simple_graph_1):
+    """Run :class:`DirectedSimplicialLifting` once and reuse the output.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph fixture from ``test/conftest.py``.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Lifted batch with the ten ``dir_*_adj_*`` attributes.
+    """
+    lifting = DirectedSimplicialLifting(signed=True)
+    data = lifting(simple_graph_1)
+    # ``DirSNNWrapper.forward`` reads ``batch.batch_0``; the test
+    # fixture is not run through a DataLoader, so we set it manually
+    # (mirroring ``sg1_clique_lifted`` in ``test/conftest.py``).
+    data.batch_0 = "null"
+    return data
+
+
+# ---------------------------------------------------------------------------
+# adj_subset wiring
+# ---------------------------------------------------------------------------
+
+
+def _make_wrapper(data, adj_subset, n_adjs):
+    """Build a tiny :class:`DirSNNWrapper` around a fresh :class:`DirSNN`.
+
+    Parameters
+    ----------
+    data : torch_geometric.data.Data
+        Lifted batch carrying edge features and adjacencies.
+    adj_subset : str or None
+        Adjacency-subset knob to test.
+    n_adjs : int
+        Number of adjacencies the backbone expects (must match the
+        subset implied by ``adj_subset``).
+
+    Returns
+    -------
+    DirSNNWrapper
+        Wrapper instance ready to call ``forward``.
+    """
+    edge_channels = data.x_1.shape[1]
+    backbone = DirSNN(
+        edge_channels=edge_channels,
+        n_layers=1,
+        n_hid=edge_channels,
+        conv_order=1,
+        n_adjs=n_adjs,
+        update_func="relu",
+    )
+    return DirSNNWrapper(
+        backbone,
+        adj_subset=adj_subset,
+        out_channels=edge_channels,
+        num_cell_dimensions=2,
+    )
+
+
+def test_wrapper_adj_subset_default_uses_all_ten(directed_lifted):
+    """``adj_subset=None`` selects the full 10-adjacency tuple.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture.
+    """
+    wrapper = _make_wrapper(directed_lifted, adj_subset=None, n_adjs=10)
+    assert wrapper._adj_keys == DIRSNN_ADJ_KEYS
+    assert len(wrapper._adj_keys) == 10
+    out = wrapper(directed_lifted)
+    for key in ("labels", "batch_0", "x_0", "x_1"):
+        assert key in out
+
+
+def test_wrapper_adj_subset_lower(directed_lifted):
+    """``adj_subset="lower"`` selects exactly the 4 lower adjacencies.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture.
+    """
+    wrapper = _make_wrapper(directed_lifted, adj_subset="lower", n_adjs=4)
+    assert wrapper._adj_keys == DIRSNN_ADJ_KEYS[:4]
+    assert all(k.startswith("dir_lower_adj_") for k in wrapper._adj_keys)
+    out = wrapper(directed_lifted)
+    for key in ("labels", "batch_0", "x_0", "x_1"):
+        assert key in out
+
+
+def test_wrapper_adj_subset_upper(directed_lifted):
+    """``adj_subset="upper"`` selects exactly the 6 upper adjacencies.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture.
+    """
+    wrapper = _make_wrapper(directed_lifted, adj_subset="upper", n_adjs=6)
+    assert wrapper._adj_keys == DIRSNN_ADJ_KEYS[4:]
+    assert all(k.startswith("dir_upper_adj_") for k in wrapper._adj_keys)
+    out = wrapper(directed_lifted)
+    for key in ("labels", "batch_0", "x_0", "x_1"):
+        assert key in out
+
+
+def test_wrapper_adj_subset_invalid_raises(directed_lifted):
+    """Construction rejects ``adj_subset`` values outside the allow-list.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture (only used to size the backbone).
+    """
+    edge_channels = directed_lifted.x_1.shape[1]
+    backbone = DirSNN(
+        edge_channels=edge_channels,
+        n_layers=1,
+        n_hid=edge_channels,
+        conv_order=1,
+        n_adjs=10,
+        update_func="relu",
+    )
+    with pytest.raises(ValueError, match="Unknown adj_subset"):
+        DirSNNWrapper(
+            backbone,
+            adj_subset="middle",  # not in (None, "lower", "upper")
+            out_channels=edge_channels,
+            num_cell_dimensions=2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hydra config wiring for the new official-lower variant
+# ---------------------------------------------------------------------------
+
+
+def test_official_lower_config_instantiates_and_runs(directed_lifted):
+    """``configs/model/simplicial/dirsnn_official_lower.yaml`` works end-to-end.
+
+    Loads the config via Hydra, instantiates backbone + wrapper, and
+    runs a forward pass on the lifted fixture. This guards the yaml
+    against accidental drift from the wrapper API (e.g. an ``n_adjs``
+    that no longer matches the subset).
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture.
+    """
+    configs_dir = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "configs",
+            "model",
+            "simplicial",
+        )
+    )
+
+    # Standalone load of the model config (we don't pull in the whole
+    # TBModel stack here -- just backbone + backbone_wrapper).
+    with initialize_config_dir(version_base=None, config_dir=configs_dir):
+        cfg = compose(
+            config_name="dirsnn_official_lower",
+            return_hydra_config=False,
+        )
+    OmegaConf.set_struct(cfg, False)
+    model_cfg = cfg
+
+    # The Hydra-side numerical values are fed through interpolations
+    # (e.g. ``${model.feature_encoder.out_channels}``) that only
+    # resolve at full-app launch time. For this standalone test we
+    # only validate (a) the static fields the new variant cares about
+    # and (b) that the backbone/wrapper sub-tree instantiates with
+    # concrete values matching those fields.
+    edge_channels = directed_lifted.x_1.shape[1]
+    # Patch the interpolated sentinel fields so ``instantiate`` doesn't
+    # try to resolve them.
+    model_cfg.backbone.edge_channels = edge_channels
+    model_cfg.backbone.n_hid = edge_channels
+    model_cfg.backbone_wrapper.out_channels = edge_channels
+    model_cfg.backbone_wrapper.num_cell_dimensions = 2
+
+    assert model_cfg.backbone.n_adjs == 4
+    assert model_cfg.backbone_wrapper.adj_subset == "lower"
+    assert model_cfg.model_name == "dirsnn_official_lower"
+
+    backbone = instantiate(model_cfg.backbone)
+    # ``backbone_wrapper`` is declared as ``_partial_: true``.
+    wrapper_partial = instantiate(model_cfg.backbone_wrapper)
+    wrapper = wrapper_partial(backbone)
+    # NB: Hydra ``_target_`` goes through the auto-discovery loader in
+    # ``topobench.nn.wrappers.__init__.WrapperExportsManager`` which
+    # re-imports the source file under a *different* module name, so
+    # the resulting class object is a distinct instance from the
+    # canonical ``simplicial.dirsnn_wrapper.DirSNNWrapper``. We
+    # therefore compare by class name rather than by ``isinstance``.
+    assert type(wrapper).__name__ == "DirSNNWrapper"
+    assert wrapper.adj_subset == "lower"
+    assert wrapper._adj_keys == DIRSNN_ADJ_KEYS[:4]
+
+    out = wrapper(directed_lifted)
+    for key in ("labels", "batch_0", "x_0", "x_1"):
+        assert key in out

--- a/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
+++ b/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
@@ -3,11 +3,13 @@
 import os
 
 import pytest
+import torch
 from hydra import compose, initialize_config_dir
 from hydra.utils import instantiate
 from omegaconf import OmegaConf
 
 from topobench.nn.backbones.simplicial.dirsnn import DirSNN
+from topobench.nn.readouts.propagate_signal_down import PropagateSignalDown
 from topobench.nn.wrappers.simplicial.dirsnn_wrapper import (
     DIRSNN_ADJ_KEYS,
     DirSNNWrapper,
@@ -39,8 +41,8 @@ def directed_lifted(simple_graph_1):
     data = lifting(simple_graph_1)
     # ``DirSNNWrapper.forward`` reads ``batch.batch_0``; the test
     # fixture is not run through a DataLoader, so we set it manually
-    # (mirroring ``sg1_clique_lifted`` in ``test/conftest.py``).
-    data.batch_0 = "null"
+    # to a single graph assignment for readout compatibility.
+    data.batch_0 = torch.zeros(data.x_0.shape[0], dtype=torch.long)
     return data
 
 
@@ -84,6 +86,16 @@ def _make_wrapper(data, adj_subset, n_adjs):
     )
 
 
+def _assert_wrapper_output(out, data):
+    """Validate the semantic shape and numerical sanity of wrapper output."""
+    for key in ("labels", "batch_0", "x_0", "x_1"):
+        assert key in out
+    assert out["x_0"].shape == (data.x_0.shape[0], data.x_1.shape[1])
+    assert out["x_1"].shape == data.x_1.shape
+    assert torch.isfinite(out["x_0"]).all()
+    assert torch.isfinite(out["x_1"]).all()
+
+
 def test_wrapper_adj_subset_default_uses_all_ten(directed_lifted):
     """``adj_subset=None`` selects the full 10-adjacency tuple.
 
@@ -96,8 +108,7 @@ def test_wrapper_adj_subset_default_uses_all_ten(directed_lifted):
     assert wrapper._adj_keys == DIRSNN_ADJ_KEYS
     assert len(wrapper._adj_keys) == 10
     out = wrapper(directed_lifted)
-    for key in ("labels", "batch_0", "x_0", "x_1"):
-        assert key in out
+    _assert_wrapper_output(out, directed_lifted)
 
 
 def test_wrapper_adj_subset_lower(directed_lifted):
@@ -112,8 +123,7 @@ def test_wrapper_adj_subset_lower(directed_lifted):
     assert wrapper._adj_keys == DIRSNN_ADJ_KEYS[:4]
     assert all(k.startswith("dir_lower_adj_") for k in wrapper._adj_keys)
     out = wrapper(directed_lifted)
-    for key in ("labels", "batch_0", "x_0", "x_1"):
-        assert key in out
+    _assert_wrapper_output(out, directed_lifted)
 
 
 def test_wrapper_adj_subset_upper(directed_lifted):
@@ -128,8 +138,51 @@ def test_wrapper_adj_subset_upper(directed_lifted):
     assert wrapper._adj_keys == DIRSNN_ADJ_KEYS[4:]
     assert all(k.startswith("dir_upper_adj_") for k in wrapper._adj_keys)
     out = wrapper(directed_lifted)
-    for key in ("labels", "batch_0", "x_0", "x_1"):
-        assert key in out
+    _assert_wrapper_output(out, directed_lifted)
+
+
+def test_wrapper_forward_backward(directed_lifted):
+    """Wrapper output remains differentiable through the Dir-SNN backbone.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture.
+    """
+    wrapper = _make_wrapper(directed_lifted, adj_subset=None, n_adjs=10)
+    out = wrapper(directed_lifted)
+    loss = out["x_0"].square().mean() + out["x_1"].square().mean()
+    loss.backward()
+    grads = [p.grad for p in wrapper.parameters() if p.requires_grad]
+    assert grads
+    assert all(g is not None and torch.isfinite(g).all() for g in grads)
+
+
+def test_wrapper_graph_readout_with_signed_projection(directed_lifted):
+    """Current signed edge-to-node projection works with graph readout.
+
+    This guards the submitted architecture: the wrapper provides an
+    edge-derived 0-cell signal and ``PropagateSignalDown`` combines it
+    with a learned downward propagation before graph-level sum pooling.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture.
+    """
+    wrapper = _make_wrapper(directed_lifted, adj_subset=None, n_adjs=10)
+    model_out = wrapper(directed_lifted)
+    readout = PropagateSignalDown(
+        readout_name="PropagateSignalDown",
+        num_cell_dimensions=2,
+        hidden_dim=directed_lifted.x_1.shape[1],
+        out_channels=1,
+        task_level="graph",
+        pooling_type="sum",
+    )
+    out = readout(model_out, directed_lifted)
+    assert out["logits"].shape == (1, 1)
+    assert torch.isfinite(out["logits"]).all()
 
 
 def test_wrapper_adj_subset_invalid_raises(directed_lifted):
@@ -258,5 +311,4 @@ def test_official_lower_config_instantiates_and_runs(directed_lifted):
     assert wrapper._adj_keys == DIRSNN_ADJ_KEYS[:4]
 
     out = wrapper(directed_lifted)
-    for key in ("labels", "batch_0", "x_0", "x_1"):
-        assert key in out
+    _assert_wrapper_output(out, directed_lifted)

--- a/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
+++ b/test/nn/wrappers/simplicial/test_dirsnn_wrapper.py
@@ -158,6 +158,20 @@ def test_wrapper_forward_backward(directed_lifted):
     assert all(g is not None and torch.isfinite(g).all() for g in grads)
 
 
+def test_wrapper_repr_includes_backbone_out_channels(directed_lifted):
+    """Wrapper ``repr`` works for Dir-SNN's edge-hidden dimension.
+
+    Parameters
+    ----------
+    directed_lifted : torch_geometric.data.Data
+        Lifted-graph fixture.
+    """
+    wrapper = _make_wrapper(directed_lifted, adj_subset=None, n_adjs=10)
+    repr_text = repr(wrapper)
+    assert "DirSNNWrapper" in repr_text
+    assert f"out_channels={directed_lifted.x_1.shape[1]}" in repr_text
+
+
 def test_wrapper_graph_readout_with_signed_projection(directed_lifted):
     """Current signed edge-to-node projection works with graph readout.
 

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,11 +1,16 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
+
 from test._utils.simplified_pipeline import run
 
-
-DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
+MODELS = [
+    "graph/gcn",
+    "cell/topotune",
+    "simplicial/topotune",
+    "simplicial/dirsnn",
+]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:

--- a/test/transforms/liftings/graph2simplicial/test_directed_simplicial.py
+++ b/test/transforms/liftings/graph2simplicial/test_directed_simplicial.py
@@ -1,0 +1,800 @@
+"""Tests for :class:`DirectedSimplicialLifting`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+import pytest
+import torch
+import torch_geometric
+
+from topobench.transforms.liftings.graph2simplicial import (
+    DirectedSimplicialLifting,
+)
+from topobench.transforms.liftings.graph2simplicial.directed_simplicial_lifting import (
+    DIR_ADJ_KEYS,
+    DIR_LOWER_KEYS,
+    DIR_UPPER_KEYS,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_data(
+    edges: list[tuple[int, int]],
+    num_nodes: int,
+    *,
+    symmetric: bool = True,
+) -> torch_geometric.data.Data:
+    """Return a ``Data`` object built from the given edge list.
+
+    Parameters
+    ----------
+    edges : list of tuple of int
+        Edges to include. By default the resulting ``edge_index`` is
+        symmetric (TopoBench default).
+    num_nodes : int
+        Number of nodes; node features are a column of indices.
+    symmetric : bool, optional
+        Whether to add the reverse direction for every edge. Default
+        is ``True``.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        A PyG ``Data`` instance with ``x``, ``edge_index``,
+        ``num_nodes`` set.
+    """
+    pairs = list(edges)
+    if symmetric:
+        pairs = pairs + [(v, u) for u, v in edges]
+    edge_index = torch.tensor(pairs).T.long()
+    x = torch.arange(num_nodes).float().unsqueeze(1)
+    return torch_geometric.data.Data(
+        x=x,
+        edge_index=edge_index,
+        num_nodes=num_nodes,
+        y=torch.zeros(num_nodes, dtype=torch.long),
+    )
+
+
+def _dense(t: torch.Tensor) -> torch.Tensor:
+    """Densify a sparse tensor for value-level assertions.
+
+    Parameters
+    ----------
+    t : torch.Tensor
+        Sparse COO tensor produced by the lifting.
+
+    Returns
+    -------
+    torch.Tensor
+        Dense view of ``t``.
+    """
+    return t.to_dense()
+
+
+def _expected_matrix(
+    size: int, coords: list[tuple[int, int]]
+) -> torch.Tensor:
+    """Build a dense adjacency matrix from one-valued coordinates.
+
+    Parameters
+    ----------
+    size : int
+        Number of rows and columns.
+    coords : list of tuple of int
+        ``(row, column)`` coordinates whose value should be one.
+
+    Returns
+    -------
+    torch.Tensor
+        Dense float adjacency matrix.
+    """
+    out = torch.zeros(size, size)
+    for row, col in coords:
+        out[row, col] = 1.0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Static method ports of compute_adj.py
+# ---------------------------------------------------------------------------
+
+
+class TestComputeLowerAdj:
+    """Unit tests for :meth:`DirectedSimplicialLifting.compute_lower_adj`."""
+
+    def test_empty_edge_list_returns_empty_matrices(self) -> None:
+        """Zero edges -> four 0x0 matrices."""
+        a100, a101, a110, a111 = (
+            DirectedSimplicialLifting.compute_lower_adj([])
+        )
+        for m in (a100, a101, a110, a111):
+            assert m.shape == (0, 0)
+
+    def test_single_edge(self) -> None:
+        """A single edge is only self-100 / self-111 adjacent.
+
+        With a single directed edge ``(0, 1)`` no two-edge lower
+        adjacency can exist except the trivial self-source / self-target
+        diagonal entries that the reference implementation also keeps.
+        """
+        a100, a101, a110, a111 = (
+            DirectedSimplicialLifting.compute_lower_adj([(0, 1)])
+        )
+        assert torch.equal(a100, torch.tensor([[1.0]]))
+        assert torch.equal(a111, torch.tensor([[1.0]]))
+        assert torch.equal(a101, torch.tensor([[0.0]]))
+        assert torch.equal(a110, torch.tensor([[0.0]]))
+
+    def test_directed_path_matches_paper_intuition(self) -> None:
+        """On the path ``0 -> 1 -> 2`` the 101 entry is at [0, 1].
+
+        Edge 0 = (0,1) ends where edge 1 = (1,2) starts, so
+        ``adj_low_101[0, 1] = 1`` and its transpose
+        ``adj_low_110[1, 0] = 1`` (Eq. (3) of arXiv:2409.08389).
+        The 100 / 111 matrices have only the diagonal (the two edges
+        share no endpoint).
+        """
+        edges = [(0, 1), (1, 2)]
+        a100, a101, a110, a111 = (
+            DirectedSimplicialLifting.compute_lower_adj(edges)
+        )
+        assert a101[0, 1].item() == 1.0
+        assert a101.sum().item() == 1.0
+        assert a110[1, 0].item() == 1.0
+        assert a110.sum().item() == 1.0
+        # Diagonal-only for 100 / 111 (no shared src / dst).
+        assert torch.equal(a100, torch.eye(2))
+        assert torch.equal(a111, torch.eye(2))
+
+    def test_shared_source(self) -> None:
+        """``adj_low_100`` marks pairs sharing the source vertex.
+
+        Edges ``(0,1)`` and ``(0,2)`` share source 0, so
+        ``adj_low_100`` is the all-ones matrix (off-diagonal entries
+        from the shared source, diagonal kept by the reference).
+        """
+        edges = [(0, 1), (0, 2)]
+        a100, _, _, a111 = DirectedSimplicialLifting.compute_lower_adj(edges)
+        assert torch.equal(a100, torch.ones(2, 2))
+        # No shared target.
+        assert torch.equal(a111, torch.eye(2))
+
+    def test_shared_target(self) -> None:
+        """``adj_low_111`` marks pairs sharing the target vertex."""
+        edges = [(0, 2), (1, 2)]
+        a100, _, _, a111 = DirectedSimplicialLifting.compute_lower_adj(edges)
+        assert torch.equal(a111, torch.ones(2, 2))
+        assert torch.equal(a100, torch.eye(2))
+
+    def test_110_is_transpose_of_101(self) -> None:
+        """``adj_low_110 == adj_low_101.T`` for any edge configuration."""
+        edges = [(0, 1), (1, 2), (2, 3), (0, 3)]
+        _, a101, a110, _ = DirectedSimplicialLifting.compute_lower_adj(edges)
+        assert torch.equal(a110, a101.t())
+
+
+class TestComputeUpperAdj:
+    """Unit tests for :meth:`DirectedSimplicialLifting.compute_upper_adj`."""
+
+    def test_empty_edge_list(self) -> None:
+        """Zero edges -> six 0x0 matrices."""
+        ups = DirectedSimplicialLifting.compute_upper_adj([])
+        assert len(ups) == 6
+        for m in ups:
+            assert m.shape == (0, 0)
+
+    def test_no_triangles_means_zero(self) -> None:
+        """A graph without 3-cycles produces six zero matrices."""
+        edges = [(0, 1), (1, 2), (2, 3)]  # directed path, no triangles
+        ups = DirectedSimplicialLifting.compute_upper_adj(edges)
+        for m in ups:
+            assert m.sum().item() == 0.0
+
+    def test_canonically_oriented_triangle(self) -> None:
+        """One canonically oriented triangle populates one entry per slot.
+
+        With canonical orientation ``src < dst`` the only triangle
+        ``{0, 1, 2}`` lands in branch 1 of ``compute_upper_adj``
+        (``(t0,t1), (t0,t2), (t1,t2)`` = ``(0,1), (0,2), (1,2)``).
+        Each of the six upper adjacencies therefore gets exactly one
+        non-zero entry, placed at the indices specified in Eq. (4) of
+        arXiv:2409.08389.
+        """
+        edges = [(0, 1), (0, 2), (1, 2)]
+        edge_to_id = {e: i for i, e in enumerate(edges)}
+        ups = DirectedSimplicialLifting.compute_upper_adj(edges)
+        a101, a102, a112, a110, a120, a121 = ups
+
+        i_01 = edge_to_id[(0, 1)]
+        i_02 = edge_to_id[(0, 2)]
+        i_12 = edge_to_id[(1, 2)]
+
+        assert a101[i_12, i_02].item() == 1.0 and a101.sum().item() == 1.0
+        assert a102[i_12, i_01].item() == 1.0 and a102.sum().item() == 1.0
+        assert a112[i_02, i_01].item() == 1.0 and a112.sum().item() == 1.0
+        assert a110[i_02, i_12].item() == 1.0 and a110.sum().item() == 1.0
+        assert a120[i_01, i_12].item() == 1.0 and a120.sum().item() == 1.0
+        assert a121[i_01, i_02].item() == 1.0 and a121.sum().item() == 1.0
+
+    @pytest.mark.parametrize(
+        "rotation",
+        [
+            ((0, 1), (1, 2), (0, 2)),  # branch 1
+            ((0, 2), (0, 1), (2, 1)),  # branch 2
+            ((1, 0), (1, 2), (0, 2)),  # branch 3
+            ((1, 2), (1, 0), (2, 0)),  # branch 4
+            ((2, 1), (2, 0), (1, 0)),  # branch 5
+            ((2, 0), (2, 1), (0, 1)),  # branch 6
+        ],
+    )
+    def test_all_six_rotation_branches_yield_one_triangle(
+        self, rotation
+    ) -> None:
+        """All six rotational forms of ``compute_upper_adj`` find the triangle.
+
+        Each parametrised ``rotation`` is one of the six matching
+        branches in ``compute_adj.compute_upper_adj`` of the upstream
+        repository. We feed exactly the three directed edges that select
+        the corresponding branch and check that each of the six upper
+        adjacencies gets exactly one non-zero entry.
+
+        Parameters
+        ----------
+        rotation : tuple of tuple of int
+            Three directed edges defining the rotation under test.
+        """
+        edges = sorted({tuple(sorted(e)) for e in rotation})
+        # We want the *digraph* defined by the rotation itself, not the
+        # undirected projection, so we feed the rotation edges directly
+        # (they are unique because each branch fixes a distinct
+        # orientation of the triangle).
+        edges = sorted(set(rotation))
+        ups = DirectedSimplicialLifting.compute_upper_adj(edges)
+        for m in ups:
+            assert m.sum().item() == 1.0, (
+                "every branch must populate one entry per adjacency"
+            )
+
+    def test_two_disjoint_triangles(self) -> None:
+        """Two disjoint triangles contribute additively.
+
+        Each canonically oriented triangle contributes exactly one entry
+        per upper adjacency (six entries total per matrix would mean six
+        triangles); two disjoint triangles must yield two non-zero
+        entries per matrix.
+        """
+        edges = [(0, 1), (0, 2), (1, 2), (3, 4), (3, 5), (4, 5)]
+        ups = DirectedSimplicialLifting.compute_upper_adj(edges)
+        for m in ups:
+            assert m.sum().item() == 2.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end lifting
+# ---------------------------------------------------------------------------
+
+
+class TestDirectedSimplicialLifting:
+    """End-to-end behaviour of :class:`DirectedSimplicialLifting`."""
+
+    def test_repr_carries_directed_input_flag(self) -> None:
+        """``repr`` is stable and surfaces the configuration knob."""
+        assert "directed_input=False" in repr(DirectedSimplicialLifting())
+
+    def test_directed_input_true_is_guarded(self) -> None:
+        """``directed_input=True`` must raise :class:`NotImplementedError`.
+
+        The raw-orientation edge list breaks row/column alignment
+        between the 10 directed adjacencies and ``incidence_1`` /
+        ``x_1`` (which use canonical ``(min, max)`` edge ordering), so
+        we refuse to construct in that mode until the alignment is
+        threaded through ``incidence_1``.
+        """
+        with pytest.raises(NotImplementedError, match="directed_input=True"):
+            DirectedSimplicialLifting(directed_input=True)
+
+    def test_complex_dim_is_forced_to_2(self) -> None:
+        """Even if the caller asks for ``complex_dim=3`` we clamp to 2.
+
+        The paper only defines the directed adjacencies up to triangles;
+        higher complex dimensions are silently ignored by the backbone
+        and would only inflate the simplicial complex's incidence
+        matrices.
+        """
+        lifting = DirectedSimplicialLifting(complex_dim=3)
+        assert lifting.complex_dim == 2
+
+    def test_lift_keys_present(self) -> None:
+        """All ten directed adjacencies appear on the lifted batch."""
+        data = _make_data([(0, 1), (1, 2), (0, 2), (0, 3), (3, 4)], 5)
+        out = DirectedSimplicialLifting()(data)
+        for key in DIR_ADJ_KEYS:
+            assert hasattr(out, key), f"missing {key}"
+            assert getattr(out, key).is_sparse, (
+                f"{key} must be a sparse COO tensor"
+            )
+
+    def test_lift_shapes_match_incidence_1(self) -> None:
+        """Each adjacency is square and matches ``incidence_1.cols``."""
+        data = _make_data([(0, 1), (1, 2), (0, 2), (0, 3), (3, 4)], 5)
+        out = DirectedSimplicialLifting()(data)
+        n_edges = out.incidence_1.shape[1]
+        for key in DIR_ADJ_KEYS:
+            mat = getattr(out, key)
+            assert mat.shape == (n_edges, n_edges)
+
+    def test_isolated_node_has_zero_block(self) -> None:
+        """Adding an isolated node leaves the n_edges dimension unchanged."""
+        data_a = _make_data([(0, 1), (1, 2), (0, 2)], 3)
+        data_b = _make_data([(0, 1), (1, 2), (0, 2)], 4)  # extra isolated
+        a = DirectedSimplicialLifting()(data_a)
+        b = DirectedSimplicialLifting()(data_b)
+        # Same edges, same adjacency matrices.
+        for key in DIR_ADJ_KEYS:
+            assert torch.equal(_dense(getattr(a, key)), _dense(getattr(b, key)))
+
+    def test_symmetric_input_uses_canonical_orientation(self) -> None:
+        """An undirected edge ``{u,v}`` is oriented as ``(min,max)``.
+
+        Concretely: feeding the symmetric edge_index
+        ``[(0,1),(1,0),(0,2),(2,0)]`` must produce the same canonical
+        ``(min, max)`` edge list as feeding only ``[(0,1),(0,2)]``, and
+        therefore the same ten directed adjacencies.
+        """
+        sym = _make_data([(0, 1), (0, 2)], 3, symmetric=True)
+        asym = _make_data([(0, 1), (0, 2)], 3, symmetric=False)
+        lifting = DirectedSimplicialLifting()
+        sym_out = lifting(sym)
+        asym_out = lifting(asym)
+        for key in DIR_ADJ_KEYS:
+            assert torch.equal(
+                _dense(getattr(sym_out, key)),
+                _dense(getattr(asym_out, key)),
+            ), key
+
+    def test_canonical_orientation_flips_reverse_edges(self) -> None:
+        """Force inputs with reverse directions into canonical ``(min,max)`` order.
+
+        Feeding the asymmetric edge_index ``[(2, 0), (0, 1)]`` (note
+        ``2 > 0`` so canonical orientation flips the first edge) must
+        match the canonical edge list ``[(0, 1), (0, 2)]`` exactly.
+        With both edges sharing source 0, ``adj_low_100`` is the
+        all-ones matrix.
+        """
+        data = _make_data([(2, 0), (0, 1)], 3, symmetric=False)
+        out = DirectedSimplicialLifting()(data)
+        a100 = _dense(out.dir_lower_adj_100)
+        # Canonical edges sorted: (0,1) -> idx 0, (0,2) -> idx 1; both
+        # share source 0.
+        assert torch.equal(a100, torch.ones(2, 2))
+
+    def test_self_loops_are_ignored(self) -> None:
+        """Drop self-loops in ``edge_index`` before lifting.
+
+        Including ``(2, 2)`` in the symmetric edge list must not change
+        the resulting directed adjacencies relative to the loop-free
+        input.
+        """
+        data_clean = _make_data([(0, 1), (0, 2), (1, 2)], 3)
+        data_loops = _make_data(
+            [(0, 1), (0, 2), (1, 2), (2, 2)], 3, symmetric=False
+        )
+        # Force the symmetrised version of the clean data to match what
+        # `_make_data(symmetric=True)` produces above.
+        data_loops.edge_index = torch.cat(
+            [
+                data_loops.edge_index,
+                data_loops.edge_index.flip(0),
+            ],
+            dim=1,
+        )
+        out_clean = DirectedSimplicialLifting()(data_clean)
+        out_loops = DirectedSimplicialLifting()(data_loops)
+        for key in DIR_ADJ_KEYS:
+            assert torch.equal(
+                _dense(getattr(out_clean, key)),
+                _dense(getattr(out_loops, key)),
+            )
+
+    def test_collapse_to_4_lower_on_symmetric_input(self) -> None:
+        """On a symmetric input, the 4 lower adjacencies collapse to one.
+
+        Reference :func:`compute_lower_adj_undirected` defines the
+        symmetric edge lower-adjacency by ``|B_1|^T |B_1|`` with the
+        diagonal zeroed: two edges are lower-adjacent iff they share at
+        least one endpoint. Under canonical orientation, that endpoint
+        is either a shared src (``A_100``), a shared dst (``A_111``),
+        or a head-to-tail / tail-to-head meeting (``A_101`` / ``A_110``
+        respectively). Summing the four matrices (off-diagonal) must
+        recover the undirected lower adjacency exactly.
+        """
+        # Symmetric input: triangle 0-1-2 plus tail 0-3-4.
+        data = _make_data([(0, 1), (1, 2), (0, 2), (0, 3), (3, 4)], 5)
+        out = DirectedSimplicialLifting()(data)
+
+        # Reference undirected lower adjacency (|B_1|^T |B_1| diag=0).
+        n_edges = out.incidence_1.shape[1]
+        inc_1 = _dense(out.incidence_1).abs()
+        ref = (inc_1.t() @ inc_1).clamp(max=1.0)
+        ref.fill_diagonal_(0.0)
+
+        ours = (
+            _dense(out.dir_lower_adj_100)
+            + _dense(out.dir_lower_adj_101)
+            + _dense(out.dir_lower_adj_110)
+            + _dense(out.dir_lower_adj_111)
+        ).clamp(max=1.0)
+        ours.fill_diagonal_(0.0)
+
+        assert ours.shape == (n_edges, n_edges)
+        assert torch.equal(ours, ref)
+
+    def test_triangle_count_matches_upper_adj_nnz(self) -> None:
+        """Number of triangles equals nnz of each upper adjacency.
+
+        With canonical orientation every undirected triangle contributes
+        exactly one entry to every upper adjacency (branch 1 of the
+        rotation chain). The line-graph triangle count is therefore
+        equal to the nnz of e.g. ``dir_upper_adj_101``.
+        """
+        # Triangle 0-1-2, plus another triangle 2-3-4 sharing one vertex.
+        data = _make_data(
+            [(0, 1), (1, 2), (0, 2), (2, 3), (3, 4), (2, 4)], 5
+        )
+        out = DirectedSimplicialLifting()(data)
+        # Count triangles via networkx for an independent ground truth.
+        und = nx.Graph()
+        und.add_edges_from(
+            [
+                (int(data.edge_index[0, k]), int(data.edge_index[1, k]))
+                for k in range(data.edge_index.shape[1])
+            ]
+        )
+        triangles = sum(
+            1 for clique in nx.find_cliques(und) if len(clique) >= 3
+        ) if False else len([
+            tuple(sorted((u, v, w)))
+            for u, v in und.edges()
+            for w in (set(und.neighbors(u)) & set(und.neighbors(v)))
+        ]) // 3
+        # Each triangle is counted three times in the above sum (once
+        # per edge), so we divide by 3 (already done) -> use a clean
+        # 3-clique enumeration:
+        n_triangles = sum(
+            1 for clique in nx.enumerate_all_cliques(und) if len(clique) == 3
+        )
+        assert triangles == n_triangles
+        for key in DIR_UPPER_KEYS:
+            assert _dense(getattr(out, key)).sum().item() == n_triangles
+
+    def test_no_edges_does_not_crash(self) -> None:
+        """A graph with nodes but no edges produces empty adjacency tensors."""
+        data = torch_geometric.data.Data(
+            x=torch.zeros(3, 1),
+            edge_index=torch.empty(2, 0, dtype=torch.long),
+            num_nodes=3,
+            y=torch.zeros(3, dtype=torch.long),
+        )
+        out = DirectedSimplicialLifting()(data)
+        for key in DIR_ADJ_KEYS:
+            mat = getattr(out, key)
+            assert mat.shape == (0, 0) or mat.values().numel() == 0
+
+
+# ---------------------------------------------------------------------------
+# Opt-in spectral_normalize
+# ---------------------------------------------------------------------------
+
+
+class TestSpectralNormalize:
+    """Tests for the opt-in ``spectral_normalize`` knob.
+
+    Mirrors :func:`spectral_normalization` in the upstream
+    ``utils.py:16-20`` applied to each of the lower adjacencies in
+    ``train.py:29-33``. Default is
+    off so the existing 10-adj evaluation at ``d507f80b`` stays
+    bit-identical.
+    """
+
+    def test_spectral_normalize_off_preserves_raw_binary(self) -> None:
+        """``spectral_normalize=False`` (default) keeps raw binary adjacencies.
+
+        The default forward output must be bit-identical to the
+        pre-review-3 behaviour, so existing eval results remain valid.
+        """
+        data = _make_data([(0, 1), (1, 2), (0, 2), (0, 3), (3, 4)], 5)
+        raw = DirectedSimplicialLifting()(data)
+        explicit_off = DirectedSimplicialLifting(spectral_normalize=False)(data)
+        for key in DIR_ADJ_KEYS:
+            mat = _dense(getattr(raw, key))
+            # Every nonzero value of the raw adjacency must be exactly 1.
+            unique = torch.unique(mat)
+            assert torch.all(
+                (unique == 0.0) | (unique == 1.0)
+            ), f"{key} has non-binary entries when spectral_normalize is off"
+            assert torch.equal(mat, _dense(getattr(explicit_off, key)))
+
+    def test_spectral_normalize_on_divides_by_max_eig_symmetric(self) -> None:
+        """On a symmetric adjacency, output = raw / max-eigenvalue.
+
+        Uses the canonical triangle ``{0, 1, 2}`` whose
+        ``adj_low_100`` (same-source) is the matrix::
+
+            [[1, 1, 0],
+             [1, 1, 0],
+             [0, 0, 1]]
+
+        (edges (0,1), (0,2), (1,2); (0,1) and (0,2) share source 0,
+        (1,2) only matches itself). This is symmetric so we can match
+        the reference ``torch.linalg.eigh`` computation exactly.
+        """
+        edges = [(0, 1), (0, 2), (1, 2)]
+        # Build a directed-only-input by constructing a Data with the
+        # exact canonical edges; the lifting will treat the symmetric
+        # version of these the same way.
+        data = _make_data(edges, 3, symmetric=True)
+        out = DirectedSimplicialLifting(spectral_normalize=True)(data)
+        a100 = _dense(out.dir_lower_adj_100)
+
+        # Reference computation: eigh on the raw binary 100, divide.
+        raw_100 = torch.tensor(
+            [[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+        max_eig = torch.linalg.eigh(raw_100)[0][-1]
+        expected = raw_100 / max_eig
+        assert torch.allclose(a100, expected, atol=1e-6), (
+            f"a100 = {a100}, expected = {expected}"
+        )
+        # Sanity: largest eigenvalue of the normalized matrix is 1.
+        norm_eigvals = torch.linalg.eigh(a100)[0]
+        assert abs(norm_eigvals[-1].item() - 1.0) < 1e-6
+
+    def test_spectral_normalize_on_non_symmetric_matches_reference(self) -> None:
+        """On a non-symmetric adjacency, reproduce the reference verbatim.
+
+        ``adj_low_101`` (line-graph adjacency) is non-symmetric in
+        general. The upstream :func:`spectral_normalization` calls
+        :func:`torch.linalg.eigh` regardless of symmetry; we reproduce
+        the same call (which treats only the lower triangle as
+        Hermitian) for bit-for-bit faithfulness when the lower triangle
+        is non-trivial.
+        """
+        # Star + back-edges so adj_low_101 has a non-trivial lower
+        # triangle: edges (0,1), (0,2), (1,2). The line-graph
+        # adjacency has (0,1)->(1,2) i.e. ``a101[0, 2] = 1`` (upper
+        # triangle) and ``a101[1, 2] = 1`` if (0,2) ends where (2,_)
+        # starts -- but (0,2) ends at 2 and (1,2) also ends at 2, so
+        # no head-to-tail meeting. To get a lower-triangle entry we
+        # need a directed cycle which our canonical orientation
+        # forbids -- so a101's lower triangle is zero here, and the
+        # reference's eigh path returns max_eig=0. Our implementation
+        # falls back to eigvals's abs max in that degenerate case;
+        # verify the fallback yields a finite, normalized result.
+        edges = [(0, 1), (1, 2), (0, 2)]
+        data = _make_data(edges, 3, symmetric=True)
+        out = DirectedSimplicialLifting(spectral_normalize=True)(data)
+        a101 = _dense(out.dir_lower_adj_101)
+        # Non-NaN and bounded by 1 in absolute value of its largest
+        # |eigvalue| (which the eigvals-fallback divides by).
+        assert torch.isfinite(a101).all()
+        eigvals_abs_max = torch.linalg.eigvals(a101).abs().max().item()
+        # Either the matrix is all-zero (no head-to-tail meeting under
+        # canonical orientation) or it has been rescaled to spectral
+        # radius 1.
+        assert eigvals_abs_max == 0.0 or abs(eigvals_abs_max - 1.0) < 1e-6
+
+    def test_spectral_normalize_repr(self) -> None:
+        """``repr`` surfaces the new ``spectral_normalize`` knob."""
+        assert "spectral_normalize=True" in repr(
+            DirectedSimplicialLifting(spectral_normalize=True)
+        )
+        assert "spectral_normalize=False" in repr(DirectedSimplicialLifting())
+
+    def test_spectral_normalize_empty_graph(self) -> None:
+        """Spectral normalization on an empty graph is a no-op."""
+        data = torch_geometric.data.Data(
+            x=torch.zeros(3, 1),
+            edge_index=torch.empty(2, 0, dtype=torch.long),
+            num_nodes=3,
+            y=torch.zeros(3, dtype=torch.long),
+        )
+        out = DirectedSimplicialLifting(spectral_normalize=True)(data)
+        for key in DIR_ADJ_KEYS:
+            mat = getattr(out, key)
+            assert mat.shape == (0, 0) or mat.values().numel() == 0
+
+    def test_spectral_normalize_helper_zero_matrix(self) -> None:
+        """The all-zero adjacency hits the second-stage fallback and is returned as-is."""
+        zero = torch.zeros(3, 3)
+        out = DirectedSimplicialLifting._spectral_normalize(zero)
+        assert torch.equal(out, zero)
+
+    def test_dirsnn_official_lower_uses_spectral_norm(self) -> None:
+        """End-to-end Hydra instantiation of ``dirsnn_official_lower`` config.
+
+        Verifies the resulting batch has spectrally normalized
+        adjacencies: the largest eigenvalue (via ``torch.linalg.eigh``,
+        matching the reference) of the symmetric lower adjacencies
+        ``dir_lower_adj_100`` / ``dir_lower_adj_111`` is approximately
+        1.0.
+        """
+        from hydra import compose, initialize_config_dir
+
+        from topobench.utils.config_resolvers import register_all_resolvers
+
+        # Ensure custom OmegaConf resolvers (notably
+        # ``get_default_transform``) are registered before composing.
+        register_all_resolvers()
+
+        config_dir = str(Path(__file__).resolve().parents[4] / "configs")
+        with initialize_config_dir(version_base="1.3", config_dir=config_dir):
+            cfg = compose(
+                config_name="run.yaml",
+                overrides=[
+                    "model=simplicial/dirsnn_official_lower",
+                    "dataset=graph/MUTAG",
+                    "trainer=cpu",
+                    "logger=wandb",
+                ],
+            )
+        # The compose result holds the transform yaml node; check the
+        # spectral_normalize knob made it through.
+        lifting_cfg = cfg.transforms.graph2simplicial_lifting
+        assert lifting_cfg.spectral_normalize is True, (
+            f"dirsnn_official_lower must set spectral_normalize=True; "
+            f"got {lifting_cfg}"
+        )
+
+        # And actually instantiate the lifting + run it on a tiny PyG
+        # batch so we can assert the normalized adjacency really has
+        # spectral radius 1.
+        from topobench.transforms import TRANSFORMS
+
+        lifting = TRANSFORMS[lifting_cfg.transform_name](
+            **{
+                k: v
+                for k, v in lifting_cfg.items()
+                if k not in ("transform_type", "transform_name")
+            }
+        )
+        data = _make_data([(0, 1), (0, 2), (1, 2), (0, 3)], 4)
+        out = lifting(data)
+        a100 = _dense(out.dir_lower_adj_100)
+        # adj_low_100 is symmetric (same-source mask), so its eigh-based
+        # spectral radius after normalization is 1.
+        max_eig = torch.linalg.eigh(a100)[0][-1].item()
+        assert abs(max_eig - 1.0) < 1e-5, f"max eigenvalue = {max_eig}"
+
+
+def test_directed_adjacencies_match_reference_example() -> None:
+    """Check all ten directed adjacencies on a fixed reference digraph."""
+    canonical_edges = [
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 2),
+        (2, 3),
+        (2, 4),
+        (3, 4),
+    ]
+    sym_pairs = canonical_edges + [(v, u) for u, v in canonical_edges]
+    data = torch_geometric.data.Data(
+        x=torch.arange(5).float().unsqueeze(1),
+        edge_index=torch.tensor(sym_pairs).T.long(),
+        num_nodes=5,
+        y=torch.zeros(5, dtype=torch.long),
+    )
+    out = DirectedSimplicialLifting()(data)
+
+    # Edge order:
+    # 0=(0,1), 1=(0,2), 2=(0,3), 3=(1,2), 4=(2,3),
+    # 5=(2,4), 6=(3,4). The expected coordinates below are the
+    # elementwise outputs of the upstream DirSNN compute_adj.py on this
+    # digraph, expressed in the canonical edge order used by TopoBench.
+    expected = {
+        "dir_lower_adj_100": _expected_matrix(
+            7,
+            [
+                (0, 0),
+                (0, 1),
+                (0, 2),
+                (1, 0),
+                (1, 1),
+                (1, 2),
+                (2, 0),
+                (2, 1),
+                (2, 2),
+                (3, 3),
+                (4, 4),
+                (4, 5),
+                (5, 4),
+                (5, 5),
+                (6, 6),
+            ],
+        ),
+        "dir_lower_adj_101": _expected_matrix(
+            7,
+            [
+                (0, 3),
+                (1, 4),
+                (1, 5),
+                (2, 6),
+                (3, 4),
+                (3, 5),
+                (4, 6),
+            ],
+        ),
+        "dir_lower_adj_110": _expected_matrix(
+            7,
+            [
+                (3, 0),
+                (4, 1),
+                (5, 1),
+                (6, 2),
+                (4, 3),
+                (5, 3),
+                (6, 4),
+            ],
+        ),
+        "dir_lower_adj_111": _expected_matrix(
+            7,
+            [
+                (0, 0),
+                (1, 1),
+                (1, 3),
+                (2, 2),
+                (2, 4),
+                (3, 1),
+                (3, 3),
+                (4, 2),
+                (4, 4),
+                (5, 5),
+                (5, 6),
+                (6, 5),
+                (6, 6),
+            ],
+        ),
+        "dir_upper_adj_101": _expected_matrix(7, [(3, 1), (4, 2), (6, 5)]),
+        "dir_upper_adj_102": _expected_matrix(7, [(3, 0), (4, 1), (6, 4)]),
+        "dir_upper_adj_112": _expected_matrix(7, [(1, 0), (2, 1), (5, 4)]),
+        "dir_upper_adj_110": _expected_matrix(7, [(1, 3), (2, 4), (5, 6)]),
+        "dir_upper_adj_120": _expected_matrix(7, [(0, 3), (1, 4), (4, 6)]),
+        "dir_upper_adj_121": _expected_matrix(7, [(0, 1), (1, 2), (4, 5)]),
+    }
+    for key, expected_dense in expected.items():
+        ours = _dense(getattr(out, key))
+        assert torch.allclose(ours, expected_dense), (
+            f"{key} disagrees with the reference compute_adj.py output. "
+            f"Diff:\n{(ours - expected_dense).abs().max().item()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+def test_adjacency_key_ordering_is_stable() -> None:
+    """Public key constants follow the reference ``compute_adj.py`` order."""
+    assert DIR_LOWER_KEYS == (
+        "dir_lower_adj_100",
+        "dir_lower_adj_101",
+        "dir_lower_adj_110",
+        "dir_lower_adj_111",
+    )
+    assert DIR_UPPER_KEYS == (
+        "dir_upper_adj_101",
+        "dir_upper_adj_102",
+        "dir_upper_adj_112",
+        "dir_upper_adj_110",
+        "dir_upper_adj_120",
+        "dir_upper_adj_121",
+    )
+    assert DIR_ADJ_KEYS == DIR_LOWER_KEYS + DIR_UPPER_KEYS
+    assert len(DIR_ADJ_KEYS) == 10

--- a/topobench/nn/backbones/simplicial/dirsnn.py
+++ b/topobench/nn/backbones/simplicial/dirsnn.py
@@ -1,0 +1,429 @@
+"""Directed Simplicial Neural Network (Dir-SNN) backbone.
+
+Implements the model introduced in *Higher-Order Topological Directionality
+and Directed Simplicial Neural Networks* by M. Lecha, A. Cavallo,
+F. Dominici, E. Isufi, and C. Battiloro (ICASSP 2025, arXiv:2409.08389).
+
+This module is a TopoBench port of Andrea Cavallo's reference
+implementation at https://github.com/ManuelLecha/DirSNN. As in the paper
+experiments, the network operates on edge (1-simplex) signals and
+propagates them through a collection of directed lower and upper edge
+adjacencies that encode higher-order topological directionality
+(Sec. III, Eqs. (3)-(4)).
+
+References
+----------
+.. [1] M. Lecha, A. Cavallo, F. Dominici, E. Isufi, C. Battiloro.
+       *Higher-Order Topological Directionality and Directed Simplicial
+       Neural Networks.* ICASSP 2025. arXiv:2409.08389.
+"""
+
+import torch
+from torch.nn.parameter import Parameter
+
+
+class DirSNN(torch.nn.Module):
+    r"""Directed Simplicial Neural Network backbone.
+
+    Implements the Dir-SNN architecture of Lecha et al. 2024
+    (arXiv:2409.08389). Edge features are first projected to a common
+    hidden dimension by an MLP and then refined by a stack of
+    :class:`DirSNNLayer` modules. Each layer aggregates over the
+    directed lower :math:`\mathcal{A}^{i,j}_{\downarrow,1}` (Eq. 3) and
+    upper :math:`\mathcal{A}^{i,j}_{\uparrow,1}` (Eq. 4) edge
+    adjacencies that are supplied as a list of sparse/dense tensors.
+
+    The number and identity of the adjacencies are not fixed by the
+    model: the user is expected to pass between one and ten matrices,
+    typically the four lower adjacencies
+    (:math:`\mathcal{A}^{0,0}_{\downarrow,1},
+    \mathcal{A}^{0,1}_{\downarrow,1},
+    \mathcal{A}^{1,0}_{\downarrow,1},
+    \mathcal{A}^{1,1}_{\downarrow,1}`) and the six upper adjacencies
+    (:math:`\mathcal{A}^{0,1}_{\uparrow,1},
+    \mathcal{A}^{0,2}_{\uparrow,1},
+    \mathcal{A}^{1,2}_{\uparrow,1},
+    \mathcal{A}^{1,0}_{\uparrow,1},
+    \mathcal{A}^{2,0}_{\uparrow,1},
+    \mathcal{A}^{2,1}_{\uparrow,1}`) used in Sec. IV-A of the paper.
+
+    Parameters
+    ----------
+    edge_channels : int
+        Dimension of the input edge features.
+    n_layers : int, optional
+        Number of stacked Dir-SNN layers, by default 2.
+    n_hid : int, optional
+        Hidden dimension on edges (input/output of every layer),
+        by default 32.
+    conv_order : int, optional
+        Order :math:`K` of the polynomial filter applied to every
+        adjacency (Chebyshev-like expansion of Eq. (6)/(7)),
+        by default 1.
+    n_adjs : int, optional
+        Number of directed adjacency matrices that will be supplied at
+        forward time. Must match the length of ``adjs`` in
+        :meth:`forward`, by default 1.
+    aggr_norm : bool, optional
+        Whether to row-normalise each aggregation step by the
+        neighbourhood size, by default False.
+    update_func : str or None, optional
+        Activation applied after the per-layer linear update
+        (``"relu"``, ``"leaky_relu"``, ``"sigmoid"`` or ``None``),
+        by default None.
+    """
+
+    def __init__(
+        self,
+        edge_channels,
+        n_layers=2,
+        n_hid=32,
+        conv_order=1,
+        n_adjs=1,
+        aggr_norm=False,
+        update_func=None,
+    ):
+        super().__init__()
+        self.edge_channels = edge_channels
+        self.n_hid = n_hid
+        self.n_layers = n_layers
+        self.conv_order = conv_order
+        self.n_adjs = n_adjs
+        self.aggr_norm = aggr_norm
+        self.update_func = update_func
+
+        # Initial linear projection of edge features (Eq. (2) of the
+        # paper maps topological signals to a learnable embedding before
+        # message passing).
+        self.in_linear_1 = torch.nn.Linear(edge_channels, n_hid)
+
+        self.layers = torch.nn.ModuleList(
+            DirSNNLayer(
+                in_channels_1=n_hid,
+                out_channels_1=n_hid,
+                conv_order=conv_order,
+                n_adjs=n_adjs,
+                aggr_norm=aggr_norm,
+                update_func=update_func,
+            )
+            for _ in range(n_layers)
+        )
+
+    def forward(self, x_1, adjs):
+        r"""Run the Dir-SNN forward pass.
+
+        Iterates the update of Eq. (10) of Lecha et al. 2024
+        (arXiv:2409.08389) for ``n_layers`` rounds.
+
+        Parameters
+        ----------
+        x_1 : torch.Tensor
+            Edge feature tensor of shape ``(n_edges, edge_channels)``.
+        adjs : sequence of torch.Tensor
+            Tuple or list of directed edge adjacency matrices, each of
+            shape ``(n_edges, n_edges)``. Length must equal ``n_adjs``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated edge features of shape ``(n_edges, n_hid)``.
+        """
+        x_1 = self.in_linear_1(x_1)
+        for layer in self.layers:
+            x_1 = layer(x_1, adjs)
+        return x_1
+
+
+class DirSNNLayer(torch.nn.Module):
+    r"""Single Dir-SNN message-passing layer.
+
+    Implements Eqs. (6)-(10) of Lecha et al. 2024 (arXiv:2409.08389)
+    specialised to edge signals. Given ``n_adjs`` directed adjacencies
+    :math:`\{A^{(s)}\}_{s=1}^{n\_adjs}`, the layer computes
+
+    .. math::
+        y = \sigma\!\left(
+            x W_0
+            + \sum_{s=1}^{n\_adjs} \sum_{k=1}^{K} (A^{(s)})^{k} x \, W_{s,k}
+        \right),
+
+    where :math:`K` is ``conv_order``, every term shares the same
+    learnable tensor ``weight_1`` via a single ``einsum`` contraction,
+    and :math:`\sigma` is the optional ``update_func``. The identity
+    term :math:`x W_0` corresponds to keeping the simplex own feature
+    in Eq. (10) (the :math:`x_\sigma^l` argument of :math:`\phi`).
+
+    Parameters
+    ----------
+    in_channels_1 : int
+        Input edge feature dimension.
+    out_channels_1 : int
+        Output edge feature dimension.
+    conv_order : int
+        Polynomial order :math:`K` of the filter applied to every
+        adjacency. Must be strictly positive.
+    n_adjs : int, optional
+        Number of directed adjacency matrices used as message passing
+        operators, by default 1.
+    aggr_norm : bool, optional
+        Whether to row-normalise every aggregation step, by default
+        False.
+    update_func : str or None, optional
+        Pointwise activation applied to the layer output, by default
+        None. Supported values are ``"relu"``, ``"leaky_relu"``,
+        ``"sigmoid"``.
+    initialization : str, optional
+        Weight initialisation: ``"xavier_uniform"`` or
+        ``"xavier_normal"``, by default ``"xavier_normal"``.
+    """
+
+    def __init__(
+        self,
+        in_channels_1,
+        out_channels_1,
+        conv_order,
+        n_adjs=1,
+        aggr_norm: bool = False,
+        update_func=None,
+        initialization: str = "xavier_normal",
+    ) -> None:
+        super().__init__()
+
+        self.in_channels_1 = in_channels_1
+        self.out_channels_1 = out_channels_1
+        self.conv_order = conv_order
+        self.n_adjs = n_adjs
+        self.aggr_norm = aggr_norm
+        self.update_func = update_func
+        self.initialization = initialization
+
+        assert initialization in ["xavier_uniform", "xavier_normal"]
+        assert self.conv_order > 0
+
+        # weight_1 stores all filter taps in a single tensor that is
+        # contracted in one einsum, mirroring the shared aggregator
+        # convention of Eq. (6)/(7).
+        self.weight_1 = Parameter(
+            torch.Tensor(
+                self.in_channels_1,
+                self.out_channels_1,
+                conv_order * n_adjs + 1,
+            )
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self, gain: float = 1.414):
+        r"""Initialise the learnable weights.
+
+        Applies Xavier initialisation as in the reference Dir-SNN
+        implementation; this is purely an implementation detail and is
+        not specified by the paper text.
+
+        Parameters
+        ----------
+        gain : float, optional
+            Gain factor passed to ``torch.nn.init.xavier_*_`` (default
+            1.414, matching ``sqrt(2)`` for ReLU-style activations).
+        """
+        if self.initialization == "xavier_uniform":
+            torch.nn.init.xavier_uniform_(self.weight_1, gain=gain)
+        elif self.initialization == "xavier_normal":
+            torch.nn.init.xavier_normal_(self.weight_1, gain=gain)
+        else:
+            raise RuntimeError(
+                "Initialization method not recognized. "
+                "Should be either xavier_uniform or xavier_normal."
+            )
+
+    def aggr_norm_func(self, conv_operator, x):
+        r"""Row-normalise an aggregation by neighbourhood size.
+
+        Optional helper invoked when ``aggr_norm=True``. The behaviour
+        is unchanged from the reference Dir-SNN code and is not a
+        specific paper equation.
+
+        Mathematical note (reference-faithful, deliberate
+        double-normalisation): for ``conv_order > 1`` this routine is
+        invoked after *every* power of the adjacency
+        (``conv_operator``, ``conv_operator^2``, ...), but each call
+        normalises by the row sums of the *original* ``conv_operator``
+        rather than by the row sums of the higher-power propagation
+        operator that was actually used. The effective propagator at
+        step ``k`` is therefore ``D^{-1} A^k`` rather than ``(D^{-1}
+        A)^k`` (i.e. a single random walk normalisation followed by raw
+        powers, not powers of the random-walk-normalised operator).
+        This matches the upstream reference implementation
+        (``compute_adj.py`` and the DirSNN model code therein)
+        verbatim and is preserved here so our results stay numerically
+        comparable to the paper's artefacts; it is *not* the standard
+        GCN-style row normalisation.
+
+        Parameters
+        ----------
+        conv_operator : torch.Tensor
+            Adjacency matrix used to define the neighbourhoods. Dense
+            or sparse, shape ``(n_edges, n_edges)``.
+        x : torch.Tensor
+            Aggregated features, shape ``(n_edges, num_channels)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Normalised features with the same shape as ``x``.
+        """
+        if conv_operator.is_sparse:
+            neighborhood_size = torch.sum(conv_operator.to_dense(), dim=1)
+        else:
+            neighborhood_size = torch.sum(conv_operator, dim=1)
+        neighborhood_size_inv = 1.0 / neighborhood_size
+        neighborhood_size_inv[~torch.isfinite(neighborhood_size_inv)] = 0.0
+        x = torch.einsum("i,ij->ij", neighborhood_size_inv, x)
+        x[~torch.isfinite(x)] = 0.0
+        return x
+
+    def update(self, x):
+        r"""Apply the pointwise activation of Eq. (10).
+
+        The update function :math:`\phi` in Eq. (10) of Lecha et al.
+        2024 is implemented as a fixed nonlinearity selected by
+        ``update_func``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Pre-activation output of shape
+            ``(n_edges, out_channels_1)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Activated tensor.
+
+        Raises
+        ------
+        ValueError
+            If ``update_func`` is not one of ``"relu"``,
+            ``"leaky_relu"``, ``"sigmoid"``. The reference Dir-SNN
+            implementation silently returned ``None`` here, which
+            propagated to ``forward`` and caused opaque downstream
+            crashes; we raise instead so the misconfiguration is
+            visible at the first call site.
+        """
+        if self.update_func == "sigmoid":
+            return torch.sigmoid(x)
+        if self.update_func == "relu":
+            return torch.nn.functional.relu(x)
+        if self.update_func == "leaky_relu":
+            return torch.nn.functional.leaky_relu(x)
+        raise ValueError(
+            f"Unknown update_func: {self.update_func!r}; expected one of "
+            "{'relu', 'leaky_relu', 'sigmoid'} or None."
+        )
+
+    def chebyshev_conv(self, conv_operator, conv_order, x):
+        r"""Apply repeated propagation by a directed adjacency.
+
+        Computes ``conv_operator^k @ x`` for ``k = 1, ..., conv_order``
+        and stacks the results along the last axis. This realises the
+        polynomial filter used inside the intra-neighbourhood
+        aggregator :math:`\psi_{\mathcal{A}}` of Eqs. (6)-(7) of the
+        paper.
+
+        Parameters
+        ----------
+        conv_operator : torch.Tensor
+            Directed adjacency matrix of shape ``(n_edges, n_edges)``.
+            Dense or sparse; for sparse tensors the propagation uses
+            ``torch.sparse.mm``.
+        conv_order : int
+            Polynomial order :math:`K`.
+        x : torch.Tensor
+            Edge feature tensor of shape
+            ``(n_edges, num_channels)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(n_edges, num_channels, conv_order)``
+            with ``X[..., k] = conv_operator^{k+1} @ x``.
+        """
+        num_simplices, num_channels = x.shape
+        out = torch.empty(
+            size=(num_simplices, num_channels, conv_order),
+            device=x.device,
+            dtype=x.dtype,
+        )
+
+        def _propagate(op, y):
+            """Apply ``op @ y`` selecting sparse or dense matmul.
+
+            Parameters
+            ----------
+            op : torch.Tensor
+                Square propagation operator. May be sparse or dense.
+            y : torch.Tensor
+                Right-hand-side tensor to be propagated.
+
+            Returns
+            -------
+            torch.Tensor
+                The matrix product ``op @ y``.
+            """
+            if op.is_sparse:
+                return torch.sparse.mm(op, y)
+            return torch.mm(op, y)
+
+        out[:, :, 0] = _propagate(conv_operator, x)
+        if self.aggr_norm:
+            out[:, :, 0] = self.aggr_norm_func(conv_operator, out[:, :, 0])
+        for k in range(1, conv_order):
+            out[:, :, k] = _propagate(conv_operator, out[:, :, k - 1])
+            if self.aggr_norm:
+                out[:, :, k] = self.aggr_norm_func(conv_operator, out[:, :, k])
+        return out
+
+    def forward(self, x_1, adjs):
+        r"""Run one Dir-SNN message-passing step.
+
+        Implements Eq. (10) of Lecha et al. 2024 (arXiv:2409.08389):
+        the edge feature is updated by concatenating its own value
+        with the polynomial expansion of every supplied directed
+        adjacency and contracting the result against ``weight_1``.
+
+        Parameters
+        ----------
+        x_1 : torch.Tensor
+            Edge features of shape ``(n_edges, in_channels_1)``.
+        adjs : sequence of torch.Tensor
+            Directed adjacency matrices, each of shape
+            ``(n_edges, n_edges)``. Length must equal ``n_adjs``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated edge features of shape
+            ``(n_edges, out_channels_1)``.
+
+        Raises
+        ------
+        AssertionError
+            If the number of adjacencies in ``adjs`` does not match
+            ``n_adjs`` set at construction time.
+        """
+        assert len(adjs) == self.n_adjs, (
+            f"Expected {self.n_adjs} adjacencies, got {len(adjs)}."
+        )
+
+        # Identity term: x_sigma^l in Eq. (10).
+        x_1_all = [
+            x_1.unsqueeze(2),
+            *(self.chebyshev_conv(adj, self.conv_order, x_1) for adj in adjs),
+        ]
+
+        x_1_all = torch.cat(x_1_all, dim=2)
+        y_1 = torch.einsum("nik,iok->no", x_1_all, self.weight_1)
+
+        if self.update_func is None:
+            return y_1
+        return self.update(y_1)

--- a/topobench/nn/backbones/simplicial/dirsnn.py
+++ b/topobench/nn/backbones/simplicial/dirsnn.py
@@ -86,6 +86,7 @@ class DirSNN(torch.nn.Module):
         super().__init__()
         self.edge_channels = edge_channels
         self.n_hid = n_hid
+        self.out_channels = n_hid
         self.n_layers = n_layers
         self.conv_order = conv_order
         self.n_adjs = n_adjs

--- a/topobench/nn/wrappers/simplicial/dirsnn_wrapper.py
+++ b/topobench/nn/wrappers/simplicial/dirsnn_wrapper.py
@@ -1,0 +1,131 @@
+"""Wrapper for the Dir-SNN model."""
+
+import torch
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+# Stable ordering of the 10 directed edge adjacencies fed to the Dir-SNN
+# backbone. Mirrors the order produced by
+# :class:`DirectedSimplicialLifting` (which itself follows
+# ``compute_lower_adj`` / ``compute_upper_adj`` of the upstream
+# reference repository).
+DIRSNN_ADJ_KEYS: tuple[str, ...] = (
+    "dir_lower_adj_100",
+    "dir_lower_adj_101",
+    "dir_lower_adj_110",
+    "dir_lower_adj_111",
+    "dir_upper_adj_101",
+    "dir_upper_adj_102",
+    "dir_upper_adj_112",
+    "dir_upper_adj_110",
+    "dir_upper_adj_120",
+    "dir_upper_adj_121",
+)
+
+# The first four entries of ``DIRSNN_ADJ_KEYS`` are the lower (Eq. 3)
+# adjacencies and the remaining six are the upper (Eq. 4) adjacencies;
+# the official experimental setup of the upstream Dir-SNN repository
+# uses only the lower four. See "official experimental mode" below.
+_DIRSNN_LOWER_KEYS: tuple[str, ...] = DIRSNN_ADJ_KEYS[:4]
+_DIRSNN_UPPER_KEYS: tuple[str, ...] = DIRSNN_ADJ_KEYS[4:]
+_VALID_ADJ_SUBSETS = (None, "lower", "upper")
+
+
+class DirSNNWrapper(AbstractWrapper):
+    r"""Wrapper for the Dir-SNN backbone.
+
+    Implements the data-marshalling expected by :class:`DirSNN`
+    (Lecha et al. 2024, arXiv:2409.08389): edge features ``x_1`` plus a
+    tuple of edge-level *directed* adjacency matrices produced by the
+    paired :class:`DirectedSimplicialLifting` transform.
+
+    Two intended operating modes are supported via ``adj_subset``:
+
+    * **Paper-compatible / challenge mode** (``adj_subset=None``,
+      default). The wrapper forwards all ten adjacency tensors named
+      in :data:`DIRSNN_ADJ_KEYS` to the backbone, in the order
+      ``(A^{0,0}_{down,1}, A^{0,1}_{down,1}, A^{1,0}_{down,1},
+      A^{1,1}_{down,1},
+      A^{0,1}_{up,1}, A^{0,2}_{up,1}, A^{1,2}_{up,1},
+      A^{1,0}_{up,1}, A^{2,0}_{up,1}, A^{2,1}_{up,1})``
+      (paper Sec. III, Eqs. (3)-(4)). This is the general formulation
+      of the paper.
+
+    * **Official experimental mode** (``adj_subset="lower"``). The
+      wrapper forwards only the four *lower* directed adjacencies
+      (``dir_lower_adj_100``, ``dir_lower_adj_101``,
+      ``dir_lower_adj_110``, ``dir_lower_adj_111``). This matches the
+      narrower experimental setup actually used in the upstream
+      reference repository (``compute_lower_adj`` of
+      ``repos/DirSNN/compute_adj.py`` returns exactly these four; the
+      upper adjacencies live in ``compute_upper_adj`` but are not used
+      in the paper's published experiments).
+
+    A symmetric ``adj_subset="upper"`` knob is also provided for the
+    six upper directed adjacencies (used for ablations).
+
+    Parameters
+    ----------
+    backbone : torch.nn.Module
+        The Dir-SNN backbone. Its ``n_adjs`` must equal the number of
+        adjacencies implied by ``adj_subset``.
+    adj_subset : {None, "lower", "upper"}, optional
+        Which directed adjacencies to forward to the backbone. ``None``
+        (default) forwards all 10. ``"lower"`` forwards the 4 lower
+        adjacencies (Eq. (3)) only. ``"upper"`` forwards the 6 upper
+        adjacencies (Eq. (4)) only.
+    **kwargs : dict
+        Forwarded to :class:`AbstractWrapper`.
+
+    Notes
+    -----
+    The Hodge-Laplacian fallback used in earlier revisions of this
+    wrapper has been removed: it did not exercise the paper's central
+    novelty (higher-order directionality). Use
+    :class:`DirectedSimplicialLifting` to produce the directed
+    adjacencies on the batch -- the default
+    ``configs/model/simplicial/dirsnn.yaml`` does so automatically.
+    """
+
+    def __init__(self, backbone, adj_subset: str | None = None, **kwargs):
+        super().__init__(backbone, **kwargs)
+        if adj_subset not in _VALID_ADJ_SUBSETS:
+            raise ValueError(
+                f"Unknown adj_subset={adj_subset!r}; expected one of "
+                f"{_VALID_ADJ_SUBSETS}."
+            )
+        self.adj_subset = adj_subset
+        if adj_subset is None:
+            self._adj_keys = DIRSNN_ADJ_KEYS
+        elif adj_subset == "lower":
+            self._adj_keys = _DIRSNN_LOWER_KEYS
+        else:  # "upper"
+            self._adj_keys = _DIRSNN_UPPER_KEYS
+
+    def forward(self, batch):
+        r"""Forward pass for the Dir-SNN wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing batched simplicial data with the ten
+            directed adjacency attributes named in
+            :data:`DIRSNN_ADJ_KEYS`.
+
+        Returns
+        -------
+        dict
+            Dictionary with updated edge embeddings under ``x_1`` and
+            node embeddings (obtained via the boundary map) under
+            ``x_0``.
+        """
+        adjs = tuple(getattr(batch, key) for key in self._adj_keys)
+        x_1 = self.backbone(batch.x_1, adjs)
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        # Project edge embeddings back to nodes via the boundary
+        # operator so that downstream readouts have access to a
+        # 0-cell signal as well.
+        model_out["x_0"] = torch.sparse.mm(batch.incidence_1, x_1)
+        model_out["x_1"] = x_1
+        return model_out

--- a/topobench/nn/wrappers/simplicial/dirsnn_wrapper.py
+++ b/topobench/nn/wrappers/simplicial/dirsnn_wrapper.py
@@ -102,6 +102,14 @@ class DirSNNWrapper(AbstractWrapper):
         else:  # "upper"
             self._adj_keys = _DIRSNN_UPPER_KEYS
 
+        expected_n_adjs = len(self._adj_keys)
+        actual_n_adjs = getattr(backbone, "n_adjs", None)
+        if actual_n_adjs != expected_n_adjs:
+            raise ValueError(
+                f"DirSNNWrapper expected backbone.n_adjs={expected_n_adjs} "
+                f"for adj_subset={adj_subset!r}, got {actual_n_adjs!r}."
+            )
+
     def forward(self, batch):
         r"""Forward pass for the Dir-SNN wrapper.
 

--- a/topobench/transforms/liftings/graph2simplicial/directed_simplicial_lifting.py
+++ b/topobench/transforms/liftings/graph2simplicial/directed_simplicial_lifting.py
@@ -1,0 +1,606 @@
+"""Directed simplicial lifting for the Dir-SNN model.
+
+Materialises the four directed lower edge adjacencies and six directed
+upper edge adjacencies introduced by Lecha et al. 2024
+(*Higher-Order Topological Directionality and Directed Simplicial Neural
+Networks*, ICASSP 2025, arXiv:2409.08389; Eqs. (3)-(4)). The
+implementation is a faithful port of ``compute_lower_adj`` and
+``compute_upper_adj`` from ``compute_adj.py`` in the upstream
+reference repository; the only
+differences are (i) numpy -> torch sparse, and (ii) an explicit
+"canonical orientation" rule that turns an undirected TopoBench input
+into a digraph in a deterministic way (see :meth:`_directed_edge_list`).
+"""
+
+from itertools import combinations
+
+import networkx as nx
+import torch
+import torch_geometric
+from toponetx.classes import SimplicialComplex
+
+from topobench.transforms.liftings.graph2simplicial.base import (
+    Graph2SimplicialLifting,
+)
+
+# Names of the 10 directed adjacencies, in a stable order. The first 4
+# are the directed lower adjacencies of Eq. (3); the last 6 are the
+# directed upper adjacencies of Eq. (4), matching the return order of
+# ``compute_lower_adj`` / ``compute_upper_adj`` in the upstream repo.
+DIR_LOWER_KEYS: tuple[str, ...] = (
+    "dir_lower_adj_100",
+    "dir_lower_adj_101",
+    "dir_lower_adj_110",
+    "dir_lower_adj_111",
+)
+DIR_UPPER_KEYS: tuple[str, ...] = (
+    "dir_upper_adj_101",
+    "dir_upper_adj_102",
+    "dir_upper_adj_112",
+    "dir_upper_adj_110",
+    "dir_upper_adj_120",
+    "dir_upper_adj_121",
+)
+DIR_ADJ_KEYS: tuple[str, ...] = DIR_LOWER_KEYS + DIR_UPPER_KEYS
+
+
+class DirectedSimplicialLifting(Graph2SimplicialLifting):
+    r"""Lift a graph to a simplicial complex with directed edge adjacencies.
+
+    This lifting performs a clique-style 2-complex construction (nodes,
+    edges, triangles) so that downstream TopoBench components keep
+    working (``incidence_1``, ``incidence_2``, ``x_0``, ``x_1`` are all
+    produced as for :class:`SimplicialCliqueLifting`).
+
+    In addition it materialises the ten directed edge adjacencies of
+    Eqs. (3)-(4) of Lecha et al. 2024 (arXiv:2409.08389) and stores them
+    on the lifted batch as sparse COO tensors of shape
+    ``(n_edges, n_edges)``:
+
+    Lower (Eq. (3); ``compute_lower_adj`` of the upstream repo):
+
+    - ``dir_lower_adj_100`` -- both edges leave the shared face
+      (same ``src`` vertex).
+    - ``dir_lower_adj_101`` -- :math:`\sigma_1` leaves, :math:`\sigma_2`
+      enters (line-graph head-to-tail).
+    - ``dir_lower_adj_110`` -- :math:`\sigma_1` enters, :math:`\sigma_2`
+      leaves (transpose of ``101``).
+    - ``dir_lower_adj_111`` -- both enter the shared face (same ``dst``
+      vertex).
+
+    Upper (Eq. (4); ``compute_upper_adj`` of the upstream repo):
+
+    - ``dir_upper_adj_{101,102,112,110,120,121}`` -- triangle-mediated
+      edge pairs; see the upstream :mod:`compute_adj` for the exact
+      indexing convention.
+
+    Canonical orientation for undirected inputs
+    -------------------------------------------
+    TopoBench graphs are stored with a symmetric ``edge_index``. For
+    every undirected edge :math:`\{u, v\}` (with :math:`u \ne v`) we
+    pick the canonical direction :math:`u \to v` whenever :math:`u < v`
+    (i.e. the natural ordering of the simplex tuple
+    ``(min(u,v), max(u,v))``). This is exactly the simplex ordering
+    used by :class:`toponetx.SimplicialComplex` for the 1-skeleton, so
+    the directed adjacencies are indexed by the same edge order as
+    ``incidence_1``. With this canonical choice every undirected
+    triangle :math:`\{a, b, c\}` (with :math:`a < b < c`) lands in
+    branch 1 of ``compute_upper_adj`` ((t0,t1), (t0,t2), (t1,t2) all
+    present in the digraph), making the upper adjacencies
+    deterministic.
+
+    Directed-input path (deferred)
+    ------------------------------
+    The ``directed_input=True`` code path is intentionally guarded with
+    a :class:`NotImplementedError`. Under that mode the digraph's raw
+    orientations would be preserved (e.g. ``(2, 0)``), but
+    :class:`toponetx.SimplicialComplex` stores 1-cells as
+    ``tuple(sorted((u, v)))`` and therefore exposes ``incidence_1``
+    columns in canonical ``(min, max)`` order. The 10 directed
+    adjacency matrices would then be indexed by the raw-orientation
+    edge list while ``incidence_1`` and ``x_1`` use the canonical
+    ordering, silently misaligning rows/columns. A correct
+    implementation requires reconciling these two orderings (e.g. by
+    threading a sign / permutation through ``incidence_1``); that work
+    is deferred. To make the bug undiscoverable from configuration we
+    raise early and force the configuration default to ``False``.
+
+    Parameters
+    ----------
+    directed_input : bool, optional
+        Must currently be ``False``. Reserved for future support of
+        genuinely directed input graphs (Sec. IV of the paper); the
+        ``True`` branch raises :class:`NotImplementedError` because it
+        does not preserve the row/column alignment between the ten
+        directed adjacencies and ``incidence_1`` / ``x_1``.
+    spectral_normalize : bool, optional
+        If ``True``, each of the ten directed adjacency matrices is
+        divided by its largest eigenvalue before being stored on the
+        lifted batch, mirroring the upstream
+        :func:`spectral_normalization` helper in
+        the upstream ``utils.py:16-20`` (which
+        :mod:`train.py:29-33` applies to the four lower adjacencies
+        before feeding the model). The default (``False``) preserves
+        the raw binary directed adjacencies and is bit-identical to the
+        pre-review-3 behaviour (so existing evaluation results remain
+        valid). Set to ``True`` only when reproducing the official
+        source-localization training pipeline; the dedicated
+        ``configs/transforms/model_defaults/dirsnn_official_lower.yaml``
+        wires this on for the four-lower-adjacency setup.
+    **kwargs : optional
+        Additional arguments forwarded to
+        :class:`Graph2SimplicialLifting`. ``complex_dim`` is forced to
+        2 because the paper only defines edge-level (1-cell) adjacencies
+        through triangles.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``directed_input=True``.
+    """
+
+    def __init__(
+        self,
+        directed_input: bool = False,
+        spectral_normalize: bool = False,
+        **kwargs,
+    ):
+        # Force complex_dim = 2: the paper's upper adjacencies are
+        # mediated by triangles, so anything beyond 2 is irrelevant.
+        kwargs["complex_dim"] = 2
+        super().__init__(**kwargs)
+        if directed_input:
+            # See class docstring: the raw-orientation edge list does
+            # not line up with the canonical ordering used by
+            # SimplicialComplex.skeleton(1) / incidence_1, so the
+            # adjacencies and x_1 would be silently misaligned.
+            raise NotImplementedError(
+                "DirectedSimplicialLifting(directed_input=True) is not "
+                "supported yet: the raw directed edge list breaks the "
+                "row/column alignment between the 10 directed "
+                "adjacencies and incidence_1 / x_1 (which use canonical "
+                "(min, max) edge ordering). Re-enable this path only "
+                "after threading canonical orientation through "
+                "incidence_1."
+            )
+        self.directed_input = directed_input
+        self.spectral_normalize = spectral_normalize
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"directed_input={self.directed_input!r}, "
+            f"spectral_normalize={self.spectral_normalize!r})"
+        )
+
+    # ------------------------------------------------------------------
+    # Spectral normalization helper (port of utils.spectral_normalization)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _spectral_normalize(adj: torch.Tensor) -> torch.Tensor:
+        r"""Divide a (possibly non-symmetric) adjacency by its largest eigenvalue.
+
+        Faithful port of :func:`spectral_normalization` in
+        the upstream ``utils.py:16-20``::
+
+            max_eig = torch.linalg.eigh(torch.tensor(adj_matrix))[0][-1]
+            adj_matrix = adj_matrix / max_eig
+
+        Two implementation notes worth surfacing:
+
+        * The reference calls :func:`torch.linalg.eigh` indiscriminately,
+          including on the non-symmetric line-graph-style lower
+          adjacency ``adj_low_101`` (and on the six non-symmetric upper
+          adjacencies). :func:`torch.linalg.eigh` is defined only for
+          Hermitian inputs; PyTorch silently treats the lower triangle
+          as the Hermitian matrix and returns real eigenvalues. We
+          preserve this verbatim so that on the symmetric source-
+          localization adjacencies (which is what the upstream
+          ``train.py`` actually feeds it) we match the reference output
+          bit-for-bit.
+        * When the upstream eigh-on-non-symmetric path returns
+          ``max_eig == 0`` (e.g. on the strictly upper-triangular
+          ``adj_low_101`` of a small directed path), dividing would
+          produce NaNs. We fall back to
+          :func:`torch.linalg.eigvals` (taking the absolute-value max
+          of the complex spectrum) in that case; this is the only
+          intentional deviation from the reference and only triggers
+          on the non-symmetric branch where the reference itself would
+          NaN out.
+
+        Parameters
+        ----------
+        adj : torch.Tensor
+            Dense ``(n, n)`` float tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            ``adj`` divided by the largest eigenvalue (real, from
+            :func:`torch.linalg.eigh`; or absolute-max from
+            :func:`torch.linalg.eigvals` on the degenerate fallback
+            branch). For ``n == 0`` returns ``adj`` unchanged.
+        """
+        if adj.numel() == 0:
+            return adj
+        # Match the upstream verbatim: eigh on the (possibly non-
+        # symmetric) dense adjacency, take the last (= largest)
+        # eigenvalue. ``eigh`` returns eigenvalues in ascending order,
+        # so ``[0][-1]`` is the maximum.
+        eigvals = torch.linalg.eigh(adj)[0]
+        max_eig = eigvals[-1]
+        if max_eig.abs().item() == 0.0:
+            # Degenerate eigh branch (matches the reference only on
+            # symmetric inputs; the upstream code would NaN here).
+            # Fall back to the general non-Hermitian solver and pick
+            # the largest |lambda|. Coverage: this branch is exercised
+            # only by tiny non-symmetric adjacencies where the strict
+            # lower triangle is zero -- not used in practice.
+            general = torch.linalg.eigvals(adj).abs()
+            max_eig = general.max()
+            if max_eig.item() == 0.0:
+                return adj
+        return adj / max_eig
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _directed_edge_list(
+        self, data: torch_geometric.data.Data
+    ) -> list[tuple[int, int]]:
+        r"""Return the canonical directed edge list of the input graph.
+
+        Every undirected edge ``{u, v}`` is oriented as
+        ``(min(u, v), max(u, v))``; the returned list is sorted
+        lexicographically so its indices match the
+        :class:`toponetx.SimplicialComplex` 1-skeleton ordering. Only
+        the ``directed_input=False`` path is supported -- see the class
+        docstring for why the directed-input path is currently guarded.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            Input batch with ``edge_index`` of shape ``(2, n_e)``.
+
+        Returns
+        -------
+        list of tuple of int
+            Canonically oriented directed edges sorted
+            lexicographically.
+        """
+        ei = data.edge_index
+        edges: set[tuple[int, int]] = set()
+        for k in range(ei.shape[1]):
+            u, v = int(ei[0, k]), int(ei[1, k])
+            if u == v:
+                continue  # drop self-loops, as the reference does
+            a, b = (u, v) if u < v else (v, u)
+            edges.add((a, b))
+        return sorted(edges)
+
+    # ------------------------------------------------------------------
+    # Core directed-adjacency computation (port of compute_adj.py)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def compute_lower_adj(
+        edge_list: list[tuple[int, int]],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        r"""Port of ``compute_lower_adj`` (Eq. (3) of arXiv:2409.08389).
+
+        Parameters
+        ----------
+        edge_list : list of tuple of int
+            Directed edges in canonical (lexicographic) order. Used both
+            for indexing and to define the digraph.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Four dense ``float32`` tensors of shape
+            ``(n_edges, n_edges)`` for ``adj_low_100``, ``adj_low_101``,
+            ``adj_low_110``, ``adj_low_111`` respectively. The caller
+            converts them to sparse COO before storing on the batch.
+
+        Notes
+        -----
+        Mirrors :func:`compute_lower_adj` from
+        upstream ``compute_adj.py``:
+
+        * ``adj_low_101`` is the line-graph adjacency of the digraph
+          (``dst -> src`` chain).
+        * ``adj_low_110`` is its transpose.
+        * ``adj_low_100`` matches edges that share the same source
+          (diagonal is kept, matching the reference).
+        * ``adj_low_111`` matches edges that share the same target
+          (diagonal is kept, matching the reference).
+
+        This matches the paper's intent under the canonical edge
+        ordering (``edge_list`` is the lexicographic order used by
+        :class:`toponetx.SimplicialComplex.skeleton(1)` and
+        :attr:`incidence_1`, so adjacency rows/cols are aligned with
+        the edge features ``x_1``). The upstream
+        ``compute_adj.compute_lower_adj`` path obtains ``adj_low_101``
+        as ``nx.adjacency_matrix(nx.line_graph(G))``, whose node order
+        follows ``nx.line_graph(G).nodes()`` rather than ``G.edges()``
+        and is **not** guaranteed to match the canonical edge order.
+        Using that path against an ``incidence_1`` built from
+        ``G.edges()`` would silently misindex the 4 lower adjacencies
+        against the edge feature tensor; the upstream code relies on
+        the empirical alignment that holds for the small graphs in
+        its experiments. Our direct vectorised construction sidesteps
+        that alignment risk entirely.
+        """
+        n = len(edge_list)
+        if n == 0:
+            zeros = torch.zeros(0, 0)
+            return zeros.clone(), zeros.clone(), zeros.clone(), zeros.clone()
+
+        srcs = torch.tensor([e[0] for e in edge_list])
+        dsts = torch.tensor([e[1] for e in edge_list])
+
+        # 100: same source -> reference uses
+        #     ``edge_index[:,0] == edge_index[:,0].T``
+        # which is symmetric *and* keeps the diagonal (an edge trivially
+        # shares its own src with itself). We preserve this verbatim.
+        adj_low_100 = (srcs.unsqueeze(1) == srcs.unsqueeze(0)).float()
+
+        # 111: same target. Also keeps the diagonal, matching the
+        # reference.
+        adj_low_111 = (dsts.unsqueeze(1) == dsts.unsqueeze(0)).float()
+
+        # 101: line graph adjacency of the digraph. Edges
+        # (u_i, v_i) and (u_j, v_j) are 101-adjacent iff v_i == u_j,
+        # i.e. one edge ends where another starts. This is exactly the
+        # adjacency matrix of ``nx.line_graph(G)`` (ordered by our
+        # canonical edge_list) -- but computed vectorially to avoid
+        # depending on NetworkX's internal node ordering for line
+        # graphs.
+        adj_low_101 = (dsts.unsqueeze(1) == srcs.unsqueeze(0)).float()
+        # Drop self-loops: ``nx.line_graph`` does not include them, and
+        # the reference does not either (an edge being adjacent to
+        # itself via ``dst == src`` would require ``u == v``, which we
+        # already filter out as a self-loop above).
+        adj_low_101.fill_diagonal_(0.0)
+        adj_low_110 = adj_low_101.t().contiguous()
+
+        return adj_low_100, adj_low_101, adj_low_110, adj_low_111
+
+    @staticmethod
+    def compute_upper_adj(
+        edge_list: list[tuple[int, int]],
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        r"""Port of ``compute_upper_adj`` (Eq. (4) of arXiv:2409.08389).
+
+        Parameters
+        ----------
+        edge_list : list of tuple of int
+            Directed edges in canonical (lexicographic) order.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Six dense ``float32`` tensors of shape
+            ``(n_edges, n_edges)`` in the order
+            ``(adj_up_101, adj_up_102, adj_up_112,
+            adj_up_110, adj_up_120, adj_up_121)``, matching the upstream
+            return signature.
+
+        Notes
+        -----
+        Algorithm (lifted verbatim from
+        the upstream ``compute_adj.py``):
+
+        1. Enumerate all undirected 3-cycles via ``nx.simple_cycles``
+           with ``length_bound=3`` on the *undirected* projection of the
+           digraph.
+        2. For each cycle ``{a, b, c}``, rotate/reflect the three
+           vertices into the unique ordering ``(t0, t1, t2)`` such that
+           the directed edges ``(t0,t1)``, ``(t0,t2)``, ``(t1,t2)`` are
+           all present in the digraph. (When several rotations match,
+           the reference picks the first one; with our canonical
+           orientation only the first branch is ever selected.)
+        3. Populate the six adjacencies according to the six paired
+           ordering rules of Eq. (4).
+
+        Edges that are not part of any (oriented) triangle contribute
+        nothing.
+        """
+        n = len(edge_list)
+        if n == 0:
+            zeros = torch.zeros(0, 0)
+            return (zeros.clone(),) * 6  # type: ignore[return-value]
+
+        edge_set: set[tuple[int, int]] = set(edge_list)
+        edge_to_id = {e: i for i, e in enumerate(edge_list)}
+
+        # Enumerate undirected triangles via the underlying simple
+        # graph. The reference implementation uses
+        # ``nx.simple_cycles(G.to_undirected(), length_bound=3)`` on
+        # NetworkX >= 3.0; we replace it with an explicit triangle
+        # enumeration so the lifting works against the NetworkX 2.8
+        # currently pinned in the TopoBench env. Semantics are
+        # identical: ``simple_cycles`` of length 3 on an undirected
+        # simple graph returns exactly the 3-cliques (each triangle is
+        # reported as a single sorted triple).
+        und = nx.Graph()
+        und.add_edges_from(edge_list)
+        nbrs = {v: set(und.neighbors(v)) for v in und.nodes}
+        seen: set[tuple[int, int, int]] = set()
+        for u, v in und.edges():
+            common = nbrs[u] & nbrs[v]
+            for w in common:
+                seen.add(tuple(sorted((u, v, w))))  # type: ignore[arg-type]
+        all_triangles = sorted(seen)
+
+        dir_triangles: list[list[int]] = []
+        for t in all_triangles:
+            if (
+                (t[0], t[1]) in edge_set
+                and (t[0], t[2]) in edge_set
+                and (t[1], t[2]) in edge_set
+            ):
+                dir_triangles.append(list(t))
+            elif (
+                (t[0], t[2]) in edge_set
+                and (t[0], t[1]) in edge_set
+                and (t[2], t[1]) in edge_set
+            ):
+                dir_triangles.append([t[0], t[2], t[1]])
+            elif (
+                (t[1], t[0]) in edge_set
+                and (t[1], t[2]) in edge_set
+                and (t[0], t[2]) in edge_set
+            ):
+                dir_triangles.append([t[1], t[0], t[2]])
+            elif (
+                (t[1], t[2]) in edge_set
+                and (t[1], t[0]) in edge_set
+                and (t[2], t[0]) in edge_set
+            ):
+                dir_triangles.append([t[1], t[2], t[0]])
+            elif (
+                (t[2], t[1]) in edge_set
+                and (t[2], t[0]) in edge_set
+                and (t[1], t[0]) in edge_set
+            ):
+                dir_triangles.append([t[2], t[1], t[0]])
+            elif (
+                (t[2], t[0]) in edge_set
+                and (t[2], t[1]) in edge_set
+                and (t[0], t[1]) in edge_set
+            ):
+                dir_triangles.append([t[2], t[0], t[1]])
+
+        adj_up_101 = torch.zeros(n, n)
+        adj_up_102 = torch.zeros(n, n)
+        adj_up_112 = torch.zeros(n, n)
+        adj_up_110 = torch.zeros(n, n)
+        adj_up_120 = torch.zeros(n, n)
+        adj_up_121 = torch.zeros(n, n)
+
+        for t in dir_triangles:
+            e_01 = edge_to_id[(t[0], t[1])]
+            e_02 = edge_to_id[(t[0], t[2])]
+            e_12 = edge_to_id[(t[1], t[2])]
+
+            adj_up_101[e_12, e_02] = 1.0
+            adj_up_102[e_12, e_01] = 1.0
+            adj_up_112[e_02, e_01] = 1.0
+            adj_up_110[e_02, e_12] = 1.0
+            adj_up_120[e_01, e_12] = 1.0
+            adj_up_121[e_01, e_02] = 1.0
+
+        return (
+            adj_up_101,
+            adj_up_102,
+            adj_up_112,
+            adj_up_110,
+            adj_up_120,
+            adj_up_121,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifting entry point
+    # ------------------------------------------------------------------
+
+    def lift_topology(self, data: torch_geometric.data.Data) -> dict:
+        r"""Lift the graph to a 2-simplicial complex with directed adjacencies.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            The input data to be lifted.
+
+        Returns
+        -------
+        dict
+            A dictionary with the standard TopoBench keys
+            (``x_0``, ``incidence_1``, ``incidence_2``, ``down/up
+            laplacians`` etc., produced by
+            :func:`get_complex_connectivity`) plus ten sparse
+            directed-adjacency tensors keyed by
+            :data:`DIR_LOWER_KEYS` / :data:`DIR_UPPER_KEYS`.
+        """
+        # 1) Standard clique 2-complex (nodes, edges, triangles) so the
+        # rest of TopoBench keeps working unchanged. Self-loops are
+        # stripped because ``toponetx.SimplicialComplex`` rejects them
+        # (a 1-simplex must have two distinct vertices).
+        graph = self._generate_graph_from_data(data)
+        graph.remove_edges_from(nx.selfloop_edges(graph))
+        simplicial_complex = SimplicialComplex(graph)
+
+        triangles: set[tuple[int, int, int]] = set()
+        for clique in nx.find_cliques(graph):
+            for c in combinations(sorted(clique), 3):
+                triangles.add(c)
+        simplicial_complex.add_simplices_from(list(triangles))
+
+        lifted_topology = self._get_lifted_topology(simplicial_complex, graph)
+
+        # 2) Directed adjacencies. Both the edge ordering inside
+        # ``edge_list`` and the simplex ordering inside
+        # ``simplicial_complex.skeleton(1)`` are obtained by sorting the
+        # 2-tuples lexicographically, so the row/column indices of the
+        # ten adjacency matrices line up with ``incidence_1``'s columns
+        # by construction.
+        edge_list = self._directed_edge_list(data)
+        n_edges = len(edge_list)
+
+        adj_low_100, adj_low_101, adj_low_110, adj_low_111 = (
+            self.compute_lower_adj(edge_list)
+        )
+        (
+            adj_up_101,
+            adj_up_102,
+            adj_up_112,
+            adj_up_110,
+            adj_up_120,
+            adj_up_121,
+        ) = self.compute_upper_adj(edge_list)
+
+        dense_adjs = {
+            "dir_lower_adj_100": adj_low_100,
+            "dir_lower_adj_101": adj_low_101,
+            "dir_lower_adj_110": adj_low_110,
+            "dir_lower_adj_111": adj_low_111,
+            "dir_upper_adj_101": adj_up_101,
+            "dir_upper_adj_102": adj_up_102,
+            "dir_upper_adj_112": adj_up_112,
+            "dir_upper_adj_110": adj_up_110,
+            "dir_upper_adj_120": adj_up_120,
+            "dir_upper_adj_121": adj_up_121,
+        }
+
+        for key, dense in dense_adjs.items():
+            # Optional opt-in spectral normalization for reference parity.
+            # Mirrors ``repos/DirSNN/utils.py:16`` applied to each of the
+            # 4 lower adjacencies in ``repos/DirSNN/train.py:29-33``. We
+            # extend that to all 10 adjacencies for symmetry: the
+            # ``dirsnn_official_lower`` wrapper only consumes the lower
+            # four, so the upper six are still computed but ignored.
+            if self.spectral_normalize:
+                dense = self._spectral_normalize(dense)
+            # Force a sparse COO layout regardless of density: TopoBench
+            # collates sparse tensors block-diagonally during batching,
+            # which is exactly what we want for the directed
+            # adjacencies too.
+            if dense.numel() == 0:
+                lifted_topology[key] = torch.sparse_coo_tensor(
+                    torch.empty(2, 0, dtype=torch.long),
+                    torch.empty(0),
+                    size=(n_edges, n_edges),
+                ).coalesce()
+            else:
+                lifted_topology[key] = dense.to_sparse().coalesce()
+
+        return lifted_topology


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

This PR adds a TopoBench implementation of Directed Simplicial Neural Networks (Dir-SNN), based on Lecha et al., *Higher-Order Topological Directionality and Directed Simplicial Neural Networks* (ICASSP 2025 / arXiv:2409.08389).

Paper: https://arxiv.org/pdf/2409.08389
Reference implementation: https://github.com/ManuelLecha/DirSNN

Main changes:

- Adds the `simplicial/dirsnn` backbone, implementing the edge-level Dir-SNN layer with polynomial directed-adjacency propagation.
- Adds `DirSNNWrapper`, which forwards directed lower/upper edge adjacencies to the backbone and projects learned edge embeddings back to nodes through `incidence_1` for downstream TopoBench readout.
- Adds `DirectedSimplicialLifting`, a TopoBench lifting that materializes the four directed lower edge adjacencies from Eq. (3) and six directed upper edge adjacencies from Eq. (4) of the paper.
- Adds Hydra configs for the default all-10-adjacency challenge model and a `dirsnn_official_lower` variant matching the official lower-adjacency experimental setup.
- Adds unit tests for the backbone, wrapper, and directed lifting.
- Adds the GraphUniverse challenge `results.json` generated by the official 2026 evaluation harness.

Challenge requirements covered:

- Track: Track2
- Team name: TJPaik
- Model: Directed Simplicial Neural Networks (Dir-SNN)
- Backbone: `topobench/nn/backbones/simplicial/dirsnn.py`
- Hydra config: `configs/model/simplicial/dirsnn.yaml`
- Results file: `2026_tdl_challenge/outputs/dirsnn/results.json`
- Requested label: `track-2-tnn`
- Registration form: submitted

## Issue

This is a submission to the 2026 Topological Deep Learning Challenge. There is no linked issue to close.

## Additional context

The default `simplicial/dirsnn` config uses all ten directed edge adjacencies: four lower and six upper. The additional `simplicial/dirsnn_official_lower` config forwards only the four lower adjacencies, matching the narrower setup used in the reference experiments.

The backbone follows the Dir-SNN edge-level propagation mechanism. The final readout is adapted to TopoBench/GraphUniverse tasks by projecting learned edge signals to 0-cells through `incidence_1`, because the challenge evaluator expects standard TopoBench node/graph-level outputs. The wrapper first constructs this edge-derived 0-cell signal from the learned edge embedding; in the submitted config, TopoBench's default wrapper residual connection is kept, so the edge-derived `x_0` and updated `x_1` are combined with the original encoded 0-cell and 1-cell signals before the downstream `PropagateSignalDown` readout. The projection uses signed incidences from the lifting, so orientation-sensitive boundary signs are preserved before the learned downward propagation/readout rather than replaced by an unsigned pooling shortcut.

This TopoBench readout is not an exact copy of the official Dir-SNN classifier, which applies its own classifier/readout over edge features after the Dir-SNN propagation. The PR therefore ports the Dir-SNN directed edge-propagation backbone and adapts the output head to TopoBench tasks rather than claiming end-to-end parity with the reference training script.

TopoBench graph inputs are undirected/symmetric, so `DirectedSimplicialLifting` uses a deterministic canonical orientation `u -> v` when `u < v`. This orientation is a deterministic adaptation for undirected GraphUniverse-style inputs, not a data-provided edge direction. The `directed_input=True` path is intentionally guarded for now because raw directed edge ordering would otherwise be misaligned with `SimplicialComplex` canonical 1-simplex ordering.

Validation:

- GitHub CI passes: Linting / `ruff`, Testing / `build (3.11)`, Docs / `build (3.11)`.
- Local full test suite was used during validation; the current head is covered by the passing GitHub Testing workflow.
- Local focused tests: Dir-SNN backbone, wrapper, and directed lifting tests pass.
- Local lint check on changed Python files passes.
