### PR TITLE
Track: Track1; Team name: TJPaik; Model: Neural Sheaf Diffusion (NSD)

### DIFF
--- a/2026_tdl_challenge/outputs/nsd/results.json
+++ b/2026_tdl_challenge/outputs/nsd/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "nsd",
+    "model_config": "graph/nsd",
+    "generated_at_utc": "2026-05-25T17:17:49.061228+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.334864377975464,
+      "test_best_rerun_accuracy": 0.29005271196365356,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28470471501350403,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2928413152694702,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28718772530555725,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.300672322511673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2899763286113739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3001375198364258,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28783711791038513,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2971961200237274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29138970375061035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2978455126285553,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28470471501350403,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.375956754161887,
+        "AvgTime/train_epoch_std": 0.01892647504274516,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.285374164581299,
+      "test_best_rerun_accuracy": 0.3078157305717468,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3001757264137268,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3087325096130371,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.302620530128479,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3167545199394226,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30838871002197266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3184735178947449,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.306440532207489,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31667813658714294,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30934372544288635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31706011295318604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30472153425216675,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3503443640057404,
+        "AvgTime/train_epoch_std": 0.02109935045795469,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.293691873550415,
+      "test_best_rerun_accuracy": 0.3013599216938019,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2954389154911041,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30483612418174744,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2975781261920929,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3145389258861542,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3076629340648651,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31518831849098206,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3040721118450165,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31343111395835876,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30594393610954285,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3152265250682831,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30147451162338257,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5022395070143573,
+        "AvgTime/train_epoch_std": 0.09206538339622974,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3500163555145264,
+      "test_best_rerun_accuracy": 0.2840934991836548,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28581252694129944,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2856215238571167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28310030698776245,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2895561158657074,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2869585156440735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.290358304977417,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2858507037162781,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2886393070220947,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28688210248947144,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.289288729429245,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2866911292076111,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5075107143349844,
+        "AvgTime/train_epoch_std": 0.030939499827833762,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3147854804992676,
+      "test_best_rerun_accuracy": 0.2934907078742981,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29627931118011475,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29616472125053406,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29490411281585693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3028879165649414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29872411489486694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3012453317642212,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30063411593437195,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3012453317642212,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3016273081302643,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30498892068862915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30197110772132874,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5140601329400505,
+        "AvgTime/train_epoch_std": 0.03291870130300463,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3153927326202393,
+      "test_best_rerun_accuracy": 0.2958209216594696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29696691036224365,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29753991961479187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2951715290546417,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30185651779174805,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30021393299102783,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3020857274532318,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3011307120323181,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046451210975647,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30074870586395264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3050271272659302,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30132171511650085,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5279851085261296,
+        "AvgTime/train_epoch_std": 0.04840346533814883,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2534537315368652,
+      "test_best_rerun_accuracy": 0.31450071930885315,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30254411697387695,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2933761179447174,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30185651779174805,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30552372336387634,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3263809382915497,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3094201385974884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3181297183036804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30376651883125305,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3179387152194977,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29585912823677063,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6891853823218237,
+        "AvgTime/train_epoch_std": 0.04625096975641594,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.311784505844116,
+      "test_best_rerun_accuracy": 0.29425472021102905,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2845519185066223,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27496370673179626,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28245091438293457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2939491271972656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28501030802726746,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3034609258174896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28856292366981506,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2956681251525879,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2829093039035797,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2957827150821686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27427610754966736,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4532125560860885,
+        "AvgTime/train_epoch_std": 0.1491292815804164,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2608025074005127,
+      "test_best_rerun_accuracy": 0.31098631024360657,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30472153425216675,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2932615280151367,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30132171511650085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3203071355819702,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30540913343429565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3277561366558075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3103369176387787,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3222935199737549,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3051799237728119,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3242035210132599,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2975781261920929,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3854215160394325,
+        "AvgTime/train_epoch_std": 0.06386421538692452,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.3002750873565674,
+      "test_best_rerun_accuracy": 0.2986859083175659,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29876232147216797,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2959355115890503,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30281153321266174,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30854153633117676,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3023149073123932,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3106425106525421,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3054855167865753,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3115975260734558,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30605852603912354,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3122851252555847,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3073573112487793,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5443623734411793,
+        "AvgTime/train_epoch_std": 0.08418366448792612,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.305393695831299,
+      "test_best_rerun_accuracy": 0.29925891757011414,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29681411385536194,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2934907078742981,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3018947243690491,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30934372544288635,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3020857274532318,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.312094122171402,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30689892172813416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3139277398586273,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3089617192745209,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31369853019714355,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30934372544288635,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5568343196064234,
+        "AvgTime/train_epoch_std": 0.1082017534091729,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.3056414127349854,
+      "test_best_rerun_accuracy": 0.2982657253742218,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30006110668182373,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29356712102890015,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3022003173828125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30869433283805847,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3108717203140259,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30540913343429565,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31316372752189636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3069753348827362,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31492093205451965,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30880892276763916,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8223629090213036,
+        "AvgTime/train_epoch_std": 0.11539096669599251,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.110271692276001,
+      "test_best_rerun_accuracy": 0.3579723536968231,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2573153078556061,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24902589619159698,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26529911160469055,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25357168912887573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3326457440853119,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37634655833244324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35678812861442566,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42188096046447754,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3941095471382141,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44839176535606384,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41511955857276917,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6660764935898453,
+        "AvgTime/train_epoch_std": 0.06969225327288335,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.053297519683838,
+      "test_best_rerun_accuracy": 0.3742455542087555,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27496370673179626,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2672473192214966,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2850485146045685,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2722897231578827,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.349071741104126,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3965543508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3802429437637329,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45564979314804077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42680877447128296,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.491595983505249,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45889678597450256,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6213542531276572,
+        "AvgTime/train_epoch_std": 0.04947900817273349,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.059058666229248,
+      "test_best_rerun_accuracy": 0.3764611482620239,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2733592987060547,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2616701126098633,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28241270780563354,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26434409618377686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3514401316642761,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39812055230140686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38245856761932373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46489417552948,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4341813623905182,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5079455971717834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4793337881565094,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5712916831008525,
+        "AvgTime/train_epoch_std": 0.03769774063241289,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1702158451080322,
+      "test_best_rerun_accuracy": 0.33501413464546204,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26636871695518494,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2604859173297882,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27278631925582886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2670944929122925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.347199946641922,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3580487370491028,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3590037524700165,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4057987630367279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4045763611793518,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44014057517051697,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4491939842700958,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4933504817191134,
+        "AvgTime/train_epoch_std": 0.04584819411281588,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.140214204788208,
+      "test_best_rerun_accuracy": 0.3410879373550415,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2693101167678833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26449689269065857,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27714112401008606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2707616984844208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3526625335216522,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3670639395713806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3771105408668518,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42952096462249756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43062877655029297,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47902819514274597,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5018718242645264,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.492123340660671,
+        "AvgTime/train_epoch_std": 0.021175845738226364,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.150068998336792,
+      "test_best_rerun_accuracy": 0.3405149281024933,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2699977159500122,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.265604704618454,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27316829562187195,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2678202986717224,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35526013374328613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3706165552139282,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3720681369304657,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42543357610702515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4186721742153168,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4698219895362854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.48292458057403564,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4833217602150113,
+        "AvgTime/train_epoch_std": 0.034681824122380876,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9945297241210938,
+      "test_best_rerun_accuracy": 0.3935365676879883,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24879670143127441,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2389792948961258,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26273971796035767,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24978989362716675,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35541293025016785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32214072346687317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3737107515335083,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.43062877655029297,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40056535601615906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4925127923488617,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4671097993850708,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.7561757781288843,
+        "AvgTime/train_epoch_std": 0.03586156701831499,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9522088766098022,
+      "test_best_rerun_accuracy": 0.4061807692050934,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2565512955188751,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24505309760570526,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26747649908065796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24936969578266144,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36396974325180054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3290931284427643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3905569612979889,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44487738609313965,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.41851937770843506,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5167316198348999,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4982045888900757,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.760508095516878,
+        "AvgTime/train_epoch_std": 0.024627068569573363,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9531192779541016,
+      "test_best_rerun_accuracy": 0.4057987630367279,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24887309968471527,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23905569314956665,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2626250982284546,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24570250511169434,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3607991337776184,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32603713870048523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3916647434234619,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44579416513442993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42405837774276733,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5209718346595764,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5060356259346008,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.741707481443882,
+        "AvgTime/train_epoch_std": 0.050805916967753564,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.989872694015503,
+      "test_best_rerun_accuracy": 0.3950263559818268,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2403544932603836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2355794906616211,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.251508891582489,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2449766993522644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3637787401676178,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33967453241348267,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39647796750068665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4550003707408905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44338756799697876,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.519787609577179,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5326610207557678,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8104419005544563,
+        "AvgTime/train_epoch_std": 0.04493106839451076,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.961374044418335,
+      "test_best_rerun_accuracy": 0.40205517411231995,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2541064918041229,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24787989258766174,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26881352066993713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2627778947353363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3685537576675415,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3446023464202881,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40121474862098694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4815112054347992,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.47276338934898376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5590572357177734,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5833524465560913,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8089235025808352,
+        "AvgTime/train_epoch_std": 0.05265219127141025,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9706065654754639,
+      "test_best_rerun_accuracy": 0.39758574962615967,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2467339038848877,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2402016967535019,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25483229756355286,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24478569626808167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36125755310058594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3394835293292999,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3906715512275696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4609977900981903,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45018717646598816,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5328902006149292,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5531362295150757,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.807616926101317,
+        "AvgTime/train_epoch_std": 0.048353178461398395,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6516287326812744,
+      "test_best_rerun_accuracy": 0.5050805807113647,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23011688888072968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21850408613681793,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24001069366931915,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22981129586696625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3666055500507355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3346703350543976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38941094279289246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38230574131011963,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4808617830276489,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.576896607875824,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5687600374221802,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.683685206530387,
+        "AvgTime/train_epoch_std": 0.04056254475933076,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6459623575210571,
+      "test_best_rerun_accuracy": 0.5072962045669556,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2366872876882553,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22515088319778442,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24417449533939362,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2275574952363968,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36927953362464905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3374207317829132,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3916265666484833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3850179612636566,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4841088056564331,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5826266407966614,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5767820477485657,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6832393461519533,
+        "AvgTime/train_epoch_std": 0.044245774875182935,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6862846612930298,
+      "test_best_rerun_accuracy": 0.498089998960495,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2211780846118927,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20945067703723907,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23099549114704132,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2145312875509262,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3549545407295227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32496753334999084,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3790205419063568,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3752005398273468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4738712012767792,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5757506489753723,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5723126530647278,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6928523480892181,
+        "AvgTime/train_epoch_std": 0.01898241593337654,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6647274494171143,
+      "test_best_rerun_accuracy": 0.49828100204467773,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2149132788181305,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20819008350372314,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21930629014968872,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21265947818756104,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34521353244781494,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32225534319877625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3713805377483368,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37783634662628174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49954161047935486,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5913362503051758,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6228130459785461,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.613043090753388,
+        "AvgTime/train_epoch_std": 0.02617032928561677,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.7336905002593994,
+      "test_best_rerun_accuracy": 0.4816257953643799,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21052028238773346,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20055007934570312,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21349988877773285,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20410268008708954,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3315379321575165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3133929371833801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.358659952878952,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3667965531349182,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48391780257225037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5758652091026306,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6124608516693115,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.590069845870689,
+        "AvgTime/train_epoch_std": 0.053622971824718174,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6771692037582397,
+      "test_best_rerun_accuracy": 0.4983955919742584,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2170906811952591,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20792268216609955,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2192680835723877,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2092214822769165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34639772772789,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3251585364341736,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3693177402019501,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3788295388221741,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5003820061683655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5898846387863159,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6254870295524597,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.606612377696567,
+        "AvgTime/train_epoch_std": 0.023404931413972072,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3545668125152588,
+      "test_best_rerun_accuracy": 0.5989380478858948,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2126212865114212,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20112307369709015,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2281304895877838,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21059668064117432,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33963632583618164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3050653338432312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3837955594062805,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37665215134620667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49392619729042053,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4762013852596283,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6127282381057739,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.744020456291107,
+        "AvgTime/train_epoch_std": 0.05132684306605112,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3260127305984497,
+      "test_best_rerun_accuracy": 0.6086026430130005,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2056688815355301,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19619527459144592,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21945908665657043,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2068912833929062,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3384903371334076,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30147451162338257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3851325511932373,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37936434149742126,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5002673864364624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4774237871170044,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6287340521812439,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.7395541956136515,
+        "AvgTime/train_epoch_std": 0.04940150803015793,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3376604318618774,
+      "test_best_rerun_accuracy": 0.6098250150680542,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21269768476486206,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20192527770996094,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22327908873558044,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21105508506298065,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3427305519580841,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3090381324291229,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3896019458770752,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3848651647567749,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5055390000343323,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4838031828403473,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6217434406280518,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.7525013103485105,
+        "AvgTime/train_epoch_std": 0.047609525449607774,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.2826428413391113,
+      "test_best_rerun_accuracy": 0.5995874404907227,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17942547798156738,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17545266449451447,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19229887425899506,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18698906898498535,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2978455126285553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2743143141269684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34059134125709534,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35067614912986755,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4533959925174713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4410191774368286,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5600504279136658,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0762668439071543,
+        "AvgTime/train_epoch_std": 0.041247789570558094,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1805803775787354,
+      "test_best_rerun_accuracy": 0.6429826617240906,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2051340788602829,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.196844682097435,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21976469457149506,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2150660902261734,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3247383236885071,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3040721118450165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.375773549079895,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3823821544647217,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4940026104450226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48662999272346497,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6021086573600769,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0700447118582845,
+        "AvgTime/train_epoch_std": 0.04080937392110312,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.16886305809021,
+      "test_best_rerun_accuracy": 0.6450454592704773,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19718848168849945,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18844068050384521,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21796928346157074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20887768268585205,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32550233602523804,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30391931533813477,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37390175461769104,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3837955594062805,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4975551962852478,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4893803894519806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6027580499649048,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0810128301382065,
+        "AvgTime/train_epoch_std": 0.052975494203241796,
+        "model/params/total": 15349,
+        "model/params/trainable": 15349,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 47.854557037353516,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 48.83784866333008,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.035185769930353085,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.490366458892822,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.023633507678383275
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8638.875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6552047781569966
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150.18035888671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.050616905590400656
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6566.70068359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8773147205870073
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113.29814910888672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09783950700249285
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163624.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7995552404560655
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13812.689453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9684959650206844
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44262.171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.268807825875237
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3476.44677734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6180349826388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743094.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.405759702725021
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256036.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.2606727801075
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1488721370697021,
+        "AvgTime/train_epoch_std": 0.014129877090454102,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 57.20855712890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 53.65940856933594,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.038659516260328486,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.190935134887695,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10100492176256681
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4739.8388671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3594872102531286
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.73836517333984,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03327885580496793
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5140.20947265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.686734732485805
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93.08625793457031,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08038536954626106
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141481.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.285385922696452
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10277.5478515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7206245864228369
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41334.8515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.118758089215234
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3144.798828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5590753472222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710295.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.034739347080981
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239195.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.980426692792838
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.133161473274231,
+        "AvgTime/train_epoch_std": 0.019479382037835585,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 40.50183868408203,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 41.66388702392578,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.03001720967141627,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.428606986999512,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.04962424729999743
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8071.890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6122025502464922
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161.5628204345703,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05445325933082923
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6280.81103515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8391197107757181
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114.26777648925781,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09867683634650934
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160610.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.729576908786922
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13652.927734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9572940495284673
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43509.1328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2302082532420933
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3454.005615234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6140454427083334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 739079.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.360347640917164
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256223.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.263784883430683
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1417768001556396,
+        "AvgTime/train_epoch_std": 0.0003979206085205078,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.3674728274345398,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.3745024800300598,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.001971065684368736,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147.2013397216797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10605283841619574
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11791.3876953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8943032002512324
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207.6634063720703,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0699910368628481
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7538.40234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0071345816633266
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124.6708984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10766053405656303
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172543.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.006680463960617
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14496.181640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0164199719972655
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45706.3828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.342835758496079
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3474.576416015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6177024739583333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752124.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.507906971482868
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258618.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3036332746742545
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0949710011482239,
+        "AvgTime/train_epoch_std": 0.022082745389394667,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.4238568842411041,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.4292960464954376,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.002259452876291777,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.0917510986328,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10669434517192566
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11743.4365234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8906664029910883
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.54168701171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06725368621898171
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7563.86328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.010536176519706
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125.4927978515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10837029175437177
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172467.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.004904401007803
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14459.6298828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0138570945738676
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45770.828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3461391216874263
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3477.969482421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6183056857638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 751831.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.504592604323383
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258266.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.297772567104322
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1031960725784302,
+        "AvgTime/train_epoch_std": 0.013482799788234552,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.34746286273002625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.3458994925022125,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.001820523644748487,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140.31346130371094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10109038998826436
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11511.658203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8730874632631779
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.5048828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06151158841001011
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7500.3466796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0020503246075485
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123.27118682861328,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10645180209724808
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171691.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9868865235463495
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14306.2900390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0031054577943135
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45697.0546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3423576137936335
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3472.1142578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6172647569444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 751379.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.499483897605286
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258145.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.295762401610837
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1132208108901978,
+        "AvgTime/train_epoch_std": 0.022185196438171413,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1695.334716796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1603.093994140625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.12158467911570914,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7043.62939453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.074660947068624
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12059.2275390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 63.46961862664474
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4130.17822265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.392038497693377
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6437.32421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.860029955744823
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8423.26171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.273973850388601
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88875.2421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0637944033879805
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8972.8388671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6291430982462137
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44340.71484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.272833812278948
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10707.3037109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.9035206597222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 663576.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.506262513715598
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231987.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8604790179388613
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.253250625398424,
+        "AvgTime/train_epoch_std": 0.02621367069892347,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3712.045654296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3773.395751953125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.28618852877915246,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4724.7080078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.4039683053404177
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1712.437255859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.012827662417763
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2960.231201171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.9977186387502106
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5573.08935546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7445677161614896
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2360.808837890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.0386950240851682
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112118.9296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.603541930324633
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7442.3349609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5218296845419647
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29626.27734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.518595383861295
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3308.5546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5881875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 641870.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.260728566903838
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208403.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4680146814104806
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2376715342203775,
+        "AvgTime/train_epoch_std": 0.023726554351266072,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1576.5089111328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1553.988037109375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.11786029860518582,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4284.587890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.086878883735591
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7543.6201171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 39.70326377467105
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1094.3291015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3688335360844287
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6845.27685546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9145326460212091
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5649.54345703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.878707648558938
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97446.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.262832644436188
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7541.28662109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.528767818054533
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49240.21484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.5239743115357016
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9280.982421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.6499524305555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 680241.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.6947763367759014
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233499.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.885634038074318
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2541631013154984,
+        "AvgTime/train_epoch_std": 0.024932200119617044,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 24.077146530151367,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 22.380765914916992,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.007543230844259181,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134.11598205566406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09662534730235163
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.3933985233306885,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.007333676438582571
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9050.7626953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6864438904294653
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7417.12353515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.990931668023547
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116.40059661865234,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1005186499297516
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160806.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7341326281813116
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10525.9248046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.73803988253313
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45331.94140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3236424935286277
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3155.983154296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.561063671875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 725648.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.208412044840108
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 228055.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.795049184181186
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.366856743307675,
+        "AvgTime/train_epoch_std": 0.01936707592500296,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 24.035076141357422,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 23.737977981567383,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.008000666660454124,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.9300422668457,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03669311402510497
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.0078604221343994,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.010567686432286312
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6674.763671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5062391863386424
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6142.62646484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8206581783358383
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81.85151672363281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07068352048672955
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149563.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4730622590795095
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8983.79296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6299111603386621
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41743.81640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1397209701291713
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2670.882568359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.47482356770833334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 703625.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.959294367838195
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215215.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.581380630855507
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3697809875011444,
+        "AvgTime/train_epoch_std": 0.025771472069200305,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 17.3758544921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 16.39531898498535,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.005525891130766887,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70.6281967163086,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.050884867951230976
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.36269998550415,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.028224736765811317
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8358.59375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6339471937808115
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6710.43310546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8965174489604208
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.7323226928711,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0869881888539474
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157119.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.648516234557867
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10091.537109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7075821840818258
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43143.859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2114849236249934
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2917.357177734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5186412760416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 715986.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.099124888295647
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221763.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6903411691045545
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.322909042753022,
+        "AvgTime/train_epoch_std": 0.06100910290668484,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1653.0328369140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1747.3681640625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.23344932051603207,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.25247192382812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11977843798546695
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161.33372497558594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8491248682925575
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7486.0751953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5677721043088737
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 584.0472412109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.19684773886448853
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210.45578002929688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.18174074268505774
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98872.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.295951592397362
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7391.630859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5182744958193101
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20625.212890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0572152796465735
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1657.26171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2946243055555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 557666.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.308229782925919
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197615.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2884885198775233
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2240231470628218,
+        "AvgTime/train_epoch_std": 0.026284132569680364,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1129.161376953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1156.5870361328125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1545206461099282,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43.202674865722656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.031125846445045142
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.5263566970825195,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.02382292998464484
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4637.52587890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.35172740833570343
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211.95834350585938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07143860583278037
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72.58890533447266,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06268471963253251
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68147.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5824688254690693
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4623.576171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3241884849162109
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11728.474609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.601182767408632
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1415.9793701171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2517296657986111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 408980.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.626323837991923
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146750.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.4420543990148604
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2158684937850288,
+        "AvgTime/train_epoch_std": 0.020877529831420678,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2117.581298828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2219.760009765625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.2965611235491817,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 602.4395751953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4340342760773145
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 831.6429443359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.377068128083882
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4067.556640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3084987971653394
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 474.31243896484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.15986263531002487
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 545.6578369140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.47120711305186747
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92719.5546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1530641530628833
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6048.37548828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.42409027403458494
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25768.544921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3208542171241477
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2150.81640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.38236736111111114
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 580612.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.567788282071875
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200560.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.337506032316576
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2214001655578612,
+        "AvgTime/train_epoch_std": 0.027624625079858425,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 73.06047058105469,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 76.92622375488281,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.06643024503875891,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140.10084533691406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10093720845598995
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.0499813556671143,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.010789375556142707
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9784.9521484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7421275804654911
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.5172004699707,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.019048601439154263
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6602.54541015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8821035952112558
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154017.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5764791937581273
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8704.916015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6103573142353808
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40367.23828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0691597868291556
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2277.550537109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4048978732638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 691405.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.821068713731434
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210569.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.504052572679014
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.057157293955485,
+        "AvgTime/train_epoch_std": 0.03165187643080927,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 74.02989959716797,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78.17601776123047,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.06750951447429229,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.43689727783203,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07308133809642077
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.219336986541748,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.022207036771272358
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8824.333984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.669270685200986
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104.56336212158203,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03524211733117021
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6394.14892578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8542617135312291
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154588.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.58974433401449
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9493.6748046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6656622356392862
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41202.421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1119699561740735
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2471.018310546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4392921440972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 707851.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.007101003359615
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225389.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7506713552327224
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1435749530792236,
+        "AvgTime/train_epoch_std": 0.02704624039453432,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 61.19765090942383,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 64.82166290283203,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.055977256392773775,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94.83602142333984,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06832566384966847
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.491703033447266,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0236405422813014
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8179.529296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6203662720420933
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201.44215393066406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06789422107538391
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5569.474609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7440847841516366
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144410.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3533882709455693
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7307.81982421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5123979683227282
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36772.05859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8848766514813675
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1961.859619140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.34877504340277776
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668575.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.562816731332647
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196468.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2694092385968414
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1394122958183288,
+        "AvgTime/train_epoch_std": 0.01879659201463496,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 21695.404296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15428.1162109375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.35826017580664826,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5347.11181640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.85238603487482
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6603.90966796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 34.757419305098686
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6653.72607421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5046436157920933
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9130.6962890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.0774170168731043
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5688.8564453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7600342612307949
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6650.6875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.743253454231433
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11727.8037109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8223112965178446
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16426.455078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8419936992221538
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7183.09326171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.276994357638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173169.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.958861690214133
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61219.55859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0187469188383007
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3743040910581263,
+        "AvgTime/train_epoch_std": 0.022076099930231338,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 34961.94140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 23041.17578125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.5350449512643972,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14919.169921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.748681499909942
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31696.796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 166.82524671052633
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5471.53955078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.41498214264552524
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10308.6083984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.474421435267105
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12627.767578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.687076496743487
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22509.228515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 19.438021170660623
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6800.09423828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.47679808149496916
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34772.9375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7824049156799426
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17616.8671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.1318875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239155.015625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.7052816717192854
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65447.25390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0890994609397102
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3497901879824123,
+        "AvgTime/train_epoch_std": 0.06632511186860622,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 30551.59375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 25665.29296875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.5959802379888074,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105834.359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 76.24953845461096
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231826.234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1220.1380756578947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31412.966796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.382477572762609
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163948.96875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 55.25748862487361
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67769.84375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 9.054087341349366
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156066.609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 134.77254695595855
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59705.83203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.1863575957965224
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78285.9921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.012814197934286
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76382.25,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 13.579066666666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 251997.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.850557249188376
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70706.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.176609588471203
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.367221039884231,
+        "AvgTime/train_epoch_std": 0.025417700276970923,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1455.4940185546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1467.1832275390625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.10287359609725583,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2022.1558837890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.4568846424993245
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 864.477783203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.549883069490131
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3031.58837890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22992706703877513
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263.57305908203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08883486992990605
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2372.2333984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.31693164975784904
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 671.2888793945312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5796967870419095
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42410.328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9848209206065391
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17855.125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9152250243477369
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1504.9503173828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.26754672309027777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 429651.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.860147562865514
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130312.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.168510163413376
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.391908274247096,
+        "AvgTime/train_epoch_std": 0.045425673037867126,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1234.525390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1255.6063232421875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.08803858668084333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 772.260498046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5563836441259906
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87.30022430419922,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4594748647589433
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3347.82177734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2539113975990709
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.59992980957031,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.030872911968173343
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1842.826904296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2462026592246994
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.44933319091797,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05824640171927286
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43679.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0142854240200632
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17546.35546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8993979941949869
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1250.834716796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.22237061631944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 421961.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.773154615793581
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119234.5859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.984167639117701
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4169396048500422,
+        "AvgTime/train_epoch_std": 0.022880585186687754,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 5119.9697265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4957.36962890625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.34759287820125156,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2760.679931640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.9889624867727846
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8057.8583984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 42.40978104440789
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4343.50830078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.32942800916050435
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4214.78271484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.420553661895433
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3367.46484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.44989510270541083
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3643.36083984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.146252884148316
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100766.46875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.339923573054059
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25876.9296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3264098460966733
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2247.3271484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.39952482638888887
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 560255.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.337511170435392
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133913.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2284435687184865
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4148968855539956,
+        "AvgTime/train_epoch_std": 0.020345265546625087,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26635.51953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27032.150390625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.3856246035483624,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4246.048828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.05911298856268
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3269.43505859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.207552939967105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4403.6357421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3339883005072052
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2119.328369140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7143000907113667
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5639.640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7534590013360053
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3951.65576171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.412483386631045
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125121.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.905483698681033
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7704.96923828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.540244652803341
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4119.0908203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7322828125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 638497.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.222578702080246
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206844.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.442069219792655
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3081654071807862,
+        "AvgTime/train_epoch_std": 0.007692821516041348,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 21098.6953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 21550.375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.1046376031575171,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1673.81689453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.2059199528323126
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 891.4109497070312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.691636577405427
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5239.75439453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3974026844543989
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 437.036865234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1472992467928463
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4692.12255859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6268700813084502
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1690.978515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.460257785513817
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105502.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.449893980470927
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6498.2041015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4556306339617515
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3081.587158203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5478377170138888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 583138.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.596364093978711
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202263.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3658391992411762
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3148398739950997,
+        "AvgTime/train_epoch_std": 0.022563312368370173,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 13045.9951171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 13661.869140625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.7002854652019581,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5546.1376953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.995776437545029
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9009.3212890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 47.41748046875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16818.630859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.2755882335513842
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4803.130859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.618850980578025
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4284.12939453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5723619765572813
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6045.857421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.22094768728411
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114553.65625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.660079329602452
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10370.228515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7271230203074603
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4615.4033203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8205161458333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 486423.40625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.502340489010554
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176848.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.942920244454429
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3169824575123035,
+        "AvgTime/train_epoch_std": 0.014396840725858888,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1791.779541015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1901.497314453125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.3380439670138889,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 471.416259765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3396370747590958
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 293.07513427734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5425007067228618
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10229.3466796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7758321334613196
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 665.766845703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.22439057826192282
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6934.0400390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9263914547845692
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.13262939453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2514098699434639
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151762.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.52412325260078
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7530.68408203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5280244062565734
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36738.4921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8831560914193448
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 633879.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.170337120912186
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155159.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.581995563127153
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2339290301005046,
+        "AvgTime/train_epoch_std": 0.02471888157843054,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1995.110107421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2099.65771484375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.3732724826388889,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 468.1833190917969,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.33730786678083347
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 721.3163452148438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.79640181692023
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4983.84228515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3779933473762799
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2608.50439453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8791723608126896
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5993.75341796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8007686597152639
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 547.3539428710938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.472671798679701
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130175.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0228326589494707
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7183.8623046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5037065141416001
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36702.91796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8813326141139988
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 626041.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.081682041333439
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165174.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.748647669029671
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.180283498764038,
+        "AvgTime/train_epoch_std": 0.05110662504416886,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1872.618896484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1993.1346435546875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.3543350477430556,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 666.667236328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.48030780715282784
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 442.7948913574219,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.330499428196957
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10315.265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7823485494880547
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 403.01763916015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1358333802359812
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7359.9765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9832968019372077
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415.38922119140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3587126262447377
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150589.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4968705734488204
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7128.70654296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.49983919106498037
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38621.04296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.979652620265006
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 648878.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.34000613666957
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166586.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7721490023796447
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.230316703969782,
+        "AvgTime/train_epoch_std": 0.019209083269705975,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 488617.6875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 314489.34375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.5574510339015646,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368044.125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 265.1614733429395
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 359311.09375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1891.111019736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239185.859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 18.140755356465682
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 319473.84375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 107.67571410515673
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348341.34375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 46.538589679358715
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 370634.9375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 320.0647128670121
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158078.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6707875923044773
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258706.3125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 18.139553533866216
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279123.28125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 14.307411002614177
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361454.40625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 64.2585611111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148012.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.4630614214633986
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3539652824401855,
+        "AvgTime/train_epoch_std": 0.015371560518525108,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 201760.25,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 142546.828125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 1.6124659584516363,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8330.2080078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.001590783726585
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1305.8775634765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.873039807771382
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26392.83984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.0017322596700797
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4032.225830078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.3590245467064797
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17477.396484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.334989510270541
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4822.46240234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.164475304269214
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42556.5703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9882168473086569
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39465.6171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.767186733101949
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45709.92578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.343017365382644
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50487.8984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 8.97562638888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141947.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.3621334847652804
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.369198987358495,
+        "AvgTime/train_epoch_std": 0.027763857803134912,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 498306.75,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 315927.25,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.573716389715281,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250648.3125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 180.58235770893373
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267367.125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1407.1953947368422
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127238.4375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.6502417519909
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 220592.8125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 74.34877401415571
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 227772.859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 30.43057573480294
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 272003.1875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 234.89049006908462
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100285.6953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.3287594118637376
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170716.8125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 11.970047153274436
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188183.59375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 9.645988710338818
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 270448.09375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 48.07966111111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116148.0703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9328053236233838
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3718550735049777,
+        "AvgTime/train_epoch_std": 0.03134494538051008,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 58769.88671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 58628.16015625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.9756237857362754,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39518.171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 28.471305385446687
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108080.0625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 568.8424342105263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18392.20703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.3949341699848312
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55348.8203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 18.654809677283453
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23468.904296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 3.1354581558951238
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72477.84375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 62.58881152849741
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46548.29296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.080909645382454
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20118.818359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.410658979061492
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24828.6015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2726742304833667
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30493.083984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 5.420992708333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 316989.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.585734859111116
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6358289858874153,
+        "AvgTime/train_epoch_std": 0.04219002606491615,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 38979.2421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 39791.18359375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.6621600451591699,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26094.232421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 18.79987926648055
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2001.6573486328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 10.535038677014803
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45795.99609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.4733406214448235
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2477.740234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.835099506024604
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19016.39453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.5406004717768873
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2815.326171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.4311970396157165
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49740.29296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1550318820534553
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5198.08740234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3644711402568889
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10708.576171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5489044119060433
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5407.29541015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9612969618055556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234000.421875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.6469737664445776
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.657331993705348,
+        "AvgTime/train_epoch_std": 0.02027133794483517,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "nsd_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 70305.5390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 69891.1484375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.1630497468507148,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136246.0625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 98.15998739193084
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212851.609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1120.2716282894737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124381.109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.433531238149412
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207313.671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 69.87316207448602
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88781.828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 11.86129968269873
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154196.171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 133.15731595423142
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178278.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.139840194245774
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97281.7265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.821043792069836
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97502.875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.997840740171203
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77271.203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 13.737102777777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 457927.15625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.179995659083968
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/nsd/logs/train/runs/notebook_gu_grid_nsd__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6684597638937144,
+        "AvgTime/train_epoch_std": 0.026789942744619304,
+        "model/params/total": 15026,
+        "model/params/trainable": 15026,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -104,7 +104,7 @@
       "outputs": [],
       "source": [
         "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-        "MODEL_CONFIG = \"graph/gin\""
+        "MODEL_CONFIG = \"graph/nsd\""
       ]
     },
     {

--- a/configs/model/graph/nsd.yaml
+++ b/configs/model/graph/nsd.yaml
@@ -17,7 +17,7 @@ backbone:
   num_layers: 2 # SWEEP: [2,4] (3 if we have a lot of time)
   dropout: 0.4 # SWEEP: [0.0, 0.25, 0.5]
   sheaf_type: bundle # SWEEP: [diag, bundle]
-  d: 3 # no sweep.
+  d: 4 # no sweep.
   input_dropout: 0.0 # no sweep.
 
 backbone_wrapper:

--- a/test/nn/backbones/graph/test_nsd.py
+++ b/test/nn/backbones/graph/test_nsd.py
@@ -2,7 +2,7 @@
 
 import pytest
 import torch
-from torch_geometric.data import Batch
+from torch_geometric.data import Batch, Data
 
 from topobench.nn.backbones.graph.nsd import NSDEncoder
 
@@ -45,8 +45,9 @@ class TestNSDEncoder:
 
         assert model.input_dim == self.input_dim
         assert model.hidden_dim == self.hidden_dim
+        assert model.out_channels == self.hidden_dim
         assert model.num_layers == 2  # default
-        assert model.sheaf_type == "diag"  # default
+        assert model.sheaf_type == "bundle"  # default
         assert model.d == 2  # default
         assert model.sheaf_model is not None
 
@@ -233,6 +234,21 @@ class TestNSDEncoder:
             x=x,
             edge_index=simple_graph_0.edge_index
         )
+
+        assert out.shape == (simple_graph_0.num_nodes, self.hidden_dim)
+
+    def test_forward_data_object(self, simple_graph_0):
+        """Test forward pass with a PyG data object."""
+        x = self._prepare_features(simple_graph_0.num_nodes)
+        data = Data(x=x, edge_index=simple_graph_0.edge_index)
+
+        model = NSDEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            num_layers=2
+        )
+
+        out = model(data)
 
         assert out.shape == (simple_graph_0.num_nodes, self.hidden_dim)
 

--- a/test/nn/backbones/graph/test_nsd.py
+++ b/test/nn/backbones/graph/test_nsd.py
@@ -103,11 +103,11 @@ class TestNSDEncoder:
             hidden_dim=self.hidden_dim,
             num_layers=2,
             sheaf_type="general",
-            d=3
+            d=4
         )
 
         assert model.sheaf_type == "general"
-        assert model.d == 3
+        assert model.d == 4
 
     def test_initialization_invalid_sheaf_type(self):
         """Test that invalid sheaf type raises error."""
@@ -186,6 +186,16 @@ class TestNSDEncoder:
                 hidden_dim=self.hidden_dim,
                 sheaf_type="general",
                 d=1
+            )
+
+    def test_initialization_hidden_dim_must_be_divisible_by_d(self):
+        """Test that stalk dimension divides hidden dimension exactly."""
+        with pytest.raises(ValueError, match="hidden_dim .* must be divisible by d"):
+            NSDEncoder(
+                input_dim=self.input_dim,
+                hidden_dim=31,
+                sheaf_type="bundle",
+                d=4
             )
 
     def test_forward_basic(self, simple_graph_0):
@@ -375,7 +385,7 @@ class TestNSDEncoder:
             hidden_dim=self.hidden_dim,
             num_layers=2,
             sheaf_type="general",
-            d=3
+            d=4
         )
 
         out = model(
@@ -1118,7 +1128,7 @@ class TestNSDEncoder:
             hidden_dim=self.hidden_dim,
             num_layers=2,
             sheaf_type="general",
-            d=3,
+            d=4,
             orth="matrix_exp"
         )
 
@@ -1182,7 +1192,7 @@ class TestNSDEncoder:
             hidden_dim=self.hidden_dim,
             num_layers=2,
             sheaf_type="general",
-            d=3
+            d=4
         )
         model.train()
 

--- a/test/nn/backbones/graph/test_nsd.py
+++ b/test/nn/backbones/graph/test_nsd.py
@@ -140,7 +140,7 @@ class TestNSDEncoder:
         assert model.d == 1
 
         # Should fail with d < 1
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="diag sheaf requires d >= 1"):
             NSDEncoder(
                 input_dim=self.input_dim,
                 hidden_dim=self.hidden_dim,
@@ -160,7 +160,7 @@ class TestNSDEncoder:
         assert model.d == 2
 
         # Should fail with d <= 1
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="bundle sheaf requires d > 1"):
             NSDEncoder(
                 input_dim=self.input_dim,
                 hidden_dim=self.hidden_dim,
@@ -180,7 +180,7 @@ class TestNSDEncoder:
         assert model.d == 2
 
         # Should fail with d <= 1
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="general sheaf requires d > 1"):
             NSDEncoder(
                 input_dim=self.input_dim,
                 hidden_dim=self.hidden_dim,

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -5,7 +5,12 @@ import hydra
 from test._utils.simplified_pipeline import run
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/nsd"]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS = [
+    "graph/gcn",
+    "cell/topotune",
+    "simplicial/topotune",
+    "graph/nsd",
+]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:
@@ -23,13 +28,13 @@ class TestPipeline:
                     config_name="run.yaml",
                     overrides=[
                         f"model={MODEL}",
-                        f"dataset={DATASET}", # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
+                        f"dataset={DATASET}",  # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
                         "trainer.max_epochs=2",
                         "trainer.min_epochs=1",
                         "trainer.check_val_every_n_epoch=1",
                         "paths=test",
                         "callbacks=model_checkpoint",
                     ],
-                    return_hydra_config=True
+                    return_hydra_config=True,
                 )
                 run(cfg)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,11 +1,11 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
+
 from test._utils.simplified_pipeline import run
 
-
-DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
+MODELS = ["graph/nsd"]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:

--- a/test/utils/test_config_resolvers.py
+++ b/test/utils/test_config_resolvers.py
@@ -169,6 +169,14 @@ class TestConfigResolvers:
         in_channels = infer_in_channels(cfg.dataset, cfg.transforms)
         assert in_channels == [27]
 
+        cfg = hydra.compose(
+            config_name="run.yaml",
+            overrides=["model=graph/nsd", "dataset=graph/graphuniverse_inductive"],
+            return_hydra_config=True,
+        )
+        in_channels = infer_in_channels(cfg.dataset, cfg.transforms)
+        assert in_channels == [35]
+
     def test_infer_num_cell_dimensions(self):
         """Test infer_num_cell_dimensions."""
         out = infer_num_cell_dimensions(None, [7, 7, 7])

--- a/test/utils/test_config_resolvers.py
+++ b/test/utils/test_config_resolvers.py
@@ -161,6 +161,14 @@ class TestConfigResolvers:
         in_channels = infer_in_channels(cfg.dataset, cfg.transforms)
         assert in_channels == [1433,1433,1433,1433]
 
+        cfg = hydra.compose(
+            config_name="run.yaml",
+            overrides=["model=graph/nsd", "dataset=graph/MUTAG"],
+            return_hydra_config=True,
+        )
+        in_channels = infer_in_channels(cfg.dataset, cfg.transforms)
+        assert in_channels == [27]
+
     def test_infer_num_cell_dimensions(self):
         """Test infer_num_cell_dimensions."""
         out = infer_num_cell_dimensions(None, [7, 7, 7])

--- a/topobench/nn/backbones/graph/nsd.py
+++ b/topobench/nn/backbones/graph/nsd.py
@@ -91,6 +91,10 @@ class NSDEncoder(Module):
         else:
             raise ValueError(f"Unknown sheaf type: {sheaf_type}")
 
+        if hidden_dim % d != 0:
+            msg = f"hidden_dim ({hidden_dim}) must be divisible by d ({d})."
+            raise ValueError(msg)
+
         self.sheaf_config = {
             "d": d,
             "layers": num_layers,

--- a/topobench/nn/backbones/graph/nsd.py
+++ b/topobench/nn/backbones/graph/nsd.py
@@ -8,7 +8,7 @@ https://arxiv.org/abs/2202.04579
 """
 
 from torch.nn import Module
-from torch_geometric.utils import to_undirected
+from torch_geometric.utils import remove_self_loops, to_undirected
 
 from topobench.nn.backbones.graph.nsd_utils.inductive_discrete_models import (
     InductiveDiscreteBundleSheafDiffusion,
@@ -30,12 +30,12 @@ class NSDEncoder(Module):
     input_dim : int
         Dimension of input node features.
     hidden_dim : int
-        Dimension of hidden layers. Must be divisible by d.
+        Dimension of the output node embeddings.
     num_layers : int, optional
         Number of sheaf diffusion layers. Default is 2.
     sheaf_type : str, optional
         Type of sheaf structure. Options are 'diag', 'bundle', or 'general'.
-        Default is 'diag'.
+        Default is 'bundle'.
     d : int, optional
         Dimension of the stalk space. For 'diag', d >= 1. For 'bundle' and 'general', d > 1.
         Default is 2.
@@ -60,7 +60,7 @@ class NSDEncoder(Module):
         input_dim,
         hidden_dim,
         num_layers=2,
-        sheaf_type="diag",
+        sheaf_type="bundle",
         d=2,
         dropout=0.1,
         input_dropout=0.1,
@@ -73,6 +73,7 @@ class NSDEncoder(Module):
 
         self.input_dim = input_dim
         self.hidden_dim = hidden_dim
+        self.out_channels = hidden_dim
         self.sheaf_type = sheaf_type
         self.d = d
         self.num_layers = num_layers
@@ -109,7 +110,7 @@ class NSDEncoder(Module):
     def forward(
         self,
         x,
-        edge_index,
+        edge_index=None,
         edge_attr=None,
         edge_weight=None,
         batch=None,
@@ -138,9 +139,14 @@ class NSDEncoder(Module):
         torch.Tensor
             Output node feature matrix of shape [num_nodes, hidden_dim].
         """
-        # Neural Sheaf Diffusion requires undirected graphs (bidirectional edges)
-        # Convert to undirected if not already
-        edge_index = to_undirected(edge_index)
+        if edge_index is None:
+            edge_index = x.edge_index
+            x = x.x if hasattr(x, "x") else x.x_0
+
+        # The sheaf Laplacian builders expect paired directed edges without
+        # self-loops. Keep isolated nodes by passing the explicit node count.
+        edge_index, _ = remove_self_loops(edge_index)
+        edge_index = to_undirected(edge_index, num_nodes=x.size(0))
 
         # Run through the sheaf model (no edge attributes)
         return self.sheaf_model(x, edge_index)

--- a/topobench/nn/backbones/graph/nsd.py
+++ b/topobench/nn/backbones/graph/nsd.py
@@ -80,13 +80,19 @@ class NSDEncoder(Module):
         self.device = device
 
         if sheaf_type == "diag":
-            assert d >= 1
+            if d < 1:
+                msg = "diag sheaf requires d >= 1."
+                raise ValueError(msg)
             self.sheaf_class = InductiveDiscreteDiagSheafDiffusion
         elif sheaf_type == "bundle":
-            assert d > 1
+            if d <= 1:
+                msg = "bundle sheaf requires d > 1."
+                raise ValueError(msg)
             self.sheaf_class = InductiveDiscreteBundleSheafDiffusion
         elif sheaf_type == "general":
-            assert d > 1
+            if d <= 1:
+                msg = "general sheaf requires d > 1."
+                raise ValueError(msg)
             self.sheaf_class = InductiveDiscreteGeneralSheafDiffusion
         else:
             raise ValueError(f"Unknown sheaf type: {sheaf_type}")

--- a/topobench/utils/config_resolvers.py
+++ b/topobench/utils/config_resolvers.py
@@ -355,8 +355,11 @@ def infer_in_channels(dataset, transforms):
         List with dimensions of the input channels.
     """
     num_features = dataset.parameters.num_features
-    if isinstance(num_features, int) and transforms is not None:
-        num_features = num_features + check_pses_in_transforms(transforms)
+    added_features = (
+        check_pses_in_transforms(transforms) if transforms is not None else 0
+    )
+    if isinstance(num_features, int):
+        num_features = num_features + added_features
 
     # Make it possible to pass lifting configuration as file path
     if transforms is not None and transforms.keys() == {"liftings"}:
@@ -458,7 +461,7 @@ def infer_in_channels(dataset, transforms):
             # If preserve_edge_attr == False
             if not transforms[lifting].preserve_edge_attr:
                 if feature_lifting == "Concatenation":
-                    return_value = [num_features[0]]
+                    return_value = [num_features[0] + added_features]
                     for i in range(2, transforms[lifting].complex_dim + 2):
                         return_value += [int(return_value[-1]) * i]
 
@@ -466,12 +469,14 @@ def infer_in_channels(dataset, transforms):
 
                 else:
                     # ProjectionSum feature lifting by default
-                    return [num_features[0]] * (
+                    return [num_features[0] + added_features] * (
                         transforms[lifting].complex_dim + 1
                     )
             # If preserve_edge_attr == True
             else:
-                return list(num_features) + [num_features[1]] * (
+                return_value = list(num_features)
+                return_value[0] += added_features
+                return return_value + [num_features[1]] * (
                     transforms[lifting].complex_dim + 1 - len(num_features)
                 )
 
@@ -501,7 +506,7 @@ def infer_in_channels(dataset, transforms):
             return [num_features]
 
         else:
-            return [num_features[0]]
+            return [num_features[0] + added_features]
 
     # This else is never executed
     else:


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

Updates the existing TopoBench Neural Sheaf Diffusion integration for TDL Challenge 2026 Track 1 compatibility (`model=graph/nsd`), rather than introducing a new model from scratch.

Reference:
- Paper: https://arxiv.org/pdf/2202.04579
- Code: https://github.com/twitter-research/neural-sheaf-diffusion

Implemented and verified:
- bundle-sheaf default config for `graph/nsd`
- direct graph input compatibility
- explicit sheaf stalk-dimension validation (`d` requirements and `hidden_dim % d == 0`)
- shared feature-dimension resolver support for `CombinedPSEs` on scalar and list-valued `num_features`
- expanded NSD unit coverage and pipeline smoke-test wiring
- challenge notebook `MODEL_CONFIG` set to `graph/nsd`

Validation:
- `PYENV_VERSION=TDL python -m pytest test/nn/backbones/graph/test_nsd.py -q` -> 56 passed
- `PYENV_VERSION=TDL python -m pytest test/utils/test_config_resolvers.py -q` -> 41 passed
- `PYENV_VERSION=TDL python -m pytest test/pipeline/test_pipeline.py -q` with baseline smoke models plus `graph/nsd` -> 1 passed
- focused ruff on PR-touched Python files -> passed
- focused coverage for `topobench/nn/backbones/graph/nsd.py` -> 100%
- official challenge sanity grid for `model_config="graph/nsd"` -> all 24 configs exercised successfully

`results.json` status: committed at `2026_tdl_challenge/outputs/nsd/results.json` with 72 completed challenge runs across train seeds 42, 43, and 44.

`results.json` provenance: generated from the checked-in `2026_tdl_challenge/utils.py` helpers via CLI with `model_config="graph/nsd"`; `run_evaluation.ipynb` now sets the same `MODEL_CONFIG`.

## Issue

TDL Challenge 2026 Track 1 model submission for Neural Sheaf Diffusion.

## Additional context

Official `results.json` artifact is included in this PR.

This PR deliberately keeps the NSD adaptation close to the existing TopoBench NSD code path and makes it GraphUniverse-compatible: direct `Data`/object inputs, self-loop removal plus undirected edge conversion, output-channel metadata, and the challenge default config.

Limitation: `NSDEncoder.forward` accepts `edge_attr` and `edge_weight` for wrapper/API compatibility, but this NSD adaptation ignores them and builds the sheaf Laplacian from `edge_index` only.

Global resolver note: `graph/nsd` uses model-default `CombinedPSEs` (LapPE=10 and RWSE=10, both concatenated to node features). The shared `infer_in_channels` update makes that +20 node-feature dimension apply consistently when `dataset.parameters.num_features` is list-valued as well as scalar; for example MUTAG `[7, 4]` resolves to `[27]`, while GraphUniverse scalar `15` resolves to `[35]`. This keeps `AllCellFeatureEncoder` input sizes aligned with transformed `x_0`. Targeted regression tests now compose `model=graph/nsd` with `dataset=graph/MUTAG` and `dataset=graph/graphuniverse_inductive`, checking the resolved input channels are `[27]` and `[35]`, respectively.

