### PR TITLE
Fix ADME dependencies

### DIFF
--- a/topobench/data/loaders/graph/adme_datasets.py
+++ b/topobench/data/loaders/graph/adme_datasets.py
@@ -4,9 +4,7 @@ import os
 from pathlib import Path
 
 import torch
-from ogb.utils.mol import smiles2graph
 from omegaconf import DictConfig
-from tdc.single_pred import ADME
 from torch_geometric.data import Data, InMemoryDataset
 
 from topobench.data.loaders.base import AbstractLoader
@@ -63,7 +61,17 @@ class ADMEDatasetLoader(AbstractLoader):
             If dataset loading or SMILES conversion fails.
         ValueError
             If invalid SMILES strings are encountered.
+        ImportError
+            If `PyTDC` or `rdkit` (via `ogb`) are not installed.
         """
+        try:
+            from ogb.utils.mol import smiles2graph
+            from tdc.single_pred import ADME
+        except ImportError as e:
+            raise ImportError(
+                "ADME datasets require additional dependencies. "
+                "Install them with: pip install PyTDC rdkit"
+            ) from e
 
         class _ADMEDataset(InMemoryDataset):
             """Internal InMemoryDataset for ADME data.


### PR DESCRIPTION
## Make ADME dataset dependencies (`PyTDC`, `rdkit`) lazy imports

`tdc` and `ogb.utils.mol` were imported at the top of `adme_datasets.py`, causing `ModuleNotFoundError` when loading any dataset even if no ADME data was involved. Moved the imports inside `load_dataset()` behind a `try/except ImportError`, so they are only required when an ADME dataset is actually used and the error message clearly tells the user what to install.