### PR TITLE
fix(ci): restore GitHub Pages docs deploy reliability

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: topobench-docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -48,6 +52,8 @@ jobs:
         run: |
           source .venv/bin/activate
           sphinx-build -b html -D version=latest -D release=latest docs docs/_build
+          # Ensure GitHub Pages serves _static, _sources, etc. (see DOCUMENTATION_SITE.md).
+          touch docs/_build/.nojekyll
 
       # 5. Deploy
       - name: Deploy Docs
@@ -60,3 +66,9 @@ jobs:
           repository-name: geometric-intelligence/geometric-intelligence.github.io
           target-folder: topobench
           clean: true
+          # Do not delete sibling trees under topobench/ that are not produced by Sphinx
+          # (e.g. challenge microsites maintained separately on the org Pages repo).
+          clean-exclude: |
+            leaderboard/**
+            tdl-challenge-2025/**
+            tdl-challenge-2026/**

--- a/.github/workflows/update_leaderboard.yml
+++ b/.github/workflows/update_leaderboard.yml
@@ -56,7 +56,7 @@ jobs:
           branch: bot/refresh-tdl-challenge-2026-leaderboard
           base: main
           add-paths: docs/_static/leaderboard/data/leaderboard.json
-          commit-message: "docs(leaderboard): refresh TDL Challenge 2026 results [skip ci]"
+          commit-message: "docs(leaderboard): refresh TDL Challenge 2026 results"
           title: "docs(leaderboard): refresh TDL Challenge 2026 results"
           body: |
             Automated refresh of the TDL Challenge 2026 leaderboard.


### PR DESCRIPTION
## Summary
- Add `.nojekyll` to the Sphinx HTML output before deploy so GitHub Pages serves `_static/` and related paths.
- Use `clean-exclude` on the Pages deploy so `leaderboard/**` and TDL challenge microsite dirs are not wiped by `clean: true`.
- Add workflow concurrency for the docs job.
- Remove `[skip ci]` from automated leaderboard PR commits so merging them still triggers the docs workflow.

## Test plan
- [ ] Merge this PR and confirm the **Docs: Check and Deploy** workflow completes on `main`.
- [ ] After deploy, verify `https://geometric-intelligence.github.io/topobench/.nojekyll` returns 200 and styling loads on the docs homepage.

Made with [Cursor](https://cursor.com)