### PR TITLE
Track: Track2; Team name: TJPaik; Model: TopNets

### DIFF
--- a/2026_tdl_challenge/outputs/topnets/results.json
+++ b/2026_tdl_challenge/outputs/topnets/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "topnets",
+    "model_config": "combinatorial/topnets",
+    "generated_at_utc": "2026-05-25T18:15:19.993577+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.632855176925659,
+      "test_best_rerun_accuracy": 0.2005118727684021,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2058216780424118,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20177248120307922,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2021544873714447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29112231731414795,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28852471709251404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2864619195461273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2806937098503113,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35556575655937195,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3441821336746216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33883413672447205,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30647870898246765,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.235415014467741,
+        "AvgTime/train_epoch_std": 0.3763456827488701,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.617204427719116,
+      "test_best_rerun_accuracy": 0.20089387893676758,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20505768060684204,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19566047191619873,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19814348220825195,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3005577325820923,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2964703142642975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28841012716293335,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2758041024208069,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3559095561504364,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34765833616256714,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34819313883781433,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3172893226146698,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0167794032175035,
+        "AvgTime/train_epoch_std": 0.12186425786158471,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.647897720336914,
+      "test_best_rerun_accuracy": 0.1931774765253067,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1991366744041443,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19042707979679108,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19042707979679108,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2852395176887512,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2791275084018707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27523112297058105,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26992130279541016,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3373061418533325,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33287492394447327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3371151387691498,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3115593194961548,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.976614942013378,
+        "AvgTime/train_epoch_std": 0.10870373282134617,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.5654284954071045,
+      "test_best_rerun_accuracy": 0.2138436883687973,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18553747236728668,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1810680776834488,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18954847753047943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2404690980911255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2767591178417206,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2416914999485016,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25525251030921936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2848193049430847,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2890213131904602,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2857743203639984,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2811139225959778,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5724345974456098,
+        "AvgTime/train_epoch_std": 0.08095961808323407,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.5554699897766113,
+      "test_best_rerun_accuracy": 0.21399648487567902,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1937122792005539,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19474367797374725,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2109786868095398,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25345709919929504,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27782872319221497,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24963709712028503,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25632211565971375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2986859083175659,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.310222327709198,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2863091230392456,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2948659062385559,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.4213854169088695,
+        "AvgTime/train_epoch_std": 0.26424243656099927,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.5560202598571777,
+      "test_best_rerun_accuracy": 0.21502788364887238,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20081748068332672,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19661547243595123,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21617388725280762,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26908090710639954,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2867293059825897,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26025670766830444,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2717167139053345,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31965771317481995,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32485294342041016,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3173275291919708,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3231339156627655,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.451528000620614,
+        "AvgTime/train_epoch_std": 0.21568362343334327,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.6293020248413086,
+      "test_best_rerun_accuracy": 0.19409427046775818,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17243486642837524,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1753762662410736,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19512568414211273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.258002907037735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24921689927577972,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2925739288330078,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2864237129688263,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31874093413352966,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.311330109834671,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35407593846321106,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3504851460456848,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.329609213051973,
+        "AvgTime/train_epoch_std": 0.39414953556603377,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.6513633728027344,
+      "test_best_rerun_accuracy": 0.18851707875728607,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1676216721534729,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16277027130126953,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1901978701353073,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24287569522857666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2342424988746643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2781343162059784,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27290090918540955,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29883870482444763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28883031010627747,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.334975928068161,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34253954887390137,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.366836538681617,
+        "AvgTime/train_epoch_std": 0.42897264678652663,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.673776149749756,
+      "test_best_rerun_accuracy": 0.17801207304000854,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14176025986671448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14554205536842346,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17602567374706268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22419588267803192,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2147986888885498,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24852930009365082,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2535335123538971,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2781725227832794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27102911472320557,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32496753334999084,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32187333703041077,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.368677267661462,
+        "AvgTime/train_epoch_std": 0.4157277935577607,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.5616002082824707,
+      "test_best_rerun_accuracy": 0.21877148747444153,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19569867849349976,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2028420865535736,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20903047919273376,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28611811995506287,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2852013111114502,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29925891757011414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.308312326669693,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33722972869873047,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34399113059043884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3606463372707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3685537576675415,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.795300239675185,
+        "AvgTime/train_epoch_std": 0.6318053663993972,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.5675652027130127,
+      "test_best_rerun_accuracy": 0.2108640819787979,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19096188247203827,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1952020823955536,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20352968573570251,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.282756507396698,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27523112297058105,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3035755157470703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31706011295318604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3400183320045471,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3434945344924927,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37199175357818604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3862403631210327,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.28135071540701,
+        "AvgTime/train_epoch_std": 0.12269421383714804,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.5523841381073,
+      "test_best_rerun_accuracy": 0.2225532829761505,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2010466754436493,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20956528186798096,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2081136852502823,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27874550223350525,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2894033193588257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3084651231765747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.310184121131897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34223392605781555,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34739094972610474,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3743983507156372,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3708457350730896,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.243364194654069,
+        "AvgTime/train_epoch_std": 0.12251179609247007,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.3857436180114746,
+      "test_best_rerun_accuracy": 0.2966231107711792,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1805332750082016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18641607463359833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19050347805023193,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18347467482089996,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28745511174201965,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3190465271472931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3122469186782837,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37691953778266907,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3661089539527893,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40396517515182495,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3984261453151703,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.49547333629043,
+        "AvgTime/train_epoch_std": 0.55304030884883,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.3491344451904297,
+      "test_best_rerun_accuracy": 0.2955153286457062,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18164107203483582,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18519367277622223,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18763847649097443,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18293987214565277,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28134310245513916,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30686071515083313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2991061210632324,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36545953154563904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3598059415817261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3769577443599701,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3752005398273468,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.2801023584145765,
+        "AvgTime/train_epoch_std": 0.3662687796682803,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.349896192550659,
+      "test_best_rerun_accuracy": 0.2994499206542969,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18588127195835114,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1848880797624588,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1893574744462967,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18198487162590027,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28497210144996643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31220871210098267,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3148445188999176,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3761555552482605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36183053255081177,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40194055438041687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38245856761932373,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.270377117044785,
+        "AvgTime/train_epoch_std": 0.398535370832033,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.371582508087158,
+      "test_best_rerun_accuracy": 0.28825730085372925,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1842004805803299,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1927572786808014,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17720986902713776,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19355948269367218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28936511278152466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2759951055049896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30579110980033875,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35403773188591003,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35717013478279114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36305293440818787,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37393996119499207,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.3068019657424,
+        "AvgTime/train_epoch_std": 0.3721135900400658,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.345144033432007,
+      "test_best_rerun_accuracy": 0.30269691348075867,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.189777672290802,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19443808495998383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17044846713542938,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.204446479678154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30063411593437195,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2777141034603119,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3057147264480591,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37420734763145447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37703415751457214,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3902895450592041,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3755061626434326,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.561415899090651,
+        "AvgTime/train_epoch_std": 0.3940869997409489,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.353384494781494,
+      "test_best_rerun_accuracy": 0.3013599216938019,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19218426942825317,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2037970870733261,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17514707148075104,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19818167388439178,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29196271300315857,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26690351963043213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36236533522605896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36622354388237,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35881274938583374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3656505346298218,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.562992451237697,
+        "AvgTime/train_epoch_std": 0.3391580380574561,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.3288464546203613,
+      "test_best_rerun_accuracy": 0.30281153321266174,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.13794025778770447,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12892505526542664,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17503246665000916,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16510047018527985,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24069829285144806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20945067703723907,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29876232147216797,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31358394026756287,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2902437150478363,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39200854301452637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39063334465026855,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.718142572571249,
+        "AvgTime/train_epoch_std": 0.15181815674959723,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.2968082427978516,
+      "test_best_rerun_accuracy": 0.3217969238758087,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16723966598510742,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16796547174453735,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18645428121089935,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19715027511119843,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2788601219654083,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26327449083328247,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3318053185939789,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3556421399116516,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34047672152519226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4137825667858124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41443195939064026,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.61727271638475,
+        "AvgTime/train_epoch_std": 0.7889218537133681,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.3541955947875977,
+      "test_best_rerun_accuracy": 0.2967759072780609,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.15467186272144318,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15153945982456207,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17403927445411682,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1779356747865677,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24910229444503784,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.238177090883255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29899153113365173,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3246237337589264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3084269165992737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3844067454338074,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3818473517894745,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.51084550221761,
+        "AvgTime/train_epoch_std": 0.7805318922528519,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.3861184120178223,
+      "test_best_rerun_accuracy": 0.28107571601867676,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.13396745920181274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.13217204809188843,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15711666643619537,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15383146703243256,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2167086899280548,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19470547139644623,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2683551013469696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2863091230392456,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26732370257377625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.348307728767395,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3870425522327423,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.259457555977074,
+        "AvgTime/train_epoch_std": 0.3783272216735504,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.2126097679138184,
+      "test_best_rerun_accuracy": 0.33722972869873047,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1717090755701065,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17056307196617126,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18248146772384644,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18939568102359772,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27714112401008606,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2592635154724121,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3112919330596924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3558713495731354,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35216593742370605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.403201162815094,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4584383964538574,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.062274240979962,
+        "AvgTime/train_epoch_std": 0.9241240691465141,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.2511911392211914,
+      "test_best_rerun_accuracy": 0.323515921831131,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.15532125532627106,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.150355264544487,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1763312667608261,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17434486746788025,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2516235113143921,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2346244901418686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3003285229206085,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.329245924949646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3110245168209076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39621055126190186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4339139759540558,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.4128327171007795,
+        "AvgTime/train_epoch_std": 0.8729750625083733,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2.21804141998291,
+      "test_best_rerun_accuracy": 0.33218732476234436,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14386126399040222,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14386126399040222,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14932386577129364,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14321185648441315,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24696309864521027,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22908549010753632,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27714112401008606,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.271334707736969,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31507372856140137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38329896330833435,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3789059519767761,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.665374559164047,
+        "AvgTime/train_epoch_std": 0.6880464595334863,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2.0471227169036865,
+      "test_best_rerun_accuracy": 0.3826495409011841,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16960807144641876,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1673542708158493,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16697226464748383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17014287412166595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29287952184677124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2703797221183777,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31163573265075684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32172054052352905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36385515332221985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43089616298675537,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4269615709781647,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.276287288501345,
+        "AvgTime/train_epoch_std": 0.42982694227531937,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2.1650919914245605,
+      "test_best_rerun_accuracy": 0.36141034960746765,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1672014743089676,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16452746093273163,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16674306988716125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1670868694782257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2824891209602356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26419129967689514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2986477315425873,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29929712414741516,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3563297390937805,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4026281535625458,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40094736218452454,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.337225890928699,
+        "AvgTime/train_epoch_std": 0.8823630598845195,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2.0973498821258545,
+      "test_best_rerun_accuracy": 0.3789059519767761,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17044846713542938,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17002826929092407,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16609366238117218,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17950187623500824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2895561158657074,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2795095145702362,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29845672845840454,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3285583257675171,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37256476283073425,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40774697065353394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.463060587644577,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.875283005532254,
+        "AvgTime/train_epoch_std": 1.3770539655941856,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2.083944082260132,
+      "test_best_rerun_accuracy": 0.37149515748023987,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16636106371879578,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1649094671010971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16743066906929016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17381006479263306,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2877989113330841,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26690351963043213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30200931429862976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32485294342041016,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3718389570713043,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40896937251091003,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4465963840484619,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3111340955451682,
+        "AvgTime/train_epoch_std": 0.03557061888997224,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2.295933723449707,
+      "test_best_rerun_accuracy": 0.2906639277935028,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.12785544991493225,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.12907785177230835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1348460465669632,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1370234489440918,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22396668791770935,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20841927826404572,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23661088943481445,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2609825134277344,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2899381220340729,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3256933391094208,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3764229416847229,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.300311045213179,
+        "AvgTime/train_epoch_std": 0.02344515441004335,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 2.191927671432495,
+      "test_best_rerun_accuracy": 0.32294294238090515,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.09469784051179886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.09450683742761612,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11616624891757965,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11108564585447311,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16865307092666626,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14813965559005737,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2138436883687973,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2146458923816681,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23638169467449188,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2214454859495163,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3280617296695709,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.348018561090742,
+        "AvgTime/train_epoch_std": 0.017880846336852496,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.9112716913223267,
+      "test_best_rerun_accuracy": 0.44823896884918213,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.15738406777381897,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1583772599697113,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1681564599275589,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17827947437763214,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.273244708776474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25234928727149963,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3191993236541748,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32825273275375366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3621361553668976,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34697073698043823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47028037905693054,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3555556468749312,
+        "AvgTime/train_epoch_std": 0.023012981564061268,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.9305133819580078,
+      "test_best_rerun_accuracy": 0.4202001690864563,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14443425834178925,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14447246491909027,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1621972620487213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.165597066283226,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24948430061340332,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22541828453540802,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2978455126285553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3061731159687042,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33883413672447205,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3193521201610565,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43685537576675415,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.351159862109593,
+        "AvgTime/train_epoch_std": 0.018277401514275968,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.9252917766571045,
+      "test_best_rerun_accuracy": 0.40411797165870667,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.11005424708127975,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10226143896579742,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11849644780158997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11578424274921417,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1953548789024353,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1752234697341919,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22469249367713928,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2510887086391449,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26625409722328186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2679349184036255,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32496753334999084,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3707245439291,
+        "AvgTime/train_epoch_std": 0.01652817240229174,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.6920998096466064,
+      "test_best_rerun_accuracy": 0.488616406917572,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1663992702960968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16227366030216217,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16445106267929077,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17407746613025665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27790510654449463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26407670974731445,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29360532760620117,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3228283226490021,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35892733931541443,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35923293232917786,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4282603859901428,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3780248343054926,
+        "AvgTime/train_epoch_std": 0.023506837926850266,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 2.02567195892334,
+      "test_best_rerun_accuracy": 0.3926961421966553,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.10539384186267853,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.10447704046964645,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11792344599962234,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12162885069847107,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17785927653312683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16227366030216217,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21884788572788239,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24448010325431824,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2489113062620163,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2408892959356308,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32618993520736694,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3682715031835766,
+        "AvgTime/train_epoch_std": 0.019366196375374765,
+        "model/params/total": 47841,
+        "model/params/trainable": 47841,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 17.620092391967773,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18.185527801513672,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.013101965274865757,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.234121561050415,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.017021692426581133
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1798.69140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.13641952265832386
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 663.8427734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.22374208744101787
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4175.77685546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5578860194347027
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60.6862678527832,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.052406103499812784
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94588.5859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1964653988830576
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5561.234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3899336961856682
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30979.5,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.587959403352299
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1975.4698486328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3511946397569444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 540885.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.118404494191374
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149801.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.4928251834656283
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9390299518903096,
+        "AvgTime/train_epoch_std": 0.02083946527506054,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 21.305805206298828,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20.764616012573242,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.014960097991767465,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.175691604614258,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0746089031821803
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4069.736328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3086641128649981
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61.59028625488281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.020758438238922417
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6033.5849609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8060901751419506
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.1186752319336,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07436845874951088
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149582.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.47350273720509
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9506.23828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6665431413020614
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41999.56640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.152830304282639
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2707.2587890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4812904513888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 729629.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.253451523138356
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 228632.21875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.804639787496048
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9396870136260986,
+        "AvgTime/train_epoch_std": 0.015915385087257303,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 20.225889205932617,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18.584888458251953,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.01338968909095962,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.6481170654296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03499008981805099
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2338.3896484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.17735226760997347
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 852.8970336914062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.28746108314506447
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5123.25439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6844695249874749
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70.25405883789062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06066844459230624
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124703.5703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8957730427387145
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6850.54541015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4803355357001998
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37248.65234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9093060814880312
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2190.00634765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.38933446180555553
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 659558.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.460813688449487
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191119.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1803886267951342
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9323158264160156,
+        "AvgTime/train_epoch_std": 0.02209015218934709,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.7122280597686768,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.6749104261398315,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.008815318032314903,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.11386108398438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04835292585301468
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7552.46337890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5728072338950512
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.181358337402344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01522796034290608
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6776.35595703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9053247771584836
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107.26908111572266,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09263305795830971
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158626.515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.683506307472599
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11250.3115234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7888312665430866
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43689.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.239459992823825
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3088.72900390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5491073784722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 730825.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.2669769408278
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239512.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9856950892782854
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7685606214735243,
+        "AvgTime/train_epoch_std": 0.01652166833903111,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.5688890218734741,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.5196266174316406,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.007998034828587582,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57.91925048828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.041728566634208396
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6862.00439453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5204402271165149
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.459938049316406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01633297541264456
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6604.77099609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8824009346818638
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.67396545410156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08693779400181482
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155196.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6038682977661156
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10588.9248046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7424572153055322
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43039.5859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2061400347275617
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2980.917236328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5299408420138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 722721.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.175300894766014
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233528.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.886120523605079
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7721545015062605,
+        "AvgTime/train_epoch_std": 0.012559151281622695,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3051235675811768,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.2340478897094727,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.011758146787944592,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.5737533569336,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0486842603436121
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8024.0009765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6085704191552901
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123.22205352783203,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04153085727260938
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6962.22705078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9301572546133935
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115.8189468383789,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10001636169117349
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163769.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8029292158183168
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12388.4345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8686323496222479
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44789.8046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2958534362345584
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3218.63427734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5722016493055555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 747398.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.454447954254945
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247854.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.12451637461934
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7634732723236084,
+        "AvgTime/train_epoch_std": 0.024134253727433132,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1358.4813232421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1351.9095458984375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.10253390564265738,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257.1527099609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.18526852302661204
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 350.7604675292969,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.8461077238384047
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 454.0867614746094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.15304575715355895
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3948.58447265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5275329956788577
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 354.30755615234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.30596507439753345
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82115.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.906814566691436
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4924.23974609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.34526993031087855
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27792.203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.424583685734789
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1919.6907958984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.34127836371527775
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 492975.78125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.576459862787462
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137492.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.288002814387699
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.003446900844574,
+        "AvgTime/train_epoch_std": 0.013541514952536277,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1434.6702880859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1387.68896484375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.10524755137229806,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128.5460205078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09261240670591679
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.1283950805664,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.516465237266139
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 309.688720703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10437772858211156
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5039.041015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6732185725617903
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201.47879028320312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.17398859264525313
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102066.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.3701003158090286
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5715.3154296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4007373040027696
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34443.26171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.765506264736788
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2399.380859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4265565972222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 583579.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.6013540264470665
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163897.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7273951936997656
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.001426590813531,
+        "AvgTime/train_epoch_std": 0.02284947340778311,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1360.720947265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1395.926025390625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.10587228103076413,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.81264114379883,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03660853108342855
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.20906448364258,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.19583718149285567
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 410.40496826171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13832321141278017
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4818.1259765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6437042052855712
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128.1205291748047,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11063948978825966
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98262.2421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.281772296755991
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5422.0546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.38017491848969287
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33935.2890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7394684024040186
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2069.522216796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3679150607638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 570515.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.453572701152676
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153610.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.556210269914965
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9979815781116486,
+        "AvgTime/train_epoch_std": 0.01537224525507292,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 21.07024574279785,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 21.96190071105957,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0074020561884258745,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.438770294189453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.022650410874776265
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.607532501220703,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10319753948010896
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5245.9111328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3978696346463785
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6151.9873046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8219087915414162
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90.19951629638672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07789250111950494
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152432.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5396789516765743
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9941.970703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6970951271297855
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42133.71875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1597067379158337
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2759.04052734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.49049609375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 725704.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.209048335463729
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230348.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8331957861148553
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0036237144470217,
+        "AvgTime/train_epoch_std": 0.02547314603516955,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 32.743019104003906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 33.08579635620117,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.01115126267482345,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.54659652709961,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03497593409733401
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60.50728988647461,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.31845942045512954
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5389.7685546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4087803226915055
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6070.0400390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8109605930611222
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110.5552978515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09547089624487262
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153298.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.559782750673416
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10137.02734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7107717952426027
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42087.765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1573512545491824
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2720.619140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.483665625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 731428.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.273799390292185
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233769.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.890131234087165
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9988197939736503,
+        "AvgTime/train_epoch_std": 0.020373532862814653,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 27.833599090576172,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28.748619079589844,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.009689457054125326,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69.49475860595703,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05006826988901803
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79.48375701904297,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4183355632581209
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5720.1298828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4338361685864619
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6261.94580078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8365993053815965
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130.93202209472656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11306737659302812
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155213.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6042434661201934
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10552.2470703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7398855048599425
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42453.734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1761102247680557
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2778.6650390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4939848958333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 734060.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.303566479644356
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236143.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9296299069775182
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.005039691925049,
+        "AvgTime/train_epoch_std": 0.013543091203843295,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 832.8497924804688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 842.8633422851562,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1126069929572687,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92.71063232421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06679440369180026
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.310137748718262,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.043737567098517165
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10943.5986328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8300036884954494
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5127.6865234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.728239475374958
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57.034393310546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04925249854105948
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16171.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3755203011796396
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12975.5556640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9097991630951129
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7543.30908203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.38665790568615765
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 488.6778259277344,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08687605794270833
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160235.203125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.8125539079556123
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34821.1953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5794550998036377
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.960668158531189,
+        "AvgTime/train_epoch_std": 0.016709037744223592,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 496.2273864746094,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 451.588134765625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.060332416134352036,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.66432189941406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1071068601580793
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.781233072280884,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.014638068801478336
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25186.3515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.9102276497914297
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11740.7568359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.9571138644885404
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.6929702758789,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0645017014472184
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18092.513671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.42013082091480125
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20680.533203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.450044397919296
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5678.8837890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.29109046025231944
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 411.86431884765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.07322032335069445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164403.421875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.8597041036503286
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37127.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6178288236566655
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9426594864238391,
+        "AvgTime/train_epoch_std": 0.01642092104763118,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 562.0445556640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 541.6012573242188,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.07235821741138528,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349.17218017578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.25156497130819977
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.79254150390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.40943442896792764
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24039.8984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.8232763320060674
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10111.29296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.4079180885574654
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128.46896362304688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11094038309416829
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17142.744140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3980759832023268
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15233.6533203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.068128826273489
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6382.833984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.32717381641165616
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 384.31976318359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.06832351345486111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171011.046875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.9344484562175492
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34431.33984375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5729675643377764
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9606380245902322,
+        "AvgTime/train_epoch_std": 0.026611815935963613,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 74.39166259765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78.71575164794922,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.06797560591360036,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.820661544799805,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.015000476617290925
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.980932235717773,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.026215432819567227
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4022.535400390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.30508421694278537
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.397216796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05608264806096225
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5923.05078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7913227496659987
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142919.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3187719150566597
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8542.501953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5989694259658533
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40756.88671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.089132539789328
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2608.186767578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.46367764756944446
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702705.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.9488846532357496
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216832.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6082834627161233
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.933924674987793,
+        "AvgTime/train_epoch_std": 0.009409904479980469,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 67.8711929321289,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 71.803955078125,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.062006869670228844,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.75263023376465,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.013510540514239661
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.505494117736816,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05002891640914114
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2782.41357421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.21102871249288965
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243.71151733398438,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08214072036871735
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4886.630859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6528564942384769
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121715.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.826382499013097
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6695.91357421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.46949330908839926
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35596.921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8246410310625865
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2170.064697265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3857892795138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 634786.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.180603316629526
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186523.71875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1039175735942623
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9361602306365966,
+        "AvgTime/train_epoch_std": 0.025438777129858037,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 91.25831604003906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 95.70452117919922,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.08264639134645874,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.635181427001953,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02135099526441063
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.416178226470947,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03903251698142604
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5477.25830078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.41541587415860826
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.11759567260742,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.015880551288374595
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6186.1611328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.826474433241483
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154121.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.578888398662456
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10347.21875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7255096585331651
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42574.10546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1822802536649752
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2809.88818359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.49953567708333335
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 734115.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.30418792348676
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 235476.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9185325245868903
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9708411693572998,
+        "AvgTime/train_epoch_std": 0.0016720063036899456,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 9239.3955078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8541.00390625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.19833280480796026,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5906.4560546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.255371797325288
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6438.3330078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 33.885963199013155
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4807.76513671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3646389940628555
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6687.19580078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.25385770164518
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3743.605712890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5001477238330828
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6052.8671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.227001025474957
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6690.638671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4691234519615061
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5992.56201171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.30716910204104514
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4721.28564453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8393396701388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54723.93359375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.6190280148156737
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30235.240234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5031408023293062
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0316371000730076,
+        "AvgTime/train_epoch_std": 0.02060907717123938,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 6443.6513671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6592.91064453125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.1530956400829289,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8023.86328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.780881326548991
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10613.6962890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 55.86155941611842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6533.99609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4955628436670459
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9108.953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.0700886838557464
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4413.15478515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5895998376962258
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9139.8017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.892747631962435
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11146.2548828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.781535190212628
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5093.33251953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.26107604282798963
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5251.3671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9335763888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54393.48828125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.6152900725229913
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24629.576171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.40985765682983044
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.022095719973246,
+        "AvgTime/train_epoch_std": 0.02848307331450217,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 8321.357421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8410.837890625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.1953101869455926,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4837.7177734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.4853874448396973
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5140.03857421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 27.052834601151314
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8039.8232421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6097704393012894
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7007.46923828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.361802911453067
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3508.2158203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4686995083917836
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5682.87353515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.907490099444084
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5852.970703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.41038919528291967
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8084.00830078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4143732790394818
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4061.877197265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7221115017361112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100825.5546875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.1405218678947546
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44041.34765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7328864868828316
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0312646627426147,
+        "AvgTime/train_epoch_std": 0.019543346973101904,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1969.5263671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1908.6954345703125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.13383083961368059,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5572.8212890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.01500092871938
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10464.3212890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 55.0753752055921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4471.87158203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3391635632939894
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3192.148193359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.0758841231410095
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4281.6884765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5720358686122244
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7665.52392578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.619623424681563
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27475.03125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6380046268344789
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11159.6259765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.572024500310754
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3394.34423828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6034389756944445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160965.234375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.8208118997658451
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33571.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5586660987968649
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.025239791188921,
+        "AvgTime/train_epoch_std": 0.014902669521997983,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2129.12060546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2182.249267578125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.1530114477337067,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3937.3974609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.8367416865543946
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7074.7265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 37.235402960526315
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2258.119140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.17126425033181647
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3281.9755859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1061596177746882
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3189.5068359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.42611981776052105
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5350.55810546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.620516498677677
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34672.8671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8051473896409994
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12805.8310546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6564063280889589
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2628.079833984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4672141927083333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262170.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.965629701480719
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63897.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0633100725126055
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.017082134882609,
+        "AvgTime/train_epoch_std": 0.0222728573522616,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2456.14501953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2450.243408203125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.1718022302764777,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6013.5869140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.332555413589698
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11987.662109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 63.092958470394734
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3028.52587890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2296947955181077
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5596.9365234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.8863958622977754
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5038.0810546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6730903212675351
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8816.5595703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.613609300787997
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32755.744140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7606293920821335
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16493.4453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8454275110205546
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4057.935791015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7214108072916666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279120.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.1573599736434286
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64377.83203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0713033469996505
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0176516914367677,
+        "AvgTime/train_epoch_std": 0.01948330267303068,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2757.99462890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2670.238037109375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.1368721122102299,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1299.94921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9365628377161384
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1007.2713623046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.30142822265625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46073.5,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.4943875616230566
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88665.265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 29.88381045669026
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1335.67041015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.17844628058199732
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1308.0467529296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.1295740526163105
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28768.1640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6680327898592792
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95950.9609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.727735306233347
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2160.48486328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.38408619791666665
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66746.28125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.7550228074839089
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86181.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4341299631404656
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.981698215007782,
+        "AvgTime/train_epoch_std": 0.0037174863838524896,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 3382.60693359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2777.579345703125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.1423742552515826,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 958.0630493164062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6902471536861716
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 901.7755126953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.746186908922698
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38255.25390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9014223667993932
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14524.283203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.8952757678210315
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 859.9174194335938,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.11488542677803523
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 770.57421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6654354220639033
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22993.048828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5339273831535621
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26132.4765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.8323150022787829
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 784.1041259765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1393962890625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78388.8828125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.886721975639967
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37334.82421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6212840799885178
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.964423808184537,
+        "AvgTime/train_epoch_std": 0.014845019137246635,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 3844.934814453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3831.342529296875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.19638846323731995,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1043.4718017578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7517808370013058
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741.9616088867188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.905061099403783
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49506.62109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.754768380261661
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35866.1015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 12.088338915571285
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 770.2772216796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.10290944845420007
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612.5939331054688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5290103049270024
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26153.08984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.607307492191854
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39626.88671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.7784943709683074
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 580.4973754882812,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10319953342013889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105479.7890625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.193169791324955
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38426.328125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.639447658213103
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9793202082316081,
+        "AvgTime/train_epoch_std": 0.025142012610309714,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 606.9341430664062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 598.873046875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.10646631944444444,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.6509246826172,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1315928852180239
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80.75757598876953,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4250398736251028
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8122.08251953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6160092923421502
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13223.21484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.456762670626896
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1136.7811279296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.15187456618967102
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116.22503662109375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1003670437142433
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24411.5859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5668675909692551
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13887.1796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9737189515846305
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11016.140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5646696716899893
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212950.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.4088651544630837
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42743.15234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7112833831519478
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9521251022815704,
+        "AvgTime/train_epoch_std": 0.016862397087416554,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 483.6753845214844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 488.2572021484375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.08680128038194444,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185.67135620117188,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13376898861755898
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.202917098999023,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.14317324788946856
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9172.6513671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6956883858314372
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12472.9462890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.2038915702940685
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1067.12646484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.14256866597778892
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88.84717559814453,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07672467668233551
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27061.8828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6284108028167379
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11136.0498046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7808196469420488
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10562.1533203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5413990117541904
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255386.453125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.8888889870818866
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49186.80078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8185113204740985
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9659031867980956,
+        "AvgTime/train_epoch_std": 0.02260851557972899,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 568.3452758789062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 571.3389282226562,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.10157136501736111,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103.65312194824219,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07467804174945403
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.108104705810547,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10583213003058183
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6191.31005859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4695722456271331
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9292.669921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.132008736729019
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1607.5966796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21477577550935203
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61.2740364074707,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05291367565411978
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24332.869140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5650396883853103
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12613.7880859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8844333253356822
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11806.962890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6052059506189451
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211180.265625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.388835962863251
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39846.3359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6630778283244305
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.979388051562839,
+        "AvgTime/train_epoch_std": 0.022890712567077396,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 21116.078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17226.306640625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.19486110924544417,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15119.0654296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.89269843637428
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21316.33203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 112.19122121710527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10911.3330078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.827556542116989
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20404.53515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.877160484074823
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7583.71484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0131883558784236
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18110.28515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 15.63927906411917
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8645.4150390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.20075736204399267
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16359.6103515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1470768722172557
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5454.6494140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.2795965664084525
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9496.1494140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.6882043402777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26968.9296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.44878654231774084
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.025369739532471,
+        "AvgTime/train_epoch_std": 0.024387466199900204,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 41563.5390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 31222.873046875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.35318793532883497,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46384.8203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 33.41845843840058
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59217.89453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 311.6731291118421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76351.5078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.790785575464543
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97582.8671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 32.8894058602966
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28524.98046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 3.810952634435538
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52893.76953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 45.67683033786701
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46595.08203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0819961459978171
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67959.109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.765047635324639
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21401.109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0969864870059973
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35475.06640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 6.306678472222222
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40794.04296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6788485009693309
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0277549425760903,
+        "AvgTime/train_epoch_std": 0.01996361449801182,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 26044.13671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24613.32421875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.2784218207385496,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43524.09375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 31.357416246397694
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59198.5859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 311.5715049342105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22399.599609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.6988698983219568
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76694.515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 25.849179516346478
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18920.953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.5278494488977956
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50381.703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 43.50751565198618
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18596.884765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.43184294922963495
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28085.666015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.9692656019930586
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16919.728515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8672781032151827
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28694.6796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 5.101276388888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22082.365234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.3674698423173248
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.032255071860093,
+        "AvgTime/train_epoch_std": 0.01623950560372794,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 14773.65625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 14025.7197265625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.23340022509381292,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99533.3828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 71.70992998018733
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123184.28125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 648.338322368421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20605.16015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.5627728597838453
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83270.8984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 28.065688721772833
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60280.62109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 8.053523192217769
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106241.734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 91.74588460708118
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22052.603515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5120890654752229
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26356.65625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.8480336733978404
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48420.25390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4819444310959042
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71308.34375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 12.67703888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62126.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.7027688539981675
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.050368150075277,
+        "AvgTime/train_epoch_std": 0.015222334607727327,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 18438.458984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17619.41796875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.293202502267319,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48803.8046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 35.16124257024496
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60875.5390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 320.3975740131579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16421.626953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.2454779638320062
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47286.453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 15.937463136164476
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29552.0234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 3.9481661239144956
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54646.1796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 47.19013789939551
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16417.548828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.38123604003634126
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17438.06640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.2226943210103771
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20227.39453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0368237496155621
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35968.734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 6.394441666666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70574.6640625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.7983288357012771
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0662606954574585,
+        "AvgTime/train_epoch_std": 0.0257575474907625,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topnets_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 18159.02734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17621.73046875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.29324098428685536,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25736.70703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 18.542296132024497
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35840.8984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 188.63630756578948
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16386.880859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.242842689372393
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41273.01953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 13.9106907756151
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13576.5751953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.8138377014445557
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30823.82421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 26.61815562931779
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16571.912109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3848205487036736
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16993.57421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1915281320116393
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11842.966796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.607051453015275
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18492.5625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.2875666666666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77474.921875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.8763834018641902
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/topnets/logs/train/runs/notebook_gu_grid_topnets__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0512070059776306,
+        "AvgTime/train_epoch_std": 0.018682308596472266,
+        "model/params/total": 47214,
+        "model/params/trainable": 47214,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -104,7 +104,7 @@
       "outputs": [],
       "source": [
         "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-        "MODEL_CONFIG = \"graph/gin\""
+        "MODEL_CONFIG = \"combinatorial/topnets\""
       ]
     },
     {

--- a/configs/model/combinatorial/topnets.yaml
+++ b/configs/model/combinatorial/topnets.yaml
@@ -1,49 +1,53 @@
 _target_: topobench.model.TBModel
 
 model_name: topnets
-model_domain: graph
+model_domain: combinatorial
 
 feature_encoder:
   _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
   encoder_name: AllCellFeatureEncoder
   in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
-  out_channels: 64
+  out_channels: 32
   proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
 
 backbone:
-  _target_: topobench.nn.backbones.TopNetsBackbone
+  _target_: topobench.nn.backbones.combinatorial.topnets.CombinatorialTopNetsBackbone
   in_channels: ${model.feature_encoder.out_channels}
   hidden_channels: ${model.feature_encoder.out_channels}
-  num_steps: 4
+  neighborhoods:
+    - down_incidence-1
+    - up_incidence-0
+    - down_incidence-2
+    - up_incidence-1
+  num_layers: 2
+  num_steps: 2
   gnn_type: gcn
-  num_filtrations: 8
+  num_filtrations: 6
   filtration_hidden: 16
-  coord_fun_count: 3
+  coord_fun_count: 2
   dropout: 0.0
   use_dim1: true
   sigmoid_filtrations: true
+  activation: relu
 
 backbone_wrapper:
-  _target_: topobench.nn.wrappers.GNNWrapper
+  _target_: topobench.nn.wrappers.combinatorial.TuneWrapper
   _partial_: true
-  wrapper_name: GNNWrapper
+  wrapper_name: TuneWrapper
   out_channels: ${model.feature_encoder.out_channels}
-  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
-  residual_connections: false
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
 
 readout:
   _target_: topobench.nn.readouts.${model.readout.readout_name}
-  readout_name: MLPReadout
-  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
-  in_channels: ${model.feature_encoder.out_channels}
-  hidden_layers:
-    - ${model.feature_encoder.out_channels}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
+  hidden_dim: ${model.feature_encoder.out_channels}
   out_channels: ${dataset.parameters.num_classes}
   task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
-  pooling_type: mean
-  dropout: 0.0
-  act: relu
-  norm: null
-  final_act: null
+  pooling_type: sum
 
 compile: false

--- a/configs/model/combinatorial/topnets.yaml
+++ b/configs/model/combinatorial/topnets.yaml
@@ -17,20 +17,19 @@ feature_encoder:
 backbone:
   _target_: topobench.nn.backbones.combinatorial.topnets.CombinatorialTopNetsBackbone
   in_channels: ${model.feature_encoder.out_channels}
-  hidden_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: 32
   neighborhoods:
     - down_incidence-1
-    - up_incidence-0
     - down_incidence-2
     - up_incidence-1
-  num_layers: 2
-  num_steps: 2
+  num_layers: 1
+  num_steps: 1
   gnn_type: gcn
-  num_filtrations: 6
-  filtration_hidden: 16
-  coord_fun_count: 2
+  num_filtrations: 2
+  filtration_hidden: 8
+  coord_fun_count: 1
   dropout: 0.0
-  use_dim1: true
+  use_dim1: false
   sigmoid_filtrations: true
   activation: relu
 
@@ -38,14 +37,15 @@ backbone_wrapper:
   _target_: topobench.nn.wrappers.combinatorial.TuneWrapper
   _partial_: true
   wrapper_name: TuneWrapper
-  out_channels: ${model.feature_encoder.out_channels}
+  out_channels: ${model.backbone.hidden_channels}
   num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
+  residual_connections: false
 
 readout:
   _target_: topobench.nn.readouts.${model.readout.readout_name}
   readout_name: PropagateSignalDown
   num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
-  hidden_dim: ${model.feature_encoder.out_channels}
+  hidden_dim: ${model.backbone.hidden_channels}
   out_channels: ${dataset.parameters.num_classes}
   task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
   pooling_type: sum

--- a/configs/model/graph/topnets.yaml
+++ b/configs/model/graph/topnets.yaml
@@ -1,0 +1,49 @@
+_target_: topobench.model.TBModel
+
+model_name: topnets
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.TopNetsBackbone
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_steps: 4
+  gnn_type: gcn
+  num_filtrations: 8
+  filtration_hidden: 16
+  coord_fun_count: 3
+  dropout: 0.0
+  use_dim1: true
+  sigmoid_filtrations: true
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  residual_connections: false
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: MLPReadout
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_layers:
+    - ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: mean
+  dropout: 0.0
+  act: relu
+  norm: null
+  final_act: null
+
+compile: false

--- a/test/_utils/simplified_pipeline.py
+++ b/test/_utils/simplified_pipeline.py
@@ -1,9 +1,6 @@
 """Test pipeline for a particular dataset and model."""
 
-from omegaconf import OmegaConf
 import hydra
-from lightning import Callback, Trainer
-from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig, OmegaConf
 
 from topobench.data.preprocessor import PreProcessor
@@ -18,6 +15,7 @@ from topobench.utils.config_resolvers import (
     get_required_lifting,
     infer_in_channels,
     infer_num_cell_dimensions,
+    infer_topotune_num_cell_dimensions,
 )
 
 OmegaConf.register_new_resolver(
@@ -45,8 +43,14 @@ OmegaConf.register_new_resolver(
     "infer_num_cell_dimensions", infer_num_cell_dimensions, replace=True
 )
 OmegaConf.register_new_resolver(
+    "infer_topotune_num_cell_dimensions",
+    infer_topotune_num_cell_dimensions,
+    replace=True,
+)
+OmegaConf.register_new_resolver(
     "parameter_multiplication", lambda x, y: int(int(x) * int(y)), replace=True
 )
+
 
 def run(cfg: DictConfig) -> DictConfig:
     """Run pipeline with given configuration.

--- a/test/nn/backbones/combinatorial/test_topnets.py
+++ b/test/nn/backbones/combinatorial/test_topnets.py
@@ -269,3 +269,57 @@ def test_activation_variants_and_invalid_activation():
             ranks=(0,),
             activation="bad",
         )
+
+
+def test_interrank_route_zero_initializes_destination_features():
+    """Inter-rank routes send source-cell signal into zero-initialized destinations."""
+
+    class SpyRoute:
+        def __init__(self):
+            self.x = None
+            self.edge_index = None
+            self.batch = None
+
+        def __call__(self, x, edge_index, batch, edge_weight=None):
+            self.x = x.clone()
+            self.edge_index = edge_index.clone()
+            self.batch = batch.clone()
+            return torch.arange(
+                x.numel(), dtype=x.dtype, device=x.device
+            ).view_as(x)
+
+    batch = _mock_complex_batch()
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        neighborhoods=["down_incidence-1"],
+        num_layers=1,
+        num_steps=1,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+    spy = SpyRoute()
+
+    out = model._interrank_forward(
+        batch=batch,
+        route_model=spy,
+        neighborhood="down_incidence-1",
+        src_x=batch.x_1,
+        dst_x=batch.x_0,
+        src_batch=batch.batch_1,
+        dst_batch=batch.batch_0,
+    )
+
+    num_dst = batch.x_0.shape[0]
+    expected_route_out = torch.arange(
+        spy.x.numel(),
+        dtype=spy.x.dtype,
+        device=spy.x.device,
+    ).view_as(spy.x)
+    torch.testing.assert_close(spy.x[:num_dst], torch.zeros_like(batch.x_0))
+    torch.testing.assert_close(spy.x[num_dst:], batch.x_1)
+    torch.testing.assert_close(out, expected_route_out[:num_dst])
+    assert spy.edge_index.shape[0] == 2
+    assert spy.edge_index.max() < spy.x.shape[0]
+    assert spy.batch.shape[0] == spy.x.shape[0]

--- a/test/nn/backbones/combinatorial/test_topnets.py
+++ b/test/nn/backbones/combinatorial/test_topnets.py
@@ -11,6 +11,7 @@ from topobench.nn.backbones.combinatorial.topnets import (
     _node_adjacency_from_incidence,
     _rank_neighborhood_matrix,
 )
+from topobench.nn.readouts.propagate_signal_down import PropagateSignalDown
 from topobench.nn.wrappers.combinatorial import TuneWrapper
 
 
@@ -120,6 +121,58 @@ def test_combinatorial_topnets_tune_wrapper_output():
     assert torch.equal(model_out["batch_0"], batch.batch_0)
 
 
+def test_combinatorial_topnets_omits_unconfigured_rank_three():
+    """Rank-3 cells from complex_dim=3 lifting are not exposed to rank-2 readouts."""
+    batch = _mock_complex_batch()
+    batch.x_3 = torch.randn(2, 8)
+    batch.batch_3 = torch.zeros(2, dtype=torch.long)
+    batch["incidence_3"] = torch.sparse_coo_tensor(
+        indices=torch.tensor([[0, 0], [0, 1]]),
+        values=torch.ones(2),
+        size=(1, 2),
+    ).coalesce()
+
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        neighborhoods=[
+            "down_incidence-1",
+            "down_incidence-2",
+            "up_incidence-1",
+        ],
+        num_layers=1,
+        num_steps=1,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(batch)
+
+    assert set(out) == {0, 1, 2}
+
+    wrapper = TuneWrapper(
+        model,
+        out_channels=8,
+        num_cell_dimensions=3,
+        residual_connections=False,
+    )
+    model_out = wrapper(batch)
+    assert "x_3" not in model_out
+
+    readout = PropagateSignalDown(
+        readout_name="PropagateSignalDown",
+        num_cell_dimensions=3,
+        hidden_dim=8,
+        out_channels=2,
+        task_level="graph",
+        pooling_type="sum",
+    )
+    readout_out = readout(model_out, batch)
+    assert readout_out["logits"].shape == (1, 2)
+    assert torch.isfinite(readout_out["logits"]).all()
+
+
 def test_combinatorial_topnets_updates_without_adjacency_keys():
     """Incidence-only combinatorial neighborhoods are enough to run TopNets."""
     batch = _mock_complex_batch()
@@ -174,9 +227,9 @@ def test_rank_fallback_updates_intrarank_routes():
 
     out = model(batch)
 
+    assert set(out) == {0, 1}
     assert out[0].shape == batch.x_0.shape
     assert out[1].shape == batch.x_1.shape
-    assert out[2].shape == batch.x_2.shape
 
 
 def test_membership_fallbacks():

--- a/test/nn/backbones/combinatorial/test_topnets.py
+++ b/test/nn/backbones/combinatorial/test_topnets.py
@@ -1,0 +1,271 @@
+"""Unit tests for the combinatorial TopNets backbone."""
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from topobench.nn.backbones.combinatorial.topnets import (
+    CombinatorialTopNetsBackbone,
+    _interrank_edge_index,
+    _make_activation,
+    _node_adjacency_from_incidence,
+    _rank_neighborhood_matrix,
+)
+from topobench.nn.wrappers.combinatorial import TuneWrapper
+
+
+def _mock_complex_batch() -> Data:
+    x_0 = torch.randn(4, 8)
+    x_1 = torch.randn(4, 8)
+    x_2 = torch.randn(1, 8)
+
+    batch = Data(
+        x_0=x_0,
+        x_1=x_1,
+        x_2=x_2,
+        y=torch.tensor([1]),
+        batch_0=torch.zeros(x_0.shape[0], dtype=torch.long),
+        batch_1=torch.zeros(x_1.shape[0], dtype=torch.long),
+        batch_2=torch.zeros(x_2.shape[0], dtype=torch.long),
+        cell_statistics=torch.tensor([[4, 4, 1]]),
+    )
+
+    batch["incidence_1"] = torch.sparse_coo_tensor(
+        indices=torch.tensor(
+            [[0, 1, 1, 2, 2, 3, 3, 0], [0, 0, 1, 1, 2, 2, 3, 3]]
+        ),
+        values=torch.ones(8),
+        size=(4, 4),
+    ).coalesce()
+    batch["incidence_2"] = torch.sparse_coo_tensor(
+        indices=torch.tensor([[0, 1, 2, 3], [0, 0, 0, 0]]),
+        values=torch.ones(4),
+        size=(4, 1),
+    ).coalesce()
+    batch["down_incidence-1"] = batch["incidence_1"]
+    batch["up_incidence-0"] = batch["incidence_1"].t().coalesce()
+    batch["down_incidence-2"] = batch["incidence_2"]
+    batch["up_incidence-1"] = batch["incidence_2"].t().coalesce()
+    batch["up_adjacency-0"] = torch.sparse_coo_tensor(
+        indices=torch.tensor(
+            [[0, 1, 1, 2, 2, 3, 3, 0], [1, 0, 2, 1, 3, 2, 0, 3]]
+        ),
+        values=torch.ones(8),
+        size=(4, 4),
+    ).coalesce()
+    batch["up_adjacency-1"] = torch.sparse_coo_tensor(
+        indices=torch.tensor(
+            [[0, 1, 1, 2, 2, 3, 3, 0], [1, 0, 2, 1, 3, 2, 0, 3]]
+        ),
+        values=torch.ones(8),
+        size=(4, 4),
+    ).coalesce()
+    return batch
+
+
+def test_combinatorial_topnets_forward_contract():
+    """The backbone returns rank-keyed finite embeddings for TuneWrapper."""
+    batch = _mock_complex_batch()
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        neighborhoods=[
+            "down_incidence-1",
+            "up_incidence-0",
+            "down_incidence-2",
+            "up_incidence-1",
+        ],
+        num_layers=1,
+        num_steps=2,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(batch)
+
+    assert set(out) == {0, 1, 2}
+    assert out[0].shape == batch.x_0.shape
+    assert out[1].shape == batch.x_1.shape
+    assert out[2].shape == batch.x_2.shape
+    assert all(torch.isfinite(value).all() for value in out.values())
+
+
+def test_combinatorial_topnets_tune_wrapper_output():
+    """TuneWrapper exposes combinatorial TopNets outputs in TopoBench format."""
+    batch = _mock_complex_batch()
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        neighborhoods=["down_incidence-1", "down_incidence-2"],
+        num_layers=1,
+        num_steps=2,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+    wrapper = TuneWrapper(
+        model,
+        out_channels=8,
+        num_cell_dimensions=3,
+        residual_connections=False,
+    )
+
+    model_out = wrapper(batch)
+
+    assert model_out["x_0"].shape == batch.x_0.shape
+    assert model_out["x_1"].shape == batch.x_1.shape
+    assert model_out["x_2"].shape == batch.x_2.shape
+    assert torch.equal(model_out["labels"], batch.y)
+    assert torch.equal(model_out["batch_0"], batch.batch_0)
+
+
+def test_combinatorial_topnets_updates_without_adjacency_keys():
+    """Incidence-only combinatorial neighborhoods are enough to run TopNets."""
+    batch = _mock_complex_batch()
+    del batch["up_adjacency-0"]
+    del batch["up_adjacency-1"]
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        neighborhoods=["down_incidence-1"],
+        num_layers=1,
+        num_steps=2,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(batch)
+
+    assert out[0].shape == batch.x_0.shape
+    assert torch.isfinite(out[0]).all()
+
+
+def test_combinatorial_topnets_invalid_parameters():
+    """Invalid combinatorial TopNets construction raises clear errors."""
+    with pytest.raises(ValueError, match="neighborhoods"):
+        CombinatorialTopNetsBackbone(
+            in_channels=8, hidden_channels=8, neighborhoods=[]
+        )
+
+    with pytest.raises(ValueError, match="num_layers"):
+        CombinatorialTopNetsBackbone(
+            in_channels=8,
+            hidden_channels=8,
+            neighborhoods=["down_incidence-1"],
+            num_layers=0,
+        )
+
+
+def test_rank_fallback_updates_intrarank_routes():
+    """Rank fallback API uses up-adjacency neighborhoods."""
+    batch = _mock_complex_batch()
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        ranks=(0, 1),
+        num_layers=1,
+        num_steps=1,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(batch)
+
+    assert out[0].shape == batch.x_0.shape
+    assert out[1].shape == batch.x_1.shape
+    assert out[2].shape == batch.x_2.shape
+
+
+def test_membership_fallbacks():
+    """Membership falls back to cell_statistics and single-complex batches."""
+    batch = _mock_complex_batch()
+    del batch.batch_0
+    del batch.batch_1
+    del batch.batch_2
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        ranks=(0,),
+        num_layers=1,
+        num_steps=1,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out_with_stats = model(batch)
+    assert out_with_stats[0].shape == batch.x_0.shape
+
+    del batch.cell_statistics
+    out_without_stats = model(batch)
+    assert out_without_stats[0].shape == batch.x_0.shape
+
+
+def test_missing_route_rank_is_ignored():
+    """Routes whose source rank is absent are skipped safely."""
+    batch = _mock_complex_batch()
+    model = CombinatorialTopNetsBackbone(
+        in_channels=8,
+        hidden_channels=8,
+        neighborhoods=["down_incidence-3"],
+        num_layers=1,
+        num_steps=1,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(batch)
+
+    assert out[0].shape == batch.x_0.shape
+    assert out[1].shape == batch.x_1.shape
+    assert out[2].shape == batch.x_2.shape
+
+
+def test_helper_edge_cases():
+    """Helper functions handle sparse edge cases explicitly."""
+    batch = _mock_complex_batch()
+
+    with pytest.raises(KeyError, match="Missing combinatorial neighborhood"):
+        _rank_neighborhood_matrix(batch, "missing", rank=1)
+
+    empty_incidence = torch.sparse_coo_tensor(
+        torch.empty((2, 0), dtype=torch.long),
+        torch.empty(0),
+        (3, 2),
+    ).coalesce()
+    empty_adj = _node_adjacency_from_incidence(empty_incidence)
+    assert empty_adj._nnz() == 0
+
+    singleton_incidence = torch.sparse_coo_tensor(
+        torch.tensor([[0, 1], [0, 1]]),
+        torch.ones(2),
+        (3, 2),
+    ).coalesce()
+    singleton_adj = _node_adjacency_from_incidence(singleton_incidence)
+    assert singleton_adj._nnz() == 0
+
+    empty_interrank = _interrank_edge_index(
+        empty_incidence, num_dst=3, device=torch.device("cpu")
+    )
+    assert empty_interrank.shape == (2, 0)
+
+
+def test_activation_variants_and_invalid_activation():
+    """Supported activation names resolve and invalid names fail."""
+    for activation in ["elu", "tanh", "sigmoid", "id"]:
+        assert isinstance(_make_activation(activation), torch.nn.Module)
+
+    with pytest.raises(ValueError, match="Unsupported activation"):
+        _make_activation("bad")
+
+    with pytest.raises(ValueError, match="Unsupported activation"):
+        CombinatorialTopNetsBackbone(
+            in_channels=8,
+            hidden_channels=8,
+            ranks=(0,),
+            activation="bad",
+        )

--- a/test/nn/backbones/graph/test_topnets.py
+++ b/test/nn/backbones/graph/test_topnets.py
@@ -1,0 +1,125 @@
+"""Unit tests for the TopNets graph backbone."""
+
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.topnets import TopNetsBackbone
+from topobench.nn.wrappers.graph import GNNWrapper
+
+
+def _batch_data() -> Batch:
+    graph_0 = Data(
+        x=torch.randn(4, 5),
+        edge_index=torch.tensor(
+            [[0, 1, 1, 2, 2, 3, 3, 0], [1, 0, 2, 1, 3, 2, 0, 3]],
+            dtype=torch.long,
+        ),
+        y=torch.tensor([0]),
+    )
+    graph_1 = Data(
+        x=torch.randn(3, 5),
+        edge_index=torch.tensor(
+            [[0, 1, 1, 2, 2, 0], [1, 0, 2, 1, 0, 2]],
+            dtype=torch.long,
+        ),
+        y=torch.tensor([1]),
+    )
+    batch = Batch.from_data_list([graph_0, graph_1])
+    batch.x_0 = batch.x
+    batch.batch_0 = batch.batch
+    return batch
+
+
+def test_topnets_forward_shape_and_gradients():
+    """TopNets returns finite node embeddings and supports backprop."""
+    batch = _batch_data()
+    model = TopNetsBackbone(
+        in_channels=5,
+        hidden_channels=8,
+        num_steps=2,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(batch.x, batch.edge_index, batch=batch.batch)
+
+    assert out.shape == (batch.num_nodes, 8)
+    assert torch.isfinite(out).all()
+
+    out.sum().backward()
+    assert model.input_projection.weight.grad is not None
+
+
+def test_topnets_gin_variant():
+    """TopNets supports the GIN branch used in the reference code."""
+    batch = _batch_data()
+    model = TopNetsBackbone(
+        in_channels=5,
+        hidden_channels=8,
+        num_steps=2,
+        gnn_type="gin",
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(batch.x, batch.edge_index, batch=batch.batch)
+
+    assert out.shape == (batch.num_nodes, 8)
+    assert torch.isfinite(out).all()
+
+
+def test_topnets_wrapper_output():
+    """The graph wrapper exposes TopNets outputs in TopoBench format."""
+    batch = _batch_data()
+    model = TopNetsBackbone(
+        in_channels=5,
+        hidden_channels=8,
+        num_steps=2,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+    wrapper = GNNWrapper(
+        model,
+        out_channels=8,
+        num_cell_dimensions=1,
+        residual_connections=False,
+    )
+
+    model_out = wrapper(batch)
+
+    assert model_out["x_0"].shape == (batch.num_nodes, 8)
+    assert torch.equal(model_out["labels"], batch.y)
+    assert torch.equal(model_out["batch_0"], batch.batch_0)
+
+
+def test_topnets_without_edges():
+    """TopNets handles edgeless graph batches."""
+    x = torch.randn(3, 5)
+    edge_index = torch.empty((2, 0), dtype=torch.long)
+    batch = torch.zeros(3, dtype=torch.long)
+    model = TopNetsBackbone(
+        in_channels=5,
+        hidden_channels=8,
+        num_steps=2,
+        num_filtrations=2,
+        filtration_hidden=4,
+        coord_fun_count=1,
+    )
+
+    out = model(x, edge_index, batch=batch)
+
+    assert out.shape == (3, 8)
+    assert torch.isfinite(out).all()
+
+
+def test_topnets_invalid_parameters():
+    """Invalid TopNets construction parameters raise clear errors."""
+    with pytest.raises(ValueError, match="num_steps must be positive"):
+        TopNetsBackbone(in_channels=5, hidden_channels=8, num_steps=0)
+
+    with pytest.raises(ValueError, match="gnn_type"):
+        TopNetsBackbone(in_channels=5, hidden_channels=8, gnn_type="gat")

--- a/test/nn/backbones/graph/test_topnets.py
+++ b/test/nn/backbones/graph/test_topnets.py
@@ -137,9 +137,9 @@ def test_proxy_persistence_pairs_for_single_edge():
         coord_fun_count=1,
     )
     filtrations = torch.tensor([[0.2], [0.7], [0.5]])
-    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_index = torch.tensor([[0], [1]], dtype=torch.long)
     batch = torch.zeros(3, dtype=torch.long)
-    edge_batch = torch.zeros(2, dtype=torch.long)
+    edge_batch = torch.zeros(1, dtype=torch.long)
 
     persistence0, persistence1 = layer._compute_persistence(
         filtrations=filtrations,
@@ -150,6 +150,6 @@ def test_proxy_persistence_pairs_for_single_edge():
     )
 
     expected0 = torch.tensor([[[0.2, 0.7], [0.7, 0.7], [0.5, 0.7]]])
-    expected1 = torch.tensor([[[0.7, 0.7], [0.7, 0.7]]])
+    expected1 = torch.tensor([[[0.7, 0.7]]])
     torch.testing.assert_close(persistence0, expected0)
     torch.testing.assert_close(persistence1, expected1)

--- a/test/nn/backbones/graph/test_topnets.py
+++ b/test/nn/backbones/graph/test_topnets.py
@@ -4,7 +4,10 @@ import pytest
 import torch
 from torch_geometric.data import Batch, Data
 
-from topobench.nn.backbones.graph.topnets import _TopNetsRouteOperator
+from topobench.nn.backbones.graph.topnets import (
+    _TopNetsRouteOperator,
+    _TopologicalFiltrationLayer,
+)
 from topobench.nn.wrappers.graph import GNNWrapper
 
 
@@ -123,3 +126,30 @@ def test_topnets_invalid_parameters():
 
     with pytest.raises(ValueError, match="gnn_type"):
         _TopNetsRouteOperator(in_channels=5, hidden_channels=8, gnn_type="gat")
+
+
+def test_proxy_persistence_pairs_for_single_edge():
+    """Proxy persistence uses node births, incident edge deaths, and graph maxima."""
+    layer = _TopologicalFiltrationLayer(
+        channels=2,
+        num_filtrations=1,
+        filtration_hidden=2,
+        coord_fun_count=1,
+    )
+    filtrations = torch.tensor([[0.2], [0.7], [0.5]])
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    batch = torch.zeros(3, dtype=torch.long)
+    edge_batch = torch.zeros(2, dtype=torch.long)
+
+    persistence0, persistence1 = layer._compute_persistence(
+        filtrations=filtrations,
+        edge_index=edge_index,
+        batch=batch,
+        edge_batch=edge_batch,
+        num_graphs=1,
+    )
+
+    expected0 = torch.tensor([[[0.2, 0.7], [0.7, 0.7], [0.5, 0.7]]])
+    expected1 = torch.tensor([[[0.7, 0.7], [0.7, 0.7]]])
+    torch.testing.assert_close(persistence0, expected0)
+    torch.testing.assert_close(persistence1, expected1)

--- a/test/nn/backbones/graph/test_topnets.py
+++ b/test/nn/backbones/graph/test_topnets.py
@@ -1,10 +1,10 @@
-"""Unit tests for the TopNets graph backbone."""
+"""Unit tests for the TopNets graph route operator."""
 
 import pytest
 import torch
 from torch_geometric.data import Batch, Data
 
-from topobench.nn.backbones.graph.topnets import TopNetsBackbone
+from topobench.nn.backbones.graph.topnets import _TopNetsRouteOperator
 from topobench.nn.wrappers.graph import GNNWrapper
 
 
@@ -34,7 +34,7 @@ def _batch_data() -> Batch:
 def test_topnets_forward_shape_and_gradients():
     """TopNets returns finite node embeddings and supports backprop."""
     batch = _batch_data()
-    model = TopNetsBackbone(
+    model = _TopNetsRouteOperator(
         in_channels=5,
         hidden_channels=8,
         num_steps=2,
@@ -55,7 +55,7 @@ def test_topnets_forward_shape_and_gradients():
 def test_topnets_gin_variant():
     """TopNets supports the GIN branch used in the reference code."""
     batch = _batch_data()
-    model = TopNetsBackbone(
+    model = _TopNetsRouteOperator(
         in_channels=5,
         hidden_channels=8,
         num_steps=2,
@@ -74,7 +74,7 @@ def test_topnets_gin_variant():
 def test_topnets_wrapper_output():
     """The graph wrapper exposes TopNets outputs in TopoBench format."""
     batch = _batch_data()
-    model = TopNetsBackbone(
+    model = _TopNetsRouteOperator(
         in_channels=5,
         hidden_channels=8,
         num_steps=2,
@@ -101,7 +101,7 @@ def test_topnets_without_edges():
     x = torch.randn(3, 5)
     edge_index = torch.empty((2, 0), dtype=torch.long)
     batch = torch.zeros(3, dtype=torch.long)
-    model = TopNetsBackbone(
+    model = _TopNetsRouteOperator(
         in_channels=5,
         hidden_channels=8,
         num_steps=2,
@@ -119,7 +119,7 @@ def test_topnets_without_edges():
 def test_topnets_invalid_parameters():
     """Invalid TopNets construction parameters raise clear errors."""
     with pytest.raises(ValueError, match="num_steps must be positive"):
-        TopNetsBackbone(in_channels=5, hidden_channels=8, num_steps=0)
+        _TopNetsRouteOperator(in_channels=5, hidden_channels=8, num_steps=0)
 
     with pytest.raises(ValueError, match="gnn_type"):
-        TopNetsBackbone(in_channels=5, hidden_channels=8, gnn_type="gat")
+        _TopNetsRouteOperator(in_channels=5, hidden_channels=8, gnn_type="gat")

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -5,7 +5,7 @@ import hydra
 from test._utils.simplified_pipeline import run
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/topnets"]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS = ["combinatorial/topnets"]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -5,7 +5,12 @@ import hydra
 from test._utils.simplified_pipeline import run
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["combinatorial/topnets"]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS = [
+    "graph/gcn",
+    "cell/topotune",
+    "simplicial/topotune",
+    "combinatorial/topnets",
+]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:
@@ -30,6 +35,6 @@ class TestPipeline:
                         "paths=test",
                         "callbacks=model_checkpoint",
                     ],
-                    return_hydra_config=True
+                    return_hydra_config=True,
                 )
                 run(cfg)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,11 +1,11 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
+
 from test._utils.simplified_pipeline import run
 
-
-DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
+MODELS = ["graph/topnets"]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:
@@ -23,7 +23,7 @@ class TestPipeline:
                     config_name="run.yaml",
                     overrides=[
                         f"model={MODEL}",
-                        f"dataset={DATASET}", # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
+                        f"dataset={DATASET}",  # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
                         "trainer.max_epochs=2",
                         "trainer.min_epochs=1",
                         "trainer.check_val_every_n_epoch=1",

--- a/topobench/nn/backbones/combinatorial/topnets.py
+++ b/topobench/nn/backbones/combinatorial/topnets.py
@@ -162,7 +162,11 @@ class CombinatorialTopNetsBackbone(nn.Module):
             for rank, outputs in route_outputs.items():
                 x_by_rank[rank] = self.activation(torch.stack(outputs).sum(dim=0))
 
-        return {rank: x_by_rank[rank] for rank in sorted(x_by_rank)}
+        return {
+            rank: x_by_rank[rank]
+            for rank in range(self.max_rank + 1)
+            if rank in x_by_rank
+        }
 
     def _intrarank_forward(
         self,

--- a/topobench/nn/backbones/combinatorial/topnets.py
+++ b/topobench/nn/backbones/combinatorial/topnets.py
@@ -1,0 +1,315 @@
+"""Track-2 TopNets backbone for combinatorial-complex inputs.
+
+This module adapts the TopNets learned-filtration dynamics to TopoBench's
+combinatorial domain.  A graph-to-combinatorial lifting supplies Hasse-style
+neighborhoods between cells of different ranks; each selected neighborhood is
+processed with a TopNets graph-filtration route operator, and route outputs are
+aggregated back to rank-wise cell embeddings.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch_geometric.data import Data
+
+from topobench.data.utils import get_routes_from_neighborhoods
+from topobench.nn.backbones.graph.topnets import _TopNetsRouteOperator
+
+
+class CombinatorialTopNetsBackbone(nn.Module):
+    """TopNets dynamics on combinatorial-complex neighborhoods.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input feature dimension after ``AllCellFeatureEncoder``.
+    hidden_channels : int, optional
+        Hidden cell embedding dimension. Defaults to ``in_channels``.
+    neighborhoods : list[str], optional
+        Neighborhood names provided by the combinatorial lifting.
+    ranks : tuple[int, ...] | list[int], optional
+        Rank-wise fallback API. If ``neighborhoods`` is omitted, each rank is
+        processed through its ``up_adjacency-{rank}`` neighborhood.
+    num_layers : int, optional
+        Number of rank-wise neighborhood aggregation layers.
+    num_steps : int, optional
+        Number of fixed TopNets dynamics steps inside each route operator.
+    gnn_type : str, optional
+        Route message-passing layer type, either ``"gcn"`` or ``"gin"``.
+    num_filtrations : int, optional
+        Number of learned filtration functions per route operator.
+    filtration_hidden : int, optional
+        Hidden dimension of each route filtration MLP.
+    coord_fun_count : int, optional
+        Number of coordinates per TOGL coordinate function.
+    dropout : float, optional
+        Dropout in route graph-convolution blocks.
+    use_dim1 : bool, optional
+        Whether route operators include cycle-style topology summaries.
+    sigmoid_filtrations : bool, optional
+        Whether learned filtration values are sigmoid-constrained.
+    activation : str, optional
+        Rank aggregation activation. Supports ``relu``, ``elu``, ``tanh``,
+        ``sigmoid``, and ``id``.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int | None = None,
+        neighborhoods: list[str] | None = None,
+        ranks: tuple[int, ...] | list[int] | None = None,
+        num_layers: int = 2,
+        num_steps: int = 2,
+        gnn_type: str = "gcn",
+        num_filtrations: int = 6,
+        filtration_hidden: int = 16,
+        coord_fun_count: int = 2,
+        dropout: float = 0.0,
+        use_dim1: bool = True,
+        sigmoid_filtrations: bool = True,
+        activation: str = "relu",
+    ) -> None:
+        super().__init__()
+        if num_layers <= 0:
+            msg = "num_layers must be positive"
+            raise ValueError(msg)
+        if neighborhoods:
+            self.neighborhoods = list(neighborhoods)
+            self.routes = [
+                tuple(route)
+                for route in get_routes_from_neighborhoods(self.neighborhoods)
+            ]
+        elif ranks:
+            self.neighborhoods = [f"up_adjacency-{rank}" for rank in ranks]
+            self.routes = [(int(rank), int(rank)) for rank in ranks]
+        else:
+            msg = "neighborhoods or ranks must contain at least one route"
+            raise ValueError(msg)
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels or in_channels
+        self.out_channels = self.hidden_channels
+        self.max_rank = max(max(route) for route in self.routes)
+        self.num_layers = num_layers
+        self.activation = _make_activation(activation)
+
+        route_layers = []
+        for layer_idx in range(num_layers):
+            route_in_channels = in_channels if layer_idx == 0 else self.hidden_channels
+            route_layers.append(
+                nn.ModuleList(
+                    [
+                        _TopNetsRouteOperator(
+                            in_channels=route_in_channels,
+                            hidden_channels=self.hidden_channels,
+                            num_steps=num_steps,
+                            gnn_type=gnn_type,
+                            num_filtrations=num_filtrations,
+                            filtration_hidden=filtration_hidden,
+                            coord_fun_count=coord_fun_count,
+                            dropout=dropout,
+                            use_dim1=use_dim1,
+                            sigmoid_filtrations=sigmoid_filtrations,
+                        )
+                        for _ in self.routes
+                    ]
+                )
+            )
+        self.route_layers = nn.ModuleList(route_layers)
+
+    def forward(self, batch: Data) -> dict[int, torch.Tensor]:
+        """Return updated cell embeddings keyed by rank."""
+        x_by_rank = {}
+        rank = 0
+        while hasattr(batch, f"x_{rank}"):
+            x_by_rank[rank] = getattr(batch, f"x_{rank}")
+            rank += 1
+        membership = {
+            rank: self._membership(batch, rank, x.device)
+            for rank, x in x_by_rank.items()
+        }
+
+        for layer_routes in self.route_layers:
+            route_outputs: dict[int, list[torch.Tensor]] = {}
+            for route_idx, (src_rank, dst_rank) in enumerate(self.routes):
+                if src_rank not in x_by_rank or dst_rank not in x_by_rank:
+                    continue
+                neighborhood = self.neighborhoods[route_idx]
+                route_model = layer_routes[route_idx]
+                if src_rank == dst_rank:
+                    x_out = self._intrarank_forward(
+                        batch=batch,
+                        route_model=route_model,
+                        neighborhood=neighborhood,
+                        rank=src_rank,
+                        x=x_by_rank[src_rank],
+                        batch_vector=membership[src_rank],
+                    )
+                else:
+                    x_out = self._interrank_forward(
+                        batch=batch,
+                        route_model=route_model,
+                        neighborhood=neighborhood,
+                        src_x=x_by_rank[src_rank],
+                        dst_x=x_by_rank[dst_rank],
+                        src_batch=membership[src_rank],
+                        dst_batch=membership[dst_rank],
+                    )
+                route_outputs.setdefault(dst_rank, []).append(x_out)
+
+            for rank, outputs in route_outputs.items():
+                x_by_rank[rank] = self.activation(torch.stack(outputs).sum(dim=0))
+
+        return {rank: x_by_rank[rank] for rank in sorted(x_by_rank)}
+
+    def _intrarank_forward(
+        self,
+        *,
+        batch: Data,
+        route_model: _TopNetsRouteOperator,
+        neighborhood: str,
+        rank: int,
+        x: torch.Tensor,
+        batch_vector: torch.Tensor,
+    ) -> torch.Tensor:
+        matrix = _rank_neighborhood_matrix(batch, neighborhood, rank)
+        edge_index = matrix.indices().to(device=x.device, dtype=torch.long)
+        edge_weight = matrix.values().to(device=x.device, dtype=x.dtype)
+        if edge_weight.dim() != 1:
+            edge_weight = None
+        return route_model(
+            x=x,
+            edge_index=edge_index,
+            batch=batch_vector,
+            edge_weight=edge_weight,
+        )
+
+    def _interrank_forward(
+        self,
+        *,
+        batch: Data,
+        route_model: _TopNetsRouteOperator,
+        neighborhood: str,
+        src_x: torch.Tensor,
+        dst_x: torch.Tensor,
+        src_batch: torch.Tensor,
+        dst_batch: torch.Tensor,
+    ) -> torch.Tensor:
+        matrix = batch[neighborhood].coalesce()
+        edge_index = _interrank_edge_index(
+            matrix=matrix,
+            num_dst=dst_x.shape[0],
+            device=dst_x.device,
+        )
+        if edge_index.numel() > 0:
+            edge_index = torch.cat([edge_index, edge_index.flip(0)], dim=1)
+        expanded_x = torch.cat([torch.zeros_like(dst_x), src_x], dim=0)
+        expanded_batch = torch.cat([dst_batch, src_batch], dim=0)
+        expanded_out = route_model(
+            x=expanded_x,
+            edge_index=edge_index,
+            batch=expanded_batch,
+        )
+        return expanded_out[: dst_x.shape[0]]
+
+    @staticmethod
+    def _membership(batch: Data, rank: int, device: torch.device) -> torch.Tensor:
+        batch_key = f"batch_{rank}"
+        if hasattr(batch, batch_key):
+            return getattr(batch, batch_key).to(device=device, dtype=torch.long)
+
+        x = getattr(batch, f"x_{rank}")
+        if not hasattr(batch, "cell_statistics"):
+            return torch.zeros(x.shape[0], dtype=torch.long, device=device)
+
+        stats = batch.cell_statistics.to(device=device)
+        if rank >= stats.shape[1]:
+            return torch.zeros(x.shape[0], dtype=torch.long, device=device)
+
+        graph_ids = torch.arange(stats.shape[0], device=device, dtype=torch.long)
+        return torch.repeat_interleave(graph_ids, stats[:, rank].to(torch.long))
+
+
+def _rank_neighborhood_matrix(
+    batch: Data,
+    neighborhood: str,
+    rank: int,
+) -> torch.Tensor:
+    if neighborhood in batch:
+        return batch[neighborhood].coalesce()
+    if rank == 0 and "incidence_1" in batch:
+        return _node_adjacency_from_incidence(batch["incidence_1"].coalesce())
+    msg = f"Missing combinatorial neighborhood: {neighborhood}"
+    raise KeyError(msg)
+
+
+def _node_adjacency_from_incidence(incidence: torch.Tensor) -> torch.Tensor:
+    indices = incidence.indices().to(dtype=torch.long)
+    num_nodes = incidence.shape[0]
+    if indices.numel() == 0:
+        return torch.sparse_coo_tensor(
+            indices.new_empty((2, 0)),
+            incidence.values().new_empty((0,)),
+            (num_nodes, num_nodes),
+            device=incidence.device,
+        ).coalesce()
+
+    rows: list[int] = []
+    cols: list[int] = []
+    node_ids, edge_ids = indices[0], indices[1]
+    for edge_id in edge_ids.unique(sorted=True).tolist():
+        nodes = node_ids[edge_ids == edge_id].unique(sorted=True)
+        if nodes.numel() < 2:
+            continue
+        src = nodes.repeat_interleave(nodes.numel())
+        dst = nodes.repeat(nodes.numel())
+        mask = src != dst
+        rows.extend(src[mask].tolist())
+        cols.extend(dst[mask].tolist())
+
+    if not rows:
+        edge_index = indices.new_empty((2, 0))
+        values = incidence.values().new_empty((0,))
+    else:
+        edge_index = torch.tensor(
+            [rows, cols],
+            dtype=torch.long,
+            device=incidence.device,
+        )
+        values = incidence.values().new_ones(edge_index.shape[1])
+    return torch.sparse_coo_tensor(
+        edge_index,
+        values,
+        (num_nodes, num_nodes),
+        device=incidence.device,
+    ).coalesce()
+
+
+def _interrank_edge_index(
+    matrix: torch.Tensor,
+    num_dst: int,
+    device: torch.device,
+) -> torch.Tensor:
+    indices = matrix.indices().to(device=device, dtype=torch.long)
+    if indices.numel() == 0:
+        return indices.new_empty((2, 0))
+    dst_nodes = indices[0]
+    src_nodes = indices[1] + num_dst
+    return torch.stack([src_nodes, dst_nodes], dim=0)
+
+
+def _make_activation(name: str) -> nn.Module:
+    if name == "relu":
+        return nn.ReLU()
+    if name == "elu":
+        return nn.ELU()
+    if name == "tanh":
+        return nn.Tanh()
+    if name == "sigmoid":
+        return nn.Sigmoid()
+    if name == "id":
+        return nn.Identity()
+    msg = f"Unsupported activation: {name}"
+    raise ValueError(msg)

--- a/topobench/nn/backbones/graph/topnets.py
+++ b/topobench/nn/backbones/graph/topnets.py
@@ -1,4 +1,4 @@
-"""TopNets graph backbone with learned-filtration PH features.
+"""TopNets graph route operator with learned-filtration PH features.
 
 This module ports the challenge-relevant graph-classification model from the
 reference TopNets repository. The original graph models combine a GCN/GIN
@@ -9,8 +9,8 @@ with message-passing features.
 
 The reference code calls compiled ``ph_cpu``/``rephine_mt`` extensions. This
 TopoBench implementation keeps the same standard graph-filtration branch in
-portable PyTorch: it computes 0-dimensional union-find pairs and graph-cycle
-1-dimensional proxy pairs from the learned filtration values.
+portable PyTorch using batched proxy persistence pairs from the learned
+filtration values.
 """
 
 from __future__ import annotations
@@ -198,14 +198,24 @@ class _TopologicalFiltrationLayer(nn.Module):
         self, persistence: torch.Tensor
     ) -> torch.Tensor:
         """Apply TOGL coordinate functions to persistence pairs."""
-        per_filtration = [
-            torch.cat(
-                [module(filtration_pairs) for module in self.coord_modules],
-                dim=1,
+        num_filtrations, num_items, _ = persistence.shape
+        if num_items == 0:
+            return persistence.new_zeros((0, self.topological_dim))
+
+        flat_pairs = persistence.reshape(num_filtrations * num_items, 2)
+        flat_activations = torch.cat(
+            [module(flat_pairs) for module in self.coord_modules],
+            dim=1,
+        )
+        return (
+            flat_activations.view(
+                num_filtrations,
+                num_items,
+                self.coord_dim,
             )
-            for filtration_pairs in persistence
-        ]
-        return torch.cat(per_filtration, dim=1)
+            .transpose(0, 1)
+            .reshape(num_items, self.topological_dim)
+        )
 
     def _collapse_dim1(
         self,
@@ -238,48 +248,76 @@ class _TopologicalFiltrationLayer(nn.Module):
         edge_batch: torch.Tensor,
         num_graphs: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Compute standard graph-filtration H0 pairs and H1 cycle pairs."""
-        persistence0 = []
-        persistence1 = []
+        """Compute batched proxy H0 and H1 persistence pairs."""
+        num_nodes = filtrations.shape[0]
+        graph_max = scatter(
+            filtrations,
+            batch,
+            dim=0,
+            reduce="max",
+            dim_size=num_graphs,
+        )
 
-        for filtration_id in range(self.num_filtrations):
-            values = filtrations[:, filtration_id]
-            pairs0 = values.new_zeros(values.shape[0], 2)
-            pairs1 = values.new_zeros(edge_index.shape[1], 2)
+        if edge_index.numel() == 0:
+            persistence0 = torch.stack(
+                [filtrations.t(), filtrations.t()],
+                dim=2,
+            )
+            persistence1 = filtrations.new_zeros(
+                (self.num_filtrations, 0, 2)
+            )
+            return persistence0, persistence1
 
-            for graph_id in range(num_graphs):
-                node_idx = (batch == graph_id).nonzero(as_tuple=False).view(-1)
-                if node_idx.numel() == 0:
-                    continue
+        row, col = edge_index
+        edge_values = self._edge_filtration_values(filtrations, edge_index)
 
-                edge_idx = (
-                    (edge_batch == graph_id).nonzero(as_tuple=False).view(-1)
-                )
-                graph_max = values[node_idx].max()
-                if edge_idx.numel() > 0:
-                    edge_values = self._edge_filtration_values(
-                        values, edge_index[:, edge_idx]
-                    )
-                    graph_max = torch.maximum(graph_max, edge_values.max())
-                    self._fill_graph_pairs(
-                        values=values,
-                        edge_index=edge_index,
-                        edge_idx=edge_idx,
-                        edge_values=edge_values,
-                        node_idx=node_idx,
-                        graph_max=graph_max,
-                        pairs0=pairs0,
-                        pairs1=pairs1,
-                    )
-                else:
-                    pairs0[node_idx] = torch.stack(
-                        [values[node_idx], values[node_idx]], dim=1
-                    )
+        incident_nodes = torch.cat([row, col], dim=0)
+        incident_values = torch.cat([edge_values, edge_values], dim=0)
+        min_incident_death = scatter(
+            incident_values,
+            incident_nodes,
+            dim=0,
+            reduce="min",
+            dim_size=num_nodes,
+        )
 
-            persistence0.append(pairs0)
-            persistence1.append(pairs1)
+        has_incident_edge = torch.zeros(
+            num_nodes,
+            dtype=torch.bool,
+            device=filtrations.device,
+        )
+        has_incident_edge[incident_nodes] = True
 
-        return torch.stack(persistence0), torch.stack(persistence1)
+        graph_edge_count = scatter(
+            torch.ones(
+                edge_batch.shape[0],
+                dtype=filtrations.dtype,
+                device=filtrations.device,
+            ),
+            edge_batch,
+            dim=0,
+            reduce="sum",
+            dim_size=num_graphs,
+        )
+        graph_has_edges = graph_edge_count > 0
+
+        death0 = torch.where(
+            has_incident_edge[:, None],
+            min_incident_death,
+            graph_max[batch],
+        )
+        death0 = torch.where(
+            graph_has_edges[batch, None],
+            death0,
+            filtrations,
+        )
+        persistence0 = torch.stack([filtrations.t(), death0.t()], dim=2)
+
+        persistence1 = torch.stack(
+            [edge_values.t(), graph_max[edge_batch].t()],
+            dim=2,
+        )
+        return persistence0, persistence1
 
     @staticmethod
     def _edge_filtration_values(
@@ -287,78 +325,8 @@ class _TopologicalFiltrationLayer(nn.Module):
     ) -> torch.Tensor:
         return torch.maximum(values[edge_index[0]], values[edge_index[1]])
 
-    @staticmethod
-    def _fill_graph_pairs(
-        values: torch.Tensor,
-        edge_index: torch.Tensor,
-        edge_idx: torch.Tensor,
-        edge_values: torch.Tensor,
-        node_idx: torch.Tensor,
-        graph_max: torch.Tensor,
-        pairs0: torch.Tensor,
-        pairs1: torch.Tensor,
-    ) -> None:
-        """Populate persistence pairs for a single graph and filtration."""
-        parent = list(range(node_idx.numel()))
-        birth = list(range(node_idx.numel()))
-        paired_nodes: set[int] = set()
-        local_of_global = {
-            int(node.item()): pos for pos, node in enumerate(node_idx)
-        }
 
-        def find(component: int) -> int:
-            while parent[component] != component:
-                parent[component] = parent[parent[component]]
-                component = parent[component]
-            return component
-
-        for edge_position in torch.argsort(edge_values).tolist():
-            global_edge_pos = int(edge_idx[edge_position].item())
-            source = int(edge_index[0, global_edge_pos].item())
-            target = int(edge_index[1, global_edge_pos].item())
-            source_root = find(local_of_global[source])
-            target_root = find(local_of_global[target])
-            death = edge_values[edge_position]
-
-            if source_root == target_root:
-                pairs1[global_edge_pos] = torch.stack([death, graph_max])
-                continue
-
-            source_birth = values[node_idx[birth[source_root]]]
-            target_birth = values[node_idx[birth[target_root]]]
-            source_birth_value = float(source_birth.detach())
-            target_birth_value = float(target_birth.detach())
-            source_birth_pos = birth[source_root]
-            target_birth_pos = birth[target_root]
-
-            if (
-                source_birth_value > target_birth_value
-                or (
-                    source_birth_value == target_birth_value
-                    and source_birth_pos > target_birth_pos
-                )
-            ):
-                dying_root = source_root
-                surviving_root = target_root
-            else:
-                dying_root = target_root
-                surviving_root = source_root
-
-            dying_node = int(node_idx[birth[dying_root]].item())
-            pairs0[dying_node] = torch.stack([values[dying_node], death])
-            paired_nodes.add(dying_node)
-            parent[dying_root] = surviving_root
-
-        for local_pos, global_node in enumerate(node_idx.tolist()):
-            root = find(local_pos)
-            birth_node = int(node_idx[birth[root]].item())
-            if global_node == birth_node and global_node not in paired_nodes:
-                pairs0[global_node] = torch.stack(
-                    [values[global_node], graph_max]
-                )
-
-
-class TopNetsBackbone(nn.Module):
+class _TopNetsRouteOperator(nn.Module):
     """Continuous TopNets-style graph backbone for TopoBench.
 
     Parameters

--- a/topobench/nn/backbones/graph/topnets.py
+++ b/topobench/nn/backbones/graph/topnets.py
@@ -1,6 +1,6 @@
 """TopNets graph route operator with learned-filtration PH features.
 
-This module ports the challenge-relevant graph-classification model from the
+This module adapts the challenge-relevant graph-classification route from the
 reference TopNets repository. The original graph models combine a GCN/GIN
 state evolution with a TOGL/RePHINE-style topological layer: node embeddings
 parameterize graph filtrations, persistence pairs are transformed by learned
@@ -8,9 +8,9 @@ coordinate functions, and the resulting topological features are fused back
 with message-passing features.
 
 The reference code calls compiled ``ph_cpu``/``rephine_mt`` extensions. This
-TopoBench implementation keeps the same standard graph-filtration branch in
-portable PyTorch using batched proxy persistence pairs from the learned
-filtration values.
+TopoBench implementation keeps the learned standard-filtration interface while
+replacing compiled persistence with portable PyTorch proxy pairs from the
+learned filtration values.
 """
 
 from __future__ import annotations

--- a/topobench/nn/backbones/graph/topnets.py
+++ b/topobench/nn/backbones/graph/topnets.py
@@ -1,0 +1,545 @@
+"""TopNets graph backbone with learned-filtration PH features.
+
+This module ports the challenge-relevant graph-classification model from the
+reference TopNets repository. The original graph models combine a GCN/GIN
+state evolution with a TOGL/RePHINE-style topological layer: node embeddings
+parameterize graph filtrations, persistence pairs are transformed by learned
+coordinate functions, and the resulting topological features are fused back
+with message-passing features.
+
+The reference code calls compiled ``ph_cpu``/``rephine_mt`` extensions. This
+TopoBench implementation keeps the same standard graph-filtration branch in
+portable PyTorch: it computes 0-dimensional union-find pairs and graph-cycle
+1-dimensional proxy pairs from the learned filtration values.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torch_geometric.nn import GCNConv, GINConv
+from torch_geometric.utils import scatter
+
+
+class _TriangleTransform(nn.Module):
+    """Triangle coordinate function from TOGL."""
+
+    def __init__(self, output_dim: int) -> None:
+        super().__init__()
+        self.t_param = nn.Parameter(torch.randn(output_dim) * 0.1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.relu(x[:, 1, None] - torch.abs(self.t_param - x[:, 0, None]))
+
+
+class _GaussianTransform(nn.Module):
+    """Gaussian coordinate function from TOGL."""
+
+    def __init__(self, output_dim: int) -> None:
+        super().__init__()
+        self.t_param = nn.Parameter(torch.randn(output_dim) * 0.1)
+        self.sigma = nn.Parameter(torch.ones(1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        sigma = self.sigma.abs().clamp_min(1e-6)
+        return torch.exp(
+            -((x[:, :, None] - self.t_param).pow(2).sum(dim=1))
+            / (2 * sigma.pow(2))
+        )
+
+
+class _LineTransform(nn.Module):
+    """Linear coordinate function from TOGL."""
+
+    def __init__(self, output_dim: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(2, output_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+class _RationalHatTransform(nn.Module):
+    """Rational hat coordinate function used for persistence barcodes."""
+
+    def __init__(self, output_dim: int) -> None:
+        super().__init__()
+        self.c_param = nn.Parameter(torch.randn(1, output_dim) * 0.1)
+        self.r_param = nn.Parameter(torch.randn(1, output_dim) * 0.1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        distance = torch.norm(x[:, :, None] - self.c_param, p=1, dim=1)
+        radius_gap = torch.abs(self.r_param.abs() - distance)
+        return (1 / (1 + distance)) - (1 / (1 + radius_gap))
+
+
+class _GraphConvBlock(nn.Module):
+    """GCN/GIN block matching the graph layers used by TopNets."""
+
+    def __init__(
+        self,
+        gnn_type: str,
+        in_channels: int,
+        out_channels: int,
+        dropout: float,
+        activation: bool,
+    ) -> None:
+        super().__init__()
+        self.gnn_type = gnn_type.lower()
+        self.activation = nn.ReLU() if activation else nn.Identity()
+        self.dropout = nn.Dropout(dropout)
+
+        if self.gnn_type == "gcn":
+            self.conv = GCNConv(in_channels, out_channels)
+        elif self.gnn_type == "gin":
+            gin_mlp = nn.Sequential(
+                nn.Linear(in_channels, out_channels),
+                nn.ReLU(),
+                nn.Linear(out_channels, out_channels),
+            )
+            self.conv = GINConv(gin_mlp)
+        else:
+            msg = "gnn_type must be either 'gcn' or 'gin'"
+            raise ValueError(msg)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply one graph-convolution block."""
+        if self.gnn_type == "gcn":
+            x = self.conv(x, edge_index, edge_weight=edge_weight)
+        else:
+            x = self.conv(x, edge_index)
+        return self.dropout(self.activation(x))
+
+
+class _TopologicalFiltrationLayer(nn.Module):
+    """Learned-filtration layer used inside TopNets."""
+
+    def __init__(
+        self,
+        channels: int,
+        num_filtrations: int = 8,
+        filtration_hidden: int = 16,
+        coord_fun_count: int = 3,
+        use_dim1: bool = True,
+        sigmoid_filtrations: bool = True,
+    ) -> None:
+        super().__init__()
+        final_activation = nn.Sigmoid() if sigmoid_filtrations else nn.Identity()
+        self.filtrations = nn.Sequential(
+            nn.Linear(channels, filtration_hidden),
+            nn.ReLU(),
+            nn.Linear(filtration_hidden, num_filtrations),
+            final_activation,
+        )
+
+        self.coord_modules = nn.ModuleList(
+            [
+                _TriangleTransform(coord_fun_count),
+                _GaussianTransform(coord_fun_count),
+                _LineTransform(coord_fun_count),
+                _RationalHatTransform(coord_fun_count),
+            ]
+        )
+        self.num_filtrations = num_filtrations
+        self.coord_dim = coord_fun_count * len(self.coord_modules)
+        self.topological_dim = self.num_filtrations * self.coord_dim
+        self.use_dim1 = use_dim1
+
+        self.out = nn.Linear(self.topological_dim, channels)
+        self.bn = nn.BatchNorm1d(channels)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor,
+        edge_batch: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Fuse learned-filtration topological features with node features."""
+        num_graphs = _num_graphs(batch)
+        filtrations = self.filtrations(x)
+        persistence0, persistence1 = self._compute_persistence(
+            filtrations=filtrations,
+            edge_index=edge_index,
+            batch=batch,
+            edge_batch=edge_batch,
+            num_graphs=num_graphs,
+        )
+
+        node_topology = self._coordinate_activations(persistence0)
+        update = self.out(node_topology)
+        if update.shape[0] > 1:
+            update = self.bn(update)
+        x = x + update
+
+        if self.use_dim1:
+            graph_topology = self._collapse_dim1(
+                persistence1=persistence1,
+                edge_batch=edge_batch,
+                num_graphs=num_graphs,
+            )
+        else:
+            graph_topology = scatter(
+                node_topology,
+                batch,
+                dim=0,
+                reduce="mean",
+                dim_size=num_graphs,
+            )
+        return x, graph_topology
+
+    def _coordinate_activations(
+        self, persistence: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply TOGL coordinate functions to persistence pairs."""
+        per_filtration = [
+            torch.cat(
+                [module(filtration_pairs) for module in self.coord_modules],
+                dim=1,
+            )
+            for filtration_pairs in persistence
+        ]
+        return torch.cat(per_filtration, dim=1)
+
+    def _collapse_dim1(
+        self,
+        persistence1: torch.Tensor,
+        edge_batch: torch.Tensor,
+        num_graphs: int,
+    ) -> torch.Tensor:
+        """Pool 1-dimensional persistence coordinates to graph features."""
+        if edge_batch.numel() == 0:
+            return persistence1.new_zeros(num_graphs, self.topological_dim)
+
+        edge_topology = self._coordinate_activations(persistence1)
+        mask = (persistence1 != 0).any(dim=2).any(dim=0)
+        if not mask.any():
+            return edge_topology.new_zeros(num_graphs, self.topological_dim)
+
+        return scatter(
+            edge_topology[mask],
+            edge_batch[mask],
+            dim=0,
+            reduce="sum",
+            dim_size=num_graphs,
+        )
+
+    def _compute_persistence(
+        self,
+        filtrations: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor,
+        edge_batch: torch.Tensor,
+        num_graphs: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute standard graph-filtration H0 pairs and H1 cycle pairs."""
+        persistence0 = []
+        persistence1 = []
+
+        for filtration_id in range(self.num_filtrations):
+            values = filtrations[:, filtration_id]
+            pairs0 = values.new_zeros(values.shape[0], 2)
+            pairs1 = values.new_zeros(edge_index.shape[1], 2)
+
+            for graph_id in range(num_graphs):
+                node_idx = (batch == graph_id).nonzero(as_tuple=False).view(-1)
+                if node_idx.numel() == 0:
+                    continue
+
+                edge_idx = (
+                    (edge_batch == graph_id).nonzero(as_tuple=False).view(-1)
+                )
+                graph_max = values[node_idx].max()
+                if edge_idx.numel() > 0:
+                    edge_values = self._edge_filtration_values(
+                        values, edge_index[:, edge_idx]
+                    )
+                    graph_max = torch.maximum(graph_max, edge_values.max())
+                    self._fill_graph_pairs(
+                        values=values,
+                        edge_index=edge_index,
+                        edge_idx=edge_idx,
+                        edge_values=edge_values,
+                        node_idx=node_idx,
+                        graph_max=graph_max,
+                        pairs0=pairs0,
+                        pairs1=pairs1,
+                    )
+                else:
+                    pairs0[node_idx] = torch.stack(
+                        [values[node_idx], values[node_idx]], dim=1
+                    )
+
+            persistence0.append(pairs0)
+            persistence1.append(pairs1)
+
+        return torch.stack(persistence0), torch.stack(persistence1)
+
+    @staticmethod
+    def _edge_filtration_values(
+        values: torch.Tensor, edge_index: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.maximum(values[edge_index[0]], values[edge_index[1]])
+
+    @staticmethod
+    def _fill_graph_pairs(
+        values: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_idx: torch.Tensor,
+        edge_values: torch.Tensor,
+        node_idx: torch.Tensor,
+        graph_max: torch.Tensor,
+        pairs0: torch.Tensor,
+        pairs1: torch.Tensor,
+    ) -> None:
+        """Populate persistence pairs for a single graph and filtration."""
+        parent = list(range(node_idx.numel()))
+        birth = list(range(node_idx.numel()))
+        paired_nodes: set[int] = set()
+        local_of_global = {
+            int(node.item()): pos for pos, node in enumerate(node_idx)
+        }
+
+        def find(component: int) -> int:
+            while parent[component] != component:
+                parent[component] = parent[parent[component]]
+                component = parent[component]
+            return component
+
+        for edge_position in torch.argsort(edge_values).tolist():
+            global_edge_pos = int(edge_idx[edge_position].item())
+            source = int(edge_index[0, global_edge_pos].item())
+            target = int(edge_index[1, global_edge_pos].item())
+            source_root = find(local_of_global[source])
+            target_root = find(local_of_global[target])
+            death = edge_values[edge_position]
+
+            if source_root == target_root:
+                pairs1[global_edge_pos] = torch.stack([death, graph_max])
+                continue
+
+            source_birth = values[node_idx[birth[source_root]]]
+            target_birth = values[node_idx[birth[target_root]]]
+            source_birth_value = float(source_birth.detach())
+            target_birth_value = float(target_birth.detach())
+            source_birth_pos = birth[source_root]
+            target_birth_pos = birth[target_root]
+
+            if (
+                source_birth_value > target_birth_value
+                or (
+                    source_birth_value == target_birth_value
+                    and source_birth_pos > target_birth_pos
+                )
+            ):
+                dying_root = source_root
+                surviving_root = target_root
+            else:
+                dying_root = target_root
+                surviving_root = source_root
+
+            dying_node = int(node_idx[birth[dying_root]].item())
+            pairs0[dying_node] = torch.stack([values[dying_node], death])
+            paired_nodes.add(dying_node)
+            parent[dying_root] = surviving_root
+
+        for local_pos, global_node in enumerate(node_idx.tolist()):
+            root = find(local_pos)
+            birth_node = int(node_idx[birth[root]].item())
+            if global_node == birth_node and global_node not in paired_nodes:
+                pairs0[global_node] = torch.stack(
+                    [values[global_node], graph_max]
+                )
+
+
+class TopNetsBackbone(nn.Module):
+    """Continuous TopNets-style graph backbone for TopoBench.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input node feature dimension.
+    hidden_channels : int
+        Hidden node feature dimension used by the GNN and topology layer.
+    num_steps : int, optional
+        Number of fixed integration steps for the continuous TopNets dynamics.
+    gnn_type : str, optional
+        Message-passing layer type, either ``"gcn"`` or ``"gin"``.
+    num_filtrations : int, optional
+        Number of learned filtration functions.
+    filtration_hidden : int, optional
+        Hidden dimension of the filtration MLP.
+    coord_fun_count : int, optional
+        Number of outputs per TOGL coordinate transform.
+    dropout : float, optional
+        Dropout applied in graph-convolution blocks.
+    use_dim1 : bool, optional
+        Whether to include cycle-based 1-dimensional topological summaries.
+    sigmoid_filtrations : bool, optional
+        Whether to constrain filtration values with a sigmoid.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_steps: int = 4,
+        gnn_type: str = "gcn",
+        num_filtrations: int = 8,
+        filtration_hidden: int = 16,
+        coord_fun_count: int = 3,
+        dropout: float = 0.0,
+        use_dim1: bool = True,
+        sigmoid_filtrations: bool = True,
+    ) -> None:
+        super().__init__()
+        if num_steps <= 0:
+            msg = "num_steps must be positive"
+            raise ValueError(msg)
+
+        self.hidden_channels = hidden_channels
+        self.out_channels = hidden_channels
+        self.num_steps = num_steps
+        self.input_projection = nn.Linear(in_channels, hidden_channels)
+        self.first_gnn = _GraphConvBlock(
+            gnn_type=gnn_type,
+            in_channels=hidden_channels + 1,
+            out_channels=hidden_channels,
+            dropout=dropout,
+            activation=True,
+        )
+        self.topology = _TopologicalFiltrationLayer(
+            channels=hidden_channels,
+            num_filtrations=num_filtrations,
+            filtration_hidden=filtration_hidden,
+            coord_fun_count=coord_fun_count,
+            use_dim1=use_dim1,
+            sigmoid_filtrations=sigmoid_filtrations,
+        )
+        self.second_gnn = _GraphConvBlock(
+            gnn_type=gnn_type,
+            in_channels=hidden_channels,
+            out_channels=hidden_channels,
+            dropout=dropout,
+            activation=False,
+        )
+        self.node_readout = nn.Sequential(
+            nn.Linear(hidden_channels, 2 * hidden_channels),
+            nn.ReLU(),
+            nn.Linear(2 * hidden_channels, hidden_channels),
+        )
+        self.topology_projection = nn.Linear(
+            self.topology.topological_dim, hidden_channels
+        )
+        self.output_projection = nn.Sequential(
+            nn.Linear(2 * hidden_channels, hidden_channels),
+            nn.ReLU(),
+            nn.Linear(hidden_channels, hidden_channels),
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Run fixed-step TopNets dynamics and return node embeddings."""
+        del kwargs
+        batch = _ensure_batch(batch, x.shape[0], x.device)
+        unique_edges, edge_batch = _unique_undirected_edges(
+            edge_index=edge_index,
+            batch=batch,
+            num_nodes=x.shape[0],
+        )
+
+        h = self.input_projection(x.float())
+        graph_topology = []
+        step_size = 1.0 / self.num_steps
+        denom = max(self.num_steps - 1, 1)
+
+        for step in range(self.num_steps):
+            time = h.new_full((h.shape[0], 1), step / denom)
+            rhs = self.first_gnn(
+                torch.cat([time, h], dim=1),
+                edge_index=edge_index,
+                edge_weight=edge_weight,
+            )
+            rhs, topo = self.topology(
+                rhs,
+                edge_index=unique_edges,
+                batch=batch,
+                edge_batch=edge_batch,
+            )
+            rhs = self.second_gnn(
+                rhs,
+                edge_index=edge_index,
+                edge_weight=edge_weight,
+            )
+            h = h + step_size * rhs
+            graph_topology.append(topo)
+
+        topo_embedding = torch.stack(graph_topology).mean(dim=0)
+        topo_embedding = self.topology_projection(topo_embedding)
+        node_embedding = self.node_readout(h)
+        return self.output_projection(
+            torch.cat([node_embedding, topo_embedding[batch]], dim=1)
+        )
+
+
+def _ensure_batch(
+    batch: torch.Tensor | None, num_nodes: int, device: torch.device
+) -> torch.Tensor:
+    if batch is None:
+        return torch.zeros(num_nodes, dtype=torch.long, device=device)
+    return batch.to(device=device, dtype=torch.long)
+
+
+def _num_graphs(batch: torch.Tensor) -> int:
+    if batch.numel() == 0:
+        return 1
+    return int(batch.max().item()) + 1
+
+
+def _unique_undirected_edges(
+    edge_index: torch.Tensor,
+    batch: torch.Tensor,
+    num_nodes: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return one undirected edge per graph edge for persistence."""
+    if edge_index.numel() == 0:
+        empty_edges = edge_index.new_empty((2, 0))
+        empty_batch = batch.new_empty((0,))
+        return empty_edges, empty_batch
+
+    row, col = edge_index
+    source = torch.minimum(row, col)
+    target = torch.maximum(row, col)
+    mask = (source != target) & (batch[source] == batch[target])
+
+    if not mask.any():
+        empty_edges = edge_index.new_empty((2, 0))
+        empty_batch = batch.new_empty((0,))
+        return empty_edges, empty_batch
+
+    source = source[mask]
+    target = target[mask]
+    keys = source * num_nodes + target
+    order = torch.argsort(keys)
+    sorted_keys = keys[order]
+    keep = torch.ones(
+        sorted_keys.shape[0], dtype=torch.bool, device=edge_index.device
+    )
+    keep[1:] = sorted_keys[1:] != sorted_keys[:-1]
+    unique_positions = order[keep]
+    unique_edges = torch.stack(
+        [source[unique_positions], target[unique_positions]], dim=0
+    )
+    return unique_edges, batch[unique_edges[0]]


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

Adds a TDL Challenge 2026 Track 2 implementation for TopNets as `model=combinatorial/topnets`.

Reference:
- Paper: https://arxiv.org/pdf/2406.03164
- Code: https://github.com/Aalto-QuML/TopNets

Implementation details:
- adds a combinatorial-domain TopNets backbone using TopoBench `GraphTriangleInducedCC` lifting
- uses `TuneWrapper` and `PropagateSignalDown` so the submitted entrypoint is Track 2 (`model_domain: combinatorial`)
- uses a lightweight challenge config (`hidden_channels=32`, one TopNets layer/step) so the official 72-run grid is feasible
- keeps `topobench/nn/backbones/graph/topnets.py` as a private graph-neighborhood route helper used by the Track 2 combinatorial backbone, not as a submitted graph-model entrypoint
- removes the previous `graph/topnets` config entrypoint from the PR diff
- includes focused tests for proxy persistence pairs and inter-rank route feature initialization
- challenge notebook `MODEL_CONFIG` set to `combinatorial/topnets`

Validation:
- `PYENV_VERSION=TDL python -m pytest test/nn/backbones/graph/test_topnets.py test/nn/backbones/combinatorial/test_topnets.py test/pipeline/test_pipeline.py -q` -> 17 passed
- `PYENV_VERSION=TDL python -m pytest test/pipeline/test_pipeline.py -q` with baseline smoke models plus `combinatorial/topnets` -> 1 passed
- focused ruff on TopNets-touched files -> passed
- focused coverage run across TopNets graph route helper and combinatorial backbone -> completed locally
- official challenge sanity grid for `model_config="combinatorial/topnets"` -> all 24 configs passed

`results.json` status: committed at `2026_tdl_challenge/outputs/topnets/results.json` with 72 completed challenge runs across train seeds 42, 43, and 44.

`results.json` provenance: generated from the checked-in `2026_tdl_challenge/utils.py` helpers via CLI with `model_config="combinatorial/topnets"`; `run_evaluation.ipynb` now sets the same `MODEL_CONFIG`.

## Issue

TDL Challenge 2026 Track 2 model submission for TopNets.

## Additional context

Official `results.json` artifact is included in this PR.

This is a TopoBench Track 2 adaptation of TopNets, not an exact reproduction of the official TopNets experiment stack. It uses a portable learned-filtration proxy persistence path and a lightweight challenge config for the official 72-run grid.

### Fidelity note

This submission is a TopoBench Track 2 adaptation of TopNets, not a drop-in reproduction of the upstream experiment stack. The reference TopNets graph-classification path uses the RePHINE/TOGL code path and compiled `ph_cpu` / `rephine_mt` kernels to compute `standard` / `rephine` persistence diagrams. In this PR, those kernels are intentionally replaced by an autograd-compatible PyTorch proxy that constructs H0/H1-style persistence pairs from the learned filtration values, so the model can run portably inside the TopoBench/GraphUniverse challenge pipeline without custom compiled extensions.

The adaptation preserves the challenge-relevant TopNets route structure: GCN/GIN state evolution, learned filtration MLPs, TOGL-style coordinate transforms, topology feature fusion, and node/topology embedding fusion. It does not claim bit-for-bit or diagram-level equivalence to the upstream RePHINE persistence kernels.

For Track 2, the route operator is applied over TopoBench combinatorial-complex neighborhoods and exposed through `TuneWrapper` + `PropagateSignalDown`. The submitted config is intentionally lightweight (`hidden_channels=32`, one layer/step, `use_dim1=false`) for the official 72-run GraphUniverse grid; this is a computational adaptation under the challenge criteria, not a claim of exact upstream hyperparameter reproduction.

The committed results use TopoBench's existing `GraphTriangleInducedCC` graph-to-combinatorial lifting with `complex_dim=3`. This lifting is not a clique-complex transform that preserves every structural triangle as a separate 2-cell; the TopNets adaptation runs over the rank neighborhoods produced by that available TopoBench lifting. The lifting may materialize rank-3 cells / `incidence_3`, but the submitted TopNets path intentionally consumes only ranks 0/1/2 through `selected_dimensions: [0, 1, 2]`, the configured incidence routes, and `PropagateSignalDown` with three cell dimensions. Changing the lifting dimension, adding rank-3 routes, or otherwise consuming `incidence_3` would change preprocessing/model behavior and would require regenerating `results.json`.

`use_dim1=false` is the submitted runtime-motivated challenge default. It disables proxy H1/cycle-summary pooling inside the route operator, while keeping H0-style learned-filtration node summaries and higher-order signal through the configured combinatorial incidence routes (`down_incidence-1`, `down_incidence-2`, `up_incidence-1`). The implementation supports the dim-1 proxy path, but the committed 72-run artifact uses the lighter route to keep the official grid feasible; this is a computational Track 2 adaptation, not a full H1-persistence TopNets reproduction for the triangle-counting task.

For inter-rank incidence routes (`down_incidence-*` / `up_incidence-*`), destination-cell features are intentionally zero-initialized inside the bipartite route graph, while source-cell features provide the signal into the destination block. The sparse incidence matrices are used only for their nonzero support to build an unweighted bipartite route graph. Incidence values, signs, and weights are not propagated as edge weights on those routes; this is intentional for the submitted Track 2 adaptation and differs from intrarank neighborhoods, where sparse matrix values are passed as `edge_weight` when available. The route output is then sliced back to destination-rank embeddings before TopoBench readout.

Note: `topobench/nn/backbones/graph/topnets.py` is a private graph-neighborhood route helper used by the Track 2 combinatorial backbone; it is not a submitted graph-model entrypoint. The only submitted TopNets model config is `configs/model/combinatorial/topnets.yaml` (`model=combinatorial/topnets`), and this PR intentionally does not add `configs/model/graph/topnets.yaml`.

