### PR TITLE
Track: Track1; Team name: TJPaik; Model: GFT

### DIFF
--- a/2026_tdl_challenge/outputs/gft/results.json
+++ b/2026_tdl_challenge/outputs/gft/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "gft",
+    "model_config": "graph/gft",
+    "generated_at_utc": "2026-05-25T13:43:45.467468+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2447407245635986,
+      "test_best_rerun_accuracy": 0.32676294445991516,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3155321180820465,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3304683268070221,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31599053740501404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.349071741104126,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33703872561454773,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3556039333343506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3314233422279358,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39808234572410583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38532355427742004,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42230117321014404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39200854301452637,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.89094996878079,
+        "AvgTime/train_epoch_std": 0.06035342910957406,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2399630546569824,
+      "test_best_rerun_accuracy": 0.3249293267726898,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3133547306060791,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3215295374393463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30823591351509094,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35014134645462036,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3348613381385803,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3499503433704376,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3269157409667969,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3983115553855896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38738635182380676,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4229123592376709,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38685154914855957,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8776045695118521,
+        "AvgTime/train_epoch_std": 0.07153506332797953,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.238690137863159,
+      "test_best_rerun_accuracy": 0.32427993416786194,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3148063123226166,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31801512837409973,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3040721118450165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34658873081207275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3331805467605591,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3447933495044708,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31641072034835815,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3977385461330414,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38028115034103394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4120635688304901,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3730613589286804,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8645894687909347,
+        "AvgTime/train_epoch_std": 0.030129644227087075,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.28025484085083,
+      "test_best_rerun_accuracy": 0.31408053636550903,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3241271376609802,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3237069249153137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3361601233482361,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3288257420063019,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3436473309993744,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3389105498790741,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3769959509372711,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37378713488578796,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40602797269821167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40721216797828674,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8813908582038068,
+        "AvgTime/train_epoch_std": 0.046922533704857855,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2952167987823486,
+      "test_best_rerun_accuracy": 0.31083351373672485,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3134693205356598,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32385972142219543,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32118573784828186,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3317289352416992,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32374513149261475,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3465123474597931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34234854578971863,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37852394580841064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37378713488578796,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4094659686088562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4134005606174469,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8767946217511151,
+        "AvgTime/train_epoch_std": 0.039476303818119285,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.277891159057617,
+      "test_best_rerun_accuracy": 0.3128199279308319,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31843534111976624,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3279089331626892,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32500573992729187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3326839208602905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3271831274032593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34456413984298706,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3438001275062561,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38005194067955017,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37527695298194885,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.408931165933609,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4102681577205658,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.875480979046923,
+        "AvgTime/train_epoch_std": 0.02558195251988919,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.175165891647339,
+      "test_best_rerun_accuracy": 0.3478875458240509,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.296890527009964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.288486510515213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33875772356987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33000993728637695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3128199279308319,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38494154810905457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37798914313316345,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42245396971702576,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4122163653373718,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5146306157112122,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5215830206871033,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8683889372306958,
+        "AvgTime/train_epoch_std": 0.029768624237889466,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1784865856170654,
+      "test_best_rerun_accuracy": 0.34697073698043823,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29669952392578125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28772252798080444,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3345557451248169,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32771793007850647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30999311804771423,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3834899663925171,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3761937618255615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41851937770843506,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4059515595436096,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5079838037490845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5177630186080933,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9069389669518721,
+        "AvgTime/train_epoch_std": 0.04581267747496809,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1804089546203613,
+      "test_best_rerun_accuracy": 0.35010313987731934,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3016273081302643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29368171095848083,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3409351408481598,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33382993936538696,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3144625127315521,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3857055604457855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3763083517551422,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4226449728012085,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4095041751861572,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5116128325462341,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5149744153022766,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8828814133353855,
+        "AvgTime/train_epoch_std": 0.06176563061087998,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1912271976470947,
+      "test_best_rerun_accuracy": 0.33868134021759033,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29708153009414673,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29467490315437317,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3379555344581604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32741233706474304,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3153793215751648,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3723737597465515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37607914209365845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4163801670074463,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.41171976923942566,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5077546238899231,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5397661924362183,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8766443871740085,
+        "AvgTime/train_epoch_std": 0.03894521214678125,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2045235633850098,
+      "test_best_rerun_accuracy": 0.3372679352760315,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29734891653060913,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29276493191719055,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34032392501831055,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32538771629333496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3098403215408325,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3758881390094757,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37581175565719604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42039117217063904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4122927784919739,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5110780000686646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5379708409309387,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8836558081886985,
+        "AvgTime/train_epoch_std": 0.04439547332403238,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.200590133666992,
+      "test_best_rerun_accuracy": 0.33978912234306335,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3000229299068451,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29219192266464233,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.343379944562912,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32634273171424866,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3118267357349396,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3714187443256378,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37527695298194885,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42203375697135925,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4093131721019745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5105050206184387,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5369775891304016,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8641742174176202,
+        "AvgTime/train_epoch_std": 0.04108247105784971,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0833969116210938,
+      "test_best_rerun_accuracy": 0.3877301514148712,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27232789993286133,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26285430788993835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26866069436073303,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2645350992679596,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3669493496417999,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3942623436450958,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3807395398616791,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5103521943092346,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5006493926048279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5666590332984924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5420582294464111,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8602399998816891,
+        "AvgTime/train_epoch_std": 0.02857252992495214,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0885510444641113,
+      "test_best_rerun_accuracy": 0.3851325511932373,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2710673213005066,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2574681043624878,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26636871695518494,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2627778947353363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36847734451293945,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38547635078430176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36958515644073486,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5116891860961914,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5048514008522034,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5631828308105469,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5326610207557678,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8528059338623623,
+        "AvgTime/train_epoch_std": 0.016221318510091714,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.1080281734466553,
+      "test_best_rerun_accuracy": 0.3769577443599701,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26663610339164734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25551989674568176,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26147910952568054,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2559783160686493,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3591947555541992,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38123616576194763,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3663763403892517,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5092825889587402,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49656200408935547,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5583696365356445,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.527427613735199,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8920148968696594,
+        "AvgTime/train_epoch_std": 0.05771904571795214,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1208465099334717,
+      "test_best_rerun_accuracy": 0.36969974637031555,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27332112193107605,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27156391739845276,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2587287127971649,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27370309829711914,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38685154914855957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37974634766578674,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39361295104026794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.50836580991745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5064557790756226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5521048307418823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5619222521781921,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8700259761376814,
+        "AvgTime/train_epoch_std": 0.04038561745897809,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.129159450531006,
+      "test_best_rerun_accuracy": 0.370005339384079,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2707616984844208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26449689269065857,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2543739080429077,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2683551013469696,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3840629458427429,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3777599632740021,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39414775371551514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5092061758041382,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5085185766220093,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5585606098175049,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5611200332641602,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8692615985870361,
+        "AvgTime/train_epoch_std": 0.0410031753571899,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1304187774658203,
+      "test_best_rerun_accuracy": 0.37092214822769165,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27110549807548523,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2661777138710022,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2526167035102844,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2638475000858307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3832607567310333,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3724501430988312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38585835695266724,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.50764000415802,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5092061758041382,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5530598163604736,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.553288996219635,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.879520930253066,
+        "AvgTime/train_epoch_std": 0.03422156378057403,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9597396850585938,
+      "test_best_rerun_accuracy": 0.43345558643341064,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25143250823020935,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24272289872169495,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29398730397224426,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2936435043811798,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3603789508342743,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3347085416316986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4414393901824951,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49950340390205383,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4909083843231201,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6087936162948608,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6346168518066406,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8744302920575412,
+        "AvgTime/train_epoch_std": 0.02430363000891598,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9656708240509033,
+      "test_best_rerun_accuracy": 0.42948275804519653,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25021010637283325,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24234089255332947,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28925052285194397,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2905111014842987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3591565489768982,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33325693011283875,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4373137652873993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.500764012336731,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49220719933509827,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6067308187484741,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6322866678237915,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8929212005050094,
+        "AvgTime/train_epoch_std": 0.047684946650407525,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9772558212280273,
+      "test_best_rerun_accuracy": 0.42898616194725037,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25036290287971497,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23848269879817963,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28756970167160034,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28925052285194397,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36099013686180115,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33203452825546265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43505996465682983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5004584193229675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4912903904914856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6095576286315918,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6317136287689209,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.872623036647665,
+        "AvgTime/train_epoch_std": 0.027836942448029423,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9414533376693726,
+      "test_best_rerun_accuracy": 0.4473603665828705,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24383069574832916,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23894108831882477,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26843151450157166,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2745053172111511,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3606463372707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34509894251823425,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4220719635486603,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.511383593082428,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5077164173126221,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.612919270992279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.658530056476593,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8933235983694753,
+        "AvgTime/train_epoch_std": 0.04748701269175409,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9011993408203125,
+      "test_best_rerun_accuracy": 0.4446863830089569,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23210328817367554,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2293528914451599,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2557108998298645,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26965391635894775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3481549322605133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33772632479667664,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41821375489234924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5039346218109131,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5009931921958923,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6105508208274841,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6538314819335938,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8721890951457777,
+        "AvgTime/train_epoch_std": 0.020456912628216688,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.921221375465393,
+      "test_best_rerun_accuracy": 0.449728786945343,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24207349121570587,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24165329337120056,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2704178988933563,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.277064710855484,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3598441481590271,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3473527431488037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42233937978744507,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5158529877662659,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5116509795188904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6168538331985474,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6616242527961731,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8673174346702687,
+        "AvgTime/train_epoch_std": 0.02199510520816149,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.628483533859253,
+      "test_best_rerun_accuracy": 0.5427840352058411,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23481549322605133,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22679349780082703,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22331729531288147,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22576208412647247,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3741309642791748,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3541523516178131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3816945552825928,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40083277225494385,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5370540022850037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6200244426727295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6406142711639404,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8693656314503063,
+        "AvgTime/train_epoch_std": 0.02491778375260106,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6222565174102783,
+      "test_best_rerun_accuracy": 0.5436626076698303,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2331346869468689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22557109594345093,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2253800928592682,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22748109698295593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37974634766578674,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3573611378669739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3829551637172699,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3949117660522461,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5376651883125305,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6189548373222351,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6285430788993835,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8845835297794665,
+        "AvgTime/train_epoch_std": 0.025846457889899033,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.620377779006958,
+      "test_best_rerun_accuracy": 0.5448086261749268,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23466269671916962,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22644968330860138,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23282909393310547,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2388646900653839,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37351974844932556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35377034544944763,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3886851668357849,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40381234884262085,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5363281965255737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6218962669372559,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6430972814559937,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8796387544045081,
+        "AvgTime/train_epoch_std": 0.027246402198638324,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6096210479736328,
+      "test_best_rerun_accuracy": 0.5411795973777771,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23023149371147156,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22453969717025757,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21743448078632355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2309572994709015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3678279519081116,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.358659952878952,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38574376702308655,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4191305637359619,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5367484092712402,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6219344735145569,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6662464737892151,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8920014227850962,
+        "AvgTime/train_epoch_std": 0.04108610553310951,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6132404804229736,
+      "test_best_rerun_accuracy": 0.5386965870857239,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23030789196491241,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22602948546409607,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2188860923051834,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23004049062728882,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36905035376548767,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35526013374328613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.380357563495636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4134005606174469,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5406066179275513,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6217816472053528,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6634196639060974,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8828056255976359,
+        "AvgTime/train_epoch_std": 0.04401335267761905,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6282097101211548,
+      "test_best_rerun_accuracy": 0.5409504175186157,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23187409341335297,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22725188732147217,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21949729323387146,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2296202927827835,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3693177402019501,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35911834239959717,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38345175981521606,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41481396555900574,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5362899899482727,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.616701066493988,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6595614552497864,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8844620551703111,
+        "AvgTime/train_epoch_std": 0.02596849762637316,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3520876169204712,
+      "test_best_rerun_accuracy": 0.6312552690505981,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21903888881206512,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21082589030265808,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.243334099650383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2494460940361023,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35403773188591003,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32890212535858154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40854915976524353,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43211856484413147,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5253648161888123,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5155091881752014,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6709832549095154,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8728720932676081,
+        "AvgTime/train_epoch_std": 0.02280315698548123,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3635109663009644,
+      "test_best_rerun_accuracy": 0.6317518353462219,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21567729115486145,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20780807733535767,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24558790028095245,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2524639070034027,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3494919538497925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3225991427898407,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40843456983566284,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4328825771808624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.522041380405426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5105050206184387,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6685002446174622,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8662820866233424,
+        "AvgTime/train_epoch_std": 0.023027781009829447,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3710358142852783,
+      "test_best_rerun_accuracy": 0.6281610727310181,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21048209071159363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20288027822971344,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23729848861694336,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2406218945980072,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34632134437561035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3193521201610565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4045381546020508,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4324623644351959,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5208190083503723,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5108488202095032,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6701046824455261,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8778499901294708,
+        "AvgTime/train_epoch_std": 0.030304746059712846,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.169908881187439,
+      "test_best_rerun_accuracy": 0.6687676906585693,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2176254838705063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21292687952518463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23156848549842834,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2392466962337494,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34647414088249207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3280617296695709,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3958285450935364,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4280693829059601,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.511383593082428,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5116509795188904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6121552586555481,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8707034975983375,
+        "AvgTime/train_epoch_std": 0.03154103833739946,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1484997272491455,
+      "test_best_rerun_accuracy": 0.6720528602600098,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21605928242206573,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21307969093322754,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22545649111270905,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23282909393310547,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3416227400302887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.328138142824173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3977385461330414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42719078063964844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5154709815979004,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5147070288658142,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.620482861995697,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8985555584614093,
+        "AvgTime/train_epoch_std": 0.04365292269310106,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1675256490707397,
+      "test_best_rerun_accuracy": 0.6725112795829773,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21816028654575348,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2143784910440445,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22858889400959015,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23481549322605133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3432653248310089,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32974252104759216,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3964397609233856,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42856597900390625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.514439582824707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5195966362953186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6186874508857727,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.8673059542973837,
+        "AvgTime/train_epoch_std": 0.022784127895300488,
+        "model/params/total": 112289,
+        "model/params/trainable": 112289,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 69.27470397949219,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 68.26677703857422,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.049183556944217735,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.187730073928833,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.016777526704888596
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1885.3095703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14298897006541525
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 538.12646484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.18137056449064712
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4591.2275390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6133904527805611
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.84051513671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08880873500580203
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118341.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.748043609511425
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7703.42236328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5401361915075901
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37041.4453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8986849819314162
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2718.152587890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4832271267361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 665676.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.530025847539111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210146.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.497012963240311
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5080716099057879,
+        "AvgTime/train_epoch_std": 0.0212475568015165,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 39.09499740600586,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 38.3929443359375,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.027660622720416066,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.4430902004241943,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.012858369475916813
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2262.005859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.17155903370307168
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2146.02783203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7232988985612572
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4436.5166015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5927209888527054
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90.4023208618164,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07806763459569638
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115368.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.679010818200817
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6855.63232421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.48069221176684546
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36411.37890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.866388790109693
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2506.843505859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.44566106770833336
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 659562.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.4608660056785405
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201666.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3559061579551694
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5292868084377713,
+        "AvgTime/train_epoch_std": 0.024527894817017303,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 74.87232971191406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 66.85770416259766,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.04816837475691474,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.378410816192627,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.01251795166417172
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2345.216552734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1778700457136424
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2119.2919921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.714287830194641
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4075.518798828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5444914894893954
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88.71534729003906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07661083531091456
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111713.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.59413278782742
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6541.50244140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.45866655738369444
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35838.4453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8370211344763956
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2448.537841796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.43529561631944447
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 655926.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.41973405879891
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200093.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3297233038789877
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5514303710725572,
+        "AvgTime/train_epoch_std": 0.042219115446657934,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.7318191528320312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.7097033262252808,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.008998438559080425,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.23001098632812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10030980618611536
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10994.6220703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8338734979379977
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210.99655151367188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07111444270767506
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7705.5732421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.029468703031062
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.27508544921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13667969382488665
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171449.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.981273148685677
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14797.4501953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.037543836440366
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46572.44921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3872289311984214
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3782.450439453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6724356336805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754314.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.532674230512539
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260129.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.328777894263891
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5155057112375895,
+        "AvgTime/train_epoch_std": 0.027126702307172065,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3495993614196777,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.331380844116211,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012270425495348479,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161.02359008789062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1160112320517944
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11273.736328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8550425732366326
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170.48776245117188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.057461328766825706
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7811.90087890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0436741321184035
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.172119140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13400010288482297
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172440.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.004291214819803
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14569.93359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.021591192942785
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46763.42578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.397018083000154
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3778.896728515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6718038628472223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755621.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.5474694014909
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260203.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3300199794485215
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5201341724395752,
+        "AvgTime/train_epoch_std": 0.029276827150517902,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.9371757507324219,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.914522647857666,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.010076434988724558,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149.84173583984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10795514109498829
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10954.98046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8308669297497155
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173.56832885742188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05849960527718971
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7716.81005859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0309699477079157
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.1210174560547,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13309241576515948
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171119.65625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9736126753204535
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14495.4501953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0163686856901206
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46561.1015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.386647268568353
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3762.669189453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6689189670138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753383.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.52214927660826
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259117.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.311939150566622
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5233481062783135,
+        "AvgTime/train_epoch_std": 0.02577341026763573,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2651.089111328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2555.45556640625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.19381536339827454,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 657.3941040039062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.47362687608350595
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 924.3241577148438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.8648639879728615
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348.4861755371094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11745405309643053
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4816.41650390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6434758188251503
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1180.91015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.0197842454663213
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88660.1171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.058798931532138
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8222.818359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5765543654028187
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36873.83203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8900933943948948
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4567.63623046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.81202421875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610577.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.906755851045779
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194753.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2408610403873994
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.547766473558214,
+        "AvgTime/train_epoch_std": 0.04782008875756906,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1726.4320068359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1609.1185302734375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.12204160259942644,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122.26337432861328,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08808600455951965
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.505176544189453,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.11318513970626028
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206.27630615234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06952352752016978
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3357.638916015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.44858235350910153
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135.17141723632812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11672833958232136
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82223.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.909328811478265
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8415.849609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5900890204301641
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30104.693359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.543118220276539
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2665.58740234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4738822048611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 579603.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.556376056242435
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183780.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0582734781921355
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5289119780063629,
+        "AvgTime/train_epoch_std": 0.02721278413489627,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2428.250244140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2340.08544921875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.17748088352057262,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245.31622314453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.17674079477271704
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.596044540405273,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1031370765284488
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156.18763732910156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05264160341392031
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3223.697021484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4306876448208918
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.51412963867188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1412039116050707
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80512.4921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8696008774730632
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7761.4609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5442056469990184
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30229.673828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.549524518331283
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2446.156005859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.43487217881944445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 576288.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.518884398719501
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182000.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.028651423626712
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5608816804557011,
+        "AvgTime/train_epoch_std": 0.04105544942321718,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 149.90325927734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 150.48605346679688,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.050719937130703364,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 350.7205810546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2526805339010717
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.7505340576172,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8407922845137746
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9034.837890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6852360933352294
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8352.8525390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.115945563001002
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 410.42095947265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3544222447950399
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165683.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8473714268298345
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13103.9912109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9188046004022928
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48838.703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.5033934658362806
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4458.6259765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7926446180555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752795.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.515502160560162
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255339.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.2490779916129995
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5315378189086915,
+        "AvgTime/train_epoch_std": 0.01656441870367435,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 144.65548706054688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 144.52566528320312,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04871104323667109,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 794.427001953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.572353747804845
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 529.5946655273438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.7873403448807568
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9384.1064453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7117259344188471
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9629.8056640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2865471829074817
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 846.837646484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.731293304390652
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166699.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8709696614341444
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13110.619140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9192693269264479
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51195.7421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.6242115017427854
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5173.02001953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9196480034722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754448.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.534198500050904
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254886.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.241539415988551
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5245633920033773,
+        "AvgTime/train_epoch_std": 0.019981535317530906,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 153.68678283691406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 153.28306579589844,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.05166264435318451,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169.73117065429688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12228470508234646
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.909740447998047,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.11005126551577919
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9384.6650390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7117683002701934
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7746.37255859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.034919513506179
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.41673278808594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1558002873817668
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166298.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8616517712010032
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12913.0615234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9054172993575585
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47146.05859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.416631226292993
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3817.39794921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6786485243055556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 749842.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.482091246903385
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254496.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.235038814837003
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5190704663594564,
+        "AvgTime/train_epoch_std": 0.009041743784053974,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 771.0555419921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 698.5449829101562,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.09332598302072896,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.935302734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1440456071573307
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.75270080566406,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.21975105687191612
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40585.48828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.0781561077929465
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6721.0390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.2652642610380855
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84.56934356689453,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07303052121493483
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32044.982421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7441246150351802
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11423.8798828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.801001253878313
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10561.099609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5413450002242555
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 379.60009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.06748446180555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 322360.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.6464935437711388
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67461.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1226252953755014
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5280165507875639,
+        "AvgTime/train_epoch_std": 0.02441074309961155,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 790.98779296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 737.7857055664062,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.09856856453793003,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 439.9134521484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.31694052748446505
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 443.3660888671875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.333505730879934
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21777.642578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.6516983373625331
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2350.15478515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7920980064564375
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 356.1400146484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.307547508331984
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26016.212890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6041290379580392
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7027.92578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4927728075480297
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12171.181640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.623875218649085
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 516.546630859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.09183051215277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368202.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.165047778355938
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77143.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2837333903283243
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5248236656188965,
+        "AvgTime/train_epoch_std": 0.024138516483696477,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1097.769775390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1010.3338623046875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.13498114392848196,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.73974609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.21523036462085735
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.92440795898438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9469705682051809
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46375.74609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.517311042377702
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3101.363525390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.0452859876611476
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.96559143066406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1346853121162902
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30585.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7102230836661713
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8149.97314453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5714467216751683
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11852.7060546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6075506717252294
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 496.4029235839844,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08824940863715278
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 351482.40625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.975910390484486
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75550.2421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2572220090110329
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5291162014007569,
+        "AvgTime/train_epoch_std": 0.019879125495940467,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 59.451629638671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 62.33688735961914,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.05383150894613052,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.68614196777344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12009088038024023
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.068011283874512,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.021410585704602695
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6112.96337890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.46363013871113007
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5508.62890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.856632593950118
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3219.867431640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.43017600957122576
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88495.875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.054985022292402
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6491.1298828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.45513461525820365
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31420.26953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6105525414552258
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1936.37060546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.34424366319444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 605209.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.846024738979446
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173518.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8875048362538065
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5272671107588143,
+        "AvgTime/train_epoch_std": 0.02029263778437497,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 53.78004837036133,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 54.506038665771484,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.04706911801880093,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156.0255126953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11241031174013869
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.822273254394531,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.04643301712839227
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6127.3251953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4647193928943876
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7350.6064453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.4774541440217392
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3229.545166015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4314689600555277
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88754.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0609793708201747
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7337.47998046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5144776315011044
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30959.244140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5869211205405198
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1829.983154296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.32533033854166665
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 599443.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.780804243068674
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167839.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7930036568319103
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5319021729861989,
+        "AvgTime/train_epoch_std": 0.022954642127993502,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 95.07254791259766,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 91.82784271240234,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.0792986551920573,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224.70156860351562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16188873818697092
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.351329803466797,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03869120949193051
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4795.041015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3636739488528631
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3962.5986328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.3355573416961577
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3469.04833984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.46346671206997325
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93000.3515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1595846080833176
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6163.021484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.43212883777695976
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32127.6640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6468124487416065
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2013.6600341796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3579840060763889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 615394.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.961237882198568
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178940.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.977720470770306
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.527100227095864,
+        "AvgTime/train_epoch_std": 0.024037634179485227,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 20848.177734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20433.44921875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.4744902753750232,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4946.509765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.5637678426693085
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4037.512939453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 21.25006810238487
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15324.044921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.1622332136423967
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3706.40576171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.2492098960966465
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5590.06982421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7468363158608884
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3636.57373046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.140391822511874
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9606.1435546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6735481387384308
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15443.8095703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7916248690508227
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5851.6220703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.0402883680555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282613.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.1968796307817606
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92833.2734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.544826742507447
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5306538384536217,
+        "AvgTime/train_epoch_std": 0.021911855235065024,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 29346.63671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28306.66015625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.6573160913117685,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47580.0390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 34.27956704791066
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40072.0234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 210.9053865131579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35424.34375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.686715491088358
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8422.1220703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.8385986081268957
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50605.21875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.760884268537074
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35528.15234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 30.680615150043177
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12732.529296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8927590307723321
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32017.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6411540026398073
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26982.6171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 4.796909722222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 306473.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.466772550139701
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78857.5234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3122580573028473
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5316843475614276,
+        "AvgTime/train_epoch_std": 0.025850407108877163,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 105154.578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 74683.8828125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.73425326984256,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60119.70703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 43.313909964877524
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61511.46484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 323.7445518092105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45909.6875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.481963405384907
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75942.25,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 25.595635321873946
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45536.57421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.0837106504676015
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59116.5,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 51.05051813471503
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47250.6484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.3130450454003646
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39216.8984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.010195214388231
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50207.8515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 8.925840277777779
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 469470.40625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.310570978926054
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119975.9296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9965042465428586
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5424103736877441,
+        "AvgTime/train_epoch_std": 0.02244853973388672,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 5518.8212890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5642.1259765625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.3956055235284322,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4214.0009765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.0360237583303316
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 562.2989501953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.9594681589226974
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16817.115234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.2754732828498294
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1877.078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6326518790023593
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3462.619384765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.46260780023588843
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764.4337158203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6601327425045876
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57963.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3459756118799926
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24518.8671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2567977439899534
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2100.62353515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3734441840277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 491276.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.5572322206259965
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144789.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.4094281467891436
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5264615376790365,
+        "AvgTime/train_epoch_std": 0.030047379318887017,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 5285.97021484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5160.04931640625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.36180404686623546,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1430.1298828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0303529415075647
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 425.15435791015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.2376545153166116
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11344.6875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8604237770193401
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1738.1986083984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5858438181322675
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2246.92919921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3001909417793921
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 559.7474365234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.48337429751592187
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38455.9140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8929944747933308
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19279.541015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9882383010725819
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1540.817626953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.27392313368055554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 410920.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.648267027137088
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104760.984375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.743314269132844
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5295828234764838,
+        "AvgTime/train_epoch_std": 0.0247962855928727,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 6246.57861328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6361.794921875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.4460661142809564,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1631.4193115234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1753741437488743
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 943.5262451171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.965927605879934
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8504.421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6450073473644293
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1595.4144287109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5377197265625
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3743.777099609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5001706211902973
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1060.58203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9158739475388601
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70634.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6402287873862158
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30075.712890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5416327280037418
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3404.447509765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6052351128472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 546656.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.183683670237436
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159106.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.647664869452349
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5435688018798828,
+        "AvgTime/train_epoch_std": 0.019371614932668594,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 7460.71484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5859.05615234375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.3003258061583756,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1249.159423828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.899970766446776
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.24658203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.0486662212171052
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99043.4140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.511825109025407
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27954.529296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 9.421816412832827
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3017.802978515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4031800906500501
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 307.11444091796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.26521108887562067
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73308.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7023224154746424
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53189.69140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.7294693175045577
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1163.2667236328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2068029730902778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158474.296875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.7926348299831454
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62378.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.038034016025161
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5494225476239178,
+        "AvgTime/train_epoch_std": 0.03628357584522996,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 7929.5498046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6676.38818359375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.34222093308697266,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1287.463134765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9275670999752341
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 798.2999877929688,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.201578883120888
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81006.15625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.143811623056504
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15014.1767578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.060389874557634
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3060.686767578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4089093877859886
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743.97216796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6424630120628239
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63329.87890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4705990829056752
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38772.80859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.7186094933214133
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1533.412353515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.272606640625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180717.703125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.044248533703607
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61077.66796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0163857349233687
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.531392748291428,
+        "AvgTime/train_epoch_std": 0.023872898357962993,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 7010.90478515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5741.42333984375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.294296137159452,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1244.7125244140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8967669484251171
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 418.7491760253906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.203943031712582
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130728.6953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.914956034319303
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27383.595703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 9.229388507962588
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3155.127197265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.42152667966140617
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 519.7032470703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.44879382303135795
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98122.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.2785234984557867
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44068.75,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.0899418033936334
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1045.4364013671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.18585536024305555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166808.40625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.8869088860106558
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60883.74609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0131587055688682
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.528670766136863,
+        "AvgTime/train_epoch_std": 0.018097169906691773,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 682.8321533203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 715.0083618164062,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.12711259765625,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 679.4846801757812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.48954227678370404
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.1470832824707,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.23235306990774054
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47305.5234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.587828853811149
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17413.19140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.868955647539602
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1113.02783203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.14870111316382764
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.7032699584961,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10509781516277729
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41536.79296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9645363405338566
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14982.1181640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0504920883510378
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16402.203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8407505830642268
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 421087.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.763275496872278
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94613.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5744523072570848
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5301345792309992,
+        "AvgTime/train_epoch_std": 0.023202669059277693,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 916.9826049804688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 929.876220703125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.165311328125,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 321.2502746582031,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.23144832468170254
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.00910186767578,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.35794264140881993
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18664.740234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.4156041133390216
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12912.84765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.3521562710650485
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1751.8487548828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2340479298440631
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.11131286621094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08731546879638251
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51638.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1991030065716144
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12299.2421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.862378501437386
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19411.98828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9950273351401917
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 447415.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.061090262773888
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98751.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6433047006306891
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5484087908709491,
+        "AvgTime/train_epoch_std": 0.052035224751115994,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1182.449951171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1110.78857421875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.19747352430555556,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1018.6776123046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7339175881157691
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84.22600555419922,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4432947660747327
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48456.203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.675100729996208
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25191.556640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.490581948306371
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1600.796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2138673179692719
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 246.01708984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.21244999122949051
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42847.94140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9949828489283392
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23156.04296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.6236182140478195
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17614.54296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.902893175905992
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 425848.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.8171268933181
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95844.0234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5949282518346564
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5249393162903963,
+        "AvgTime/train_epoch_std": 0.028461238275403842,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 64852.19921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 52057.05859375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.5888607693602027,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54357.11328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 39.16218536113112
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56588.3203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 297.83326480263156
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83631.5390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.34293053185438
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38782.19140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 13.07118011670037
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58625.51953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.832400738977956
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55387.21875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 47.830068005181346
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141924.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2956529816087685
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47389.38671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.3227728732821484
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33252.4375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7044665282690041
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38624.0078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 6.866490277777777
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60828.2265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.012234812082938
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5493898232777913,
+        "AvgTime/train_epoch_std": 0.03559279673447754,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 477022.59375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 326836.6875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.697122128208319,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 543225.9375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 391.3731538184438
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 543937.0625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2862.826644736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 516005.96875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 39.135833807356846
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 623570.1875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 210.16858358611393
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 489880.4375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 65.44828824315297
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 540069.125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 466.38093696027636
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 303258.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 7.042038448588148
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 517380.6875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 36.276867725424204
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 391723.96875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 20.079141357834846
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 512879.71875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 91.17861666666667
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 264951.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.409023825570366
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5422624945640564,
+        "AvgTime/train_epoch_std": 0.006950771609755726,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 139413.671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 96410.4375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 1.0905787982308293,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68348.9296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 49.24274473162824
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66906.921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 352.14169407894735
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85252.21875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.465848976109215
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34235.2890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 11.538688595382542
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78712.515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 10.516034151636607
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75211.6640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 64.94962354274611
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122941.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8548526611554896
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47696.6875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.3443196956948533
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65636.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.3644119380798605
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71961.296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 12.793119444444445
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72846.6640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2122321079410248
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5326058279004013,
+        "AvgTime/train_epoch_std": 0.02462201160905085,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 136418.90625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 119898.34375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.9952131487860483,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107485.40625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 77.4390534942363
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93329.21875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 491.2064144736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144527.59375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 10.9615164012135
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151889.1875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 51.19285052241321
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75375.9296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 10.070264487307949
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77569.28125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 66.98556239205527
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99429.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.308887281139699
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91847.328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.440003374351424
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55189.03125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.828901084115024
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73451.6171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 13.058065277777779
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 453078.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.125150942275715
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5133851936885289,
+        "AvgTime/train_epoch_std": 0.024043888714339427,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 106857.7890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 104122.953125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.732696871931839,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149889.078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 107.98924936959654
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153652.734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 808.6986019736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135333.9375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 10.264234926052332
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197738.671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 66.64599658746208
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117397.0546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 15.684309243486974
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144829.375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 125.06854490500864
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87643.453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.035190719046071
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135171.046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 9.477706273664282
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82995.9765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.254240430698652
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124818.015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 22.189869444444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 377327.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.268270731762497
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.5417280793190002,
+        "AvgTime/train_epoch_std": 0.02039530451427859,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gft_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111134.8984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 106398.5859375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7705653892716289,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131263.3125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 94.570109870317
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133953.96875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 705.0208881578948
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113543.3359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.611553730565037
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161173.3125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 54.321979271991914
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103501.6015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 13.827869280227121
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124340.4765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 107.37519564982729
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84456.6796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9611898497004459
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106616.828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 7.4755874439068855
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74983.7421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.843546167794351
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108427.1171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 19.275931944444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 401246.40625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.538832463264821
+        }
+      },
+      "output_dir": "/home/paiktj/Sync/TDL/wt/gft/logs/train/runs/notebook_gu_grid_gft__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.53047776222229,
+        "AvgTime/train_epoch_std": 0.018104554111199975,
+        "model/params/total": 111662,
+        "model/params/trainable": 111662,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -104,7 +104,7 @@
       "outputs": [],
       "source": [
         "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-        "MODEL_CONFIG = \"graph/gin\""
+        "MODEL_CONFIG = \"graph/gft\""
       ]
     },
     {

--- a/configs/model/graph/gft.yaml
+++ b/configs/model/graph/gft.yaml
@@ -1,0 +1,52 @@
+_target_: topobench.model.TBModel
+
+model_name: GFT
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.GFT
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  out_channels: ${model.feature_encoder.out_channels}
+  num_layers: 2
+  backbone: sage
+  normalize: batch
+  dropout: 0.15
+  activation: relu
+  tree_depth: 2
+  codebook_size: 128
+  codebook_heads: 4
+  code_dim: ${model.feature_encoder.out_channels}
+  use_cosine_sim: true
+  learnable_codebook: true
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: MLPReadout
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_layers: [32]
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+  dropout: 0.2
+  act: relu
+  norm: null
+  final_act: null
+
+compile: false

--- a/test/nn/backbones/graph/test_gft.py
+++ b/test/nn/backbones/graph/test_gft.py
@@ -1,0 +1,398 @@
+"""Unit tests for the GFT graph backbone."""
+
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.gft import GFT, _TreeVocabulary
+from topobench.nn.wrappers import GNNWrapper
+
+
+class TestGFT:
+    """Test the TopoBench GFT core encoder."""
+
+    def setup_method(self):
+        """Set up test dimensions."""
+        self.in_channels = 16
+        self.hidden_channels = 32
+        self.out_channels = 24
+
+    def _features(self, num_nodes, channels=None):
+        """Create node features."""
+        channels = self.in_channels if channels is None else channels
+        return torch.randn(num_nodes, channels)
+
+    def test_initialization_default(self):
+        """Test default initialization."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+        )
+
+        assert model.in_channels == self.in_channels
+        assert model.hidden_channels == self.hidden_channels
+        assert model.out_channels == self.hidden_channels
+        assert model.num_layers == 2
+        assert model.backbone == "sage"
+        assert model.vocabulary.codebook.shape == (4, 128, 32)
+
+    def test_initialization_custom(self):
+        """Test custom initialization."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            num_layers=3,
+            backbone="gcn",
+            normalize="layer",
+            tree_depth=3,
+            codebook_size=17,
+            codebook_heads=2,
+            code_dim=8,
+        )
+
+        assert model.out_channels == self.out_channels
+        assert model.num_layers == 3
+        assert model.tree_depth == 3
+        assert model.vocabulary.codebook.shape == (2, 17, 8)
+
+    def test_initialization_aliases(self):
+        """Test input_dim and hidden_dim aliases."""
+        model = GFT(input_dim=self.in_channels, hidden_dim=20)
+
+        assert model.in_channels == self.in_channels
+        assert model.hidden_channels == 20
+
+    def test_invalid_backbone(self):
+        """Test that invalid message-passing backbone names fail."""
+        with pytest.raises(ValueError, match="Unsupported backbone"):
+            GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                backbone="invalid",
+            )
+
+    def test_invalid_normalization(self):
+        """Test that invalid normalization names fail."""
+        with pytest.raises(ValueError, match="Unsupported normalize"):
+            GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                normalize="invalid",
+            )
+
+    def test_invalid_core_dimensions(self):
+        """Test validation for required and non-negative dimensions."""
+        with pytest.raises(ValueError, match="in_channels or input_dim"):
+            GFT(hidden_channels=self.hidden_channels)
+
+        with pytest.raises(ValueError, match="num_layers"):
+            GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                num_layers=0,
+            )
+
+        with pytest.raises(ValueError, match="tree_depth"):
+            GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                tree_depth=-1,
+            )
+
+        with pytest.raises(ValueError, match="Unsupported activation"):
+            GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                activation="sigmoid",
+            )
+
+    def test_tree_vocabulary_validation(self):
+        """Test vocabulary parameter validation."""
+        with pytest.raises(ValueError, match="codebook_size"):
+            _TreeVocabulary(
+                dim=8,
+                codebook_size=0,
+                code_dim=4,
+                num_heads=2,
+            )
+
+        with pytest.raises(ValueError, match="code_dim"):
+            _TreeVocabulary(
+                dim=8,
+                codebook_size=4,
+                code_dim=0,
+                num_heads=2,
+            )
+
+        with pytest.raises(ValueError, match="num_heads"):
+            _TreeVocabulary(
+                dim=8,
+                codebook_size=4,
+                code_dim=4,
+                num_heads=0,
+            )
+
+    def test_tree_vocabulary_fixed_euclidean_lookup(self):
+        """Test fixed codebooks and Euclidean nearest-code lookup."""
+        vocabulary = _TreeVocabulary(
+            dim=8,
+            codebook_size=5,
+            code_dim=4,
+            num_heads=2,
+            use_cosine_sim=False,
+            learnable_codebook=False,
+        )
+        assert "codebook" in dict(vocabulary.named_buffers())
+        assert "codebook" not in dict(vocabulary.named_parameters())
+
+        out, token_ids, commitment_loss = vocabulary(torch.randn(6, 8))
+
+        assert out.shape == (6, 8)
+        assert token_ids.shape == (6, 2)
+        assert commitment_loss.dim() == 0
+
+    def test_tree_vocabulary_empty_input(self):
+        """Test empty graph tokenization."""
+        vocabulary = _TreeVocabulary(
+            dim=8,
+            codebook_size=5,
+            code_dim=4,
+            num_heads=2,
+        )
+
+        out, token_ids, commitment_loss = vocabulary(torch.empty(0, 8))
+
+        assert out.shape == (0, 8)
+        assert token_ids.shape == (0, 2)
+        assert commitment_loss.item() == 0
+
+    def test_forward_basic(self, simple_graph_0):
+        """Test a basic forward pass."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            normalize="none",
+        )
+        x = self._features(simple_graph_0.num_nodes)
+
+        out = model(x=x, edge_index=simple_graph_0.edge_index)
+
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+        assert model.last_tree_token_ids.shape == (
+            simple_graph_0.num_nodes,
+            model.codebook_heads,
+        )
+
+    def test_forward_with_aux(self, simple_graph_0):
+        """Test optional tree-token diagnostics."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            codebook_heads=2,
+            code_dim=8,
+        )
+        x = self._features(simple_graph_0.num_nodes)
+
+        out, aux = model(
+            x=x,
+            edge_index=simple_graph_0.edge_index,
+            return_aux=True,
+        )
+
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+        assert aux["tree_token_ids"].shape == (simple_graph_0.num_nodes, 2)
+        assert aux["commitment_loss"].dim() == 0
+
+    def test_forward_with_edge_weight(self, simple_graph_0):
+        """Test scalar edge weights are accepted by the forward API."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+        )
+        x = self._features(simple_graph_0.num_nodes)
+        edge_weight = torch.rand(simple_graph_0.edge_index.size(1))
+
+        out = model(
+            x=x,
+            edge_index=simple_graph_0.edge_index,
+            edge_weight=edge_weight,
+        )
+
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_forward_with_scalar_edge_attr_shapes(self, simple_graph_0):
+        """Test scalar edge attributes are coerced to GCN edge weights."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            backbone="gcn",
+            normalize="none",
+        )
+        x = self._features(simple_graph_0.num_nodes)
+        one_dim_attr = torch.rand(simple_graph_0.edge_index.size(1))
+        two_dim_attr = one_dim_attr.view(-1, 1)
+
+        out_one_dim = model(
+            x=x,
+            edge_index=simple_graph_0.edge_index,
+            edge_attr=one_dim_attr,
+        )
+        out_two_dim = model(
+            x=x,
+            edge_index=simple_graph_0.edge_index,
+            edge_attr=two_dim_attr,
+        )
+
+        assert out_one_dim.shape == (simple_graph_0.num_nodes, self.out_channels)
+        assert out_two_dim.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_forward_with_ignored_vector_edge_attr(self, simple_graph_0):
+        """Test vector edge attributes are ignored without failing."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+        )
+        x = self._features(simple_graph_0.num_nodes)
+        edge_attr = torch.randn(simple_graph_0.edge_index.size(1), 4)
+
+        out = model(
+            x=x,
+            edge_index=simple_graph_0.edge_index,
+            edge_attr=edge_attr,
+        )
+
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_edgeless_graph(self):
+        """Test tree descriptors on a graph with no edges."""
+        num_nodes = 4
+        edge_index = torch.empty(2, 0, dtype=torch.long)
+        x = self._features(num_nodes)
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            tree_depth=2,
+            normalize="none",
+        )
+
+        out = model(x=x, edge_index=edge_index)
+
+        assert out.shape == (num_nodes, self.out_channels)
+
+    def test_activation_and_normalization_variants(self, simple_graph_0):
+        """Test supported activation and normalization variants."""
+        x = self._features(simple_graph_0.num_nodes)
+
+        for activation in ["gelu", "elu", "leaky_relu"]:
+            model = GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                out_channels=self.out_channels,
+                activation=activation,
+                normalize="none",
+            )
+            out = model(x=x, edge_index=simple_graph_0.edge_index)
+            assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+        for normalize in ["batch", "batch_norm", "layer", "layer_norm", None]:
+            model = GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                out_channels=self.out_channels,
+                normalize=normalize,
+            )
+            out = model(x=x, edge_index=simple_graph_0.edge_index)
+            assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_different_local_backbones(self, simple_graph_0):
+        """Test supported message-passing backbones."""
+        x = self._features(simple_graph_0.num_nodes)
+
+        for backbone in ["sage", "gcn", "gin", "gat"]:
+            model = GFT(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                out_channels=self.out_channels,
+                backbone=backbone,
+                normalize="none",
+            )
+            out = model(x=x, edge_index=simple_graph_0.edge_index)
+            assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_wrapper_compatibility(self, simple_graph_0):
+        """Test compatibility with the standard graph wrapper."""
+        channels = self.in_channels
+        x = self._features(simple_graph_0.num_nodes, channels)
+        batch = Data(
+            x=x,
+            x_0=x,
+            edge_index=simple_graph_0.edge_index,
+            y=simple_graph_0.y,
+            batch_0=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        model = GFT(
+            in_channels=channels,
+            hidden_channels=channels,
+            out_channels=channels,
+            normalize="none",
+        )
+        wrapper = GNNWrapper(
+            model,
+            out_channels=channels,
+            num_cell_dimensions=1,
+            residual_connections=False,
+        )
+
+        model_out = wrapper(batch)
+
+        assert model_out["x_0"].shape == x.shape
+        assert model_out["batch_0"].shape == (simple_graph_0.num_nodes,)
+        assert torch.equal(model_out["labels"], simple_graph_0.y)
+
+    def test_batched_graphs(self, simple_graph_0, simple_graph_1):
+        """Test batched graph inputs."""
+        batch_data = Batch.from_data_list([simple_graph_0, simple_graph_1])
+        x = self._features(batch_data.num_nodes)
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            normalize="none",
+        )
+
+        out = model(
+            x=x,
+            edge_index=batch_data.edge_index,
+            batch=batch_data.batch,
+        )
+
+        assert out.shape == (batch_data.num_nodes, self.out_channels)
+
+    def test_backward_pass(self, simple_graph_0):
+        """Test gradients flow through encoder and tree-vocabulary path."""
+        model = GFT(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            normalize="none",
+        )
+        x = self._features(simple_graph_0.num_nodes).requires_grad_(True)
+
+        out = model(x=x, edge_index=simple_graph_0.edge_index)
+        out.mean().backward()
+
+        assert x.grad is not None
+        assert any(
+            param.grad is not None
+            for param in model.parameters()
+            if param.requires_grad
+        )

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -4,8 +4,13 @@ import hydra
 
 from test._utils.simplified_pipeline import run
 
-DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gft"]                                                # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
+MODELS = [
+    "graph/gcn",
+    "cell/topotune",
+    "simplicial/topotune",
+    "graph/gft",
+]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:
@@ -23,13 +28,13 @@ class TestPipeline:
                     config_name="run.yaml",
                     overrides=[
                         f"model={MODEL}",
-                        f"dataset={DATASET}", # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
+                        f"dataset={DATASET}",  # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
                         "trainer.max_epochs=2",
                         "trainer.min_epochs=1",
                         "trainer.check_val_every_n_epoch=1",
                         "paths=test",
                         "callbacks=model_checkpoint",
                     ],
-                    return_hydra_config=True
+                    return_hydra_config=True,
                 )
                 run(cfg)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,11 +1,11 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
+
 from test._utils.simplified_pipeline import run
 
-
 DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS   = ["graph/gft"]                                                # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/gft.py
+++ b/topobench/nn/backbones/graph/gft.py
@@ -1,0 +1,434 @@
+"""GFT backbone adapted for TopoBench graph tasks.
+
+This module implements the encoder core of "GFT: Graph Foundation Model with
+Transferable Tree Vocabulary" for supervised TopoBench graph tasks.  The
+official GFT pretrains a message-passing encoder and a transferable
+computation-tree vocabulary with reconstruction losses, then reuses that
+vocabulary for task adaptation.  TopoBench challenge runs do not ship the
+pretrained vocabulary, LLM/text features, reconstruction heads, or prototype
+task heads, so this backbone keeps the dependency-free core:
+
+* a SAGE/GCN/GIN/GAT message-passing encoder mirroring the reference encoder;
+* a structural computation-tree descriptor built by repeated neighborhood
+  aggregation of root structural statistics;
+* a cosine vector-quantized tree vocabulary fallback that is learned with the
+  supervised task instead of loaded from GFT pretraining.
+
+The forward pass returns node embeddings of shape ``[num_nodes, out_channels]``
+and is compatible with :class:`topobench.nn.wrappers.GNNWrapper`.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch_geometric.nn import GATConv, GCNConv, GINConv, SAGEConv
+from torch_geometric.utils import degree, scatter, to_undirected
+
+
+class _TreeVocabulary(nn.Module):
+    """Small vector-quantized vocabulary for computation-tree tokens."""
+
+    def __init__(
+        self,
+        dim: int,
+        codebook_size: int,
+        code_dim: int,
+        num_heads: int,
+        use_cosine_sim: bool = True,
+        learnable_codebook: bool = True,
+    ) -> None:
+        super().__init__()
+        if codebook_size <= 0:
+            raise ValueError("codebook_size must be positive")
+        if code_dim <= 0:
+            raise ValueError("code_dim must be positive")
+        if num_heads <= 0:
+            raise ValueError("num_heads must be positive")
+
+        self.dim = dim
+        self.codebook_size = codebook_size
+        self.code_dim = code_dim
+        self.num_heads = num_heads
+        self.use_cosine_sim = use_cosine_sim
+
+        codebook_input_dim = code_dim * num_heads
+        self.project_in = (
+            nn.Linear(dim, codebook_input_dim)
+            if codebook_input_dim != dim
+            else nn.Identity()
+        )
+        self.project_out = (
+            nn.Linear(codebook_input_dim, dim)
+            if codebook_input_dim != dim
+            else nn.Identity()
+        )
+
+        codebook = torch.empty(num_heads, codebook_size, code_dim)
+        nn.init.xavier_uniform_(codebook)
+        if learnable_codebook:
+            self.codebook = nn.Parameter(codebook)
+        else:
+            self.register_buffer("codebook", codebook)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Quantize tree queries into vocabulary codes.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Tree-query embeddings with shape ``[num_nodes, dim]``.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            Quantized embeddings, selected token ids, and a commitment loss
+            value exposed for diagnostics.
+        """
+        if x.size(0) == 0:
+            token_ids = x.new_empty((0, self.num_heads), dtype=torch.long)
+            return x, token_ids, x.sum() * 0
+
+        projected = self.project_in(x)
+        projected = projected.view(x.size(0), self.num_heads, self.code_dim)
+
+        codebook = self.codebook
+        query = projected
+        if self.use_cosine_sim:
+            query = F.normalize(projected, p=2, dim=-1)
+            codebook = F.normalize(codebook, p=2, dim=-1)
+            scores = torch.einsum("nhd,hkd->nhk", query, codebook)
+        else:
+            scores = -(
+                projected.unsqueeze(2) - codebook.unsqueeze(0)
+            ).square().sum(dim=-1)
+
+        token_ids = scores.argmax(dim=-1)
+        expanded_codebook = codebook.unsqueeze(0).expand(
+            x.size(0),
+            -1,
+            -1,
+            -1,
+        )
+        gather_index = token_ids[..., None, None].expand(
+            -1,
+            -1,
+            1,
+            self.code_dim,
+        )
+        tokens = expanded_codebook.gather(2, gather_index).squeeze(2)
+        commitment_loss = F.mse_loss(projected, tokens.detach())
+
+        if self.training:
+            tokens = tokens + projected - projected.detach()
+
+        tokens = tokens.reshape(x.size(0), self.num_heads * self.code_dim)
+        return self.project_out(tokens), token_ids, commitment_loss
+
+
+class GFT(nn.Module):
+    """TopoBench GFT core encoder.
+
+    This is not a full reproduction of the official GFT training system.  It
+    omits cross-domain pretraining, tree/feature reconstruction losses, LLM
+    textual feature construction, and prototype task heads.  In their place it
+    provides an in-model, dependency-free tree vocabulary fallback that can be
+    optimized by the supervised TopoBench objective.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input node feature dimension.
+    hidden_channels : int
+        Hidden encoder dimension.
+    out_channels : int, optional
+        Output node embedding dimension. Defaults to ``hidden_channels``.
+    num_layers : int, optional
+        Number of message-passing layers. Defaults to 2.
+    backbone : str, optional
+        Local message-passing backbone: ``"sage"``, ``"gcn"``, ``"gin"``, or
+        ``"gat"``. Defaults to ``"sage"``, matching the reference defaults.
+    normalize : str, optional
+        Normalization type: ``"none"``, ``"batch"``, or ``"layer"``.
+    dropout : float, optional
+        Dropout applied between encoder layers and before output projection.
+    activation : str, optional
+        Activation name: ``"relu"``, ``"gelu"``, ``"elu"``, or
+        ``"leaky_relu"``.
+    tree_depth : int, optional
+        Number of neighborhood aggregation steps used to summarize rooted
+        computation trees.
+    codebook_size : int, optional
+        Number of vocabulary entries per codebook head.
+    codebook_heads : int, optional
+        Number of independent vocabulary heads.
+    code_dim : int, optional
+        Dimension of each code. Defaults to ``hidden_channels``.
+    use_cosine_sim : bool, optional
+        Use cosine similarity for nearest-code lookup, as in the reference
+        implementation.
+    learnable_codebook : bool, optional
+        If true, the fallback vocabulary is a trainable parameter. If false,
+        it remains a fixed randomly initialized buffer.
+    input_dim : int, optional
+        Alias for ``in_channels`` for compatibility with other TopoBench
+        graph encoders.
+    hidden_dim : int, optional
+        Alias for ``hidden_channels`` for compatibility with other TopoBench
+        graph encoders.
+    """
+
+    def __init__(
+        self,
+        in_channels: int | None = None,
+        hidden_channels: int | None = None,
+        out_channels: int | None = None,
+        num_layers: int = 2,
+        backbone: str = "sage",
+        normalize: str | None = "none",
+        dropout: float = 0.15,
+        activation: str = "relu",
+        tree_depth: int = 2,
+        codebook_size: int = 128,
+        codebook_heads: int = 4,
+        code_dim: int | None = None,
+        use_cosine_sim: bool = True,
+        learnable_codebook: bool = True,
+        input_dim: int | None = None,
+        hidden_dim: int | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        del kwargs
+
+        in_channels = in_channels if in_channels is not None else input_dim
+        hidden_channels = (
+            hidden_channels if hidden_channels is not None else hidden_dim
+        )
+        if in_channels is None:
+            raise ValueError("in_channels or input_dim must be provided")
+        if hidden_channels is None:
+            hidden_channels = in_channels
+        if out_channels is None:
+            out_channels = hidden_channels
+        if num_layers <= 0:
+            raise ValueError("num_layers must be positive")
+        if tree_depth < 0:
+            raise ValueError("tree_depth must be non-negative")
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels
+        self.num_layers = num_layers
+        self.backbone = backbone
+        self.normalize = "none" if normalize is None else normalize
+        self.dropout_rate = dropout
+        self.tree_depth = tree_depth
+        self.codebook_size = codebook_size
+        self.codebook_heads = codebook_heads
+        self.code_dim = hidden_channels if code_dim is None else code_dim
+
+        self.activation = self._make_activation(activation)
+        self.dropout = nn.Dropout(dropout)
+
+        dims = [in_channels, *([hidden_channels] * num_layers)]
+        self.convs = nn.ModuleList(
+            [
+                self._make_conv(dims[i], dims[i + 1], backbone)
+                for i in range(num_layers)
+            ]
+        )
+        self.norms = nn.ModuleList(
+            [self._make_norm(self.normalize, hidden_channels) for _ in dims[1:]]
+        )
+
+        tree_descriptor_dim = 4 * (tree_depth + 1)
+        self.tree_encoder = nn.Sequential(
+            nn.Linear(tree_descriptor_dim, hidden_channels),
+            self._make_activation(activation),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_channels, hidden_channels),
+        )
+        self.tree_query = nn.Linear(hidden_channels * 2, hidden_channels)
+        self.vocabulary = _TreeVocabulary(
+            dim=hidden_channels,
+            codebook_size=codebook_size,
+            code_dim=self.code_dim,
+            num_heads=codebook_heads,
+            use_cosine_sim=use_cosine_sim,
+            learnable_codebook=learnable_codebook,
+        )
+        self.output_proj = nn.Linear(hidden_channels * 3, out_channels)
+        self.output_norm = nn.LayerNorm(out_channels)
+
+        self.last_tree_token_ids: torch.Tensor | None = None
+        self.last_commitment_loss: torch.Tensor | None = None
+
+    @staticmethod
+    def _make_activation(name: str) -> nn.Module:
+        name = name.lower()
+        if name == "relu":
+            return nn.ReLU()
+        if name == "gelu":
+            return nn.GELU()
+        if name == "elu":
+            return nn.ELU()
+        if name == "leaky_relu":
+            return nn.LeakyReLU()
+        raise ValueError(
+            "Unsupported activation. Expected one of: relu, gelu, elu, "
+            "leaky_relu"
+        )
+
+    @staticmethod
+    def _make_norm(name: str, channels: int) -> nn.Module:
+        name = name.lower()
+        if name == "none":
+            return nn.Identity()
+        if name in {"batch", "batch_norm"}:
+            return nn.BatchNorm1d(channels)
+        if name in {"layer", "layer_norm"}:
+            return nn.LayerNorm(channels)
+        raise ValueError(
+            "Unsupported normalize. Expected one of: none, batch, layer"
+        )
+
+    @staticmethod
+    def _make_conv(
+        in_channels: int,
+        out_channels: int,
+        backbone: str,
+    ) -> nn.Module:
+        backbone = backbone.lower()
+        if backbone == "sage":
+            return SAGEConv(in_channels, out_channels)
+        if backbone == "gcn":
+            return GCNConv(in_channels, out_channels)
+        if backbone == "gin":
+            return GINConv(
+                nn.Sequential(
+                    nn.Linear(in_channels, out_channels),
+                    nn.ReLU(),
+                    nn.Linear(out_channels, out_channels),
+                )
+            )
+        if backbone == "gat":
+            return GATConv(in_channels, out_channels, heads=1, concat=False)
+        raise ValueError(
+            "Unsupported backbone. Expected one of: sage, gcn, gin, gat"
+        )
+
+    @staticmethod
+    def _coerce_edge_weight(
+        edge_weight: torch.Tensor | None,
+        edge_attr: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        if edge_weight is not None:
+            return edge_weight
+        if edge_attr is None:
+            return None
+        if edge_attr.dim() == 1:
+            return edge_attr
+        if edge_attr.dim() == 2 and edge_attr.size(-1) == 1:
+            return edge_attr.view(-1)
+        return None
+
+    @staticmethod
+    def _apply_conv(
+        conv: nn.Module,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if isinstance(conv, GCNConv):
+            return conv(x, edge_index, edge_weight=edge_weight)
+        return conv(x, edge_index)
+
+    def _tree_descriptors(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        """Build rooted computation-tree descriptors from local structure."""
+        num_nodes = x.size(0)
+        if num_nodes == 0:
+            return x.new_empty((0, 4 * (self.tree_depth + 1)))
+
+        tree_edge_index = to_undirected(edge_index, num_nodes=num_nodes)
+        source, target = tree_edge_index[0], tree_edge_index[1]
+
+        deg = degree(target, num_nodes=num_nodes, dtype=x.dtype).view(-1, 1)
+        feat_mean = x.mean(dim=-1, keepdim=True)
+        feat_mean = feat_mean.sign() * torch.log1p(feat_mean.abs())
+        feat_norm = torch.log1p(torch.linalg.vector_norm(x, dim=-1)).view(
+            -1,
+            1,
+        )
+        state = torch.cat(
+            [
+                torch.log1p(deg),
+                feat_mean,
+                feat_norm,
+                torch.ones_like(deg),
+            ],
+            dim=-1,
+        )
+
+        descriptors = [state]
+        for _ in range(self.tree_depth):
+            if tree_edge_index.numel() == 0:
+                state = torch.zeros_like(state)
+            else:
+                state = scatter(
+                    state[source],
+                    target,
+                    dim=0,
+                    dim_size=num_nodes,
+                    reduce="mean",
+                )
+            descriptors.append(state)
+
+        return torch.cat(descriptors, dim=-1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        edge_attr: torch.Tensor | None = None,
+        return_aux: bool = False,
+        **kwargs,
+    ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Return node embeddings with shape ``[num_nodes, out_channels]``."""
+        del batch, kwargs
+        edge_weight = self._coerce_edge_weight(edge_weight, edge_attr)
+
+        z = x
+        for index, conv in enumerate(self.convs):
+            z = self._apply_conv(conv, z, edge_index, edge_weight)
+            z = self.norms[index](z)
+            if index < self.num_layers - 1:
+                z = self.dropout(self.activation(z))
+
+        tree_descriptors = self._tree_descriptors(x, edge_index)
+        tree_repr = self.tree_encoder(tree_descriptors)
+        tree_query = self.tree_query(torch.cat([z, tree_repr], dim=-1))
+        tree_tokens, token_ids, commitment_loss = self.vocabulary(tree_query)
+
+        self.last_tree_token_ids = token_ids.detach()
+        self.last_commitment_loss = commitment_loss.detach()
+
+        fused = torch.cat([z, tree_repr, tree_tokens], dim=-1)
+        out = self.output_norm(self.output_proj(self.dropout(fused)))
+
+        if not return_aux:
+            return out
+
+        aux = {
+            "tree_token_ids": token_ids,
+            "commitment_loss": commitment_loss,
+        }
+        return out, aux

--- a/topobench/nn/backbones/graph/gft.py
+++ b/topobench/nn/backbones/graph/gft.py
@@ -8,7 +8,8 @@ vocabulary for task adaptation.  TopoBench challenge runs do not ship the
 pretrained vocabulary, LLM/text features, reconstruction heads, or prototype
 task heads, so this backbone keeps the dependency-free core:
 
-* a SAGE/GCN/GIN/GAT message-passing encoder mirroring the reference encoder;
+* a SAGE/GCN/GIN/GAT message-passing encoder modeled after the reference
+  encoder choices;
 * a structural computation-tree descriptor built by repeated neighborhood
   aggregation of root structural statistics;
 * a cosine vector-quantized tree vocabulary fallback that is learned with the


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

Adds a TDL Challenge 2026 Track 1 implementation for GFT (`model=graph/gft`).

Reference:
- Paper: https://arxiv.org/abs/2411.06070
- Code: https://github.com/Zehong-Wang/GFT

Implemented and verified:
- supervised TopoBench-compatible GFT core encoder
- message-passing encoder plus computation-tree descriptors
- fallback vector-quantized tree vocabulary for challenge runs without pretrained GFT assets
- model config, unit tests, and pipeline smoke-test wiring
- challenge notebook `MODEL_CONFIG` set to `graph/gft`

Validation:
- `PYENV_VERSION=TDL python -m pytest test/nn/backbones/graph/test_gft.py -q` -> 20 passed
- `PYENV_VERSION=TDL python -m pytest test/pipeline/test_pipeline.py -q` with baseline smoke models plus `graph/gft` -> 1 passed
- focused ruff on GFT-touched files -> passed
- focused coverage for `topobench/nn/backbones/graph/gft.py` -> 99%
- official challenge sanity grid for `model_config="graph/gft"` -> all 24 configs passed

`results.json` status: committed at `2026_tdl_challenge/outputs/gft/results.json` with 72 completed challenge runs across train seeds 42, 43, and 44.

`results.json` provenance: generated from the checked-in `2026_tdl_challenge/utils.py` helpers via CLI with `model_config="graph/gft"`; `run_evaluation.ipynb` now sets the same `MODEL_CONFIG`.

## Issue

TDL Challenge 2026 Track 1 model submission for GFT.

## Additional context

This submission implements a supervised TopoBench-compatible GFT core, not the full official cross-domain graph foundation training system. It intentionally excludes pretrained vocabulary assets, cross-domain pretraining, tree-reconstruction objectives, text/LLM features, reconstruction heads, and prototype task heads because those artifacts/interfaces are not available in the GraphUniverse challenge pipeline.

The transferable-tree-vocabulary mechanism is represented by an in-model vector-quantized computation-tree vocabulary trained under the supervised challenge objective, using dependency-free structural proxy descriptors. The optional `commitment_loss` returned by `return_aux=True` is diagnostic only in this PR; the standard `GNNWrapper` challenge path optimizes the task loss only.
