### PR TITLE
Track: Track2; Team name: r2; Model: AirTNN

### DIFF
--- a/2026_tdl_challenge/outputs/airtnn_full/results.json
+++ b/2026_tdl_challenge/outputs/airtnn_full/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-05-24_00-02-52",
+    "model_config": "cell/airtnn",
+    "generated_at_utc": "2026-05-24T01:30:11.274385+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.218029499053955,
+      "test_best_rerun_accuracy": 0.31965771317481995,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3149591386318207,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3219115436077118,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.321682333946228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3066697120666504,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29723432660102844,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30292612314224243,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29612651467323303,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3019329309463501,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29452210664749146,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2887157201766968,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2738941013813019,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.099163204431534,
+        "AvgTime/train_epoch_std": 0.9305121994553793,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2018208503723145,
+      "test_best_rerun_accuracy": 0.3190847337245941,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3162197172641754,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3259607255458832,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3240507245063782,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2984185218811035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29452210664749146,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2998701333999634,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.291160523891449,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2872259020805359,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2792420983314514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2804645001888275,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26464971899986267,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.978999878679003,
+        "AvgTime/train_epoch_std": 0.22527572470795698,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2025856971740723,
+      "test_best_rerun_accuracy": 0.3227137327194214,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32034534215927124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3284819424152374,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3308503329753876,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2997173070907593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29681411385536194,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30090153217315674,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2954389154911041,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29028192162513733,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28122851252555847,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2735503017902374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25276950001716614,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.788932128828399,
+        "AvgTime/train_epoch_std": 0.19556351584731743,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2382493019104004,
+      "test_best_rerun_accuracy": 0.31003132462501526,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31438612937927246,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3228665292263031,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32363054156303406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29452210664749146,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2882191240787506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2927267253398895,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2928031086921692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28470471501350403,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27809610962867737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27343571186065674,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2628925144672394,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6239169251685048,
+        "AvgTime/train_epoch_std": 0.06656175048962173,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.236517906188965,
+      "test_best_rerun_accuracy": 0.3106043338775635,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31125372648239136,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31476813554763794,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32088011503219604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28527772426605225,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28367331624031067,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2869967222213745,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2845519185066223,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27045610547065735,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27412331104278564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.266750693321228,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2518908977508545,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7098952433642218,
+        "AvgTime/train_epoch_std": 0.1459751745646582,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2386276721954346,
+      "test_best_rerun_accuracy": 0.3125525116920471,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31438612937927246,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3204217255115509,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32023072242736816,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2883719205856323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28798991441726685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2928413152694702,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2876461148262024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27698829770088196,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2745053172111511,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26610130071640015,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25632211565971375,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6037216186523438,
+        "AvgTime/train_epoch_std": 0.07737735241237892,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3.068431854248047,
+      "test_best_rerun_accuracy": 0.09316983819007874,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.09744823724031448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10275804251432419,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09423943608999252,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.15425166487693787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1400030553340912,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1254870444536209,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11570784449577332,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22790129482746124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23550309240818024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2346244901418686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21178089082241058,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.02381917146536,
+        "AvgTime/train_epoch_std": 0.05344454188322339,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3.0348777770996094,
+      "test_best_rerun_accuracy": 0.09993124008178711,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10841163992881775,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11284284293651581,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10107724368572235,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16391626000404358,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15612345933914185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13969746232032776,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12800824642181396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24230270087718964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2506684958934784,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24772709608078003,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24719229340553284,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.3501321841508913,
+        "AvgTime/train_epoch_std": 0.4260641747250036,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.998206615447998,
+      "test_best_rerun_accuracy": 0.10585223883390427,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11154404282569885,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1124226450920105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11032164096832275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17105966806411743,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17445947229862213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14928565919399261,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13492245972156525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2622430920600891,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2847811281681061,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2867293059825897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3080449104309082,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.002004629228173,
+        "AvgTime/train_epoch_std": 0.05499437647558746,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.8792781829833984,
+      "test_best_rerun_accuracy": 0.11819084733724594,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11322484165430069,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11968065053224564,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09916724264621735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19963328540325165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19485828280448914,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16746886074543,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16192986071109772,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3257315158843994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3238215148448944,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3341355323791504,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33829933404922485,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0382825763602006,
+        "AvgTime/train_epoch_std": 0.2459300951110248,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.8659493923187256,
+      "test_best_rerun_accuracy": 0.11780884861946106,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1165100485086441,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12052104622125626,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10520283877849579,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21563908457756042,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21090228855609894,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17759187519550323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17476506531238556,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34253954887390137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3454427421092987,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34998854994773865,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37130415439605713,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.2347132788764106,
+        "AvgTime/train_epoch_std": 0.5908543172622266,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.8621292114257812,
+      "test_best_rerun_accuracy": 0.11964245140552521,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1099778413772583,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11345404386520386,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10138284415006638,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19825807213783264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18771487474441528,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1540224552154541,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15776605904102325,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3183971345424652,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3324929475784302,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3309267461299896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3697379529476166,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.551781131671025,
+        "AvgTime/train_epoch_std": 3.8578323338357103,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.4511985778808594,
+      "test_best_rerun_accuracy": 0.3025059103965759,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1786232739686966,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17919626832008362,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10271984338760376,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09687523543834686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28256550431251526,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17980746924877167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13816945254802704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5010696053504944,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4691343903541565,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48903658986091614,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40805256366729736,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8352899507240013,
+        "AvgTime/train_epoch_std": 0.08361887508654015,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.4468541145324707,
+      "test_best_rerun_accuracy": 0.3091527223587036,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17705707252025604,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18546107411384583,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09798303991556168,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09889984130859375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2882955074310303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18695087730884552,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13889525830745697,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4991978108882904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45438918471336365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.46649858355522156,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4056841731071472,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9189443494759353,
+        "AvgTime/train_epoch_std": 0.16066434349375772,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.4501140117645264,
+      "test_best_rerun_accuracy": 0.30170372128486633,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17923447489738464,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18431507050991058,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09649323672056198,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10038963705301285,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2772939205169678,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18347467482089996,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14160746335983276,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5026739835739136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4553059935569763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48009780049324036,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42027658224105835,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.2099200599598436,
+        "AvgTime/train_epoch_std": 1.99041337514589,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.163574695587158,
+      "test_best_rerun_accuracy": 0.3598059415817261,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2104438841342926,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2465810924768448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11249904334545135,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18301627039909363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.334975928068161,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22706088423728943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3144243359565735,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5065321922302246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5054625868797302,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5147833824157715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.534265398979187,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0056282601705413,
+        "AvgTime/train_epoch_std": 0.46079964413163543,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1442999839782715,
+      "test_best_rerun_accuracy": 0.3658415377140045,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21216288208961487,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24562609195709229,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11891664564609528,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19382688403129578,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3397509455680847,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23401328921318054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32661011815071106,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5164642333984375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5150508284568787,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5175337791442871,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5368630290031433,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8216694690085746,
+        "AvgTime/train_epoch_std": 0.24480879848231216,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1312167644500732,
+      "test_best_rerun_accuracy": 0.36347314715385437,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2113988846540451,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2459316998720169,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1298418492078781,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20964168012142181,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33627474308013916,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2368018925189972,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3375353217124939,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5148597955703735,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5019099712371826,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5133318305015564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5192909836769104,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.094375673093294,
+        "AvgTime/train_epoch_std": 0.3516423288391398,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.738800287246704,
+      "test_best_rerun_accuracy": 0.22816869616508484,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11979524791240692,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11910764873027802,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10184124112129211,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10512644052505493,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23756588995456696,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20738787949085236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45480936765670776,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4452593922615051,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5364810228347778,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5438536405563354,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.23719691094898,
+        "AvgTime/train_epoch_std": 0.21556674697338737,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.6598896980285645,
+      "test_best_rerun_accuracy": 0.27251890301704407,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.13434945046901703,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14229506254196167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11330124735832214,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1495530605316162,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2871113121509552,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2626250982284546,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34158453345298767,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4617617726325989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4461379647254944,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5585988163948059,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5640996098518372,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.222501117736101,
+        "AvgTime/train_epoch_std": 0.2538476764895039,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.7874832153320312,
+      "test_best_rerun_accuracy": 0.22721369564533234,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12365344911813736,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1264420449733734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10187944024801254,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.0954236388206482,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2649553120136261,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24100390076637268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2093360871076584,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4514859914779663,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4423943758010864,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.534227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.534227192401886,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.153771254751417,
+        "AvgTime/train_epoch_std": 0.16885356204253302,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.221670389175415,
+      "test_best_rerun_accuracy": 0.3716479539871216,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.13645045459270477,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1450454592704773,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12132325023412704,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1572694629430771,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29807472229003906,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2871495187282562,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2753075063228607,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49247458577156067,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4821988046169281,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5716250538825989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6134158372879028,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.912504321650455,
+        "AvgTime/train_epoch_std": 0.13978669293187043,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.2431447505950928,
+      "test_best_rerun_accuracy": 0.36847734451293945,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1344640552997589,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14103445410728455,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11318664252758026,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15123386681079865,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2982275187969208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.280846506357193,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2705325186252594,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48972418904304504,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4808617830276489,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5691420435905457,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6070746183395386,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.3740896030708596,
+        "AvgTime/train_epoch_std": 0.5428467572812704,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.2419707775115967,
+      "test_best_rerun_accuracy": 0.3687829375267029,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1332416534423828,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.13748185336589813,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11807624995708466,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15853005647659302,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29994651675224304,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2796241044998169,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27427610754966736,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.490449994802475,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4796393811702728,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5700588226318359,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6114294528961182,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.9155657092730203,
+        "AvgTime/train_epoch_std": 0.4956286240137703,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.7705291509628296,
+      "test_best_rerun_accuracy": 0.5179539918899536,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16185346245765686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1544426679611206,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10390403866767883,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09091603755950928,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2864237129688263,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2546412944793701,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15639086067676544,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1204446479678154,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49411720037460327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5028268098831177,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4392237663269043,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9321424456743093,
+        "AvgTime/train_epoch_std": 0.20073015003799305,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.7550621032714844,
+      "test_best_rerun_accuracy": 0.5135610103607178,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1511574536561966,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14252425730228424,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09477423876523972,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.08786003291606903,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28214532136917114,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25238749384880066,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15532125532627106,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11838185042142868,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49682939052581787,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5111162066459656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4781113862991333,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7709074858072642,
+        "AvgTime/train_epoch_std": 0.1324771778503942,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.7705665826797485,
+      "test_best_rerun_accuracy": 0.5135610103607178,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16044005751609802,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15971426665782928,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10543204098939896,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09064863622188568,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2843991219997406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24803270399570465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15841546654701233,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11685384809970856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4949575960636139,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4997326135635376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46283137798309326,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5781776452886647,
+        "AvgTime/train_epoch_std": 0.05898569593423752,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.7470436096191406,
+      "test_best_rerun_accuracy": 0.5207043886184692,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.13778746128082275,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1389334499835968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.10226143896579742,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09091603755950928,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2677057087421417,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2481091022491455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14726105332374573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13278324902057648,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4919779896736145,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5146306157112122,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5328902006149292,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.744036926942713,
+        "AvgTime/train_epoch_std": 1.0576638925216597,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.7293405532836914,
+      "test_best_rerun_accuracy": 0.5263962149620056,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14187484979629517,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14099626243114471,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09622583538293839,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.08736343681812286,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26338911056518555,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24745969474315643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13843685388565063,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12472304701805115,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4933150112628937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5018718242645264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5284208059310913,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8090986367818473,
+        "AvgTime/train_epoch_std": 0.6193754131734185,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.7248836755752563,
+      "test_best_rerun_accuracy": 0.5289174318313599,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1488654613494873,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15650546550750732,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09519443660974503,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.08938803523778915,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2708381116390228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24936969578266144,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14420506358146667,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1363358497619629,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5022156238555908,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.50382000207901,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5218886137008667,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.032796435885959,
+        "AvgTime/train_epoch_std": 0.19118524050113284,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.6304614543914795,
+      "test_best_rerun_accuracy": 0.5556955933570862,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11261364817619324,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11234624683856964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09152723848819733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.0861792340874672,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24952250719070435,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22098708152770996,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18259607255458832,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14680266380310059,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4745969772338867,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4711971879005432,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5563450455665588,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.919125991709092,
+        "AvgTime/train_epoch_std": 0.06314254237028873,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.59101140499115,
+      "test_best_rerun_accuracy": 0.5636793971061707,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1185346469283104,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.11631904542446136,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09041943401098251,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09187103807926178,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2641530930995941,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2255328893661499,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18916647136211395,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14420506358146667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48468178510665894,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4872030019760132,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5721216201782227,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.1488796293735506,
+        "AvgTime/train_epoch_std": 0.3111468857708173,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.6260318756103516,
+      "test_best_rerun_accuracy": 0.5529070496559143,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11349224299192429,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1118878424167633,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.08778363466262817,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.08235923200845718,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25479409098625183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2238902896642685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1874474734067917,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14317364990711212,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48949500918388367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4740239977836609,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5505385994911194,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.146753849806609,
+        "AvgTime/train_epoch_std": 0.1063597893799586,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.4789221286773682,
+      "test_best_rerun_accuracy": 0.5875544548034668,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12590725719928741,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12785544991493225,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09106883406639099,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.08682863414287567,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26801130175590515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24872030317783356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1995568871498108,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16403086483478546,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47272518277168274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49667659401893616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5525632500648499,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.3429480533973845,
+        "AvgTime/train_epoch_std": 0.19812791559743526,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.4518731832504272,
+      "test_best_rerun_accuracy": 0.5898464322090149,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11941324919462204,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12583084404468536,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.09030483663082123,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09110703319311142,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27454352378845215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2550615072250366,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21265947818756104,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20647108554840088,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4817785918712616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5003437995910645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5535182356834412,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.608081294041054,
+        "AvgTime/train_epoch_std": 4.47098090121607,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.4811546802520752,
+      "test_best_rerun_accuracy": 0.5778516530990601,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1192222461104393,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12353885173797607,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.0878218337893486,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.09007563441991806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2680877149105072,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25021010637283325,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19226068258285522,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.165597066283226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4836885929107666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5016043782234192,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5544350147247314,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6782708849225725,
+        "AvgTime/train_epoch_std": 0.09010696758036639,
+        "model/params/total": 57134,
+        "model/params/trainable": 57134,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 85.6572494506836,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 83.81580352783203,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.06038602559642077,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.714885711669922,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08270992479826275
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8650.7529296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6561056450274934
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105.5812759399414,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03558519580045211
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6607.962890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.882827373496994
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119.75468444824219,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10341509883267892
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163660.875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.800410435630689
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13557.1279296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9505769127532955
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43454.25,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.227395048439182
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3251.168212890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5779854600694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 733332.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.295333585964277
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247495.515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.118541521059025
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7847562386439397,
+        "AvgTime/train_epoch_std": 0.4957254856726157,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 87.56071472167969,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 83.65861511230469,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.06027277745843277,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.52252769470215,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.13432909313001132
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8232.75,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6244027303754266
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.29188537597656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.049980413001677305
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6655.45068359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.889171768015197
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114.21273803710938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09862930745864368
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161310.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7458317852498606
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12563.080078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8808778627208667
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43637.21875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.236773732636219
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3073.108154296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5463303385416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 731057.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.269597751207538
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244257.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.0646521329439365
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2937424182891846,
+        "AvgTime/train_epoch_std": 0.06999964000950148,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 95.92472839355469,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 90.71898651123047,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.06535950036832167,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.614294052124023,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.14533838974802119
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7760.33740234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5885731818235684
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.63755798339844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0730156919391299
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6414.61328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8569957623580494
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108.45232391357422,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09365485657476184
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158958.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6912259224642394
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12240.2041015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8582389637892652
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42812.17578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1944833554385155
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2979.006103515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5296010850694445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728326.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.238707255409885
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 242810.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.040570969164461
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.631448268890381,
+        "AvgTime/train_epoch_std": 0.5466344215281428,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.0503602027893066,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.9304484128952026,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.010160254804711593,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181.85006713867188,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1310158985148933
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12511.14453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9488922663064088
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.68634033203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09831019222515378
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8125.44189453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0855633793628925
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168.4175262451172,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14543827827730327
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177507.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.121954750487646
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15660.478515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0980562695011218
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47595.9921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4396940995181713
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3886.326171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6909024305555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 763404.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.635505158195988
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 264879.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.407823602582663
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6764270533686099,
+        "AvgTime/train_epoch_std": 0.08587945348386244,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.9725990295410156,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.9318222999572754,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.010167485789248818,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176.12525939941406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1268913972618257
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11942.841796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9057900490614335
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255.01559448242188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08595065536987592
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7951.42431640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0623145379300267
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164.03831481933594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14165657583707766
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175106.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.066190002089913
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15437.240234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0824036063928621
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47316.03125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4253437516018246
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3828.374267578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6805998697916666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 760200.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.599266286212007
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262962.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.375930848850948
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6943290063313075,
+        "AvgTime/train_epoch_std": 0.08729757503534266,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.182713270187378,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.0680320262908936,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.010884379085741545,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 193.93971252441406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1397260176688862
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12004.3828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9104575511945392
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234.3457489013672,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07898407445276953
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8049.4990234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0754173712007349
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168.59866333007812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1455947006304647
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174997.671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.063665053757199
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15271.3935546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0707750353868672
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47548.26171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4372475123660875
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3899.9267578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6933203125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 761998.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.619599306584618
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263830.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3903662864227115
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.739300537109375,
+        "AvgTime/train_epoch_std": 0.07858362738603775,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3302.0234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3037.817626953125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.23039951664415054,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2868.194580078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.06642260812545
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 515.7547607421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.7144987407483554
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.5850524902344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10063533956529638
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4303.5048828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5749505521459586
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 748.103515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6460306697970639
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120392.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7956566099294076
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9805.7197265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6875417000815103
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29098.68359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.491551775782972
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2986.373046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5309107638888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 624937.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.069192363381333
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182629.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0391195729951908
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.4555181094578336,
+        "AvgTime/train_epoch_std": 0.06195203555276177,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3133.471435546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2957.171875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.22428303943875616,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1787.389404296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.2877445275914086
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 318.98944091796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.6788917943050987
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 468.4161071777344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1578753310339516
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3831.703857421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5119176830222946
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 395.5381774902344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3415701014596152
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119584.1171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.776892931160598
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11037.380859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7739013363746319
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32506.97265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6662551979214721
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2105.40283203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.37429383680555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 642518.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.268060755856702
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194446.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.235763992894347
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.8847223611978383,
+        "AvgTime/train_epoch_std": 0.46359019891197784,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3108.06689453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2926.005859375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.22191929157186197,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1491.6783447265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.074696213779944
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209.1359100341797,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.1007153159693668
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 432.8770751953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14589722790539686
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4097.0361328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5473662168086172
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 301.5690002441406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.26042228000357565
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123634.6171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8709506127507893
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10535.2314453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7386924306066821
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31902.3359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.635262491029781
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2342.310302734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4164107204861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 646709.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.315475012160221
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 190008.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.161900356530711
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.5167285442352294,
+        "AvgTime/train_epoch_std": 0.09007339070758216,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 76.89446258544922,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 75.16366577148438,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.025333220684693084,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 659.7515869140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4753253508026387
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713.9118041992188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.7574305484169406
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6783.9658203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5145214880783087
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8715.2939453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1643679285654642
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 672.6387939453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5808625163603734
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157564.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6588377182797696
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12096.2470703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8481452159804025
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52858.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.7094161668973293
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4326.787109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7692065972222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 750751.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.492372996391525
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244367.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.06648496913118
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.3777991599506803,
+        "AvgTime/train_epoch_std": 0.2517735259772006,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 72.90144348144531,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 69.70379638671875,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.023493022037990814,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172.20297241210938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1240655420836523
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204.14627075195312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.0744540565892269
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6452.0625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4893486916951081
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6994.82080078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9345117970315632
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229.97740173339844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1985987925158881
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155847.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.618984607212521
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12154.939453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.852260514172276
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46439.87109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3804331894894664
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3139.8955078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5582036458333334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 732891.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.290347895433413
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 238041.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9612205248531445
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.37163975409099,
+        "AvgTime/train_epoch_std": 0.4421085639109827,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 79.33125305175781,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 73.42125701904297,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.024745957876320515,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 482.4297790527344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.34757188692560115
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 510.4330139160156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.686489546926398
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7444.49658203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5646186258650929
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8714.4248046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1642518109134936
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 539.3851318359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.46579026928837436
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161939.96875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.760448837776333
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12435.4384765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8719280939954074
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51875.0703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.6590327701317342
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4195.5009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7458668402777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 756566.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.55814847912401
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250027.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.160683492669695
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.5427456474304195,
+        "AvgTime/train_epoch_std": 0.9926739245310199,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3745.40625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3863.080810546875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.5161096607277054,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1606.7939453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1576325254412825
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 832.401611328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.381061112253289
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4785.869140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.36297831934963976
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9273.3173828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.125486141830974
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 942.5458374023438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8139428647688634
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119578.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7767577762167934
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8337.5478515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5845987835901346
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33389.14453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7114739110795019
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2715.6015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4827736111111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 639229.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.230854015135233
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188641.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.139157482984707
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.155944347381592,
+        "AvgTime/train_epoch_std": 0.21373985547206648,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3746.624267578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3870.06005859375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.517042091996493,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2360.21240234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.7004412120632204
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2326.48681640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 12.244667454769736
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7305.146484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5540497902445961
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17308.056640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.83352094392484
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2142.22802734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.849937847447107
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107203.9296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.489409476302712
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10483.26953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7350490486081896
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34890.0234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.788406552744887
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2943.6826171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5233213541666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 629003.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.115181328687941
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177169.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9482611847469755
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0047386487325034,
+        "AvgTime/train_epoch_std": 0.16208947130545195,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3172.312255859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3300.851318359375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.440995500114813,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2582.595947265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.860659904370047
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1224.149658203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.442892937911184
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7612.10498046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.577330677320345
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15780.8681640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.318796145622683
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1204.5391845703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.0401892785581281
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104646.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4300169515140255
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9844.6005859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6902678857058968
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30939.939453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5859315932710545
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2762.802978515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4911649739583333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 604236.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.835021153128287
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173925.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8942797518013745
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5443308353424072,
+        "AvgTime/train_epoch_std": 0.2718860618713977,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 107.39776611328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 110.79447937011719,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.09567744332479895,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92.66371154785156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06676059909787577
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.83010482788086,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17279002540989927
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7620.90478515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5779980876113955
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.7033233642578,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.052141329074572904
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6563.50439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8768876946601536
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159790.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.710540924554152
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12207.3779296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.855937311014409
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43276.99609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.218309297952227
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2931.373779296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5211331163194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728383.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.239354857866815
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240828.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.007602018953954
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6309618651866913,
+        "AvgTime/train_epoch_std": 0.07377080455371758,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 83.73799133300781,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 88.73274230957031,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07662585691672738,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211.2545623779297,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15220069335585712
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.804752349853516,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09897238078870271
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5989.38232421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.45425728663016685
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93.1878662109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03140811129455258
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5732.96435546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7659271015990314
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148030.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4374557344882035
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12412.0966796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8702914513874281
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41390.3828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1216045318827206
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2632.84228515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4680608506944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 715958.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.098806035994254
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230566.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8368338970429168
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6371680895487468,
+        "AvgTime/train_epoch_std": 0.10038519899057925,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 85.12351989746094,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 87.88859558105469,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07589688737569489,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174.81275939941406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12594579207450582
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.462106704711914,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.14453740370901008
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6516.384765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.49422713429086085
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.61001586914062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0342467192009237
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5636.13525390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7529906818846025
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149565.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4730898343163665
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12569.587890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8813341670610714
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41098.51171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.106643688489928
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2669.8203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.47463472222222225
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 709819.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.029356328405145
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231370.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8502131591865942
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9218281005558215,
+        "AvgTime/train_epoch_std": 0.357082357375089,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 61369.1015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 52843.80859375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.2270994007465632,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18528.783203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 13.349267437409942
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5673.97607421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 29.86303196957237
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51192.74609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.8826504432119835
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11618.7197265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.9159823817197505
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19188.927734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.5636509999165
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6309.98486328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.449037014923359
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7611.56005859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5336951380306935
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32048.689453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6427643371328617
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14066.6865234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.500744270833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 416295.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.709068131172019
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121541.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0225559237348776
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.957464390787585,
+        "AvgTime/train_epoch_std": 0.11463430602153249,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 64119.7890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 55315.9609375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.2845058735254504,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26437.142578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 19.04693269317363
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7999.77001953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 42.104052734375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59154.88671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.4865291405953736
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18652.203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.286553126053253
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26385.2734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 3.5250866315965266
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9181.8017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.929017062014249
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9380.28125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6577114885710279
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41610.6875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1328969962581374
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16887.34765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.002195138888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 461170.65625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.2166855904211396
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132604.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2066528651423627
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.180582460604216,
+        "AvgTime/train_epoch_std": 0.16002045889170666,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 79193.7890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 59594.71484375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.3838638966131804,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14681.8564453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.57770637270353
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3588.854248046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 18.888706568667764
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44022.92578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.3388642989192263
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35825.4296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 12.074630835018537
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14489.8583984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.9358528254425518
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6718.146484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.801508190306563
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18741.75390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.3141041863869023
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28581.33984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.465033566238659
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10621.0537109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8881873263888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 466456.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.276483476239494
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122428.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0373170283976503
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0171114338768854,
+        "AvgTime/train_epoch_std": 0.06165281412161175,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3466.203857421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3447.07568359375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.24169651406491025,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11914.775390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.584132125810518
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13712.5830078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 72.17148951480263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40560.94921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.07629497298066
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1652.4228515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5569338899772498
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6949.00732421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9283910920799934
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8933.40625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.71451316925734
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67232.390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5612202913106075
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31635.373046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6215784021156903
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7462.10009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.3265955729166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 507645.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.742405871407079
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110208.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8339599662190271
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.1249324917793273,
+        "AvgTime/train_epoch_std": 0.4879955524186269,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3197.389892578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3213.009765625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.22528465612291404,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7762.70068359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.592723835442183
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11159.6298828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 58.73489412006579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33452.7578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.53718299677664
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1544.425048828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5205342260964358
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5516.890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.737059535738143
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8331.0908203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.194378946729275
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68061.6171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5804759703580717
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36341.23828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.862793494348762
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7560.03076171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.34400546875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 543004.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.142373561983191
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120731.3203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0090746062353353
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.187986433506012,
+        "AvgTime/train_epoch_std": 0.10322348815998104,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3387.45166015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3352.291748046875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.2350506063698552,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6808.0810546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.904957532195605
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 965.9781494140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.084095523231908
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29327.04296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.22427326270383
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1873.7806396484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6315404919610508
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4651.703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6214700233800935
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 928.0620727539062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8014352959878293
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71975.0234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6713501634195616
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25279.25390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2957739456789175
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1910.0958251953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3395725911458333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 517062.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.848927284707533
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120025.6171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9973310899355998
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.181524503231048,
+        "AvgTime/train_epoch_std": 1.017050827905613,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 14200.892578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 14768.8837890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.7570292577304065,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18971.83203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 13.668466881304035
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2301.874755859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 12.11513029399671
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53560.05078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.062195736158514
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8887.2353515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.99536075212757
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15991.5537109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.136480121701737
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3908.103759765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.374873713096395
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72175.4921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6760052987994614
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12482.912109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8752567739009255
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3849.1533203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6842939236111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 342213.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.8710624215241562
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89832.9765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4948991823090876
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4357865708214894,
+        "AvgTime/train_epoch_std": 0.1399972704754067,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 14505.087890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 14825.66796875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.7599399235609205,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18338.33984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 13.212060406159942
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4746.64208984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 24.982326788651317
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51037.0703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.870843406332954
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43607.89453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 14.697638871334682
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14288.4931640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.9089503225200402
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4698.34326171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.057291245007556
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61103.10546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4188906155663663
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26440.794921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.853933173599425
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4493.6689453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7988744791666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 366658.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.147581247242741
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93071.5859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5487924706288585
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8831474452183163,
+        "AvgTime/train_epoch_std": 0.10041628106330494,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 17769.384765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18522.0859375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.9494123705725562,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29378.599609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 21.166138047100144
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3960.5341796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 20.84491673519737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91975.5703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.975773250853242
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51489.54296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 17.35407582364341
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19532.126953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.6095025989478957
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8107.46337890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.001263712354275
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61370.80859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4251070173172486
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30183.216796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.1163382973548592
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6741.66015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.198517361111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 369653.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.181461248487042
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88446.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4718303816584295
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.01461124420166,
+        "AvgTime/train_epoch_std": 0.08421888290303094,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1593.779541015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1618.5316162109375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.28773895399305555,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2326.620361328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.6762394534064302
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376.5119323730469,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.9816417493318257
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3801.34423828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.28830824712030717
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 318.62615966796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10739000999931539
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3639.093017578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.48618477188752507
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 388.2564697265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3352819254978951
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117346.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7249420920026006
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11463.8876953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8038064573911443
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29197.419921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4966128413488646
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 597279.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.756329677725869
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177686.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9568608760587756
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2885652505434475,
+        "AvgTime/train_epoch_std": 0.3787951166973497,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1156.8583984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1189.6160888671875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.2114873046875,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4180.74658203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.0120652608294307
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 320.6872863769531,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.6878278230365953
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4378.29296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.332066209233978
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1962.8541259765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6615618894427241
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3320.827392578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4436643143056947
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389.4166259765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3362837875445272
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104757.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.432606121122051
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9848.3037109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6905275354745127
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25939.349609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.329609391018248
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 562521.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.363151561598588
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157171.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.615473880069226
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.155203802245004,
+        "AvgTime/train_epoch_std": 0.5209730580012998,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1080.5225830078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1081.434326171875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.19225499131944446,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3240.845947265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.334903420220191
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279.2090759277344,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.4695214522512337
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4648.58935546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.35256650401734924
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3358.016357421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1317884588546934
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2916.6806640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3896700953991316
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 337.5278625488281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.29147483812506747
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97838.0859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.271922857549229
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8594.4482421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6026117123957019
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25204.95703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2919656072197447
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 540749.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.116870326798864
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147680.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.457524170868487
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.129841748873393,
+        "AvgTime/train_epoch_std": 0.21020688472305774,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 323321.3125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 215767.75,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 2.4407288214200875,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218180.140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 157.19030304394812
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120520.0546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 634.3160773026316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 316442.4375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 24.000184869169512
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140830.046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 47.46546911863835
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 305070.28125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 40.75755260521042
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155923.140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 134.64865338946458
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 287245.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 6.6701907335593535
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114268.1875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 8.012073166456318
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201544.59375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 10.330852106719975
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138303.96875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 24.58737222222222
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114520.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9057146319038822
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.950101867318153,
+        "AvgTime/train_epoch_std": 1.5255853630525353,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 223938.953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 157192.359375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 1.7781337666708144,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90884.34375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 65.47863382564842
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22128.99609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 116.46840049342106
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 308812.5625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 23.421506446719757
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151617.765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 51.101370281429055
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146913.765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 19.627757598530394
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44276.6484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 38.2354477007772
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202202.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.695401393855657
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93145.1484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.531001853702145
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88808.859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.552199465631247
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79779.6171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 14.183043055555556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105111.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.749152095501972
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.6595434515099776,
+        "AvgTime/train_epoch_std": 0.6615900571184116,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 311845.90625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 194296.140625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 2.197845555297897,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133732.296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 96.34891705691642
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32101.486328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 168.9551912006579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 277605.8125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.054669131588927
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51107.64453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 17.225360475648802
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142564.78125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 19.04673096192385
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36207.2890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 31.267089000431778
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181664.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.218467716654282
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39556.015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.773525145491516
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53309.15234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.732541511289661
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43122.171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 7.666163888888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63773.34765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0612441990955686
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.588597711763884,
+        "AvgTime/train_epoch_std": 0.49438761424977756,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 56850.125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 57723.97265625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.9605773160975488,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262157.03125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 188.87394182276657
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164694.59375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 866.8136513157895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121907.5625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.245928138035646
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25884.18359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.724025478176609
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 283986.15625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 37.94070223780895
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173297.359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 149.65229652417963
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100066.578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.3236712364155676
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23439.658203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.6435042913423783
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256827.4375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.164561868881028
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180913.40625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 32.16238333333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 283474.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.2066120493648405
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.089586544036865,
+        "AvgTime/train_epoch_std": 0.0847197914376642,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 62587.1484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 57862.11328125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.9628760967375568,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123495.7578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 88.9738889139049
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42079.26171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 221.46979851973686
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188266.765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 14.278859736442927
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54683.23828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 18.43048138902932
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135702.796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 18.12996618236473
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42860.21875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 37.01227871329879
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114210.5078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.652110993231005
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34932.11328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.4493137905798625
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78297.5078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.013404470372649
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53691.328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.545125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 275243.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.113512479780098
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.6000445756045254,
+        "AvgTime/train_epoch_std": 0.5579675760388979,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "airtnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 44855.2734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 39454.83984375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.65656299142579,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86896.3984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 62.6054743786023
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15582.4970703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 82.01314247532895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240966.484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 18.275804654910882
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65750.8671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.16072368975396
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104979.03125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.025254676018704
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17153.94921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 14.813427650043177
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159650.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7072845067806055
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46366.484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.251050650329547
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40549.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.078476600543339
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12613.609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.2424194444444443
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196653.953125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.2245167372713595
+        }
+      },
+      "output_dir": "/Users/aniervs/TopoBench/logs/train/runs/notebook_gu_grid_2026-05-24_00-02-52__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.822768457730611,
+        "AvgTime/train_epoch_std": 0.7045146311197122,
+        "model/params/total": 55899,
+        "model/params/trainable": 55899,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/cell/airtnn.yaml
+++ b/configs/model/cell/airtnn.yaml
@@ -1,0 +1,42 @@
+_target_: topobench.model.TBModel
+
+model_name: airtnn
+model_domain: cell
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 32
+  proj_dropout: 0.
+  selected_dimensions:
+    - 0
+    - 1
+
+backbone:
+  _target_: topobench.nn.backbones.cell.airtnn.AirTNN
+  in_channels: ${model.feature_encoder.out_channels}
+  n_layers: 2          # SWEEP: [2, 4]
+  k: 1                 # SWEEP: [1, 2]  shift orders per neighborhood
+  snr_db: 100          # SWEEP: [100, 20, 10]  100 = ideal/noise-free filter
+  delta: 1.0           # channel fading scale (no sweep)
+  dropout: 0.0         # SWEEP: [0.0, 0.25]
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.CCCNWrapper
+  _partial_: true
+  wrapper_name: CCCNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/cell/test_airtnn.py
+++ b/test/nn/backbones/cell/test_airtnn.py
@@ -1,0 +1,144 @@
+"""Unit tests for the AirTNN cell-complex backbone."""
+
+import pytest
+import torch
+
+from topobench.nn.backbones.cell.airtnn import AirTNN, AirTNNLayer
+
+
+def _random_sparse_laplacian(n, density=0.3, seed=0):
+    """Build a small symmetric coalesced sparse matrix to stand in for a Laplacian.
+
+    Parameters
+    ----------
+    n : int
+        Number of cells (matrix is ``[n, n]``).
+    density : float, optional
+        Approximate fraction of off-diagonal nonzeros (default: 0.3).
+    seed : int, optional
+        RNG seed for reproducibility (default: 0).
+
+    Returns
+    -------
+    torch.Tensor
+        Coalesced sparse ``[n, n]`` float32 tensor.
+    """
+    g = torch.Generator().manual_seed(seed)
+    dense = (torch.rand(n, n, generator=g) < density).float()
+    dense = torch.triu(dense, diagonal=1)
+    dense = dense + dense.t()
+    dense.fill_diagonal_(1.0)
+    return dense.to_sparse_coo().coalesce()
+
+
+@pytest.fixture
+def toy_complex():
+    """Return ``(x, Ld, Lu)`` for a small synthetic rank-1 signal.
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        Signal ``x`` of shape ``[n, f]`` and two ``[n, n]`` sparse Laplacians.
+    """
+    n, f = 12, 8
+    x = torch.randn(n, f)
+    return x, _random_sparse_laplacian(n, seed=1), _random_sparse_laplacian(n, seed=2)
+
+
+def test_layer_output_shape(toy_complex):
+    """Layer maps ``[n, c_in]`` to ``[n, c_out]``.
+
+    Parameters
+    ----------
+    toy_complex : tuple of torch.Tensor
+        Signal and the up/down Laplacians from the fixture.
+    """
+    x, ld, lu = toy_complex
+    layer = AirTNNLayer(c_in=8, c_out=16, k=1, snr_db=100)
+    out = layer(x, ld, lu)
+    assert out.shape == (12, 16)
+    assert out.dtype == torch.float32
+
+
+def test_backbone_output_shape(toy_complex):
+    """Backbone preserves the channel dimension and cell count.
+
+    Parameters
+    ----------
+    toy_complex : tuple of torch.Tensor
+        Signal and the up/down Laplacians from the fixture.
+    """
+    x, ld, lu = toy_complex
+    model = AirTNN(in_channels=8, n_layers=3, k=2, snr_db=100)
+    out = model(x, ld, lu)
+    assert out.shape == (12, 8)
+
+
+def test_ideal_channel_is_deterministic(toy_complex):
+    """With ``snr_db == 100`` the filter is noise-free and repeatable.
+
+    Parameters
+    ----------
+    toy_complex : tuple of torch.Tensor
+        Signal and the up/down Laplacians from the fixture.
+    """
+    x, ld, lu = toy_complex
+    layer = AirTNNLayer(8, 8, k=2, snr_db=100).eval()
+    torch.testing.assert_close(layer(x, ld, lu), layer(x, ld, lu))
+
+
+def test_noisy_channel_is_stochastic(toy_complex):
+    """With finite SNR, channel fading + noise make repeated passes differ.
+
+    Parameters
+    ----------
+    toy_complex : tuple of torch.Tensor
+        Signal and the up/down Laplacians from the fixture.
+    """
+    x, ld, lu = toy_complex
+    layer = AirTNNLayer(8, 8, k=1, snr_db=10).eval()
+    a, b = layer(x, ld, lu), layer(x, ld, lu)
+    assert not torch.allclose(a, b)
+
+
+def test_gradients_flow_to_linears(toy_complex):
+    """Backprop populates gradients on every learnable map (ideal channel).
+
+    Parameters
+    ----------
+    toy_complex : tuple of torch.Tensor
+        Signal and the up/down Laplacians from the fixture.
+    """
+    x, ld, lu = toy_complex
+    layer = AirTNNLayer(8, 8, k=1, snr_db=100)
+    layer(x, ld, lu).pow(2).sum().backward()
+    assert layer.h_lin.weight.grad is not None
+    assert all(lin.weight.grad is not None for lin in layer.up_lins)
+    assert all(lin.weight.grad is not None for lin in layer.low_lins)
+
+
+@pytest.mark.parametrize("k", [1, 2, 3])
+def test_shift_order_parameterization(k):
+    """A layer of order ``k`` holds ``k + 1`` maps per neighborhood.
+
+    Parameters
+    ----------
+    k : int
+        Shift order under test.
+    """
+    layer = AirTNNLayer(4, 4, k=k, snr_db=100)
+    assert len(layer.up_lins) == k + 1
+    assert len(layer.low_lins) == k + 1
+
+
+def test_output_is_finite(toy_complex):
+    """Noisy forward pass produces no NaNs/Infs (mirrors the upstream guard).
+
+    Parameters
+    ----------
+    toy_complex : tuple of torch.Tensor
+        Signal and the up/down Laplacians from the fixture.
+    """
+    x, ld, lu = toy_complex
+    out = AirTNN(8, n_layers=2, k=2, snr_db=10)(x, ld, lu)
+    assert torch.all(torch.isfinite(out))

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -5,7 +5,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS   = ["cell/airtnn"]
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/cell/airtnn.py
+++ b/topobench/nn/backbones/cell/airtnn.py
@@ -31,11 +31,30 @@ class AirTNNLayer(nn.Module):
     (self) contributions, each passed through a learnable linear map:
 
     .. math::
-        y = H_0 x + \sum_{j=1}^{k} \big( U_j\, S_u^{(j)} x + L_j\, S_d^{(j)} x \big),
+        y = H_0 x + \sum_{j=1}^{k+1} \big( U_j\, S_u^{(j)} x + L_j\, S_d^{(j)} x \big),
 
     where :math:`S_u, S_d` are the upper/lower shift operators. Over the air,
     each application of a shift multiplies the operator entries by sampled
     channel fading and adds white noise (see :meth:`_shift`).
+
+    Notes
+    -----
+    The shift operators :math:`S_d, S_u` are instantiated as the lower/upper
+    Hodge Laplacians :math:`L_d = B_1^\top B_1` and :math:`L_u = B_2 B_2^\top`
+    supplied by TopoBench, matching the cell-complex FIR filter of [1, Eq. (2)]
+    (the standard convolutional filter of Yang et al. and Barbarossa--
+    Sardellitti). Per [1, Eq. (8)-(9)], the over-the-air channel gains are
+    placed on exactly the nonzero entries of the shift operator; since the
+    Hodge Laplacians carry a populated diagonal (the lower/upper cell degrees),
+    fading is applied to those diagonal entries as well, by design -- the paper
+    constrains only the *off-support* entries (:math:`[S]_{ij}=0` iff cells are
+    not neighbors) and leaves :math:`S` as the Laplacian.
+
+    The order-0 (self) contribution :math:`H_0 x` -- the :math:`w_0`,
+    :math:`S^0 = I` term of the filter polynomial -- is realized by the
+    separate ``h_lin`` branch acting directly on ``x``. It never passes through
+    :meth:`_fade` or the noise injection, so each cell retains exact, un-faded
+    knowledge of its own state independently of the diagonal of :math:`S`.
 
     Parameters
     ----------
@@ -44,7 +63,9 @@ class AirTNNLayer(nn.Module):
     c_out : int
         Number of output channels.
     k : int, optional
-        Number of shift orders per neighborhood (default: 1).
+        Filter-order parameter: each neighborhood branch spans shift orders
+        ``1..k+1`` (i.e. ``k+1`` learnable maps per branch), in addition to the
+        order-0 self term. Default: 1.
     snr_db : float, optional
         Channel signal-to-noise ratio in dB. Use ``100`` for the ideal,
         noise-free filter (default: 100).
@@ -61,7 +82,7 @@ class AirTNNLayer(nn.Module):
         self.snr_lin = 10 ** (snr_db / 10)
         self.delta = float(delta)
 
-        # One linear map per shift order (0..k) for each of the two
+        # One linear map per shift order (1..k+1) for each of the two
         # neighborhoods, plus an order-0 self map.
         self.up_lins = nn.ModuleList(
             [Linear(c_in, c_out, bias=False) for _ in range(k + 1)]
@@ -142,7 +163,9 @@ class AirTNNLayer(nn.Module):
         r"""Apply one over-the-air topological shift ``L @ x``.
 
         Ideal channel (``snr_db == 100``) is a plain sparse matmul; otherwise
-        the operator is faded and white noise is added.
+        the operator is faded and white noise is added. Fading is applied to
+        every nonzero of the Hodge Laplacian per [1, Eq. (8)-(9)], diagonal
+        included; the un-faded self term is handled separately by ``h_lin``.
 
         Parameters
         ----------
@@ -208,7 +231,8 @@ class AirTNN(nn.Module):
     n_layers : int, optional
         Number of AirTNN layers (default: 2).
     k : int, optional
-        Shift orders per layer (default: 1).
+        Per-layer filter-order parameter; each layer spans neighborhood shift
+        orders ``1..k+1`` (default: 1).
     snr_db : float, optional
         Channel SNR in dB; ``100`` is the ideal noise-free filter (default: 100).
     delta : float, optional

--- a/topobench/nn/backbones/cell/airtnn.py
+++ b/topobench/nn/backbones/cell/airtnn.py
@@ -1,0 +1,270 @@
+"""Topological Neural Networks over the Air (AirTNN).
+
+This module implements the AirTNN backbone[1] adapted for the TopoBench
+training framework. AirTNN is a cell-complex convolutional architecture whose
+topological shift operator embeds a wireless communication model -- channel
+fading and additive white noise -- directly into the lower/upper neighborhood
+filtering. Setting ``snr_db = 100`` recovers the ideal (noise-free) cell-complex
+filter.
+
+Adapted from Fiorellino et al. [1]. The reference implementation operates on
+dense ``[batch, num_cells, features]`` tensors with a shared Laplacian; here we
+operate on TopoBench's flat ``[num_cells, features]`` rank-1 signal with
+block-diagonal *sparse* lower/upper Laplacians, so each shift is a single
+``torch.sparse.mm`` and the batch dimension disappears.
+
+[1] Fiorellino, Battiloro, Di Lorenzo. "Topological Neural Networks over the
+    Air." https://arxiv.org/abs/2502.10070
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.nn import Linear
+
+
+class AirTNNLayer(nn.Module):
+    r"""A single AirTNN cell-complex convolutional layer.
+
+    Implements the over-the-air topological filter of [1, Eq. (10)-(13)]. The
+    output is a sum of (i) lower-shifted, (ii) upper-shifted, and (iii) order-0
+    (self) contributions, each passed through a learnable linear map:
+
+    .. math::
+        y = H_0 x + \sum_{j=1}^{k} \big( U_j\, S_u^{(j)} x + L_j\, S_d^{(j)} x \big),
+
+    where :math:`S_u, S_d` are the upper/lower shift operators. Over the air,
+    each application of a shift multiplies the operator entries by sampled
+    channel fading and adds white noise (see :meth:`_shift`).
+
+    Parameters
+    ----------
+    c_in : int
+        Number of input channels.
+    c_out : int
+        Number of output channels.
+    k : int, optional
+        Number of shift orders per neighborhood (default: 1).
+    snr_db : float, optional
+        Channel signal-to-noise ratio in dB. Use ``100`` for the ideal,
+        noise-free filter (default: 100).
+    delta : float, optional
+        Scale of the (Rayleigh) channel fading (default: 1.0).
+    """
+
+    def __init__(self, c_in, c_out, k=1, snr_db=100, delta=1.0):
+        super().__init__()
+        self.c_in = c_in
+        self.c_out = c_out
+        self.k = k
+        self.snr_db = snr_db
+        self.snr_lin = 10 ** (snr_db / 10)
+        self.delta = float(delta)
+
+        # One linear map per shift order (0..k) for each of the two
+        # neighborhoods, plus an order-0 self map.
+        self.up_lins = nn.ModuleList(
+            [Linear(c_in, c_out, bias=False) for _ in range(k + 1)]
+        )
+        self.low_lins = nn.ModuleList(
+            [Linear(c_in, c_out, bias=False) for _ in range(k + 1)]
+        )
+        self.h_lin = Linear(c_in, c_out, bias=False)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Reinitialize all learnable linear maps."""
+        for lin in self.up_lins:
+            lin.reset_parameters()
+        for lin in self.low_lins:
+            lin.reset_parameters()
+        self.h_lin.reset_parameters()
+
+    @staticmethod
+    def _white_noise(x, snr_lin):
+        r"""Sample additive white Gaussian noise scaled to the signal power.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Signal of shape ``[num_cells, features]``.
+        snr_lin : float
+            Linear-scale SNR (already converted from dB).
+
+        Returns
+        -------
+        torch.Tensor
+            Noise tensor with the same shape as ``x``. Sampled under
+            ``no_grad`` -- noise is a channel effect, not a learnable quantity.
+        """
+        with torch.no_grad():
+            power = (x.detach() ** 2).sum() / x.numel()
+            std = torch.sqrt(power / snr_lin)
+            return torch.randn_like(x) * std
+
+    @staticmethod
+    def _fade(laplacian, delta):
+        r"""Apply Rayleigh channel fading to the nonzero entries of a sparse op.
+
+        Each existing connection (nonzero of the sparse Laplacian) is scaled by
+        an independent fading magnitude :math:`|h|`, with
+        :math:`h \sim \mathcal{CN}(0, \delta^2)`.
+
+        Parameters
+        ----------
+        laplacian : torch.Tensor
+            Coalesced sparse ``[num_cells, num_cells]`` shift operator.
+        delta : float
+            Fading scale.
+
+        Returns
+        -------
+        torch.Tensor
+            A new coalesced sparse tensor with faded values. The fading is
+            sampled under ``no_grad``; gradients still flow through the dense
+            signal in the subsequent ``sparse.mm``.
+        """
+        values = laplacian.values()
+        with torch.no_grad():
+            fading = (
+                torch.randn(
+                    values.shape,
+                    dtype=torch.complex64,
+                    device=laplacian.device,
+                )
+                * delta
+            ).abs()
+        return torch.sparse_coo_tensor(
+            laplacian.indices(), values * fading, laplacian.shape
+        ).coalesce()
+
+    def _shift(self, x, laplacian):
+        r"""Apply one over-the-air topological shift ``L @ x``.
+
+        Ideal channel (``snr_db == 100``) is a plain sparse matmul; otherwise
+        the operator is faded and white noise is added.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Signal of shape ``[num_cells, features]``.
+        laplacian : torch.Tensor
+            Coalesced sparse lower or upper Laplacian.
+
+        Returns
+        -------
+        torch.Tensor
+            Shifted signal of shape ``[num_cells, features]``.
+        """
+        if self.snr_db == 100:
+            return torch.sparse.mm(laplacian, x)
+        return torch.sparse.mm(
+            self._fade(laplacian, self.delta), x
+        ) + self._white_noise(x, self.snr_lin)
+
+    def forward(self, x, down_laplacian, up_laplacian):
+        r"""Forward pass of the AirTNN layer.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Rank-1 cell signal of shape ``[num_cells, c_in]``.
+        down_laplacian : torch.Tensor
+            Coalesced sparse lower Laplacian ``L_d`` (``[num_cells, num_cells]``).
+        up_laplacian : torch.Tensor
+            Coalesced sparse upper Laplacian ``L_u`` (``[num_cells, num_cells]``).
+
+        Returns
+        -------
+        torch.Tensor
+            Output signal of shape ``[num_cells, c_out]``.
+        """
+        x_up = self._shift(x, up_laplacian)
+        x_low = self._shift(x, down_laplacian)
+        out = self.up_lins[0](x_up) + self.low_lins[0](x_low)
+
+        for up_lin, low_lin in zip(
+            self.up_lins[1:], self.low_lins[1:], strict=True
+        ):
+            x_up = self._shift(x_up, up_laplacian)
+            x_low = self._shift(x_low, down_laplacian)
+            out = out + up_lin(x_up) + low_lin(x_low)
+
+        return out + self.h_lin(x)
+
+
+class AirTNN(nn.Module):
+    r"""AirTNN backbone: a stack of :class:`AirTNNLayer` over a cell complex.
+
+    Mirrors the rank-1 contract of TopoBench's ``CCCN`` backbone -- it consumes
+    the rank-1 signal and the lower/upper Laplacians and returns rank-1
+    embeddings -- so it can reuse ``CCCNWrapper`` without modification.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input (and hidden) channels. Held constant across layers to
+        match the feature-encoder output and the readout hidden dim.
+    n_layers : int, optional
+        Number of AirTNN layers (default: 2).
+    k : int, optional
+        Shift orders per layer (default: 1).
+    snr_db : float, optional
+        Channel SNR in dB; ``100`` is the ideal noise-free filter (default: 100).
+    delta : float, optional
+        Channel fading scale (default: 1.0).
+    dropout : float, optional
+        Dropout applied to the input of each layer (default: 0.0).
+    last_act : bool, optional
+        Whether to apply the activation after the final layer (default: False).
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        n_layers=2,
+        k=1,
+        snr_db=100,
+        delta=1.0,
+        dropout=0.0,
+        last_act=False,
+    ):
+        super().__init__()
+        self.dropout = dropout
+        self.last_act = last_act
+        self.layers = nn.ModuleList(
+            [
+                AirTNNLayer(
+                    in_channels, in_channels, k=k, snr_db=snr_db, delta=delta
+                )
+                for _ in range(n_layers)
+            ]
+        )
+
+    def forward(self, x, down_laplacian, up_laplacian):
+        r"""Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Rank-1 cell signal of shape ``[num_cells, in_channels]``.
+        down_laplacian : torch.Tensor
+            Coalesced sparse lower Laplacian.
+        up_laplacian : torch.Tensor
+            Coalesced sparse upper Laplacian.
+
+        Returns
+        -------
+        torch.Tensor
+            Rank-1 embeddings of shape ``[num_cells, in_channels]``.
+        """
+        last = len(self.layers) - 1
+        for i, layer in enumerate(self.layers):
+            x = layer(
+                F.dropout(x, p=self.dropout, training=self.training),
+                down_laplacian,
+                up_laplacian,
+            )
+            if not (i == last and not self.last_act):
+                x = x.relu()
+        return x


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description
This PR contributes **AirTNN** (*Topological Neural Networks over the Air*, Fiorellino, Battiloro & Di Lorenzo — arXiv:2502.10070) as a **Track 2 (TNN)** submission for the TDL Challenge 2026, operating on the **cell** domain.

**Files added**
- `topobench/nn/backbones/cell/airtnn.py`: the `AirTNN` backbone and `AirTNNLayer`.
- `configs/model/cell/airtnn.yaml`: full `TBModel` composition.
- `test/nn/backbones/cell/test_airtnn.py`: unit tests.
- `test/pipeline/test_pipeline.py`: set to `MODELS = ["cell/airtnn"]`.
- `2026_tdl_challenge/outputs/airtnn_full/results.json`: results of training and evaluation in GraphUniverse

**Adaptation to TopoBench.**
The reference implementation filters dense `[batch, num_cells, F]` tensors against a single shared Laplacian via a custom `batch_mm`. TopoBench batches complexes as a disjoint union, so the signal is a flat `[N, F]` tensor and the Laplacians are block-diagonal sparse operators. Each shift therefore becomes a single `torch.sparse.mm(L, x)`; block-diagonal multiplication keeps per-complex message passing isolated, so this is exact (not an approximation) and additionally supports the inductive, variable-size setting GraphUniverse requires. Channel fading is sampled per nonzero of the sparse operator (independent channel per complex); noise is added per cell.

**Complexity (per layer).**
Sparse shifts cost `O(k · nnz(L) · F)` and the linear maps `O(k · N · F²)`;
memory `O(nnz(L) + N · F)`.

## Additional context
- **Paper:** Fiorellino, Battiloro, Di Lorenzo, *Topological Neural Networks over the Air*, arXiv:2502.10070.
- **Channel model on GraphUniverse.** GraphUniverse has no wireless channel, so the primary runs use `snr_db = 100` (the ideal filter). An SNR sweep (100 / 20 / 10) is **planned** as a robustness ablation rather than the main result.
