### PR TITLE
Fix missing configs in pip install and unregistered OmegaConf resolvers in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,10 @@ convention = "numpy"
 version = {attr = "topobench.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["topobench", "topobench.*"]
+include = ["topobench", "topobench.*", "configs"]
+
+[tool.setuptools.package-data]
+configs = ["**/*.yaml"]
 
 [tool.mypy]
 warn_redundant_casts = true

--- a/test/_utils/simplified_pipeline.py
+++ b/test/_utils/simplified_pipeline.py
@@ -1,6 +1,5 @@
 """Test pipeline for a particular dataset and model."""
 
-from omegaconf import OmegaConf
 import hydra
 from lightning import Callback, Trainer
 from lightning.pytorch.loggers import Logger
@@ -9,44 +8,9 @@ from omegaconf import DictConfig, OmegaConf
 from topobench.data.preprocessor import PreProcessor
 from topobench.dataloader import TBDataloader
 from topobench.utils import instantiate_callbacks
-from topobench.utils.config_resolvers import (
-    get_default_metrics,
-    get_default_trainer,
-    get_default_transform,
-    get_monitor_metric,
-    get_monitor_mode,
-    get_required_lifting,
-    infer_in_channels,
-    infer_num_cell_dimensions,
-)
+from topobench.utils.config_resolvers import register_all_resolvers
 
-OmegaConf.register_new_resolver(
-    "get_default_metrics", get_default_metrics, replace=True
-)
-OmegaConf.register_new_resolver(
-    "get_default_trainer", get_default_trainer, replace=True
-)
-OmegaConf.register_new_resolver(
-    "get_default_transform", get_default_transform, replace=True
-)
-OmegaConf.register_new_resolver(
-    "get_required_lifting", get_required_lifting, replace=True
-)
-OmegaConf.register_new_resolver(
-    "get_monitor_metric", get_monitor_metric, replace=True
-)
-OmegaConf.register_new_resolver(
-    "get_monitor_mode", get_monitor_mode, replace=True
-)
-OmegaConf.register_new_resolver(
-    "infer_in_channels", infer_in_channels, replace=True
-)
-OmegaConf.register_new_resolver(
-    "infer_num_cell_dimensions", infer_num_cell_dimensions, replace=True
-)
-OmegaConf.register_new_resolver(
-    "parameter_multiplication", lambda x, y: int(int(x) * int(y)), replace=True
-)
+register_all_resolvers()
 
 def run(cfg: DictConfig) -> DictConfig:
     """Run pipeline with given configuration.

--- a/test/utils/test_config_resolvers.py
+++ b/test/utils/test_config_resolvers.py
@@ -6,6 +6,7 @@ import hydra
 import torch
 import os
 from topobench.utils.config_resolvers import (
+    register_all_resolvers,
     define_task_level,
     infer_in_channels,
     infer_num_cell_dimensions,
@@ -38,6 +39,7 @@ class TestConfigResolvers:
     def setup_method(self):
         """Setup method."""
         hydra.core.global_hydra.GlobalHydra.instance().clear()
+        register_all_resolvers()
         self.dataset_config_1 = OmegaConf.load("configs/dataset/graph/MUTAG.yaml")
         self.dataset_config_2 = OmegaConf.load("configs/dataset/graph/cocitation_cora.yaml")
         self.cliq_lift_transform = OmegaConf.load("configs/transforms/liftings/graph2simplicial/clique.yaml")


### PR DESCRIPTION
### Changes
- **`pyproject.toml`**: Added `"configs"` to `[tool.setuptools.packages.find]` and a `[tool.setuptools.package-data]` entry with `configs = ["**/*.yaml"]` so the Hydra config files are bundled when installing via `pip install git+...`
- **`test/_utils/simplified_pipeline.py`**: Replaced a stale, partial set of manual `OmegaConf.register_new_resolver(...)` calls with a single `register_all_resolvers()` call
- **`test/utils/test_config_resolvers.py`**: Added `register_all_resolvers()` to `setup_method` before `hydra.initialize()` so all custom resolvers are available when Hydra composes configs
### Fixes
- `configs/` directory missing after `pip install git+...`
- `omegaconf.errors.UnsupportedInterpolationType: Unsupported interpolation type define_task_level` in `test/pipeline/test_pipeline.py`
- `omegaconf.errors.UnsupportedInterpolationType: Unsupported interpolation type set_preserve_edge_attr` in `test/utils/test_config_resolvers.py`