### PR TITLE
Track: Track1;  Team name: SweetLesson;  Model: Polynormer

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-02_07-36-33/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-02_07-36-33/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-02_07-36-33",
+    "model_config": "graph/polynormer",
+    "generated_at_utc": "2026-06-02T09:22:12.376915+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2369134426116943,
+      "test_best_rerun_accuracy": 0.30972573161125183,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3099549114704132,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3096493184566498,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3100695312023163,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.296928733587265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2967377305030823,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29734891653060913,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.296088308095932,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29169532656669617,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29196271300315857,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.293070524930954,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2934907078742981,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2228012084960938,
+      "test_best_rerun_accuracy": 0.3164871335029602,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3155321180820465,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3027733266353607,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30365192890167236,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3036901354789734,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3020475208759308,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2991825342178345,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2993353307247162,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30009931325912476,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3009779155254364,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2437431812286377,
+      "test_best_rerun_accuracy": 0.31014591455459595,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31194132566452026,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3084269165992737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30869433283805847,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29532432556152344,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2959355115890503,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2983039319515228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2975781261920929,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2923829257488251,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2916189134120941,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29180991649627686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2938727140426636,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.212364912033081,
+      "test_best_rerun_accuracy": 0.31923753023147583,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31843534111976624,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3151119351387024,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31954312324523926,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046451210975647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30242952704429626,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3024677336215973,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30472153425216675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2958209216594696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29807472229003906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2977309226989746,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2997555136680603,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2388925552368164,
+      "test_best_rerun_accuracy": 0.3141569197177887,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31194132566452026,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3130491375923157,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31163573265075684,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29883870482444763,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2991825342178345,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2994499206542969,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.296890527009964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2902437150478363,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29054930806159973,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2902437150478363,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2917335033416748,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.237165927886963,
+      "test_best_rerun_accuracy": 0.31637251377105713,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31285813450813293,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31396591663360596,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3156849145889282,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29929712414741516,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29994651675224304,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.296928733587265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2976927161216736,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29100772738456726,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2950951159000397,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29329970479011536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2965085208415985,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.26881742477417,
+      "test_best_rerun_accuracy": 0.29834210872650146,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28145772218704224,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2811139225959778,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2899381220340729,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26881352066993713,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2638475000858307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28554511070251465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2727099061012268,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.266750693321228,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26976850628852844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28760790824890137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28283292055130005,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.208038330078125,
+      "test_best_rerun_accuracy": 0.3198869228363037,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30456870794296265,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30185651779174805,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31488272547721863,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2866911292076111,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2852395176887512,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30323171615600586,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29463672637939453,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29314690828323364,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2908167243003845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30976393818855286,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31492093205451965,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2008631229400635,
+      "test_best_rerun_accuracy": 0.32649552822113037,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3091145157814026,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3088853359222412,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3201161324977875,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29734891653060913,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28951790928840637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3094201385974884,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29708153009414673,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29696691036224365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29440751671791077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3188937306404114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31262892484664917,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.207472324371338,
+      "test_best_rerun_accuracy": 0.32076552510261536,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2983803153038025,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3020475208759308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31178852915763855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2806173264980316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27790510654449463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2887157201766968,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2947513163089752,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2788601219654083,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2838643193244934,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2959355115890503,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30292612314224243,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.171893835067749,
+      "test_best_rerun_accuracy": 0.3303155303001404,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31434792280197144,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3164489269256592,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3243945240974426,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2872259020805359,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28737872838974,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29860952496528625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3039575219154358,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29100772738456726,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29180991649627686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30689892172813416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31530293822288513,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2113564014434814,
+      "test_best_rerun_accuracy": 0.31969591975212097,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30021393299102783,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30472153425216675,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3168691396713257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2793567180633545,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27821069955825806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2882955074310303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2925739288330078,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28298571705818176,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2820689082145691,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2943311035633087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30051952600479126,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0942678451538086,
+      "test_best_rerun_accuracy": 0.3752005398273468,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2611353099346161,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2526930868625641,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22591489553451538,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20666208863258362,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3580487370491028,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3563297390937805,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34101152420043945,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.478264182806015,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.472572386264801,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5247154235839844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.530483603477478,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.071613073348999,
+      "test_best_rerun_accuracy": 0.3843303620815277,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2630835175514221,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25498509407043457,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21449308097362518,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19279547035694122,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36263275146484375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3420047461986542,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3268393278121948,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48987698554992676,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4786843955516815,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5300633907318115,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5295286178588867,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0604424476623535,
+      "test_best_rerun_accuracy": 0.3870043456554413,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2645350992679596,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2609825134277344,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22205668687820435,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.196844682097435,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3712659478187561,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36469554901123047,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3439147472381592,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49801358580589294,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49488121271133423,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5499656200408936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5516846179962158,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1107723712921143,
+      "test_best_rerun_accuracy": 0.35774314403533936,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26568111777305603,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2690427005290985,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25525251030921936,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2559783160686493,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3609519302845001,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3579723536968231,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37118953466415405,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4540835916996002,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46130338311195374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.49411720037460327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5247536301612854,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1208717823028564,
+      "test_best_rerun_accuracy": 0.3515547513961792,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2621285021305084,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2672854959964752,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24505309760570526,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24952250719070435,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3578195571899414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3497593402862549,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36683475971221924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44514477252960205,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4475513696670532,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48227518796920776,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5074490308761597,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1177849769592285,
+      "test_best_rerun_accuracy": 0.35640615224838257,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26273971796035767,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2653754949569702,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24860569834709167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25754451751708984,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3590419292449951,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3499121367931366,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3716861605644226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4498051702976227,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4556879699230194,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48838719725608826,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5193291902542114,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9838520288467407,
+      "test_best_rerun_accuracy": 0.4224921762943268,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24677209556102753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23718389868736267,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24948430061340332,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2359996885061264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3769959509372711,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3465123474597931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41534876823425293,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5115746259689331,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4956069886684418,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6029108166694641,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.615058422088623,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.009859800338745,
+      "test_best_rerun_accuracy": 0.424172967672348,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25292229652404785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24589349329471588,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24841469526290894,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2312246859073639,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38368093967437744,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3558713495731354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41687676310539246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5093590021133423,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4969821870326996,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5958438515663147,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6086026430130005,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.017144203186035,
+      "test_best_rerun_accuracy": 0.41618916392326355,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24623729288578033,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2387118935585022,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2502483129501343,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2339750975370407,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3807777464389801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34819313883781433,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41454657912254333,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5092061758041382,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49801358580589294,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5957292318344116,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6058140397071838,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9264411926269531,
+      "test_best_rerun_accuracy": 0.4499961733818054,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23389869928359985,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2382916957139969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22908549010753632,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22671708464622498,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38490334153175354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3726029396057129,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4295591711997986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5378180146217346,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5378562211990356,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6145236492156982,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6518832445144653,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9783767461776733,
+      "test_best_rerun_accuracy": 0.43292078375816345,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22690808773040771,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22518908977508545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22740468382835388,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22278249263763428,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3726029396057129,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35392314195632935,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40747955441474915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5105814337730408,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5196347832679749,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5995492339134216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6422950625419617,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8954131603240967,
+      "test_best_rerun_accuracy": 0.45847657322883606,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22782489657402039,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2364199012517929,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23202688992023468,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2389792948961258,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3835281431674957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3761937618255615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4264649748802185,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5360226035118103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5384292006492615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6258690357208252,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.656314492225647,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5562851428985596,
+      "test_best_rerun_accuracy": 0.5952708125114441,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2047520875930786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20150507986545563,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1661318689584732,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1549774557352066,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.392887145280838,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37176254391670227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3518603444099426,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3668729364871979,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5918710231781006,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6551302671432495,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6815646886825562,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5765951871871948,
+      "test_best_rerun_accuracy": 0.5820918083190918,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19573688507080078,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19566047191619873,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16727787256240845,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16563527286052704,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38245856761932373,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3660707473754883,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.352891743183136,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3756207525730133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5818626284599304,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6489800810813904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6723202466964722,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5286461114883423,
+      "test_best_rerun_accuracy": 0.596722424030304,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20387348532676697,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2013140767812729,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15887387096881866,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14347925782203674,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39594316482543945,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3779509365558624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3465123474597931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34727632999420166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5948506593704224,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.654710054397583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6793490648269653,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5240395069122314,
+      "test_best_rerun_accuracy": 0.5954236388206482,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18893727660179138,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19214607775211334,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16196806728839874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15788066387176514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3748949468135834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3652685582637787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35327374935150146,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37516236305236816,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5900756120681763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6566582918167114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6996715068817139,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4890812635421753,
+      "test_best_rerun_accuracy": 0.6001986265182495,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.191687673330307,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19722667336463928,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1681564599275589,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16059286892414093,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37787455320358276,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36736953258514404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3573993444442749,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3818473517894745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.589961051940918,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6642600893974304,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7027274966239929,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5009095668792725,
+      "test_best_rerun_accuracy": 0.5994728207588196,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19203147292137146,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19176407158374786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15921767055988312,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15134845674037933,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3799373507499695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3722209632396698,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34765833616256714,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3696615397930145,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5939720273017883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.663916289806366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7016578912734985,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3341705799102783,
+      "test_best_rerun_accuracy": 0.6682710647583008,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1814882755279541,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17751547694206238,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16242647171020508,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1559324562549591,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3807395398616791,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3522423505783081,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38249674439430237,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39483535289764404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5814042091369629,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5802200436592102,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6958515048027039,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2634131908416748,
+      "test_best_rerun_accuracy": 0.6789288520812988,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18729467689990997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1839330792427063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17254947125911713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17117427289485931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3836427628993988,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3638933598995209,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4020933508872986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42314156889915466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5909160375595093,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5868668556213379,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7114753127098083,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2890428304672241,
+      "test_best_rerun_accuracy": 0.6705248951911926,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18847887217998505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1861104816198349,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17476506531238556,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1670868694782257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3867369592189789,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3625945448875427,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3927725553512573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4200855791568756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5859118103981018,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5885858535766602,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7102146744728088,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0788440704345703,
+      "test_best_rerun_accuracy": 0.7233936786651611,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.15677286684513092,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16292306780815125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15516845881938934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15642906725406647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3400183320045471,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3339063227176666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3836045563220978,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4117579758167267,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5616165995597839,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5657804012298584,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6645656824111938,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.122693419456482,
+      "test_best_rerun_accuracy": 0.7206050753593445,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1640690714120865,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1681564599275589,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15150125324726105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14420506358146667,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3560241460800171,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3401329219341278,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38154175877571106,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4148903787136078,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5600122213363647,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5662006139755249,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6578806638717651,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.081067681312561,
+      "test_best_rerun_accuracy": 0.7302696704864502,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17186187207698822,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17044846713542938,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15474826097488403,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1508900672197342,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36981433629989624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3530063331127167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3809305429458618,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4134005606174469,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5767056345939636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.584498405456543,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6683474779129028,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 137.18350219726562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 133.71835327148438,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09633887123305791,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.68790435791016,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.393094233462685
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11705.0576171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8877556023653773
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.70677185058594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07034269357957058
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7376.94189453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9855633793628924
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153.42262268066406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1324893114686218
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173388.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.026297705159762
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14821.5771484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0392355313727037
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45496.578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3320815072530627
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3481.94287109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6190120659722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754491.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.534687029851929
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260551.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.335800082788345
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 63.0594367980957,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 57.9384651184082,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.041742410027671616,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.344778537750244,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.01760409756710655
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6956.6591796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5276192020999242
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 529.7100219726562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.17853388000426568
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6622.8623046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8848179431780228
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149.6725311279297,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12925089043862667
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153648.96875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.567921436698867
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10809.5478515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.757926507612011
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45003.21875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.306792698241837
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3480.35302734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6187294270833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728305.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.238471120889562
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241680.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.0217800430166575
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 59.62031173706055,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 60.944557189941406,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.04390818241350245,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.441740036010742,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0812723159790039
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6197.7373046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4700597121492226
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 688.992919921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2322187124778817
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6709.11376953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8963411849741149
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133.96734619140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11568855456943544
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153606.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5669348963171092
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10884.029296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7631488779185949
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45038.6171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.30860716528269
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3485.744873046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6196879774305556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 734304.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.306335050846691
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245082.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.078393594095818
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.7169189453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.679358959197998,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.014101889258936831,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200.8936767578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1447360783557727
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13089.603515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9927647717576792
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 407.25347900390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1372610310090685
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8141.6806640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0877328876503005
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174.16525268554688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15040177261273477
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178370.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.1419794520945565
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16171.5634765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.13389170358733
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47664.40625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.443200894458968
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3960.1162109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7040206597222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764915.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.652591682408968
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266766.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.439233770988301
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3875021934509277,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.338991403579712,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012310481071472168,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206.81776428222656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14900415294108543
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13121.4208984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9951779217624194
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 412.079833984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1388877094655797
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8177.1298828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0924689222194388
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177.9499969482422,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15367011826273072
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178485.125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.1446480819245775
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16203.068359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1361007123387323
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47757.01171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4479477020221436
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3984.057861328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.708276953125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765328.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.657272660430076
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266989.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.442940525518779
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.4415225982666016,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.3892674446105957,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012575091813739978,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.80918884277344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1504388968607878
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13171.6337890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9989862562808115
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 422.0809631347656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14225849785465644
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8187.30810546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0938287382055778
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.19996643066406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15474953923200696
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178634.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.14810949981423
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16247.98046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.139249787459683
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47785.53515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4494097676072584
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3992.37548828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7097556423611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765486.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.659050032238724
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267132.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.445324330620871
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5106.1064453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4756.7275390625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3607681106607888,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6098.2998046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.393587755538545
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7413.765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 39.01981907894737
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4867.3115234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.6404824817787327
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6471.666015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8646180381596527
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6578.43798828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.680861820622841
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131215.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0469892921001303
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8190.8623046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5743137221068223
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30693.7109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5733103151109744
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5375.818359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9557010416666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 658432.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.448083634039569
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205988.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4278230721548266
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5124.6787109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4769.50537109375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3617372295103337,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5981.85107421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.3096909756619235
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7282.21923828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 38.32746967516447
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4757.1240234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.6033448006193125
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6421.23828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8578808658984636
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6457.8662109375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.576741114799223
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131569.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0552197746377483
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8201.9423828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5750906172214626
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30779.267578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5776958110679686
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5298.68310546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9419881076388888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 659342.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.458366797506872
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206501.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4363572400279567
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5108.7236328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4760.48828125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.361053339495639,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6113.17724609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.40430637326639
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7428.5498046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 39.09763055098684
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4868.44091796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.640863133794658
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6477.734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8654287742150969
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6593.23095703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.693636405035622
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131181.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.046199406697009
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8199.8916015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5749468238369443
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30687.083984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5729706281395766
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5386.4794921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9575963541666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 658338.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.447017493750212
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205992.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.427894315893698
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 128.6798858642578,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 124.7621078491211,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.042049918385278426,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176.6621856689453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1272782317499606
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 237.674560546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2509187397203947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10302.96875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7814159082290482
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6813.6005859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.910300679483968
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233.11570739746094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2013089010340768
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168454.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.911724410180197
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13391.7919921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9389841531473496
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43710.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.240539822966323
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3148.1484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5596708333333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744963.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.426905054127122
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254085.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.228209296423876
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 121.39308166503906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 116.87232971191406,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.039390741392623545,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.3900604248047,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1018660377700322
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.5409698486328,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7660051044664885
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10455.06640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7929515666477057
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7044.66845703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9411714705452572
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.5123291015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15760995604625433
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169696.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.940575001741594
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13658.0478515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9576530536784813
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44494.7109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.280727404659388
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3278.449462890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5828354600694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 748442.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.466252559302285
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255928.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.258866205298454
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 94.20911407470703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 92.08318328857422,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.031035788098609445,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116.8384780883789,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08417757787347184
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.280908584594727,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08568899255049856
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9928.0673828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7529819782186197
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7489.5107421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0006026375668002
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133.56370544433594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11533998743034192
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169992.671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9474426870471855
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13805.15234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9679674900960594
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46140.06640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3650656828258754
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3585.879150390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6374896267361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753846.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.527381706503173
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257659.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.287675457207994
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5392.1572265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5535.03271484375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7394833286364395,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 934.2777099609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6731107420467849
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1361.7386474609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.167045512952303
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7170.33251953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5438249920008532
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753.486083984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.25395553892294404
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1110.97021484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9593870594505614
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153844.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5724702622840425
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10486.736328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7352921279010658
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38340.640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9652796465733764
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2737.63330078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4866903645833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713866.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.075134610816376
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236284.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9319848505649575
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5314.39697265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5483.12744140625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7325487563669004,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1325.834716796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9552123319862211
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1884.5052490234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.918448679070723
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7108.27001953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5391179385310011
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 817.2689819335938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2754529767218044
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1552.9093017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.34102703087894
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152978.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5523465075236857
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10366.0302734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7268286547074394
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37355.2578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9147705065610743
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2845.64306640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5058921006944445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 709871.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.029945957716366
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234585.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9037146069425726
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1886.6558837890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1843.1070556640625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.24624008759706914,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 550.8121948242188,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3968387570779674
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177.56005859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9345266241776315
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47435.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.5976488433826317
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36072.58203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 12.15793125421301
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.8090515136719,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.24681265242976846
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52276.6328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2139288689508638
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53384.38671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.7431206505924837
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16938.619140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8682464063060639
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1763.8201904296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.31356803385416665
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 359013.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.061101221112406
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84743.0078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4101976571730483
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 139.2740020751953,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 147.22801208496094,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12713990680912,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.40928649902344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10692311707422437
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.755123138427734,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.14607959546540913
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12305.2138671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9332737100635191
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281.0526428222656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09472620250160621
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7700.447265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0287838698229792
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175576.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.077114149869961
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15401.23828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0798792792911234
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46438.03515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.380339082282536
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3677.125732421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6537112413194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759090.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.58670944424963
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263284.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.381286089893997
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 127.2970962524414,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 131.7598114013672,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.11378222055385767,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.19926452636719,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07363059403916944
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.506803512573242,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1500358079609118
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10955.4765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8309045553659461
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150.64137268066406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.050772286039994625
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7251.95166015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.968864617255344
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170865.515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9677112118010402
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14191.8837890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9950837041833193
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45625.01171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.338664806948075
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3455.44921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6143020833333334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 750952.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.494649502844926
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257810.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.290197849583146
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 135.2063446044922,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 142.6238250732422,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12316392493371518,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.0511016845703,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10162183118484892
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.559179306030273,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.11873252266331723
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11865.78515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8999457835608646
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 219.20895385742188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07388235721517421
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7624.42236328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.018626902241984
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174043.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.041497465980866
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14955.115234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.048598740315173
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46332.875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.374948741606438
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3649.512451171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6488022135416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 756842.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.561274787054739
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261670.71875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.354429280448638
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112205.390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78779.6171875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.829361350257756,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70352.4296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 50.68618853566282
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74994.7265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 394.70908717105266
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37699.75,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.859290860826697
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65955.8828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.229822316312774
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54086.55859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.225993132097528
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71944.3359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 62.12809666450777
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41913.73828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.9388401543437106
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44673.47265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2898904431928853
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59768.9453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.625590277777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 475514.40625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.378939699444589
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123580.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0564926447339955
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112408.2890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78903.015625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8322268164824447,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69651.1171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 50.1809201639049
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74285.5703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 390.97668585526316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37225.078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.823289960182025
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65306.9453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.011103913886082
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53509.76953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.148933805110221
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71253.609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 61.5316143134715
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41454.24609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.9066222194467817
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44335.7734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2725805237326364
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59154.02734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.516271527777779
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 476561.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.390782835424138
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123926.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.062251686968532
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112204.984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78776.046875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8292784431311537,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70042.5,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 50.4628962536023
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74651.234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 392.9012335526316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37580.421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.85024056693212
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65763.265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.164902468823726
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53842.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.193319973279893
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71619.34375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 61.84744710708117
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41773.78125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.929026872107699
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44514.796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.281756977548824
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59490.921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.576163888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 475838.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.382610742848094
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123694.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0583912643735545
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8624.341796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8243.2548828125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5779873007160636,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5452.83935546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.9285586134501083
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6693.09326171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 35.226806640625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4829.78271484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.36630889001469474
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4296.6953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.4481615478597911
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6208.6533203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.829479401511356
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5907.923828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.101834048467185
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133250.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0942322038129295
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31202.1328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5993712036752268
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4954.8115234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8808553819444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 663457.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.504919233510175
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208691.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4728158333749355
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8627.4658203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8242.115234375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5779073926780957,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5382.74267578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.8780566828395173
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6613.90673828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 34.810035464638155
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4838.1015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3669398227152067
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4232.720703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.4265994954920795
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6180.0087890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8256524768286573
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5833.94970703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.037953114880182
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133477.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0995114103427457
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31261.9609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6024378972525501
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4906.58349609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8722815104166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 664038.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.511491408662602
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208973.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4775030993626546
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8626.43359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8246.525390625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5782166169278502,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5465.697265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.9378222374819885
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6706.7705078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 35.29879214638158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4829.20263671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3662648947075275
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4304.47119140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.4507823361665824
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6212.203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8299536573146292
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5921.30224609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.113387086436744
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133207.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0932416722784692
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31189.9375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.598746091547491
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4964.046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8824972222222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 663358.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.50379865502302
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208666.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4724005915830465
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 10337.654296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9564.8017578125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.4902763728439438,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1571.6075439453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.13228209217962
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1816.45458984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.560287314967105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25803.140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.957007252559727
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29156.419921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 9.82690256888271
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1729.69677734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.23108841380678022
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1900.47705078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.6411718918663645
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33032.7734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7670623592211592
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29495.263671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.0681015055304304
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3931.19921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6988798611111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239874.296875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.7134180613214482
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80918.4296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.346553337119132
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27382.8125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27873.890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4287708557588805,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13048.3056640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.400796587941283
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14998.7470703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 78.94077405427632
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5657.53564453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4290887860850398
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11301.837890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.8091802799544996
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10193.7822265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.361894753047762
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13735.884765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.861731231109673
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115343.9296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6784304683146014
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9252.228515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6487328926956247
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10419.625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8523777777777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 617065.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.980143490605522
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184245.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0660127843509226
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 15129.021484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15381.462890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.7884290784061202,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1567.0557861328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1290027277613923
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 873.5687255859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.597730134662829
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33192.52734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.517446139078498
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28660.302734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 9.659690844076508
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1592.4837646484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2127566819837592
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1099.423583984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9494158756341753
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43507.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0102986253018762
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30864.056640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.16407633155413
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1954.637451171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.34749110243055553
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 326959.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.698513483705304
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75577.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.257670662556371
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2552.86083984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2697.27490234375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4795155381944444,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 857.6934814453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6179347849029629
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1263.72412109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.651179584703947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7001.2275390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5309994341344331
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 892.6954345703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.30087476729703827
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5514.26171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7367083124582499
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1036.0546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8946931670984456
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153265.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5590193520109605
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10294.46484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7218107448990324
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38444.8671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9706221327336102
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713403.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.069902180921462
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 235170.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9134474377215316
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2660.3955078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2821.04150390625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5015184895833333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 503.8726501464844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.36302064131591094
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 792.7845458984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.172550241570724
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8771.9931640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6653009604901403
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 264.66741943359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08920371399851491
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6006.51318359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8024733712216099
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 641.3545532226562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5538467644409812
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161415.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.74827727336058
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11965.498046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8389775660408778
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40602.54296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0812211271080012
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728855.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.244689094261506
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245430.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.0841695372173135
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2650.478759765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2809.638916015625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.49949136284722223,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 558.082275390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.40207656728431196
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 869.2022094726562,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.574748470908717
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8658.373046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6566835833807357
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.5735168457031,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09624992141749347
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5949.80810546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7948975424807949
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702.0045776367188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6062215696344722
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160846.421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.735055310119822
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11862.412109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8317495519124246
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40311.77734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0663169482674664
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 727411.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.228361169869801
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244688.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.071832149751219
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 519101.3125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 332601.875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.7623369682024363,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 302688.09375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 218.07499549711815
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312445.90625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1644.4521381578948
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222290.03125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 16.85931219188472
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 293249.3125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 98.836977586788
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261124.796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 34.88641240814963
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 305967.25,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 264.2204231433506
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133809.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.10721651205183
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 227640.875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 15.961357102790632
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200620.140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 10.283466124609154
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 277130.40625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 49.267627777777776
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133120.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2152374756627227
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 502061.40625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 323365.96875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6578619362465075,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 359332.21875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 258.8848838256484
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 371083.71875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1953.0722039473685
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 284197.375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.55459802806219
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 370481.3125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 124.86731125716211
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 314134.875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 41.9685871743487
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 364355.625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 314.6421632124352
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166438.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8649150827837637
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 293759.53125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 20.597358803113167
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245098.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 12.563329745245785
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 333499.5,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 59.2888
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157665.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.6236994117451284
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 502144.5625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 323793.6875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.662700219449566,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 365186.25,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 263.1024855907781
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 375840.40625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1978.1074013157895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276180.9375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 20.94660125142207
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 355399.6875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 119.7841885743175
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 318870.8125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 42.60131095524382
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368830.65625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 318.50661161485317
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162916.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7831330984116662
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281868.8125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 19.76362449165615
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 248678.265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 12.74684840970834
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 336861.4375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 59.88647777777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153540.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.555052949178773
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111689.4140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108187.8515625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8003403318606161,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137530.140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 99.0851157240634
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144035.5625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 758.0819078947368
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86980.796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.59695084376185
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130913.4765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 44.12318050640378
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111910.65625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.95132348029392
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139746.5625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 120.67924222797927
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80238.2578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8632328119194688
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91593.984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.422239824358435
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83571.65625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.283748846686144
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121405.5859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 21.58321527777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 403718.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.566791073266744
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 112548.6484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108291.9453125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8020725427670443,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133373.34375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 96.09030529538904
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133307.359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 701.6176809210526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73566.4765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.579558328593098
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105316.140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 35.49583438658578
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107525.140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.365416249164996
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131088.765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 113.20273370034542
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77116.5859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7907436823681033
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73879.2421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.180145995477493
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79275.296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.0635243669588395
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119230.2421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 21.1964875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415015.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.694584742599233
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111451.046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108116.8046875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7991580498144542,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141428.328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 101.8936081592219
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147963.453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 778.7550164473685
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90278.09375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.847030242700038
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135048.1875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 45.51674671385238
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115308.6640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 15.40529913994656
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143607.9375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 124.01376295336787
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80940.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8795328609743638
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94887.0234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.653135846129575
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86044.4296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.410499240735045
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124968.703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 22.216658333333335
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 400565.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.531132993224212
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-02_07-36-33__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/graph/polynormer.yaml
+++ b/configs/model/graph/polynormer.yaml
@@ -1,0 +1,52 @@
+_target_: topobench.model.TBModel
+
+model_name: polynormer
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.Polynormer
+  # ``hidden_channels`` is per attention head; the working width is
+  # ``hidden_channels * heads``. With ``heads: 1`` the width equals the encoder
+  # output (64), and ``out_channels`` returns embeddings of the same width so
+  # the readout can produce the final logits.
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  out_channels: ${model.feature_encoder.out_channels}
+  local_layers: 3
+  global_layers: 2
+  heads: 1
+  beta: -1.0           # < 0 => learnable per-layer gates (paper default)
+  in_dropout: 0.15
+  dropout: 0.3
+  global_dropout: 0.3
+  pre_ln: false
+  qk_shared: true
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  # Polynormer already applies its own residual/gated updates internally, so the
+  # wrapper-level residual connection is disabled (as for the GPS transformer).
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/graph/test_polynormer.py
+++ b/test/nn/backbones/graph/test_polynormer.py
@@ -1,0 +1,419 @@
+"""Unit tests for the Polynormer graph backbone.
+
+These tests cover the global linear-attention module
+(:class:`PolynormerAttention`) and the full :class:`Polynormer` backbone,
+including the batch-aware behaviour that keeps the global attention within the
+boundaries of each graph in a mini-batch (arXiv:2403.01232).
+"""
+
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.polynormer import (
+    Polynormer,
+    PolynormerAttention,
+)
+
+
+def _features(num_nodes, dim):
+    """Create a random feature tensor.
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes.
+    dim : int
+        Feature dimension.
+
+    Returns
+    -------
+    torch.Tensor
+        Random features of shape ``[num_nodes, dim]``.
+    """
+    return torch.randn(num_nodes, dim)
+
+
+class TestPolynormerAttention:
+    """Tests for the batch-aware global linear-attention module."""
+
+    def setup_method(self):
+        """Set common dimensions used across tests."""
+        self.hidden = 8
+        self.heads = 2
+        self.width = self.hidden * self.heads
+
+    def test_initialization_shared_qk(self):
+        """Default initialization shares the query/key projections."""
+        attn = PolynormerAttention(self.hidden, self.heads, 2, -1.0, 0.0)
+        assert attn.qk_shared is True
+        assert attn.q_lins is None
+        assert len(attn.k_lins) == 2
+        assert len(attn.v_lins) == 2
+        assert attn.betas.shape == (2, self.width)
+
+    def test_initialization_separate_qk(self):
+        """With ``qk_shared=False`` separate query projections are created."""
+        attn = PolynormerAttention(
+            self.hidden, self.heads, 3, -1.0, 0.0, qk_shared=False
+        )
+        assert attn.q_lins is not None
+        assert len(attn.q_lins) == 3
+
+    def test_initialization_constant_beta(self):
+        """A non-negative ``beta`` initialises the gates to that constant."""
+        attn = PolynormerAttention(self.hidden, self.heads, 2, 0.5, 0.0)
+        assert torch.allclose(attn.betas, torch.full_like(attn.betas, 0.5))
+
+    def test_forward_shape_single_graph(self):
+        """Forward returns features of the working width."""
+        attn = PolynormerAttention(self.hidden, self.heads, 2, -1.0, 0.0)
+        attn.eval()
+        x = _features(6, self.width)
+        out = attn(x, torch.zeros(6, dtype=torch.long))
+        assert out.shape == (6, self.width)
+        assert not torch.isnan(out).any()
+
+    def test_forward_batch_none_equals_single_segment(self):
+        """``batch=None`` matches an all-zeros batch (single graph)."""
+        attn = PolynormerAttention(self.hidden, self.heads, 2, -1.0, 0.0)
+        attn.eval()
+        x = _features(5, self.width)
+        out_none = attn(x)
+        out_zero = attn(x, torch.zeros(5, dtype=torch.long))
+        assert torch.allclose(out_none, out_zero, atol=1e-6)
+
+    def test_forward_separate_qk_and_constant_beta(self):
+        """Forward works with separate q/k and a constant beta."""
+        attn = PolynormerAttention(
+            self.hidden, self.heads, 2, 0.3, 0.0, qk_shared=False
+        )
+        attn.eval()
+        x = _features(7, self.width)
+        out = attn(x, torch.zeros(7, dtype=torch.long))
+        assert out.shape == (7, self.width)
+
+    def test_reset_parameters_runs(self):
+        """``reset_parameters`` runs for both shared and separate q/k."""
+        for qk_shared in (True, False):
+            for beta in (-1.0, 0.5):
+                attn = PolynormerAttention(
+                    self.hidden, self.heads, 2, beta, 0.0,
+                    qk_shared=qk_shared,
+                )
+                attn.reset_parameters()
+                if beta >= 0:
+                    assert torch.allclose(
+                        attn.betas, torch.full_like(attn.betas, beta)
+                    )
+
+
+class TestPolynormer:
+    """Tests for the full Polynormer backbone."""
+
+    def setup_method(self):
+        """Set common dimensions used across tests."""
+        self.in_channels = 16
+        self.hidden = 8
+        self.heads = 2
+        self.out_channels = 16
+
+    def _model(self, **kwargs):
+        """Build a Polynormer with test defaults overridden by ``kwargs``.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Keyword arguments forwarded to :class:`Polynormer`.
+
+        Returns
+        -------
+        Polynormer
+            The constructed backbone.
+        """
+        params = dict(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden,
+            out_channels=self.out_channels,
+            local_layers=2,
+            global_layers=2,
+            heads=self.heads,
+        )
+        params.update(kwargs)
+        return Polynormer(**params)
+
+    def test_initialization_default(self):
+        """Default construction wires the expected submodules."""
+        model = self._model()
+        assert model.use_global is True
+        assert model.global_attn is not None
+        assert len(model.local_convs) == 2
+        assert model.pre_lns is None
+        assert model.betas.shape == (2, self.hidden * self.heads)
+
+    def test_initialization_local_only(self):
+        """``global_layers=0`` disables the global module."""
+        model = self._model(global_layers=0)
+        assert model.use_global is False
+        assert model.global_attn is None
+
+    def test_initialization_pre_ln(self):
+        """``pre_ln=True`` creates the per-layer input norms."""
+        model = self._model(pre_ln=True)
+        assert model.pre_lns is not None
+        assert len(model.pre_lns) == 2
+
+    def test_initialization_constant_beta(self):
+        """A non-negative ``beta`` initialises the local gates to a constant."""
+        model = self._model(beta=0.5)
+        assert torch.allclose(model.betas, torch.full_like(model.betas, 0.5))
+
+    def test_forward_shape(self, simple_graph_0):
+        """Forward returns ``[num_nodes, out_channels]``.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model().eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        out = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+
+    def test_forward_local_only(self, simple_graph_0):
+        """Local-only variant produces valid embeddings.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model(global_layers=0).eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        out = model(x, simple_graph_0.edge_index)
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_forward_pre_ln_and_constant_beta(self, simple_graph_0):
+        """Forward works with pre-layer-norm and a constant beta.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model(pre_ln=True, beta=0.4).eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        out = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_forward_separate_qk(self, simple_graph_0):
+        """Forward works when the global module uses separate q/k.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model(qk_shared=False).eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        out = model(x, simple_graph_0.edge_index)
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_edge_weight_accepted_and_ignored(self, simple_graph_0):
+        """An ``edge_weight`` argument is accepted but does not change output.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model().eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+        out_a = model(x, simple_graph_0.edge_index, batch=batch)
+        edge_weight = torch.rand(simple_graph_0.edge_index.shape[1])
+        out_b = model(
+            x, simple_graph_0.edge_index, batch=batch, edge_weight=edge_weight
+        )
+        assert torch.allclose(out_a, out_b)
+
+    def test_extra_kwargs_ignored(self, simple_graph_0):
+        """Unknown keyword arguments are ignored gracefully.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model().eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        out = model(
+            x, simple_graph_0.edge_index, unused="x", another=1
+        )
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_batch_isolation(self, simple_graph_0, simple_graph_1):
+        """Global attention must not leak across graphs in a batch.
+
+        Running the model on graph A alone must give the same node embeddings
+        as running it on the batch ``[A, B]`` (in eval mode), proving the
+        batch-aware global attention restricts attention to each graph.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            First test graph fixture.
+        simple_graph_1 : torch_geometric.data.Data
+            Second test graph fixture.
+        """
+        torch.manual_seed(0)
+        model = self._model().eval()
+
+        n_a = simple_graph_0.num_nodes
+        n_b = simple_graph_1.num_nodes
+        x_a = _features(n_a, self.in_channels)
+        x_b = _features(n_b, self.in_channels)
+        data_a = Data(x=x_a, edge_index=simple_graph_0.edge_index, num_nodes=n_a)
+        data_b = Data(x=x_b, edge_index=simple_graph_1.edge_index, num_nodes=n_b)
+
+        out_a_alone = model(
+            data_a.x, data_a.edge_index, batch=torch.zeros(n_a, dtype=torch.long)
+        )
+
+        batch = Batch.from_data_list([data_a, data_b])
+        out_batched = model(batch.x, batch.edge_index, batch=batch.batch)
+        out_a_in_batch = out_batched[:n_a]
+
+        assert torch.allclose(out_a_alone, out_a_in_batch, atol=1e-5)
+
+    def test_eval_is_deterministic(self, simple_graph_0):
+        """In eval mode (dropout off) repeated calls match.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model(dropout=0.5, in_dropout=0.5).eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+        out1 = model(x, simple_graph_0.edge_index, batch=batch)
+        out2 = model(x, simple_graph_0.edge_index, batch=batch)
+        assert torch.allclose(out1, out2)
+
+    def test_backward_pass(self, simple_graph_0):
+        """Gradients flow to the input and the parameters.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model().train()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        x.requires_grad_(True)
+        out = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        out.sum().backward()
+        assert x.grad is not None
+        assert model.betas.grad is not None
+        assert model.lin_in.weight.grad is not None
+
+    def test_reset_parameters_runs(self, simple_graph_0):
+        """``reset_parameters`` runs across configuration branches.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        for kwargs in (
+            dict(),
+            dict(global_layers=0),
+            dict(pre_ln=True),
+            dict(beta=0.5),
+        ):
+            model = self._model(**kwargs)
+            model.reset_parameters()
+
+    def test_batched_two_graphs_shape(self, simple_graph_0, simple_graph_1):
+        """Forward on a batch returns one embedding per node.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            First test graph fixture.
+        simple_graph_1 : torch_geometric.data.Data
+            Second test graph fixture.
+        """
+        model = self._model().eval()
+        n = simple_graph_0.num_nodes + simple_graph_1.num_nodes
+        x = _features(n, self.in_channels)
+        batch_data = Batch.from_data_list([simple_graph_0, simple_graph_1])
+        out = model(x, batch_data.edge_index, batch=batch_data.batch)
+        assert out.shape == (n, self.out_channels)
+
+    @pytest.mark.parametrize("heads", [1, 2, 4])
+    def test_parametrized_heads(self, simple_graph_0, heads):
+        """Forward works for several head counts.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        heads : int
+            Number of attention heads.
+        """
+        model = Polynormer(
+            self.in_channels,
+            self.hidden,
+            self.out_channels,
+            local_layers=2,
+            global_layers=1,
+            heads=heads,
+        ).eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        out = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    @pytest.mark.parametrize("local_layers", [1, 2, 4])
+    def test_parametrized_local_layers(self, simple_graph_0, local_layers):
+        """Forward works for several local-layer counts.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        local_layers : int
+            Number of local attention layers.
+        """
+        model = Polynormer(
+            self.in_channels,
+            self.hidden,
+            self.out_channels,
+            local_layers=local_layers,
+            global_layers=1,
+            heads=self.heads,
+        ).eval()
+        x = _features(simple_graph_0.num_nodes, self.in_channels)
+        out = model(x, simple_graph_0.edge_index)
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+        assert len(model.local_convs) == local_layers

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "graph/polynormer", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/polynormer.py
+++ b/topobench/nn/backbones/graph/polynormer.py
@@ -1,0 +1,464 @@
+r"""Polynormer: a polynomial-expressive graph transformer in linear time.
+
+This module re-implements the Polynormer architecture for the TopoBench
+framework. Polynormer learns a high-degree *equivariant polynomial* on the node
+features whose coefficients are produced by attention. It is built from two
+modules that are applied sequentially:
+
+* a **local** equivariant-attention module that mixes a node with its graph
+  neighbours through a GAT-style sparse attention, and
+* a **global** equivariant-attention module that mixes all nodes through a
+  *linear* (kernel) attention, i.e. in :math:`O(N d^2)` time instead of the
+  :math:`O(N^2 d)` of vanilla softmax attention.
+
+The released reference implementation operates on a single (large) graph. In
+TopoBench the model is fed *mini-batches of disjoint graphs*, so the global
+attention here is made **batch-aware**: the kernel sums are computed per graph
+segment (using the ``batch`` vector) so that nodes never attend across graph
+boundaries. For a single graph this reduces exactly to the original
+formulation.
+
+Equation numbers below refer to the paper.
+
+References
+----------
+.. [1] Chenhui Deng, Zichao Yue, Zhiru Zhang. "Polynormer: Polynomial-Expressive
+   Graph Transformer in Linear Time." ICLR 2024. https://arxiv.org/abs/2403.01232
+.. [2] Official implementation:
+   https://github.com/cornell-zhang/polynormer (``model.py``).
+"""
+
+import torch
+import torch.nn.functional as F
+from torch_geometric.nn import GATConv
+from torch_geometric.utils import scatter
+
+
+class PolynormerAttention(torch.nn.Module):
+    r"""Batch-aware global linear (kernel) attention module of Polynormer.
+
+    Implements the equivariant global attention of Polynormer (Eq. 6 and Eq. 8
+    of [1]_). Each layer computes, per attention head, a linear attention via
+    the kernel trick with a sigmoid feature map :math:`\sigma`:
+
+    .. math::
+        \mathrm{num} = \sigma(Q)\,\big(\sigma(K)^\top V\big), \qquad
+        \mathrm{den} = \sigma(Q)\,\textstyle\sum_i \sigma(K_{i,:}),
+
+    so the attended features are :math:`\mathrm{num} / \mathrm{den}`. This costs
+    :math:`O(N d^2)` instead of :math:`O(N^2 d)` because the :math:`N\times N`
+    attention matrix is never materialised. The result is normalised, gated by
+    a learnable per-layer vector :math:`\beta` as
+    :math:`\mathrm{LN}(\mathrm{num}/\mathrm{den})\odot(H+\beta)`, passed through
+    a ReLU and a linear layer, and dropped out.
+
+    Unlike the single-graph reference implementation, the kernel sums
+    :math:`\sigma(K)^\top V` and :math:`\sum_i \sigma(K_{i,:})` are accumulated
+    **per graph** in the batch (segment-wise over the ``batch`` vector), so the
+    attention is restricted to each graph and never leaks across the disjoint
+    graphs of a mini-batch. For a single graph this is identical to Eq. 6/8.
+
+    Parameters
+    ----------
+    hidden_channels : int
+        Hidden dimension *per attention head*. The working width is
+        ``hidden_channels * heads``.
+    heads : int
+        Number of attention heads.
+    num_layers : int
+        Number of stacked global-attention layers.
+    beta : float
+        Gating initialisation. If ``beta < 0`` the per-layer gates are learnable
+        and squashed by a sigmoid at runtime; otherwise they are held constant
+        at ``beta``.
+    dropout : float
+        Dropout probability applied to each layer's output.
+    qk_shared : bool, optional
+        If ``True`` (default) the query and key projections are shared (a single
+        projection is used for both), as in the reference implementation.
+
+    References
+    ----------
+    .. [1] Deng, Yue, Zhang. "Polynormer: Polynomial-Expressive Graph
+       Transformer in Linear Time." ICLR 2024. https://arxiv.org/abs/2403.01232
+    """
+
+    def __init__(
+        self,
+        hidden_channels: int,
+        heads: int,
+        num_layers: int,
+        beta: float,
+        dropout: float,
+        qk_shared: bool = True,
+    ):
+        super().__init__()
+
+        self.hidden_channels = hidden_channels
+        self.heads = heads
+        self.num_layers = num_layers
+        self.beta = beta
+        self.dropout = dropout
+        self.qk_shared = qk_shared
+        # Small constant guarding the (strictly positive) denominator against
+        # floating-point underflow; the reference uses no epsilon.
+        self.eps = 1e-6
+
+        width = heads * hidden_channels
+        if self.beta < 0:
+            self.betas = torch.nn.Parameter(torch.zeros(num_layers, width))
+        else:
+            self.betas = torch.nn.Parameter(
+                torch.ones(num_layers, width) * self.beta
+            )
+
+        self.h_lins = torch.nn.ModuleList()
+        self.q_lins = torch.nn.ModuleList() if not qk_shared else None
+        self.k_lins = torch.nn.ModuleList()
+        self.v_lins = torch.nn.ModuleList()
+        self.lns = torch.nn.ModuleList()
+        for _ in range(num_layers):
+            self.h_lins.append(torch.nn.Linear(width, width))
+            if not qk_shared:
+                self.q_lins.append(torch.nn.Linear(width, width))
+            self.k_lins.append(torch.nn.Linear(width, width))
+            self.v_lins.append(torch.nn.Linear(width, width))
+            self.lns.append(torch.nn.LayerNorm(width))
+        self.lin_out = torch.nn.Linear(width, width)
+
+    def reset_parameters(self):
+        r"""Reset all learnable parameters to their initial values.
+
+        Returns
+        -------
+        None
+            This method updates the module in place.
+        """
+        for h_lin in self.h_lins:
+            h_lin.reset_parameters()
+        if not self.qk_shared:
+            for q_lin in self.q_lins:
+                q_lin.reset_parameters()
+        for k_lin in self.k_lins:
+            k_lin.reset_parameters()
+        for v_lin in self.v_lins:
+            v_lin.reset_parameters()
+        for ln in self.lns:
+            ln.reset_parameters()
+        if self.beta < 0:
+            torch.nn.init.xavier_normal_(self.betas)
+        else:
+            torch.nn.init.constant_(self.betas, self.beta)
+        self.lin_out.reset_parameters()
+
+    def forward(
+        self, x: torch.Tensor, batch: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        r"""Apply the stacked batch-aware global linear-attention layers.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``[num_nodes, heads * hidden_channels]``.
+        batch : torch.Tensor, optional
+            Batch assignment vector of shape ``[num_nodes]`` mapping each node to
+            its graph. If ``None``, all nodes are treated as a single graph,
+            recovering the original (single-graph) formulation.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of shape
+            ``[num_nodes, heads * hidden_channels]``.
+        """
+        num_nodes = x.size(0)
+        if batch is None:
+            batch = x.new_zeros(num_nodes, dtype=torch.long)
+        num_graphs = int(batch.max().item()) + 1
+
+        for i in range(self.num_layers):
+            h = self.h_lins[i](x)
+            k = torch.sigmoid(self.k_lins[i](x)).view(
+                num_nodes, self.hidden_channels, self.heads
+            )
+            if self.qk_shared:
+                q = k
+            else:
+                q = torch.sigmoid(self.q_lins[i](x)).view(
+                    num_nodes, self.hidden_channels, self.heads
+                )
+            v = self.v_lins[i](x).view(
+                num_nodes, self.hidden_channels, self.heads
+            )
+
+            # Numerator (Eq. 6): per node n, q_n . sum_{m in g(n)} k_m (x) v_m.
+            # The per-node outer products k (x) v are summed *within each graph*
+            # (segment-sum over ``batch``), then gathered back to every node.
+            kv_node = k.unsqueeze(2) * v.unsqueeze(1)  # [N, d, d, h]
+            kv = scatter(
+                kv_node, batch, dim=0, dim_size=num_graphs, reduce="sum"
+            )  # [num_graphs, d, d, h]
+            kv_per_node = kv.index_select(0, batch)  # [N, d, d, h]
+            num = torch.einsum("ndh,ndmh->nmh", q, kv_per_node)
+
+            # Denominator (Eq. 6): per node n, q_n . sum_{m in g(n)} k_m.
+            k_sum = scatter(
+                k, batch, dim=0, dim_size=num_graphs, reduce="sum"
+            )  # [num_graphs, d, h]
+            k_sum_per_node = k_sum.index_select(0, batch)  # [N, d, h]
+            den = torch.einsum("ndh,ndh->nh", q, k_sum_per_node).unsqueeze(1)
+
+            if self.beta < 0:
+                beta = torch.sigmoid(self.betas[i]).unsqueeze(0)
+            else:
+                beta = self.betas[i].unsqueeze(0)
+
+            x = (num / (den + self.eps)).reshape(num_nodes, -1)
+            x = self.lns[i](x) * (h + beta)
+            x = F.relu(self.lin_out(x))
+            x = F.dropout(x, p=self.dropout, training=self.training)
+
+        return x
+
+
+class Polynormer(torch.nn.Module):
+    r"""Polynormer backbone: local-to-global equivariant polynomial attention.
+
+    A faithful re-implementation of the Polynormer encoder of [1]_ adapted to
+    the TopoBench pipeline. The forward pass runs ``local_layers`` equivariant
+    *local* attention layers followed (when ``global_layers > 0``) by a
+    :class:`PolynormerAttention` *global* module, returning node embeddings.
+
+    **Local module (Eq. 7).** Each local layer combines a GAT message-passing
+    term with a node-wise linear term and a ReLU feature map :math:`H`, then
+    applies the Polynormer gated polynomial update
+
+    .. math::
+        X \leftarrow (1-\beta)\,\mathrm{LN}\!\big(H \odot X\big) + \beta\, X,
+
+    where :math:`X = \mathrm{GAT}(X, E) + WX`, :math:`H = \mathrm{ReLU}(W_h X)`
+    and :math:`\beta` is a learnable per-layer gate. The Hadamard product
+    :math:`H \odot X` injects a degree-2 interaction per layer, so stacking
+    :math:`L` layers yields up to degree-:math:`2^L` polynomial expressivity
+    (Thm. 3.3 of [1]_). The per-layer outputs are summed into ``x_local``.
+
+    **Global module (Eq. 8).** When enabled, :class:`PolynormerAttention` is
+    applied to :math:`\mathrm{LN}(\text{x\_local})` to mix information across
+    the whole graph in linear time.
+
+    Differences from the reference implementation (documented for the TDL
+    challenge correctness criterion):
+
+    * The reference toggles a ``_global`` flag during training (a local warm-up
+      followed by enabling the global module). TopoBench runs a single training
+      loop, so the local and global modules are trained **jointly**: the global
+      module is active whenever ``global_layers > 0``. Setting
+      ``global_layers = 0`` gives the faithful local-only Polynormer variant.
+    * The reference ends with task-specific prediction heads
+      (``pred_local`` / ``pred_global``). Here the backbone instead emits node
+      embeddings of width ``out_channels`` via a single output projection; the
+      final logits are produced by the TopoBench readout.
+    * The global attention is batch-aware (see :class:`PolynormerAttention`) so
+      that mini-batches of disjoint graphs are handled correctly.
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the input node features.
+    hidden_channels : int
+        Hidden dimension *per attention head*. The working width is
+        ``hidden_channels * heads``.
+    out_channels : int
+        Dimension of the returned node embeddings.
+    local_layers : int, optional
+        Number of local (GAT-based) attention layers. Default is 3.
+    global_layers : int, optional
+        Number of global linear-attention layers. If 0, the global module is
+        disabled (local-only variant). Default is 2.
+    in_dropout : float, optional
+        Dropout applied to the raw input features. Default is 0.15.
+    dropout : float, optional
+        Dropout applied within the local layers. Default is 0.5.
+    global_dropout : float, optional
+        Dropout applied within the global layers. Default is 0.5.
+    heads : int, optional
+        Number of attention heads. Default is 1.
+    beta : float, optional
+        Gating initialisation shared by the local and global modules. If
+        ``beta < 0`` the gates are learnable (sigmoid-squashed); otherwise they
+        are held constant. Default is -1.0.
+    pre_ln : bool, optional
+        If ``True``, apply a layer norm at the start of each local layer.
+        Default is False.
+    qk_shared : bool, optional
+        Whether the global module shares its query and key projections. Default
+        is True.
+
+    References
+    ----------
+    .. [1] Deng, Yue, Zhang. "Polynormer: Polynomial-Expressive Graph
+       Transformer in Linear Time." ICLR 2024. https://arxiv.org/abs/2403.01232
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        local_layers: int = 3,
+        global_layers: int = 2,
+        in_dropout: float = 0.15,
+        dropout: float = 0.5,
+        global_dropout: float = 0.5,
+        heads: int = 1,
+        beta: float = -1.0,
+        pre_ln: bool = False,
+        qk_shared: bool = True,
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels
+        self.local_layers = local_layers
+        self.global_layers = global_layers
+        self.in_dropout = in_dropout
+        self.dropout = dropout
+        self.heads = heads
+        self.beta = beta
+        self.pre_ln = pre_ln
+        self.use_global = global_layers > 0
+
+        width = heads * hidden_channels
+
+        if self.beta < 0:
+            self.betas = torch.nn.Parameter(torch.zeros(local_layers, width))
+        else:
+            self.betas = torch.nn.Parameter(
+                torch.ones(local_layers, width) * self.beta
+            )
+
+        self.h_lins = torch.nn.ModuleList()
+        self.local_convs = torch.nn.ModuleList()
+        self.lins = torch.nn.ModuleList()
+        self.lns = torch.nn.ModuleList()
+        self.pre_lns = torch.nn.ModuleList() if pre_ln else None
+        for _ in range(local_layers):
+            self.h_lins.append(torch.nn.Linear(width, width))
+            self.local_convs.append(
+                GATConv(
+                    width,
+                    hidden_channels,
+                    heads=heads,
+                    concat=True,
+                    add_self_loops=False,
+                    bias=False,
+                )
+            )
+            self.lins.append(torch.nn.Linear(width, width))
+            self.lns.append(torch.nn.LayerNorm(width))
+            if pre_ln:
+                self.pre_lns.append(torch.nn.LayerNorm(width))
+
+        self.lin_in = torch.nn.Linear(in_channels, width)
+        self.ln = torch.nn.LayerNorm(width)
+        if self.use_global:
+            self.global_attn = PolynormerAttention(
+                hidden_channels,
+                heads,
+                global_layers,
+                beta,
+                global_dropout,
+                qk_shared,
+            )
+        else:
+            self.global_attn = None
+        self.lin_out = torch.nn.Linear(width, out_channels)
+
+    def reset_parameters(self):
+        r"""Reset all learnable parameters to their initial values.
+
+        Returns
+        -------
+        None
+            This method updates the module in place.
+        """
+        for local_conv in self.local_convs:
+            local_conv.reset_parameters()
+        for lin in self.lins:
+            lin.reset_parameters()
+        for h_lin in self.h_lins:
+            h_lin.reset_parameters()
+        for ln in self.lns:
+            ln.reset_parameters()
+        if self.pre_ln:
+            for p_ln in self.pre_lns:
+                p_ln.reset_parameters()
+        self.lin_in.reset_parameters()
+        self.ln.reset_parameters()
+        if self.use_global:
+            self.global_attn.reset_parameters()
+        self.lin_out.reset_parameters()
+        if self.beta < 0:
+            torch.nn.init.xavier_normal_(self.betas)
+        else:
+            torch.nn.init.constant_(self.betas, self.beta)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""Compute Polynormer node embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node feature matrix of shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            Graph connectivity of shape ``[2, num_edges]``.
+        batch : torch.Tensor, optional
+            Batch assignment vector of shape ``[num_nodes]`` mapping each node to
+            its graph. Used to keep the global attention within graph
+            boundaries. If ``None``, all nodes are treated as one graph.
+        edge_weight : torch.Tensor, optional
+            Accepted for API compatibility with the TopoBench ``GNNWrapper`` but
+            unused: the local GAT attention learns its own edge coefficients.
+        **kwargs : dict
+            Additional unused keyword arguments.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``[num_nodes, out_channels]``.
+        """
+        x = F.dropout(x, p=self.in_dropout, training=self.training)
+        x = self.lin_in(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+
+        # --- Equivariant local attention (Eq. 7), summed over layers ---
+        x_local = 0
+        for i, local_conv in enumerate(self.local_convs):
+            if self.pre_ln:
+                x = self.pre_lns[i](x)
+            h = F.relu(self.h_lins[i](x))
+            x = local_conv(x, edge_index) + self.lins[i](x)
+            x = F.relu(x)
+            x = F.dropout(x, p=self.dropout, training=self.training)
+            if self.beta < 0:
+                beta = torch.sigmoid(self.betas[i]).unsqueeze(0)
+            else:
+                beta = self.betas[i].unsqueeze(0)
+            x = (1 - beta) * self.lns[i](h * x) + beta * x
+            x_local = x_local + x
+
+        # --- Equivariant global attention (Eq. 8) ---
+        if self.use_global:
+            x = self.global_attn(self.ln(x_local), batch)
+        else:
+            x = x_local
+
+        return self.lin_out(x)

--- a/tutorials/tutorial_polynormer.ipynb
+++ b/tutorials/tutorial_polynormer.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Polynormer: a polynomial-expressive graph transformer\n",
+    "\n",
+    "This tutorial introduces **Polynormer** ([Deng, Yue & Zhang, ICLR 2024](https://arxiv.org/abs/2403.01232)), a graph transformer that learns a high-degree *equivariant polynomial* on the node features whose coefficients are produced by attention. It is integrated into TopoBench as the graph backbone `topobench.nn.backbones.Polynormer`.\n",
+    "\n",
+    "Polynormer is built from two modules applied in sequence:\n",
+    "\n",
+    "1. **Local equivariant attention** (Eq. 7). Each layer mixes a node with its graph neighbours via a GAT-style sparse attention and applies the gated polynomial update\n",
+    "$$X \\leftarrow (1-\\beta)\\,\\mathrm{LN}(H \\odot X) + \\beta\\, X, \\qquad X = \\mathrm{GAT}(X, E) + W X, \\quad H = \\mathrm{ReLU}(W_h X).$$\n",
+    "The Hadamard product $H \\odot X$ injects a degree-2 interaction per layer, so $L$ stacked layers reach degree-$2^L$ polynomial expressivity (Thm. 3.3).\n",
+    "\n",
+    "2. **Global linear attention** (Eq. 6 & 8). A kernel-trick attention with a sigmoid feature map $\\sigma$,\n",
+    "$$\\mathrm{num}=\\sigma(Q)\\,(\\sigma(K)^\\top V), \\qquad \\mathrm{den}=\\sigma(Q)\\,\\textstyle\\sum_i \\sigma(K_{i,:}),$$\n",
+    "mixes all nodes in **linear** $O(Nd^2)$ time (the $N\\times N$ attention matrix is never formed).\n",
+    "\n",
+    "**TopoBench adaptation.** The reference implementation runs on a single graph. TopoBench feeds *mini-batches of disjoint graphs*, so our global attention is made **batch-aware**: the kernel sums are accumulated per graph (segment-wise over the `batch` vector), so nodes never attend across graph boundaries. For a single graph this is identical to the paper. We verify this property numerically below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. The backbone\n",
+    "\n",
+    "The backbone maps node features `[num_nodes, in_channels]` to embeddings `[num_nodes, out_channels]`; the final task logits are produced by the TopoBench readout. We build a small instance and run it on a synthetic graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch_geometric.data import Batch, Data\n",
+    "\n",
+    "from topobench.nn.backbones.graph.polynormer import Polynormer\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "model = Polynormer(\n",
+    "    in_channels=16,\n",
+    "    hidden_channels=32,\n",
+    "    out_channels=16,\n",
+    "    local_layers=3,\n",
+    "    global_layers=2,\n",
+    "    heads=1,\n",
+    "    beta=-1.0,  # learnable per-layer gates\n",
+    ").eval()\n",
+    "\n",
+    "n = 12\n",
+    "x = torch.randn(n, 16)\n",
+    "edge_index = torch.randint(0, n, (2, 36))\n",
+    "out = model(x, edge_index, batch=torch.zeros(n, dtype=torch.long))\n",
+    "print('output shape:', tuple(out.shape))\n",
+    "print('parameters  :', sum(p.numel() for p in model.parameters()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Local-only vs. local-to-global\n",
+    "\n",
+    "Setting `global_layers=0` gives the faithful **local-only** Polynormer variant. Comparing it to the full model shows that the global module is wired in only when requested (it adds long-range, all-pairs mixing on top of the local message passing)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_only = Polynormer(16, 32, 16, local_layers=3, global_layers=0).eval()\n",
+    "local_plus_global = Polynormer(16, 32, 16, local_layers=3, global_layers=2).eval()\n",
+    "\n",
+    "print('local-only uses global module :', local_only.use_global)\n",
+    "print('full model uses global module :', local_plus_global.use_global)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. The global attention is batch-aware\n",
+    "\n",
+    "This is the key correctness property for TopoBench. We run the model on a graph **A** on its own, then on a batch **[A, B]**, and check that A's node embeddings are unchanged. If the global attention leaked across graphs, batching B in would perturb A's outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g_a = Data(x=torch.randn(9, 16), edge_index=torch.randint(0, 9, (2, 24)), num_nodes=9)\n",
+    "g_b = Data(x=torch.randn(15, 16), edge_index=torch.randint(0, 15, (2, 40)), num_nodes=15)\n",
+    "\n",
+    "out_a_alone = model(g_a.x, g_a.edge_index, batch=torch.zeros(9, dtype=torch.long))\n",
+    "\n",
+    "batch = Batch.from_data_list([g_a, g_b])\n",
+    "out_batched = model(batch.x, batch.edge_index, batch=batch.batch)\n",
+    "out_a_in_batch = out_batched[:9]\n",
+    "\n",
+    "max_diff = (out_a_alone - out_a_in_batch).abs().max().item()\n",
+    "print(f'max |A_alone - A_in_batch| = {max_diff:.2e}  (almost 0 => no cross-graph leakage)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Training Polynormer in the TopoBench pipeline\n",
+    "\n",
+    "The model ships with the Hydra config `configs/model/graph/polynormer.yaml`, so the canonical way to train it is `python -m topobench model=graph/polynormer dataset=<dataset>`. Here we run a short training on the MUTAG graph-classification dataset directly from the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from hydra import compose, initialize_config_dir\n",
+    "from hydra.core.global_hydra import GlobalHydra\n",
+    "\n",
+    "from topobench.run import run\n",
+    "from topobench.utils.config_resolvers import register_all_resolvers\n",
+    "\n",
+    "# Locate the repository root (the directory containing configs/run.yaml).\n",
+    "root = Path.cwd().resolve()\n",
+    "while not (root / 'configs' / 'run.yaml').exists():\n",
+    "    root = root.parent\n",
+    "os.environ['PROJECT_ROOT'] = str(root)\n",
+    "\n",
+    "out_dir = root / 'logs' / 'tutorial_polynormer'\n",
+    "out_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "register_all_resolvers()\n",
+    "GlobalHydra.instance().clear()\n",
+    "with initialize_config_dir(version_base='1.3', config_dir=str(root / 'configs')):\n",
+    "    cfg = compose(\n",
+    "        config_name='run.yaml',\n",
+    "        overrides=[\n",
+    "            'model=graph/polynormer',\n",
+    "            'dataset=graph/MUTAG',\n",
+    "            'logger=csv',\n",
+    "            'trainer.max_epochs=10',\n",
+    "            'trainer.accelerator=cpu',\n",
+    "            'trainer.devices=1',\n",
+    "            '+trainer.enable_progress_bar=False',\n",
+    "            f'paths.output_dir={out_dir.as_posix()}',\n",
+    "            f'paths.work_dir={root.as_posix()}',\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "metric_dict, _ = run(cfg)\n",
+    "print('\\nMetrics:')\n",
+    "for key, value in metric_dict.items():\n",
+    "    print(f'{key:<20s} {float(value):.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's it. We built the Polynormer backbone, saw its local-to-global structure, verified the batch-aware global attention, and trained it end-to-end through the standard TopoBench pipeline. To benchmark it on the challenge's GraphUniverse datasets, set `MODEL_CONFIG = \"graph/polynormer\"` in `2026_tdl_challenge/run_evaluation.ipynb`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows PEP8 guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

**Track 1 (GNNs) submission — Team `SweetLesson` — Model: Polynormer.**

This PR integrates **Polynormer** into TopoBench:

> Chenhui Deng, Zichao Yue, Zhiru Zhang. *Polynormer: Polynomial-Expressive Graph Transformer in Linear Time.* ICLR 2024. [arXiv:2403.01232](https://arxiv.org/abs/2403.01232) · official code: [cornell-zhang/polynormer](https://github.com/cornell-zhang/polynormer).

Polynormer learns a high-degree **equivariant polynomial** on the node features whose coefficients are produced by attention, composed of a **local** GAT-style equivariant attention (Eq. 7) followed by a **global linear (kernel) attention** in `O(N·d²)` time (Eq. 6 & 8). Stacking `L` local layers reaches degree-`2^L` expressivity (Thm. 3.3).

### What's added
- **Backbone** — `topobench/nn/backbones/graph/polynormer.py`: `Polynormer` and `PolynormerAttention`. Faithful to the official `model.py`; every block's docstring cites the corresponding paper equation and the reference implementation.
- **Config** — `configs/model/graph/polynormer.yaml`: reuses `GNNWrapper` + `NoReadOut`, so a single config serves both challenge tasks (node-level community detection and graph-level triangle counting).
- **Unit tests** — `test/nn/backbones/graph/test_polynormer.py`: **100% line coverage** of the backbone, including a *batch-isolation* correctness test (below).
- **Pipeline test** — `graph/polynormer` added to `test/pipeline/test_pipeline.py`.
- **Tutorial** — `tutorials/tutorial_polynormer.ipynb`: walks through the local→global structure, the batch-aware property, and an end-to-end MUTAG run.
- **Results** — `2026_tdl_challenge/outputs/<study>/results.json` from the official GraphUniverse grid. (The notebook also renders in-distribution and OOD heatmaps; per the repo's `.gitignore`, only `results.json` under `outputs/` is committed.)

### Adaptations to TopoBench (correctness notes)
1. **Batch-aware global attention.** The reference runs on a single graph; TopoBench feeds *mini-batches of disjoint graphs*. The global linear attention is therefore made batch-aware: the kernel sums `σ(K)ᵀV` and `Σ σ(Kᵢ)` are accumulated **per graph segment** (via `torch_geometric.utils.scatter` over the `batch` vector), so nodes never attend across graph boundaries — essential for graph-level triangle counting. This reduces *exactly* to Eq. 6/8 for a single graph and preserves the `O(N·d²)` linear-in-N complexity. A unit test verifies a graph's embeddings are identical whether it is run alone or inside a batch.
2. **Embeddings, not class logits.** The paper's `pred_local`/`pred_global` task heads are replaced by a single output projection to node embeddings; the TopoBench readout produces the final logits.
3. **Joint local+global training.** The reference toggles a `_global` flag mid-training (local warm-up → global). TopoBench runs a single Lightning loop, so the two modules are trained jointly (`global_layers=0` recovers the faithful local-only variant).

### Complexity / scalability
Local layers are `O(E·d)` (sparse GAT); the global module is `O(N·d²)` time and `O(N·d²)` memory (linear in N), versus `O(N²·d)` for dense attention — the paper's central efficiency claim, preserved here. The benchmarked config (`in=hidden=out=64`, `heads=1`, `local_layers=3`, `global_layers=2`) has **76,160 trainable parameters**.

### Results summary (GraphUniverse grid, 72 runs over 3 seeds)
- **Community detection** (node, accuracy): 0.30–0.73 in-distribution across the 12 settings — well above the multi-community random baseline, and higher under homophily, as expected.
- **Triangle counting** (graph, normalized MSE / total triangles): 0.012–3.76 in-distribution; all finite.
- Full per-setting, per-seed, and OOD (each model evaluated on the 11 other settings) results are in `results.json`. The notebook additionally renders in-distribution and OOD heatmaps locally (not committed — the repo's `.gitignore` keeps only `results.json` under `outputs/`).
- Note: the optional `wandb_config` timing/param fields are empty because the grid was run with `WANDB_MODE=offline` (no W&B account); `utils.py` reads those from online `run-*` dirs only. The model's parameter count is reported above.

### Note on `results.json` generation
On upstream `main`, `2026_tdl_challenge/run_evaluation.ipynb` carries a self-integrity hash (`expected_hash = f87b2c…`) that does **not** match the hash of its own shipped cells (`hash_remaining_cells(...) → 3c1d78…`), so the guard cell raises `ValueError` before any work — for the *unmodified* notebook. To produce the required artifact without modifying the notebook or `utils.py`, I invoked the notebook's own backend directly — `run_challenge_grid(...)` + `save_challenge_artifacts(...)` from `2026_tdl_challenge/utils.py` — which runs the identical pipeline. Happy to open a separate issue/PR to refresh the stored hash for maintainers.

## Issue

Submission to the **TDL Challenge 2026**, Track 1 (GNNs). No existing PR implements Polynormer.

## Additional context

Tested with the project environment (Python 3.11, torch 2.3.0+cu121). Unit tests, the pipeline test, the tutorial notebook, and a 1-epoch GraphUniverse sanity over all 12 settings × both tasks all pass locally.