### PR TITLE
Track: Track1; Team name: LangDiff; Model: HiD-Net

### DIFF
--- a/2026_tdl_challenge/outputs/2026-05-25_12-13-20/results.json
+++ b/2026_tdl_challenge/outputs/2026-05-25_12-13-20/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-05-25_12-13-20",
+    "model_config": "graph/hid_net",
+    "generated_at_utc": "2026-05-25T14:45:21.980452+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2020633220672607,
+      "test_best_rerun_accuracy": 0.3145771324634552,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.312094122171402,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32821452617645264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32894033193588257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3630911409854889,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3602261543273926,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3636641502380371,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36477193236351013,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42856597900390625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43792498111724854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4519061744213104,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4703567922115326,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8591405542770234,
+        "AvgTime/train_epoch_std": 0.08811538892107597,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.211085796356201,
+      "test_best_rerun_accuracy": 0.3133165240287781,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3128199279308319,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3255787193775177,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32714492082595825,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3587363362312317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3556421399116516,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3616395592689514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3614867329597473,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4216899573802948,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4324241876602173,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4480861723423004,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4655817747116089,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.980410122009645,
+        "AvgTime/train_epoch_std": 0.7228953676367972,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1885199546813965,
+      "test_best_rerun_accuracy": 0.3196195363998413,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3160287141799927,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33352434635162354,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3339063227176666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3648865520954132,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36290013790130615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36885935068130493,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3670639395713806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42757275700569153,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4415539801120758,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45182979106903076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46974557638168335,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.531511955483015,
+        "AvgTime/train_epoch_std": 0.1605783129531731,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1890130043029785,
+      "test_best_rerun_accuracy": 0.3156467378139496,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3179769217967987,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3277561366558075,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33069753646850586,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3591565489768982,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3564443290233612,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3565971553325653,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35801053047180176,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41630375385284424,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42340895533561707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4318893849849701,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44949957728385925,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.499126804286036,
+        "AvgTime/train_epoch_std": 0.15356866051755902,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.18110990524292,
+      "test_best_rerun_accuracy": 0.3188173174858093,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3212239146232605,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3318435251712799,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.331155925989151,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35858353972435,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35636794567108154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3597295582294464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3612193465232849,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41374436020851135,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42054396867752075,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43005576729774475,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4452211856842041,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.533053593463208,
+        "AvgTime/train_epoch_std": 0.6284833333889517,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1936843395233154,
+      "test_best_rerun_accuracy": 0.3148445188999176,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3169073164463043,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32741233706474304,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3303155303001404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3568645417690277,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35648253560066223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3580869436264038,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.356711745262146,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4129803776741028,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4261975586414337,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4318893849849701,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44800978899002075,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.378441119012032,
+        "AvgTime/train_epoch_std": 0.8545401861579311,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.134871006011963,
+      "test_best_rerun_accuracy": 0.3352051377296448,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3069753348827362,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3022385239601135,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33165252208709717,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3831843435764313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3760409355163574,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39376574754714966,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39242875576019287,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47696539759635925,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49545419216156006,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5231873989105225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5577965974807739,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.904796539259351,
+        "AvgTime/train_epoch_std": 0.11390644661652548,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1456310749053955,
+      "test_best_rerun_accuracy": 0.3336007297039032,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3049507141113281,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29807472229003906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32771793007850647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38108333945274353,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3737489581108093,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3930399715900421,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39216136932373047,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4791809916496277,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49625641107559204,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5259377956390381,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5606998205184937,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9104540131308814,
+        "AvgTime/train_epoch_std": 0.12035395251502613,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.148102045059204,
+      "test_best_rerun_accuracy": 0.3322637379169464,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30556192994117737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2994499206542969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3291313350200653,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37936434149742126,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37405455112457275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3935747444629669,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3923523426055908,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47696539759635925,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4934678077697754,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.523684024810791,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5590954422950745,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9002417616727874,
+        "AvgTime/train_epoch_std": 0.13005569519127194,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.16740345954895,
+      "test_best_rerun_accuracy": 0.32550233602523804,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30128350853919983,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2955153286457062,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32347771525382996,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3748185634613037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37065476179122925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38341355323791504,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38696616888046265,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47177019715309143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4911375939846039,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5176101922988892,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.554129421710968,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9053262833392983,
+        "AvgTime/train_epoch_std": 0.10080639203896954,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.151594638824463,
+      "test_best_rerun_accuracy": 0.3302009403705597,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30812132358551025,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.302582323551178,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32890212535858154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37879136204719543,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37443655729293823,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3859729468822479,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3894491493701935,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47383299469947815,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4908702075481415,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5181450247764587,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5519520044326782,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9030826165504062,
+        "AvgTime/train_epoch_std": 0.10339434965867667,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1652281284332275,
+      "test_best_rerun_accuracy": 0.32725954055786133,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30334633588790894,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2978455126285553,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32317212224006653,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37393996119499207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3716861605644226,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3850943446159363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3874627649784088,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47196120023727417,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49151960015296936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5169990062713623,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5532508492469788,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9173309480821765,
+        "AvgTime/train_epoch_std": 0.10162679404431073,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9363114833831787,
+      "test_best_rerun_accuracy": 0.41038277745246887,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2877989113330841,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2792420983314514,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3133929371833801,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3077775239944458,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39731836318969727,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4232943654060364,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42719078063964844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5619222521781921,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5783100128173828,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.632630467414856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6752616763114929,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9198087880640853,
+        "AvgTime/train_epoch_std": 0.1292238984779803,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9575128555297852,
+      "test_best_rerun_accuracy": 0.40492016077041626,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28352051973342896,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27263352274894714,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3081595301628113,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3034227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39403316378593445,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4182901680469513,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42230117321014404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5599740147590637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.576170802116394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.632706880569458,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6780120730400085,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5393467510447785,
+        "AvgTime/train_epoch_std": 0.9557002647022549,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9469585418701172,
+      "test_best_rerun_accuracy": 0.40560775995254517,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28611811995506287,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27710291743278503,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30854153633117676,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39456796646118164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41985636949539185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4264649748802185,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5611964464187622,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5736114382743835,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6305676698684692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6717472672462463,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3578703778130667,
+        "AvgTime/train_epoch_std": 0.8450919499416365,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9842904806137085,
+      "test_best_rerun_accuracy": 0.3938039541244507,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28718772530555725,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27928030490875244,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31029871106147766,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30919092893600464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4026663601398468,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4098479747772217,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4181373715400696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5514936447143555,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5691038370132446,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6183436512947083,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6610130667686462,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.543961162298498,
+        "AvgTime/train_epoch_std": 0.7213214006236662,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9808918237686157,
+      "test_best_rerun_accuracy": 0.393727570772171,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2874933183193207,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28161051869392395,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31140652298927307,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3107571303844452,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40041255950927734,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4103063642978668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4189777672290802,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5524486303329468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5683398246765137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.620368242263794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6618916392326355,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.238485262674444,
+        "AvgTime/train_epoch_std": 0.19804018314687713,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9819453954696655,
+      "test_best_rerun_accuracy": 0.39319276809692383,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2876461148262024,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27981510758399963,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3127817213535309,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3107571303844452,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4019787609577179,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4100389778614044,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41905418038368225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5527924299240112,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5698678493499756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6189166307449341,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6622354388237,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4081364328211006,
+        "AvgTime/train_epoch_std": 0.5547469316441711,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8508154153823853,
+      "test_best_rerun_accuracy": 0.4397967755794525,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26866069436073303,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2541064918041229,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30934372544288635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29807472229003906,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40923675894737244,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3960195481777191,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.443998783826828,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5726564526557922,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5877072215080261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6549774408340454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7003591060638428,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.230293783423019,
+        "AvgTime/train_epoch_std": 0.1124037997209961,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8929164409637451,
+      "test_best_rerun_accuracy": 0.42921537160873413,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2581939101219177,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2449766993522644,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2998701333999634,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2947131097316742,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.396707147359848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3825731575489044,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43601498007774353,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5595155954360962,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5781572461128235,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6426770687103271,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6913820505142212,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.8122491902775235,
+        "AvgTime/train_epoch_std": 1.1503449073790446,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8771765232086182,
+      "test_best_rerun_accuracy": 0.4334173798561096,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26434409618377686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2501718997955322,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30498892068862915,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2957063317298889,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40121474862098694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38910534977912903,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4396439790725708,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5684162378311157,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5841164588928223,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6504698395729065,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6969974637031555,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.575954335927963,
+        "AvgTime/train_epoch_std": 0.21467862191271905,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.812727928161621,
+      "test_best_rerun_accuracy": 0.4555733799934387,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25765910744667053,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24738329648971558,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2952861189842224,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29368171095848083,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40354496240615845,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39170295000076294,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.440216988325119,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5771640539169312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5924822092056274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6597142815589905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7063564658164978,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.491881491008558,
+        "AvgTime/train_epoch_std": 0.22285460822866945,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8194196224212646,
+      "test_best_rerun_accuracy": 0.45125678181648254,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25700971484184265,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2457789033651352,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2937581241130829,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29383450746536255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39930474758148193,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3891817629337311,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4342195689678192,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.573878824710846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5906104445457458,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.655588686466217,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7030330896377563,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.432719415739963,
+        "AvgTime/train_epoch_std": 0.12376508391921472,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8298782110214233,
+      "test_best_rerun_accuracy": 0.4487355649471283,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25712430477142334,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24543510377407074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2915043234825134,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2913515269756317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39338377118110657,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3863549530506134,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43154558539390564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5713958144187927,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5870578289031982,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6529528498649597,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7013905048370361,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9939263922827584,
+        "AvgTime/train_epoch_std": 0.10764401734425091,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4160659313201904,
+      "test_best_rerun_accuracy": 0.6061578392982483,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24050728976726532,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22751928865909576,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2539154887199402,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2460463047027588,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4030865728855133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3908625543117523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41332417726516724,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42356178164482117,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6190312504768372,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6855374574661255,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7273665070533752,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.013215555334991,
+        "AvgTime/train_epoch_std": 0.11889550759254322,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4375256299972534,
+      "test_best_rerun_accuracy": 0.5979066491127014,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23542669415473938,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22358469665050507,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25360989570617676,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2418442964553833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39770036935806274,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3844831585884094,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.412751168012619,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4207349717617035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6131866574287415,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6836656928062439,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7282068729400635,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.017736625671387,
+        "AvgTime/train_epoch_std": 0.09180542119979639,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4044173955917358,
+      "test_best_rerun_accuracy": 0.6057376265525818,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24669569730758667,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2332874983549118,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2587287127971649,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24803270399570465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.406982958316803,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3915501534938812,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41592177748680115,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4205821752548218,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6164718270301819,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6835510730743408,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7254182696342468,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.06754912200727,
+        "AvgTime/train_epoch_std": 0.13598580933315613,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3529714345932007,
+      "test_best_rerun_accuracy": 0.620444655418396,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23718389868736267,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22381389141082764,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2495989054441452,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23810069262981415,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4000687599182129,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3877301514148712,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40996256470680237,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41821375489234924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6062724590301514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6848498582839966,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7293146848678589,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.149867300717336,
+        "AvgTime/train_epoch_std": 0.681677560887936,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.355972170829773,
+      "test_best_rerun_accuracy": 0.6146764755249023,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23661088943481445,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22835968434810638,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2517381012439728,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23962870240211487,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40045076608657837,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3859729468822479,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4097333550453186,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4197799563407898,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5998548269271851,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6792726516723633,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7241194844245911,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.983084727141817,
+        "AvgTime/train_epoch_std": 0.07498568930610312,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3502709865570068,
+      "test_best_rerun_accuracy": 0.6170448660850525,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23985789716243744,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2289326936006546,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2510887086391449,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23863549530506134,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4026281535625458,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38902896642684937,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41240736842155457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41825196146965027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6048208475112915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6844296455383301,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7282450795173645,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.0531980730593204,
+        "AvgTime/train_epoch_std": 0.0743067009754003,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1449674367904663,
+      "test_best_rerun_accuracy": 0.6909618973731995,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22610588371753693,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21258307993412018,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2427992969751358,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23091909289360046,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3962487578392029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3830697536468506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41729697585105896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4255099594593048,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6059286594390869,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6209794282913208,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.733211100101471,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.053082929467255,
+        "AvgTime/train_epoch_std": 0.08462060843025311,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1455276012420654,
+      "test_best_rerun_accuracy": 0.6869890689849854,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22862708568572998,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21678508818149567,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24914050102233887,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23768049478530884,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40014517307281494,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.384177565574646,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4220719635486603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4343341588973999,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6016502380371094,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.615784227848053,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.73244708776474,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.100680355298317,
+        "AvgTime/train_epoch_std": 0.07725908027068625,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1517994403839111,
+      "test_best_rerun_accuracy": 0.6870654821395874,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22847428917884827,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2151806801557541,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.245244100689888,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23240889608860016,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3978913724422455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38356634974479675,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41905418038368225,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4284895658493042,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6040950417518616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6146000623703003,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.731683075428009,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.1226109161711575,
+        "AvgTime/train_epoch_std": 0.08509247865746064,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9943367838859558,
+      "test_best_rerun_accuracy": 0.7337458729743958,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22167469561100006,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20891588926315308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2398196905851364,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23080448806285858,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39361295104026794,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38031935691833496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4173733592033386,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4309343695640564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6018030643463135,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6156314611434937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6885170936584473,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.615166632634289,
+        "AvgTime/train_epoch_std": 0.19909100362452314,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9945241212844849,
+      "test_best_rerun_accuracy": 0.7319505214691162,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22278249263763428,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21074947714805603,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23878829181194305,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2287798970937729,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3904423415660858,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3788295388221741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41932156682014465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4292917847633362,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5998930335044861,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6137978434562683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6856138706207275,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.3256021976470946,
+        "AvgTime/train_epoch_std": 0.1052268756072839,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9944226145744324,
+      "test_best_rerun_accuracy": 0.7313010692596436,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22461609542369843,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20998547971248627,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24302849173545837,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23076629638671875,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3943769633769989,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38081595301628113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4177935719490051,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4315837621688843,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6023378372192383,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6122698187828064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6887462735176086,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.4560582488775253,
+        "AvgTime/train_epoch_std": 0.15377682775140342,
+        "model/params/total": 10689,
+        "model/params/trainable": 10689,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 56.71802520751953,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 54.97233581542969,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.03960542926183695,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.067399978637695,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1161442104138826
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8008.80810546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.607418134658229
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 295.88201904296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09972430705863457
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6829.537109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9124298075317301
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.94854736328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14157905644497518
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162180.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7660270179268065
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14528.5283203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0186880045093605
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44944.28515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3037718568993797
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3594.681640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6390545138888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743844.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.414245698675384
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257613.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.286908156940076
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4858178240912303,
+        "AvgTime/train_epoch_std": 0.09017204344994509,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 58.41924285888672,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 56.94816970825195,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.041028940711997086,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.924955368041992,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.12065765983179996
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8087.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6133485020857035
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312.19842529296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10522360137949739
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6749.515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9017388944555779
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.9754180908203,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14073870301452532
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162184.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7661224427596136
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14464.763671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.014217057346445
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44872.09765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3000716416141267
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3560.944580078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6330568142361112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744100.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.41714011402328
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257653.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.287586272527582
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6412526405218877,
+        "AvgTime/train_epoch_std": 0.12276824069528249,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 67.97669219970703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 65.20396423339844,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.04697691947651184,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.722493171691895,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07748680616679944
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8233.2509765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6244407263225256
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 271.5873107910156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09153599959252295
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6807.24658203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9094517811664997
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.25169372558594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13320526228461652
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162303.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7688959310561025
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14408.365234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0102626023261114
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44667.94921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2896073206596954
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3535.126220703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6284668836805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742840.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.40288225512709
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256844.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.274114705539747
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.632645425796509,
+        "AvgTime/train_epoch_std": 0.23005555346632603,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.920886516571045,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.9585824012756348,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.020834644217240184,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186.79295349121094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1345770558294027
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12685.7998046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9621387792709518
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415.3173828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13997889545416245
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8084.24755859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0800597940673013
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.48468017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15585896388236722
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177080.109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.112021859906186
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16089.8046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.128159072184827
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47583.25390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.439041155684556
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3979.822998046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7075240885416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 763547.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.637121336379987
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266401.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.433160372256336
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.432843631313693,
+        "AvgTime/train_epoch_std": 0.09086039614626831,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.3488693237304688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.430906057357788,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.018057400301883096,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203.03790283203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14628090982134817
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13013.3095703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9869783519387562
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 422.7464294433594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.142482787139656
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8134.1923828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.086732449273547
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.78929138183594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1552584554247288
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178024.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.133962314810515
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16158.283203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1329605387130135
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47726.54296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.446385922843303
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3979.958740234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7075482204861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764994.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.653490266167438
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266897.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.441402284791906
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.420812533961402,
+        "AvgTime/train_epoch_std": 0.08943966250591076,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 4.425505638122559,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.198760509490967,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.022098739523636668,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200.5941925048828,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14452031160294151
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12997.0185546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9857427800293894
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 426.1947937011719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1436450265255045
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8155.517578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.089581506763527
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.24957275390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15565593502064443
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177998.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.133352394111091
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16224.9716796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.137636494158428
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47732.59765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4466962763980726
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3981.393310546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7078032552083333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764756.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.650797342850355
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266898.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.441426206047294
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.424909996431927,
+        "AvgTime/train_epoch_std": 0.09040481210495498,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2392.578369140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2305.984130859375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.1748945112521331,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 737.7993774414062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5315557474361716
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 869.748046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.5776212993421055
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 745.4173583984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.25123604934224386
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5145.3212890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6874176738894455
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 733.5271606445312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6334431439071945
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127929.6015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9706855276449007
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12478.654296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8749582314454495
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40922.3203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0976124000461325
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3773.657470703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6708724392361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 700579.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.92483993755868
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241595.734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.020364008703177
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4279463997593633,
+        "AvgTime/train_epoch_std": 0.08715983059810155,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2057.2451171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2035.528076171875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.1543821066493648,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 883.400390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.636455612842219
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1569.2950439453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.259447599712171
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1373.849365234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.463043264318967
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4986.73095703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6662299207790581
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1203.8134765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.039562587705095
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125551.6640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.915466841503344
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12937.837890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9071545288616604
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41282.5234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1160758335896253
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4052.456787109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7204367621527777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 698814.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.90487243079986
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241053.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.01133269473982
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4393640041351317,
+        "AvgTime/train_epoch_std": 0.0913346493747131,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2442.00634765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2352.918701171875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.178454205625474,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 798.1309204101562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5750222769525621
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1502.2227783203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.906435675370066
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1158.2296142578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3903706148492796
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5409.41259765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7227004138485303
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1234.7974853515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.0663190719788969
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127659.3046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.96440889577141
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13315.2275390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9336157298459192
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42245.59375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1654412706955766
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4354.8046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7741875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 703606.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.959075201067837
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244300.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.065368470537334
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.432459907872336,
+        "AvgTime/train_epoch_std": 0.09448484880346512,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 135.79013061523438,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 135.3357391357422,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0456136633420095,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214.2322540283203,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15434600434317025
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 304.47882080078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.602520109477796
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10045.333984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7618759184205537
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6670.328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8911594021376086
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 287.5423583984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.24830946321108593
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167096.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8801819675366898
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13412.919921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9404655673730893
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43207.0078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2147218110871907
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3132.783447265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5569392795138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741786.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.390965945725824
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253508.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.218602832276638
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4066800276438394,
+        "AvgTime/train_epoch_std": 0.024843770258886642,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 137.63258361816406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 139.9362335205078,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04716421756673671,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262.09100341796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1888263713385942
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 223.18020629882812,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.1746326647306744
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7258.84765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5505383129503223
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5998.419921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8013921071309286
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 251.8495330810547,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2174866434205999
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157207.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.650559341909716
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12576.841796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8818427848040247
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41674.28515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.136156909951817
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2949.39794921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5243374131944445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728953.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.245799067904935
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247906.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.125386120263592
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4235606964896705,
+        "AvgTime/train_epoch_std": 0.09364114339074767,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 134.6964569091797,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.60232543945312,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04536647301633068,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252.40879821777344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1818507191770702
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239.73245239257812,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2617497494346217
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7811.802734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.592476506209708
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6170.51123046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8243835979250167
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 268.7364501953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.23206947339837003
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159030.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.692894587126138
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12750.2890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8940042814822605
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41918.18359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.148658752050336
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2982.0869140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5301487847222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 730782.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.26648629005803
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 248668.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.138058925332402
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4051034351189933,
+        "AvgTime/train_epoch_std": 0.06900176576579453,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 4519.5380859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4693.29296875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.6270264487307949,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1029.97607421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.74205769035933
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 300.94488525390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5839204487047698
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2701.8955078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2049219194397042
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 387.0184326171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13044099515240562
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 378.20416259765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.32660117668191385
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128388.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.981349343419097
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10303.27734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7224286456142196
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37600.328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9273324170895485
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2739.039306640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4869403211805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 689689.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.8016547798151645
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232653.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.87155897941524
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4133107878945093,
+        "AvgTime/train_epoch_std": 0.07670840942735795,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 4209.1220703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4372.8359375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.5842132181028724,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1048.3492431640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.755294843778143
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 269.3125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.4174342105263158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2624.2294921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.19903143664675768
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 345.9242858886719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11659059180609097
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 311.7479248046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2692123702976576
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129219.5234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0006391286805685
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9909.5078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.694818946325901
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37164.25,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9049797529345431
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2496.232177734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.443774609375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 690286.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.808400874404715
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230804.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8407863644684075
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3995075821876526,
+        "AvgTime/train_epoch_std": 0.05680675917642408,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 4515.79248046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4753.01416015625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.6350052318178022,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1494.3553466796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0766248895386799
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 278.5728454589844,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.4661728708367598
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2844.673828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2157507643629124
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 465.14984130859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1567744662314101
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 477.8566589355469,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4126568730013358
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123737.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8733358707389
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9703.3564453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6803643560028397
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36359.6875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.86373917166436
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2751.746337890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.48919934895833334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 678893.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.679525157517279
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 226460.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7685010109330537
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.406373408532912,
+        "AvgTime/train_epoch_std": 0.06903193052595588,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 136.6871795654297,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 142.85781860351562,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12336599188559208,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106.02242279052734,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07638503082891018
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.882152557373047,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.13095869767038446
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10800.3701171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8191406990661737
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 265.77154541015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08957584948100986
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7335.46435546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9800219579784569
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170549.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9603827297742895
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14850.4931640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0412630180944118
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45685.1640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3417481194576864
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3587.7470703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6378217013888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752518.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.512359591869053
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260605.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.336698169919957
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.377249312400818,
+        "AvgTime/train_epoch_std": 0.06957564476486996,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 137.50302124023438,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 145.33145141601562,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12550211693956445,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135.22525024414062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09742453187618201
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30.492204666137695,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.16048528771651419
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11864.392578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8998401651971938
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 290.4154052734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09788183527921722
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7527.22021484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0056406432656981
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173937.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.0390577831831695
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15156.8916015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0627465714179287
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46143.05859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3652190575503615
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3616.556640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6429434027777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757304.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.566501561032997
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262353.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.365792396784983
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3891651034355164,
+        "AvgTime/train_epoch_std": 0.07344543470359213,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 140.3968505859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.48629760742188,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.1264993934433695,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113.9006118774414,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08206095956587997
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.930715560913086,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.14700376611006888
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10743.650390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8148388616325369
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267.86865234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09028266004170879
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7304.82666015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.975928745511857
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170230.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.952957008754412
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14847.658203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0410642408585753
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45538.44921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3342277522553694
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3555.33203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6320590277777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 751837.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.50465835435449
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259974.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.32619569875027
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4268111965873023,
+        "AvgTime/train_epoch_std": 0.051124857398320435,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 100826.625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 72427.171875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.6818496162688092,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48777.99609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 35.14264848252882
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34447.7109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 181.3037417763158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46969.76171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.56236342197573
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36544.31640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 12.316924976828446
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37751.3515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 5.043600743152973
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35826.26171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 30.938049843480137
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24091.849609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.6892336004329687
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34750.48828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7812542047900968
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33129.46484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 5.889682638888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 489455.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.536636200128955
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132593.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2064760558634116
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.421723849243588,
+        "AvgTime/train_epoch_std": 0.07800040807575959,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 107274.6015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 75126.6484375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.7445348420374327,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57439.30859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 41.38278717128963
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50420.4921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 265.3710115131579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39549.12890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9995547141638226
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45355.75390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 15.286738761796427
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44353.203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 5.92561163994656
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50547.21484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 43.650444597366146
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29048.06640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.036745646210209
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38900.4453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9939743355630735
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44944.83984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 7.99019375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 484633.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.482095842335667
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126803.7578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.110125269374137
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.434157417880164,
+        "AvgTime/train_epoch_std": 0.07549540533504631,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 108711.890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 76343.0703125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.7727816810444919,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60955.25390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 43.91588898144813
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58771.359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 309.3229440789474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37785.12890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.8657663182593858
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53139.73828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 17.910258942113245
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47307.71875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.320336506346026
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57768.921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 49.88680645509499
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34320.59765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.4064365205616323
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40300.3203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.065729679250602
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49062.88671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 8.722290972222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 482695.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.460175630351912
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126478.6015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1047143854109462
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4255585259404677,
+        "AvgTime/train_epoch_std": 0.07560036866980048,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 7589.99462890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7264.3935546875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5093530749325129,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4984.92431640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.5914440319929755
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3316.2734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.45407072368421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3857.636962890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2925776991195013
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2816.723388671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.9493506534114846
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5634.55126953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.752779060725618
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3342.865478515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.8867577534677245
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118010.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7403461272756826
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30667.13671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5719481633476857
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3636.0849609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6464151041666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 647870.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.328605929663021
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203771.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.390935456292746
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4495222030147428,
+        "AvgTime/train_epoch_std": 0.10135811195449125,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 6859.0634765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6713.77978515625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.4707460233597146,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6570.88232421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.734065075085555
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2617.8056640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 13.777924547697369
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6077.99755859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4609781993624384
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3013.32421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.0156131509100101
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6080.3564453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8123388704492318
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3045.453857421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.6299256108997193
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102001.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.3686010937209736
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29047.962890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4889519140204521
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3885.274658203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6907154947916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 620949.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.0240751162290875
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 193019.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2120177266902967
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4529978938219026,
+        "AvgTime/train_epoch_std": 0.09770124543762959,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 6687.68505859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6690.88818359375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.46914094682328916,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6149.3115234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.430339714292147
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2982.429931640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 15.696999640213816
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5136.30517578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.38955670654389457
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3216.254150390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.084008813748104
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6138.7939453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8201461516783567
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3443.2470703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.973443065900259
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106114.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.464106838078209
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29322.86328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.503042866433441
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4035.61376953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7174424479166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 627604.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.099358194857641
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194560.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2376574122609956
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4521373957395554,
+        "AvgTime/train_epoch_std": 0.09208717572243516,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 25873.076171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 26526.06640625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.359683551501871,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13699.0966796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.869666195740274
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10894.9111328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 57.34163754111842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8066.93310546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6118265533157945
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10062.9091796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.391610778458881
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10353.84375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.3832790581162324
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10724.880859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 9.261555146265112
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100561.5078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.3351641234557867
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8335.4873046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5844543054752138
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8943.2119140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.5899043402777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 596521.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.74775530807778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177534.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9543226228512474
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4381320561681474,
+        "AvgTime/train_epoch_std": 0.09345069467593989,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26409.28515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 26959.962890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.3819243882631094,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11817.8466796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.514298760581772
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8675.173828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 45.658809621710525
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7174.16015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5441152943686007
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8081.32080078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.7237346817597743
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9114.5673828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2177110731880427
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8733.4072265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.541802440900259
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102018.7890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.36900401872794
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7545.4716796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5290612592685108
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7621.083984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.354859375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 604058.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.833007646799317
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181076.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.013266676235169
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4480283004896983,
+        "AvgTime/train_epoch_std": 0.08384180431307106,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26587.287109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27135.51171875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.390922739184479,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11372.6025390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.193517679439841
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9012.7998046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 47.43578844572368
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6533.6689453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.49553803149886233
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8094.8193359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.7282842386038086
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8956.69140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1966187583500334
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8892.74609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.679400771804836
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104853.0390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.434818852463775
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7686.94677734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5389809828455862
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7553.7265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.3428847222222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 607903.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.876504473830074
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182752.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.041158079976037
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.440915822982788,
+        "AvgTime/train_epoch_std": 0.11410431370629702,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2483.004638671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2628.22314453125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4672396701388889,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 732.7132568359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5278913954149406
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 480.84442138671875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.5307601125616777
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4885.52490234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.37053658720847554
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260.2875671386719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08772752515627633
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5239.82958984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7000440333792585
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 483.6031188964844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.41761927365844936
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145431.875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.377110231283671
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10832.8330078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7595591787836559
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38571.33203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9771045174662976
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 707940.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.008109170503264
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236935.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.942817019037159
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.460534581431636,
+        "AvgTime/train_epoch_std": 0.0802713540949186,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2333.91943359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2478.585693359375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4406374565972222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 901.7892456054688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6497040674390985
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 384.3013916015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.0226389031661185
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3697.330322265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.28041944044487105
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.31005859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10054265540739804
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4730.82470703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6320407090222111
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 430.1855773925781,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.37149013591759766
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137949.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2033601151774103
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10153.4794921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7119253605516407
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37295.6796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9117166275821416
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 698084.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.896617620442745
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232236.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8646186951891237
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4505167217815624,
+        "AvgTime/train_epoch_std": 0.08985154613683573,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2494.54052734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2622.48974609375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.46622039930555553,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1041.852783203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.750614397120407
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 562.6727294921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.961435418379934
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4076.857177734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3092041848869454
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 387.1531677246094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13048640637836514
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5024.470703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.671271971025384
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 626.9953002929688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5414467187331337
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139363.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.236189885983652
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10142.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7111204599635395
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37287.734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.911309363627044
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 697368.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.888520468762373
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231554.21875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8532644193167256
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.43098785566247,
+        "AvgTime/train_epoch_std": 0.07577985180164884,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 502881.90625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 324630.09375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.672161507528025,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389135.375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 280.3568984149856
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 406541.125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2139.6901315789473
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 289060.125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.923407281001136
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 384667.28125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 129.64856125716213
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 339126.84375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 45.30752755511022
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 397273.84375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 343.06894969775476
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171200.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9755001277168867
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 304700.71875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.36451540807741
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266031.375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.63634091957558
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361280.28125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 64.22760555555556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162463.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7035407618191805
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4377603265974255,
+        "AvgTime/train_epoch_std": 0.10044360965476494,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 501799.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 324394.78125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6694996917525424,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389304.0625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 280.4784311959654
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 404211.46875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2127.4287828947367
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 292640.875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 22.19498483124763
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 383892.125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 129.3873019885406
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 339626.625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 45.37429859719439
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 395522.96875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 341.55696783246975
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173129.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.020279409715772
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 304812.125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.372326812508764
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266239.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.646999461786868
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 360334.34375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 64.05943888888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162655.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.706721508744779
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.441641705376761,
+        "AvgTime/train_epoch_std": 0.0888812747316615,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 503027.59375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 324833.0,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6744567492053437,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 381770.3125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 275.0506574207493
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 396398.8125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2086.3095394736843
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 286013.375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.69233029958286
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 375613.4375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 126.5970466801483
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 332886.65625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 44.473835170340685
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 387855.53125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 334.93569192573403
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169292.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9311885362483747
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 297715.34375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 20.874726107839013
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260589.96875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.35742317648265
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 353178.4375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 62.78727777777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159901.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.660905544322966
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.440933877771551,
+        "AvgTime/train_epoch_std": 0.10398268438128151,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 108795.265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 105106.4765625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7490635608556737,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132928.0625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 95.76949747838617
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137739.40625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 724.9442434210526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87515.71875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.637521331058021
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128153.15625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 43.192839989888775
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108431.09375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.486452070808284
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133206.03125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 115.03111506908463
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83414.9765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.937000198831971
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88280.609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.189917919997195
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81619.1796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.183668034625045
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114932.2109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.432393055555554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 414211.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.68548684716582
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4420089258088007,
+        "AvgTime/train_epoch_std": 0.0891486338310869,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 110796.859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107027.109375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7810245681693375,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127821.796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 92.09063175432277
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133905.921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 704.768009868421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79490.8984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.028888770383011
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120923.71875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 40.75622472194136
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103256.4921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 13.795122536740147
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129752.640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 112.04891245682211
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79208.46875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8393198204997214
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83118.1484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.82794477895807
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77554.9453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.9753419095033062
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112246.078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 19.954858333333334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 412904.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.6707019275363955
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.438469156142204,
+        "AvgTime/train_epoch_std": 0.0765088237373681,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hid_net_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 108994.859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 105468.515625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.755088207029105,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130479.7578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 94.00558920208934
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122404.9765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 644.23671875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103643.578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.86071885665529
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116804.015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 39.36771675935288
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108251.7421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.462490606212425
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120818.0546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 104.33338055915371
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87068.890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0218486583921607
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81435.015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.709929576847567
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83057.765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.257407638782101
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109635.3203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 19.49072361111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 413578.65625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.67833281958757
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-05-25_12-13-20__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.442719668149948,
+        "AvgTime/train_epoch_std": 0.09285257584057845,
+        "model/params/total": 9454,
+        "model/params/trainable": 9454,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/graph/hid_net.yaml
+++ b/configs/model/graph/hid_net.yaml
@@ -1,0 +1,41 @@
+_target_: topobench.model.TBModel
+
+model_name: hid_net
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.HiDNet
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_layers: 10
+  alpha: 0.1
+  beta: 0.8
+  gamma: 0.5
+  dropout: 0.0
+  add_self_loops: true
+  cached: false
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+compile: false

--- a/configs/model/graph/hid_net.yaml
+++ b/configs/model/graph/hid_net.yaml
@@ -20,7 +20,6 @@ backbone:
   gamma: 0.5
   dropout: 0.0
   add_self_loops: true
-  cached: false
 
 backbone_wrapper:
   _target_: topobench.nn.wrappers.GNNWrapper

--- a/test/nn/backbones/graph/test_hid_net.py
+++ b/test/nn/backbones/graph/test_hid_net.py
@@ -1,6 +1,7 @@
 """Unit tests for the HiD-Net graph backbone."""
 
 import torch
+
 from topobench.nn.backbones.graph import HiDNet
 
 
@@ -51,8 +52,8 @@ class TestHiDNet:
 
         assert out.shape == x.shape
 
-    def test_supports_weighted_cached_propagation(self):
-        """Test weighted diffusion and normalized adjacency caching."""
+    def test_supports_weighted_propagation(self):
+        """Test propagation with supplied graph edge weights."""
         x = torch.randn(4, self.in_channels)
         edge_index = torch.tensor(
             [[0, 1, 2, 3, 0], [1, 2, 3, 0, 2]], dtype=torch.long
@@ -63,16 +64,15 @@ class TestHiDNet:
             in_channels=self.in_channels,
             hidden_channels=self.in_channels,
             num_layers=2,
-            cached=True,
         )
         model.eval()
 
         out_first = model(x, edge_index, edge_weight=edge_weight)
-        out_cached = model(x, edge_index, edge_weight=edge_weight)
+        out_second = model(x, edge_index, edge_weight=edge_weight)
 
-        assert model._cached_edge_index is not None
-        assert model._cached_grad_edge_index is not None
-        assert torch.allclose(out_first, out_cached)
+        assert out_first.shape == x.shape
+        assert torch.isfinite(out_first).all()
+        assert torch.allclose(out_first, out_second)
 
     def test_backward_produces_finite_gradients(self):
         """Test that gradients propagate through the backbone."""

--- a/test/nn/backbones/graph/test_hid_net.py
+++ b/test/nn/backbones/graph/test_hid_net.py
@@ -1,0 +1,98 @@
+"""Unit tests for the HiD-Net graph backbone."""
+
+import torch
+from topobench.nn.backbones.graph import HiDNet
+
+
+class TestHiDNet:
+    """Test HiD-Net graph backbone."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.num_nodes = 5
+        self.in_channels = 8
+        self.hidden_channels = 16
+        self.edge_index = torch.tensor(
+            [
+                [0, 1, 2, 3, 4, 0],
+                [1, 2, 3, 4, 0, 2],
+            ],
+            dtype=torch.long,
+        )
+
+    def test_forward_shape(self):
+        """Test that the backbone returns finite node embeddings."""
+        x = torch.randn(self.num_nodes, self.in_channels)
+        model = HiDNet(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            num_layers=2,
+        )
+
+        out = model(x, self.edge_index)
+
+        assert out.shape == (self.num_nodes, self.hidden_channels)
+        assert torch.isfinite(out).all()
+
+    def test_accepts_topobench_wrapper_kwargs(self):
+        """Test compatibility with arguments supplied by ``GNNWrapper``."""
+        x = torch.randn(4, self.in_channels)
+        edge_index = torch.tensor(
+            [[0, 1, 2], [1, 2, 3]], dtype=torch.long
+        )
+        batch = torch.zeros(4, dtype=torch.long)
+
+        model = HiDNet(
+            in_channels=self.in_channels,
+            hidden_channels=self.in_channels,
+            num_layers=2,
+        )
+        out = model(x, edge_index, batch=batch, edge_weight=None)
+
+        assert out.shape == x.shape
+
+    def test_supports_weighted_cached_propagation(self):
+        """Test weighted diffusion and normalized adjacency caching."""
+        x = torch.randn(4, self.in_channels)
+        edge_index = torch.tensor(
+            [[0, 1, 2, 3, 0], [1, 2, 3, 0, 2]], dtype=torch.long
+        )
+        edge_weight = torch.tensor([1.0, 0.5, 1.0, 0.5, 0.75])
+
+        model = HiDNet(
+            in_channels=self.in_channels,
+            hidden_channels=self.in_channels,
+            num_layers=2,
+            cached=True,
+        )
+        model.eval()
+
+        out_first = model(x, edge_index, edge_weight=edge_weight)
+        out_cached = model(x, edge_index, edge_weight=edge_weight)
+
+        assert model._cached_edge_index is not None
+        assert model._cached_grad_edge_index is not None
+        assert torch.allclose(out_first, out_cached)
+
+    def test_backward_produces_finite_gradients(self):
+        """Test that gradients propagate through the backbone."""
+        x = torch.randn(
+            self.num_nodes,
+            self.in_channels,
+            requires_grad=True,
+        )
+
+        model = HiDNet(
+            in_channels=self.in_channels,
+            hidden_channels=self.in_channels,
+            num_layers=2,
+        )
+        model(x, self.edge_index).square().mean().backward()
+
+        assert x.grad is not None
+        assert torch.isfinite(x.grad).all()
+        assert all(
+            parameter.grad is not None
+            and torch.isfinite(parameter.grad).all()
+            for parameter in model.parameters()
+        )

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -5,7 +5,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS = ["graph/hid_net"]                                              # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/hid_net.py
+++ b/topobench/nn/backbones/graph/hid_net.py
@@ -18,6 +18,7 @@ from torch_scatter import scatter
 
 def feature_norm(x: Tensor, eps: float = 1e-12) -> Tensor:
     """Normalize each node feature vector by its L1 norm.
+    
     Parameters
     ----------
     x : torch.Tensor

--- a/topobench/nn/backbones/graph/hid_net.py
+++ b/topobench/nn/backbones/graph/hid_net.py
@@ -2,22 +2,15 @@
 
 Adapted from:
 Li et al., "A Generalized Neural Diffusion Framework on Graphs", AAAI 2024.
-Official implementation: https://github.com/BUPT-GAMMA/HiD-Net
-
-TopoBench adaptation:
-- returns node embeddings instead of log-softmax class predictions;
-- uses explicit constructor arguments instead of an argparse namespace;
-- accepts TopoBench GNNWrapper's forward signature;
-- keeps feature normalization differentiable in PyTorch.
+Official implementation: https://github.com/BUPT-GAMMA/HiD-Net,
+we return node embeddings instead of log-softmax class predictions for general use
 """
 
 from __future__ import annotations
 
 import torch
-from torch import Tensor
-from torch import nn
 import torch.nn.functional as F
-
+from torch import Tensor, nn
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.nn.dense.linear import Linear
 from torch_scatter import scatter
@@ -25,11 +18,6 @@ from torch_scatter import scatter
 
 def feature_norm(x: Tensor, eps: float = 1e-12) -> Tensor:
     """Normalize each node feature vector by its L1 norm.
-
-    The upstream HiD-Net utility obtains the denominator through NumPy, which
-    detaches it from autograd. This adaptation performs the same normalization
-    directly in PyTorch so gradients pass through the denominator.
-
     Parameters
     ----------
     x : torch.Tensor
@@ -52,10 +40,6 @@ def cal_g_gradient3(
     edge_weight: Tensor,
 ) -> Tensor:
     """HiD-Net g3 high-order gradient term.
-
-    This mirrors the official implementation's default g3 variant:
-    first aggregate weighted neighbor differences, then aggregate the
-    resulting one-step gradients again and normalize.
 
     Parameters
     ----------
@@ -115,9 +99,6 @@ class HiDNet(nn.Module):
     add_self_loops : bool
         Whether to add self-loops to the normalized graph used for ordinary
         diffusion.
-    cached : bool
-        Keep False for TopoBench/GraphUniverse unless you are certain each
-        module instance sees one fixed graph.
     """
 
     def __init__(
@@ -130,7 +111,6 @@ class HiDNet(nn.Module):
         gamma: float = 0.5,
         dropout: float = 0.0,
         add_self_loops: bool = True,
-        cached: bool = False,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -145,7 +125,6 @@ class HiDNet(nn.Module):
         self.gamma = gamma
         self.dropout = dropout
         self.add_self_loops = add_self_loops
-        self.cached = cached
 
         self.lin1 = Linear(
             in_channels,
@@ -160,18 +139,9 @@ class HiDNet(nn.Module):
             weight_initializer="glorot",
         )
 
-        self._cached_edge_index = None
-        self._cached_edge_weight = None
-        self._cached_grad_edge_index = None
-        self._cached_grad_edge_weight = None
-
     def reset_parameters(self) -> None:
         self.lin1.reset_parameters()
         self.lin2.reset_parameters()
-        self._cached_edge_index = None
-        self._cached_edge_weight = None
-        self._cached_grad_edge_index = None
-        self._cached_grad_edge_weight = None
 
     def _get_norms(
         self,
@@ -181,14 +151,6 @@ class HiDNet(nn.Module):
         dtype: torch.dtype,
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Return normalized graph for diffusion and gradient term."""
-
-        if self.cached and self._cached_edge_index is not None:
-            return (
-                self._cached_edge_index,
-                self._cached_edge_weight,
-                self._cached_grad_edge_index,
-                self._cached_grad_edge_weight,
-            )
 
         # Ordinary diffusion graph: with self-loops, as in official model.py.
         norm_edge_index, norm_edge_weight = gcn_norm(
@@ -210,13 +172,12 @@ class HiDNet(nn.Module):
             dtype=dtype,
         )
 
-        if self.cached:
-            self._cached_edge_index = norm_edge_index
-            self._cached_edge_weight = norm_edge_weight
-            self._cached_grad_edge_index = grad_edge_index
-            self._cached_grad_edge_weight = grad_edge_weight
-
-        return norm_edge_index, norm_edge_weight, grad_edge_index, grad_edge_weight
+        return (
+            norm_edge_index,
+            norm_edge_weight,
+            grad_edge_index,
+            grad_edge_weight,
+        )
 
     @staticmethod
     def _spmm(edge_index: Tensor, edge_weight: Tensor, x: Tensor) -> Tensor:

--- a/topobench/nn/backbones/graph/hid_net.py
+++ b/topobench/nn/backbones/graph/hid_net.py
@@ -1,0 +1,272 @@
+"""HiD-Net backbone for TopoBench.
+
+Adapted from:
+Li et al., "A Generalized Neural Diffusion Framework on Graphs", AAAI 2024.
+Official implementation: https://github.com/BUPT-GAMMA/HiD-Net
+
+TopoBench adaptation:
+- returns node embeddings instead of log-softmax class predictions;
+- uses explicit constructor arguments instead of an argparse namespace;
+- accepts TopoBench GNNWrapper's forward signature;
+- keeps feature normalization differentiable in PyTorch.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+from torch import nn
+import torch.nn.functional as F
+
+from torch_geometric.nn.conv.gcn_conv import gcn_norm
+from torch_geometric.nn.dense.linear import Linear
+from torch_scatter import scatter
+
+
+def feature_norm(x: Tensor, eps: float = 1e-12) -> Tensor:
+    """Normalize each node feature vector by its L1 norm.
+
+    The upstream HiD-Net utility obtains the denominator through NumPy, which
+    detaches it from autograd. This adaptation performs the same normalization
+    directly in PyTorch so gradients pass through the denominator.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Node feature matrix of shape ``[num_nodes, num_features]``.
+    eps : float, optional
+        Lower bound for each normalization denominator.
+
+    Returns
+    -------
+    torch.Tensor
+        Row-wise normalized node feature matrix.
+    """
+    norm = torch.norm(x, p=1, dim=1, keepdim=True).clamp_min(eps)
+    return x / norm
+
+
+def cal_g_gradient3(
+    edge_index: Tensor,
+    x: Tensor,
+    edge_weight: Tensor,
+) -> Tensor:
+    """HiD-Net g3 high-order gradient term.
+
+    This mirrors the official implementation's default g3 variant:
+    first aggregate weighted neighbor differences, then aggregate the
+    resulting one-step gradients again and normalize.
+
+    Parameters
+    ----------
+    edge_index : torch.Tensor
+        Edge indices of shape ``[2, num_edges]``.
+    x : torch.Tensor
+        Node feature matrix of shape ``[num_nodes, num_features]``.
+    edge_weight : torch.Tensor
+        Normalized edge weights of shape ``[num_edges, 1]``.
+
+    Returns
+    -------
+    torch.Tensor
+        Normalized high-order gradient features.
+    """
+    row, col = edge_index[0], edge_index[1]
+
+    onestep = scatter(
+        (x[col] - x[row]) * edge_weight,
+        row,
+        dim=-2,
+        dim_size=x.size(0),
+        reduce="add",
+    )
+
+    twostep = scatter(
+        onestep[col] * edge_weight,
+        row,
+        dim=-2,
+        dim_size=x.size(0),
+        reduce="add",
+    )
+
+    return feature_norm(twostep)
+
+
+class HiDNet(nn.Module):
+    """High-order Graph Diffusion Network backbone.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input node feature dimension.
+    hidden_channels : int
+        Hidden/output embedding dimension returned to TopoBench.
+    num_layers : int
+        Number of HiD diffusion iterations. Corresponds to `k` in the
+        official implementation.
+    alpha : float
+        Initial-feature retention coefficient.
+    beta : float
+        Diffusion coefficient.
+    gamma : float
+        High-order gradient coefficient.
+    dropout : float
+        Dropout used before and inside the input MLP.
+    add_self_loops : bool
+        Whether to add self-loops to the normalized graph used for ordinary
+        diffusion.
+    cached : bool
+        Keep False for TopoBench/GraphUniverse unless you are certain each
+        module instance sees one fixed graph.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_layers: int = 10,
+        alpha: float = 0.1,
+        beta: float = 0.8,
+        gamma: float = 0.5,
+        dropout: float = 0.0,
+        add_self_loops: bool = True,
+        cached: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = hidden_channels
+
+        self.num_layers = num_layers
+        self.alpha = alpha
+        self.beta = beta
+        self.gamma = gamma
+        self.dropout = dropout
+        self.add_self_loops = add_self_loops
+        self.cached = cached
+
+        self.lin1 = Linear(
+            in_channels,
+            hidden_channels,
+            bias=False,
+            weight_initializer="glorot",
+        )
+        self.lin2 = Linear(
+            hidden_channels,
+            hidden_channels,
+            bias=False,
+            weight_initializer="glorot",
+        )
+
+        self._cached_edge_index = None
+        self._cached_edge_weight = None
+        self._cached_grad_edge_index = None
+        self._cached_grad_edge_weight = None
+
+    def reset_parameters(self) -> None:
+        self.lin1.reset_parameters()
+        self.lin2.reset_parameters()
+        self._cached_edge_index = None
+        self._cached_edge_weight = None
+        self._cached_grad_edge_index = None
+        self._cached_grad_edge_weight = None
+
+    def _get_norms(
+        self,
+        edge_index: Tensor,
+        edge_weight: Tensor | None,
+        num_nodes: int,
+        dtype: torch.dtype,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Return normalized graph for diffusion and gradient term."""
+
+        if self.cached and self._cached_edge_index is not None:
+            return (
+                self._cached_edge_index,
+                self._cached_edge_weight,
+                self._cached_grad_edge_index,
+                self._cached_grad_edge_weight,
+            )
+
+        # Ordinary diffusion graph: with self-loops, as in official model.py.
+        norm_edge_index, norm_edge_weight = gcn_norm(
+            edge_index,
+            edge_weight,
+            num_nodes,
+            improved=False,
+            add_self_loops=self.add_self_loops,
+            dtype=dtype,
+        )
+
+        # Gradient graph: no self-loops, as in official model.py.
+        grad_edge_index, grad_edge_weight = gcn_norm(
+            edge_index,
+            edge_weight,
+            num_nodes,
+            improved=False,
+            add_self_loops=False,
+            dtype=dtype,
+        )
+
+        if self.cached:
+            self._cached_edge_index = norm_edge_index
+            self._cached_edge_weight = norm_edge_weight
+            self._cached_grad_edge_index = grad_edge_index
+            self._cached_grad_edge_weight = grad_edge_weight
+
+        return norm_edge_index, norm_edge_weight, grad_edge_index, grad_edge_weight
+
+    @staticmethod
+    def _spmm(edge_index: Tensor, edge_weight: Tensor, x: Tensor) -> Tensor:
+        row, col = edge_index[0], edge_index[1]
+        return scatter(
+            x[col] * edge_weight.view(-1, 1),
+            row,
+            dim=0,
+            dim_size=x.size(0),
+            reduce="add",
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        edge_weight: Tensor | None = None,
+        batch: Tensor | None = None,
+        **kwargs,
+    ) -> Tensor:
+        """Return node embeddings for TopoBench."""
+
+        edge_index, edge_weight, edge_index_g, edge_weight_g = self._get_norms(
+            edge_index=edge_index,
+            edge_weight=edge_weight,
+            num_nodes=x.size(0),
+            dtype=x.dtype,
+        )
+
+        ew_g = edge_weight_g.view(-1, 1)
+
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = self.lin1(x)
+        x = F.relu(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = self.lin2(x)
+
+        h0 = x
+
+        for _ in range(self.num_layers):
+            g = cal_g_gradient3(edge_index_g, x, edge_weight=ew_g)
+
+            ax = self._spmm(edge_index, edge_weight, x)
+            gx = self._spmm(edge_index, edge_weight, g)
+
+            x = (
+                self.alpha * h0
+                + (1.0 - self.alpha - self.beta) * x
+                + self.beta * ax
+                + self.beta * self.gamma * gx
+            )
+
+        return x


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.


## Description

Implementation of HiDNet, published at AAAI 2024 (https://arxiv.org/abs/2312.08616) based on the original implementation https://github.com/BUPT-GAMMA/HiD-Net.

The implementation uses the default `g3` high-order gradient variant from the official HiD-Net implementation. 

We add: 

- `topobench/nn/backbones/graph/hid_net.py`
- `configs/model/graph/hid_net.yaml`
- `test/nn/backbones/graph/test_hid_net.py`
- a results.json generated by the evaluation notebook using `MODEL_CONFIG = "graph/hid_net"`


## Tests 

Fully pass ruff checks, ran with:
uv run --no-sync ruff check topobench/nn/backbones/graph/hid_net.py test/nn/backbones/graph/test_hid_net.py

Added passing unit tests for:

- forward-pass output shape and finite node embeddings;
- compatibility with the `GNNWrapper` call signature, including `batch` and `edge_weight`;
- weighted edge propagation;
- differentiability of the backbone and finite gradients for inputs and learnable parameters.
