### PR TITLE
Track: Track1;  Team name: SweetLesson;  Model: TopoPolynormer

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-13_18-26-47/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-13_18-26-47/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-13_18-26-47",
+    "model_config": "graph/topo_polynormer",
+    "generated_at_utc": "2026-06-13T21:15:05.350512+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.227275848388672,
+      "test_best_rerun_accuracy": 0.3147299289703369,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3129345178604126,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29914432764053345,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3059821128845215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30170372128486633,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29925891757011414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27045610547065735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28543052077293396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2974635064601898,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29501873254776,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26132631301879883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2565130889415741,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2634689807891846,
+      "test_best_rerun_accuracy": 0.3022003173828125,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30227673053741455,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2845137119293213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2886011302471161,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2611353099346161,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2709527015686035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2834441065788269,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28310030698776245,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2557108998298645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2391320914030075,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.272686719894409,
+      "test_best_rerun_accuracy": 0.2975781261920929,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2994499206542969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.284628301858902,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27805790305137634,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28623270988464355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28336772322654724,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25876688957214355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25796470046043396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2801589071750641,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24123309552669525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23672549426555634,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2386603355407715,
+      "test_best_rerun_accuracy": 0.3110245168209076,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31014591455459595,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2813049256801605,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30621132254600525,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28432270884513855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29574450850486755,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23710750043392181,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27851632237434387,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27278631925582886,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28798991441726685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21930629014968872,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2228206843137741,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2404391765594482,
+      "test_best_rerun_accuracy": 0.30892351269721985,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30552372336387634,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27370309829711914,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30552372336387634,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2748873233795166,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29303231835365295,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22060509026050568,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2532278895378113,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2793567180633545,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1969974786043167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20058828592300415,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.274203300476074,
+      "test_best_rerun_accuracy": 0.3058675229549408,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2993353307247162,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27836352586746216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29834210872650146,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2755749225616455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2901291251182556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23561769723892212,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2745053172111511,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26147910952568054,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28027352690696716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21514248847961426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2203758955001831,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1531577110290527,
+      "test_best_rerun_accuracy": 0.33665674924850464,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27981510758399963,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2651844918727875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3145771324634552,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2543739080429077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32294294238090515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30563831329345703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2917335033416748,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27863091230392456,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33069753646850586,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31381312012672424,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.170494318008423,
+      "test_best_rerun_accuracy": 0.33627474308013916,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27183130383491516,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25849950313568115,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31874093413352966,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27603331208229065,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25196731090545654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31923753023147583,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.302582323551178,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2843991219997406,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27316829562187195,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32007792592048645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1903843879699707,
+      "test_best_rerun_accuracy": 0.32767972350120544,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2784399092197418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26747649908065796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3069371283054352,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2759568989276886,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25265491008758545,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3128199279308319,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2978073060512543,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2823363244533539,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27416151762008667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3078921139240265,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3056001365184784,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1974942684173584,
+      "test_best_rerun_accuracy": 0.32332491874694824,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2899381220340729,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3143097162246704,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2743525207042694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2718695104122162,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2775995135307312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2966613173484802,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27496370673179626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2779815196990967,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27018871903419495,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28092291951179504,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.223804473876953,
+      "test_best_rerun_accuracy": 0.3162197172641754,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28512492775917053,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28363510966300964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3002903163433075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2668271064758301,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2683168947696686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26434409618377686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26816409826278687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27412331104278564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25930169224739075,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2747344970703125,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2683401107788086,
+      "test_best_rerun_accuracy": 0.30487433075904846,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28103750944137573,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2830621004104614,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29520970582962036,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2670944929122925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26472610235214233,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25765910744667053,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2830239236354828,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26461151242256165,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24356329441070557,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2583085000514984,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9237282276153564,
+      "test_best_rerun_accuracy": 0.4186721742153168,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27018871903419495,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25425928831100464,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19680647552013397,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15371686220169067,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3836045563220978,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35652074217796326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30128350853919983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5289937853813171,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5098174214363098,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.49763160943984985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43456336855888367,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9600856304168701,
+      "test_best_rerun_accuracy": 0.40870195627212524,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2646878957748413,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2497134953737259,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22014668583869934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18152646720409393,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37118953466415405,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3628237545490265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3229811191558838,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5137901902198792,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4969821870326996,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4570249915122986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41485217213630676,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9834104776382446,
+      "test_best_rerun_accuracy": 0.40148216485977173,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2627778947353363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2427992969751358,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20742608606815338,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1771334707736969,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3685537576675415,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34689435362815857,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3090381324291229,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5087478160858154,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4953778088092804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45179158449172974,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.426082968711853,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.030066728591919,
+      "test_best_rerun_accuracy": 0.3857819437980652,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2643823027610779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26445871591567993,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19363588094711304,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19497287273406982,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.377607136964798,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2800061106681824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4840705990791321,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4988158047199249,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4321567714214325,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4269615709781647,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9936420917510986,
+      "test_best_rerun_accuracy": 0.39922836422920227,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2724043130874634,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2721368968486786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19653907418251038,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19462907314300537,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4048437476158142,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3051799237728119,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3127053380012512,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5203987956047058,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5227289795875549,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48662999272346497,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45251739025115967,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.004065990447998,
+      "test_best_rerun_accuracy": 0.3947589695453644,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2711819112300873,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2689281105995178,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21006187796592712,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2048666775226593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4033157527446747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32745054364204407,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33409732580184937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.507601797580719,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5140575766563416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4917106032371521,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4528611898422241,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8429778814315796,
+      "test_best_rerun_accuracy": 0.44732218980789185,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22113989293575287,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20410268008708954,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26327449083328247,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22591489553451538,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3543051481246948,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2954007089138031,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42298877239227295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48025059700012207,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4464053809642792,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5888914465904236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5789212584495544,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8494861125946045,
+      "test_best_rerun_accuracy": 0.4485063850879669,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23454809188842773,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21911528706550598,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25785011053085327,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23634348809719086,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36370235681533813,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31236153841018677,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41836658120155334,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4842233955860138,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44991979002952576,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5612346529960632,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5628008246421814,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.848814606666565,
+      "test_best_rerun_accuracy": 0.4442661702632904,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21880969405174255,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2077316790819168,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2589578926563263,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2334020882844925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35461074113845825,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29857131838798523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42516615986824036,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4677973985671997,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43383756279945374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5667354464530945,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5553517937660217,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7343294620513916,
+      "test_best_rerun_accuracy": 0.48143479228019714,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21934448182582855,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2141110897064209,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24596989154815674,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24260829389095306,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33505234122276306,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30563831329345703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4043089747428894,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4569103717803955,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45794177055358887,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5356405973434448,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.616586446762085,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.743726372718811,
+      "test_best_rerun_accuracy": 0.47383299469947815,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20318588614463806,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20692948997020721,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24692489206790924,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2350446879863739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3312705457210541,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30949652194976807,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42910078167915344,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45927879214286804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4643593728542328,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5588662028312683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.631904661655426,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.738013505935669,
+      "test_best_rerun_accuracy": 0.48414698243141174,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2272900938987732,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.221598282456398,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2511269152164459,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2475360929965973,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34674152731895447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31698372960090637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43334096670150757,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46210557222366333,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46607840061187744,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5728856325149536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6446252465248108,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.303898572921753,
+      "test_best_rerun_accuracy": 0.6294598579406738,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20291848480701447,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19573688507080078,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15776605904102325,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12781725823879242,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4075559675693512,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3742837607860565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3654213547706604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3245091438293457,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6105126738548279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6553212404251099,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6248376369476318,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3114726543426514,
+      "test_best_rerun_accuracy": 0.6287722587585449,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2020016759634018,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1975322812795639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1571548581123352,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1343112587928772,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4082435667514801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37256476283073425,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36740773916244507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3281763195991516,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6137978434562683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6561616659164429,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6351134777069092,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3393181562423706,
+      "test_best_rerun_accuracy": 0.621208667755127,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2007792741060257,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19115287065505981,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15516845881938934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12842844426631927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40828177332878113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3638169467449188,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36969974637031555,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3210711181163788,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6009626388549805,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6544808745384216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6147146224975586,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.2636597156524658,
+      "test_best_rerun_accuracy": 0.631790041923523,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1965772807598114,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18893727660179138,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16097486019134521,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13496065139770508,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39170295000076294,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3765757381916046,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35281533002853394,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34253954887390137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.608182430267334,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.650851845741272,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7025746703147888,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.2503600120544434,
+      "test_best_rerun_accuracy": 0.6416074633598328,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19608068466186523,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18710367381572723,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1516922563314438,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12464664876461029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3950263559818268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3792497515678406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35965314507484436,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6230040788650513,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.654748260974884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6876384615898132,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.2563319206237793,
+      "test_best_rerun_accuracy": 0.638627827167511,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1990220844745636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1862250715494156,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15833906829357147,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12877225875854492,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3938421607017517,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37676674127578735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35449615120887756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3030407130718231,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6182290315628052,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6573458909988403,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6965391039848328,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.0106559991836548,
+      "test_best_rerun_accuracy": 0.7196118831634521,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17480327188968658,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16777446866035461,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16605547070503235,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1290014535188675,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37829476594924927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3180915415287018,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41389715671539307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3579341471195221,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6025288701057434,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5781572461128235,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7338604927062988,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.0498372316360474,
+      "test_best_rerun_accuracy": 0.7063946723937988,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1761784702539444,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17186187207698822,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17946366965770721,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.147108256816864,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3666055500507355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3163343369960785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.414661169052124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3882267475128174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5868286490440369,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.568569004535675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7211399078369141,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.0587329864501953,
+      "test_best_rerun_accuracy": 0.704217255115509,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17961646616458893,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17243486642837524,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16834746301174164,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13855145871639252,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3767285645008087,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41061195731163025,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37294673919677734,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5972572565078735,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5748338103294373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7321797013282776,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.8090311884880066,
+      "test_best_rerun_accuracy": 0.7581557035446167,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1665138602256775,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16319046914577484,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15642906725406647,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13285964727401733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3335625231266022,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31396591663360596,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39659255743026733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.383375346660614,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5487813949584961,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.565474808216095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6892810463905334,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.8111200332641602,
+      "test_best_rerun_accuracy": 0.7593017220497131,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17079226672649384,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16196806728839874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16223546862602234,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.11291924864053726,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3421957492828369,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.312132328748703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40465277433395386,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36572694778442383,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5511879920959473,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5682634115219116,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6966918706893921,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.8031392097473145,
+      "test_best_rerun_accuracy": 0.7578883171081543,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16460385918617249,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15998166799545288,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1568874567747116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12812285125255585,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3373061418533325,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3078157305717468,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40858736634254456,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3904041647911072,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5367102026939392,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.553327202796936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6888608932495117,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 3.9546074867248535,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.033015727996826,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0029056309279516038,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.993905246257782,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00523108024346201
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5828.5654296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.44206032837978765
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.220775604248047,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007826348366783973
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3683.754150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4921515230982799
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.318729400634766,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.01840995630452052
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146854.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.410139922557124
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7450.36181640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5223924986962734
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29615.556640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5180458578412528
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1398.0677490234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.24854537760416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 677301.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.661518132868794
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214122.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.56318019569667
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 5.110864162445068,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.705085277557373,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.00338983089161194,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.3769271671772003,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0019838271956694755
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6577.0556640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.49882864346321576
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.699073791503906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.005628268888272297
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4390.21630859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5865352449691049
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.723115921020508,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02307695675390372
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151479.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5175487356028237
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8574.7880859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6012332131494531
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32885.24609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6856448866548772
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1692.3477783203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.30086182725694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 693944.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.84978168161714
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221797.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.690902538565224
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.9531161785125732,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.828138828277588,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.002037563997318147,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.4985777735710144,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.002624093545110602
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6656.31103515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5048396689538301
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.80135726928711,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0046516202457994975
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4579.56787109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6118327149089846
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.193376541137695,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.022619496149514418
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154486.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.587372863644808
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8507.5546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.596519049747581
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35367.38671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8128754276872212
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1880.9124755859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3343844401041667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 707235.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.000132207051797
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 227120.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.779486327442464
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.06763024628162384,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.06551864743232727,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.000344834986485933,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.80928421020508,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.040928879113980604
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10406.3271484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7892549979854001
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106.11200714111328,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03576407385949217
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6830.31591796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9125338567760521
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97.24620819091797,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08397772728058546
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168247.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.906925956135055
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13439.20703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9423087246704529
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44165.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.263858988159311
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3193.760986328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5677797309027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743276.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.407819163376809
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253057.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.211091818098613
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.11281420290470123,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.11114737391471863,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0005849861784985191,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62.12724685668945,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04476026430597223
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9806.15625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7437357792946531
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.1958236694336,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.026355181553567104
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6966.6201171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9307441706329326
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.4194564819336,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08671801077887184
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166423.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8645725693154374
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12938.4072265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9071944486441242
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44749.03515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.29376365555641
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3254.3125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5785444444444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744023.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.41627263780641
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 251372.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.183064687234786
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.04952621087431908,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.05078164115548134,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.00026727179555516495,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.88106918334961,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03377598644333545
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9459.5771484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7174499164533561
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70.8725814819336,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.023886950280395548
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6655.88818359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.889230218248998
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90.26481628417969,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07794889143711545
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165214.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8364813852637933
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12665.505859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.888059589074113
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43688.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2393907139012765
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3100.6748046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5512310763888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 738998.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.359423605533749
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 249494.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.15180922694823
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 39.262542724609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 39.79494094848633,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.0030181980241552014,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.2811918258667,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.007407198721805979
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.6205158233642578,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.008529030649285568
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.305887699127197,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.002125341320905695
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 362.88848876953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.048482096027993485
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.6896512508392334,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0031862273323309443
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40156.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9324903776936653
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 471.3348388671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.033048298896871935
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7966.544921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.40835229493438924
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.280967712402344,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.005738838704427083
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 357901.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.048523522957366
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69464.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1559465640756827
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 160.8384552001953,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 163.9759979248047,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.012436556535821364,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.801836013793945,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02003014122031264
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.926132202148438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.15224280106393914
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.00986671447754,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007418222687724145
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1209.949951171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1616499600764028
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.33973503112793,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.015837422306673513
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63784.8515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4811641176504737
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1706.9920654296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.11968812687068346
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20233.095703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.037115982527295
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759.3123779296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1349888671875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 481077.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.441863539698879
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114093.734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8986193795450386
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 56.6379508972168,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 57.87044906616211,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.004389112557160569,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.051145553588867,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.009402842617859414
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.392663955688477,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.12838244187204462
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.517141342163086,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008600317270698715
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361.76483154296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.048331974822039915
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.646393775939941,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.011784450583713248
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38416.75390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8920851269331692
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 447.3415222167969,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.031365974072135525
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8237.8232421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.42225758584179096
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.49022674560547,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.012176040310329862
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 352299.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.985152865287377
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69063.6640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1492796841978268
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 5.063612937927246,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.955611705780029,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0016702432442804278,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.80609703063965,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.017151366736772082
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.808060646057129,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.020042424452932257
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1975.876220703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14985788552924725
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4445.79541015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5939606426394456
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.980445861816406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03711610178049776
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124515.3984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.891403456193108
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6665.80078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.46738190865586876
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37336.98046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.91383363928187
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2250.597412109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.40010620659722224
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 667013.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.545149768673009
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194462.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2360224464579903
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.393692970275879,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.378718376159668,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.00080172510150309,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.403996467590332,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.006775213593364793
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.142812728881836,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.021804277520430716
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1983.2935791015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1504204458931788
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5140.28955078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6867454309660989
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.233646392822266,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04510677581418158
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129474.453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0065589152192085
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6504.54541015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4560752636485942
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39085.26171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0034477276513405
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2360.55712890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.41965460069444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 676183.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.648877159146183
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 192623.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.205415720216997
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.119338035583496,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.117076873779297,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0007135412449542625,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.038354873657227,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.007232244145286186
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.8234332203865051,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.004333859054665817
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1672.0867919921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1268173524453688
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4795.5810546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6406921916750167
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.87055587768555,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.041338994713027245
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124141.0703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8827110884381386
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5687.599609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.39879397064752486
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38162.32421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.956139434043262
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2267.99267578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4031986979166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 660729.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.4740626732124475
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183196.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.048555728204616
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 64.60192108154297,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 68.09581756591797,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.00909763761735711,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.447032928466797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.004644836403794522
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.993733882904053,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.036809125699495016
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83.808349609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.00635634050886424
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69.83850860595703,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.023538425549699035
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.66784381866455,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.00748518464478804
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16016.6533203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3719267443877136
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127.52057647705078,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0089412828829793
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2569.753662109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.13172144456965376
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39.03288269042969,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.006939179144965278
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183469.859375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.0753804664434465
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22132.962890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.36831183150491736
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 43.06719207763672,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 39.368629455566406,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.005259669933943408,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.9879276752471924,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0028731467400916373
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.183556079864502,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.016755558315076326
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 526.01220703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0398947445605802
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.614267349243164,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.009644175041875013
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.876858711242676,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.004211449664285558
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16050.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.37272214030280515
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.39649200439453,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.007179672696984611
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2938.331298828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.1506141421307153
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.00727462768555,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.007290182156032986
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191961.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.171438610680633
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24603.00390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.40941547112392457
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 70.08522033691406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 73.59326171875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.009832099094021376,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.75959300994873,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.006310945972585541
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.411459922790527,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.06532347327784488
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376.76806640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.02857550750142207
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.07613372802734,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04080759478531424
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.099641799926758,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.008721625043114644
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13801.2099609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.32048137564874374
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215.62728881835938,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.015119007770183662
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2454.031982421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.12578973716858244
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.19649505615234,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.015146043565538194
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191522.046875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.1664654692148457
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23263.3359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.38712222617442965
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 36.87519073486328,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 38.89167022705078,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.033585207449957494,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71.29386901855469,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05136445894708551
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.138657569885254,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.005992934578343442
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6205.69482421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.47066324036547214
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.419754981994629,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0031748415847639463
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3205.152099609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4282100333479459
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141660.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.289524385217351
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7677.765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5383372335577058
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27607.13671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4150974790481317
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1602.4619140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2848821180555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 636144.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.195959130346255
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204171.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3975936257134776
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 29.814865112304688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 31.296667098999023,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.027026482814334216,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164.8026580810547,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11873390351661
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.8448166847229004,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.004446403603804739
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4321.83935546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3277845548326697
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.565744400024414,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.005920372227847797
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4293.15185546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5735673821601537
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139049.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.22889841282742
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7735.88671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.542412475021035
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35417.6484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8154517626480087
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1993.4952392578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.35439915364583335
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 685480.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.754041859439159
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 217458.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6186933690280068
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 41.430335998535156,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 43.391666412353516,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.037471214518439995,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 365.4596252441406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.26329944181854514
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.014711618423462,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0053405874653866415
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11329.314453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8592578273132347
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.050931930541992,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008443185686060665
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2092.605712890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2795732415351536
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68204.328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.583789897013747
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2304.750244140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.16160077437530676
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21583.830078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.106352456718694
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1286.318115234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.22867877604166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 501001.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.66725005090325
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137236.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.283735210423843
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2196.02685546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1561.6651611328125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.036263820386699154,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 961.5215454101562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6927388655692769
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1155.65380859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.082388466282895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 335.17034912109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0254205801381186
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 534.6763305664062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.18020772853603176
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 717.3456420898438,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.09583776113424766
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 922.5157470703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.7966457228586463
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 791.9934692382812,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.055531725511027995
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 464.9129638671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.02383069167395497
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 467.73931884765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08315365668402777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15769.1337890625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.1783778128464249
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5130.68798828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.08537912882168056
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 396.9725646972656,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 382.03753662109375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.00887138994568767,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.10589599609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12975929106346812
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.38827514648438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9388856586657073
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.5136260986328,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.012629019802702526
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 326.5548400878906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11006229864775552
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161.26821899414062,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.021545520239698145
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233.0581817626953,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.20125922432011686
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 541.7293701171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.037984109530022965
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134.6416015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.006901512202701317
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 344.7056579589844,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.061281005859375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18898.880859375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.21378099000458128
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1831.1629638671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.030472150897229086
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 559.2557983398438,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 544.8981323242188,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.012653216894023284,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 993.041259765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7154475934910843
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1326.6365966796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.982297877261513
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 325.2944641113281,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.024671555867374146
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 541.5567016601562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.18252669418946957
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 583.9131469726562,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0780111084799808
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1055.977294921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.911897491296956
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 499.58319091796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.03502897145687623
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 295.4196472167969,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.015142736542969751
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 493.6430358886719,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08775876193576389
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23979.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.27125033935499926
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2099.468017578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0349369813052789
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 49.81013870239258,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 48.103031158447266,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.0033728110474300424,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196.6746063232422,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1416964022501745
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204.37008666992188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.075632035104852
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2499.23876953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1895516700440842
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.32157516479492,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.013590015222377797
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 330.6102600097656,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.04416970741613435
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.56610107421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12829542407100064
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18665.779296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4334427665074076
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2843.275146484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.1457417164633951
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73.06330108642578,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.012989031304253473
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229342.671875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.594286074850401
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30228.169921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5030231461547102
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 57.45262908935547,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 59.270755767822266,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.004155851617432497,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239.6211700439453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1726377305792113
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169.64834594726562,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.892886031301398
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1563.936767578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.11861484774957338
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.88499069213867,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.012768786886463995
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 438.5093688964844,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.05858508602491441
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.49537658691406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11355386579180834
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8098.41015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.18805522376579045
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 690.8417358398438,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.03541143758469649
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.38202667236328,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.015356804741753473
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157054.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.7765782128434555
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14509.4287109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2414495650231724
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 70.74380493164062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 69.7237777709961,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.004888779818468384,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.03451538085938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10665310906401972
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.76283264160156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8198043823242187
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 693.8309326171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.05262274801798919
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.68843650817871,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.006298765253851942
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250.78208923339844,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.03350462114006659
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108.76428985595703,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09392425721585236
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5065.638671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.11763047259601987
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 937.4171752929688,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0480504985028945
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60.779258728027344,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.010805201551649305
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134332.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.5195461409680666
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12947.912109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.21546456508037543
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 165.50723266601562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 171.4266815185547,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.00878705630829641,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.621713638305664,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.014136681295609268
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.421207427978516,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.20221688119988693
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218.89773559570312,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.016602027728153442
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.23030853271484,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.028726089832394622
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.05859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.008959063961255846
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.765090942382812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02311320461345666
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1610.2098388671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.03739108858599265
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.48117065429688,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.015178878884749466
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55.36117935180664,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.00984198744032118
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80635.15625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.9121314463310068
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4707.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.07834133135306941
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 88.1584243774414,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 83.61946868896484,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.004286199635499761,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.23726654052734,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.062130595490293476
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146.6521759033203,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7718535573858963
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.26482009887695,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0026746166172830453
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.98589515686035,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.010106469550677571
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72.32929992675781,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.009663233123147336
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95.78446960449219,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08271543143738531
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2221.404052734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.05158378350209862
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55.32616424560547,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.00387927108719713
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.940731048583984,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.008878352186414931
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90077.5703125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.018942460238906
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4891.2236328125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.08139423281933836
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 129.63357543945312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 131.9806365966797,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.00676511541322875,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.102477073669434,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.01088074717123158
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.75038146972656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17237042878803455
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130.07955932617188,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.009865723119163585
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.21701049804688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.034114260363345764
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.769365310668945,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.002507597235894315
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.262165069580078,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.016633994015181414
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2223.68798828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.05163681934518972
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152.96847534179688,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.010725597766217702
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.9033088684082,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.006382810465494792
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90428.8828125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.0229164486782123
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5970.34912109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.09935182335868986
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 38.78614044189453,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 40.42422103881836,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.007186528184678819,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.10271453857422,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.015203684826062117
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.970837593078613,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0524780925951506
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.65267944335938,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.009985034466693923
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.823341369628906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.014433212460272635
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.437255859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.006872044870991984
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.871218204498291,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.00507013661873773
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29843.51953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6930038902853892
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117.67762756347656,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.008251130806582286
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2699.212646484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.1383573041408773
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252796.21875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.8595886876010996
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38465.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6401036726407402
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 36.035850524902344,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 36.11283493041992,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.006420059543185764,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.814439296722412,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.005629999493315859
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.014291763305664,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08428574612266139
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161.47637939453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.01224697606329399
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.851890563964844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.010735386101774467
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.268138885498047,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0029750352552435602
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.629571914672852,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.007452134641340977
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19885.119140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.46175736440240106
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.8384780883789,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.005457753336725488
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3124.4794921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.16015579948677533
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240449.171875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.7199209514948586
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30206.693359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5026657573989483
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 24.735591888427734,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 25.89337158203125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.004603266059027777,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.333837509155273,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02041342760025596
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.761358261108398,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.04611241190057052
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136.37583923339844,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.010343256672991918
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.748180389404297,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.010026349979576776
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99.69657897949219,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.013319516229725076
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.068945407867432,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.00437732764064545
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9045.5791015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.21004967261662874
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211.79478454589844,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.014850286393626311
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1434.942138671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.07355282888266312
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166476.546875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.883154948078685
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16902.154296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.28126660837160733
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 15894.060546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7266.5693359375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.08219822105513953,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1123.1488037109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.809185017082808
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 903.5999755859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.755789345189145
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 861.6697998046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.06535227909023038
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1049.09130859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.353586554969245
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 778.6382446289062,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.10402648558836423
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 809.6671752929688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6991944518937554
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1239.087158203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.02877315526200829
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 700.0379028320312,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.04908413285878777
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 392.0121154785156,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.020093911296248688
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 517.6934204101562,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.09203438585069444
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3799.072998046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0632198924674567
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 19200.453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8231.0,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.09310769996493332,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117.66085815429688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08477007071635222
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.4598388671875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17610441509046051
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 464.6393737792969,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.035239998011323236
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.803155899047852,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.003641104111576627
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 272.84979248046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.03645287808690297
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.22439193725586,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.026964069030445473
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1015.0426025390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.02357056015556062
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 390.2170715332031,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.027360613625943286
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169.985107421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.008713163535900098
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.71829986572266,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.01541658664279514
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1776.0960693359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.02955578968159249
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 9315.904296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4775.08251953125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.054014937496818544,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2534.188232421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.8257840291223884
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3086.277099609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 16.243563682154605
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 509.8584289550781,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.03866958126318378
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1750.01416015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5898261409357095
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1372.01953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.18330254258517034
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2653.669677734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.2915973037429835
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2303.24072265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.05348413344455345
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758.9332885742188,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.05321366488390259
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 766.7988891601562,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.03930487924343412
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1542.7100830078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2742595703125
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3311.989990234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.05511440584151856
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 538.4459228515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 539.9487915039062,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.008985219434940945,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2962.5224609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.1343821764679394
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3357.72509765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.672237356085525
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1357.651611328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.10296940548563709
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2160.2490234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7280920200328614
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2064.386962890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2758032014549933
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2919.749267578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.521372424506153
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1423.3602294921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.033052206703794065
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 662.2816162109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.04643679821981051
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1791.6173095703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0918354251663495
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1798.0592041015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.31965496961805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7494.67236328125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.08477848447769024
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 626.6116943359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 623.567138671875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.010376701756808198,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2637.046142578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.8998891517133465
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2884.62841796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 15.182254831414474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1854.09765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14062174108835798
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1764.97119140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.59486727044363
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1920.3953857421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.25656584979855546
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2593.0341796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.239235042908031
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2111.323974609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.049027586257880715
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612.7311401367188,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.042962497555512465
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1126.9354248046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.057764899523537215
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1729.8507080078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.30752901475694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5359.73583984375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.06062843839964424
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topo_polynormer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1421.0396728515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1460.4549560546875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.024303245903094996,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2116.592529296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.5249225715395354
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2527.672607421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 13.3035400390625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 650.3062744140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.04932167420660315
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1536.97021484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5180216430211493
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1200.5406494140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1603928723332081
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2167.401611328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.871676693720315
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 792.3012084960938,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.018398226093630267
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 567.5232543945312,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.039792683662496935
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764.7033081054688,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.03919746312499199
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1209.05078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.21494236111111112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23697.017578125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.2680567127600308
+        }
+      },
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/2026_tdl_challenge/outputs/2026-06-14_10-30-09/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-14_10-30-09/results.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "study_id": "2026-06-13_18-26-47",
+    "study_id": "2026-06-14_10-30-09",
     "model_config": "graph/topo_polynormer",
-    "generated_at_utc": "2026-06-13T21:15:05.350512+00:00",
+    "generated_at_utc": "2026-06-14T15:07:24.234981+00:00",
     "n_runs": 72,
     "train_seeds": [
       42,
@@ -21,58 +21,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.227275848388672,
-      "test_best_rerun_accuracy": 0.3147299289703369,
+      "test_loss": 2.258821964263916,
+      "test_best_rerun_accuracy": 0.3054473102092743,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3129345178604126,
+          "test_best_rerun_accuracy": 0.30609673261642456,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.29914432764053345,
+          "test_best_rerun_accuracy": 0.2959355115890503,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3059821128845215,
+          "test_best_rerun_accuracy": 0.2927267253398895,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30170372128486633,
+          "test_best_rerun_accuracy": 0.2943311035633087,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29925891757011414,
+          "test_best_rerun_accuracy": 0.29192450642585754,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.27045610547065735,
+          "test_best_rerun_accuracy": 0.2857743203639984,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.28543052077293396,
+          "test_best_rerun_accuracy": 0.27740851044654846,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2974635064601898,
+          "test_best_rerun_accuracy": 0.2929559051990509,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29501873254776,
+          "test_best_rerun_accuracy": 0.2908167243003845,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.26132631301879883,
+          "test_best_rerun_accuracy": 0.28634729981422424,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2565130889415741,
+          "test_best_rerun_accuracy": 0.2710673213005066,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__00__h_lo__d_lo__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__00__h_lo__d_lo__pl_lo__s42"
     },
     {
       "experiment": "community_detection",
@@ -83,58 +83,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.2634689807891846,
-      "test_best_rerun_accuracy": 0.3022003173828125,
+      "test_loss": 2.2481467723846436,
+      "test_best_rerun_accuracy": 0.30605852603912354,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.30227673053741455,
+          "test_best_rerun_accuracy": 0.30212393403053284,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2845137119293213,
+          "test_best_rerun_accuracy": 0.29463672637939453,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.29425472021102905,
+          "test_best_rerun_accuracy": 0.2858889102935791,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_accuracy": 0.2944457232952118,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2886011302471161,
+          "test_best_rerun_accuracy": 0.28974711894989014,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2611353099346161,
+          "test_best_rerun_accuracy": 0.28432270884513855,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2709527015686035,
+          "test_best_rerun_accuracy": 0.27278631925582886,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2834441065788269,
+          "test_best_rerun_accuracy": 0.2913133203983307,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28310030698776245,
+          "test_best_rerun_accuracy": 0.28879210352897644,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2557108998298645,
+          "test_best_rerun_accuracy": 0.2877989113330841,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2391320914030075,
+          "test_best_rerun_accuracy": 0.27236610651016235,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__00__h_lo__d_lo__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__00__h_lo__d_lo__pl_lo__s43"
     },
     {
       "experiment": "community_detection",
@@ -145,58 +145,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.272686719894409,
-      "test_best_rerun_accuracy": 0.2975781261920929,
+      "test_loss": 2.267115831375122,
+      "test_best_rerun_accuracy": 0.3018947243690491,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2994499206542969,
+          "test_best_rerun_accuracy": 0.3020475208759308,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.284628301858902,
+          "test_best_rerun_accuracy": 0.28348231315612793,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.27805790305137634,
+          "test_best_rerun_accuracy": 0.2812667191028595,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.28623270988464355,
+          "test_best_rerun_accuracy": 0.2918481230735779,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28336772322654724,
+          "test_best_rerun_accuracy": 0.2872641086578369,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.25876688957214355,
+          "test_best_rerun_accuracy": 0.28119030594825745,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.25796470046043396,
+          "test_best_rerun_accuracy": 0.271334707736969,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_accuracy": 0.2908931076526642,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2801589071750641,
+          "test_best_rerun_accuracy": 0.2849339246749878,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24123309552669525,
+          "test_best_rerun_accuracy": 0.28489571809768677,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.23672549426555634,
+          "test_best_rerun_accuracy": 0.27102911472320557,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__00__h_lo__d_lo__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__00__h_lo__d_lo__pl_lo__s44"
     },
     {
       "experiment": "community_detection",
@@ -207,58 +207,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.2386603355407715,
-      "test_best_rerun_accuracy": 0.3110245168209076,
+      "test_loss": 2.2845094203948975,
+      "test_best_rerun_accuracy": 0.2959355115890503,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.31014591455459595,
+          "test_best_rerun_accuracy": 0.294216513633728,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2813049256801605,
+          "test_best_rerun_accuracy": 0.291160523891449,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30621132254600525,
+          "test_best_rerun_accuracy": 0.28737872838974,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.28432270884513855,
+          "test_best_rerun_accuracy": 0.2819161117076874,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29574450850486755,
+          "test_best_rerun_accuracy": 0.2841317057609558,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23710750043392181,
+          "test_best_rerun_accuracy": 0.2809993028640747,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.27851632237434387,
+          "test_best_rerun_accuracy": 0.2760715186595917,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.27278631925582886,
+          "test_best_rerun_accuracy": 0.2787837088108063,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28798991441726685,
+          "test_best_rerun_accuracy": 0.2781725227832794,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.21930629014968872,
+          "test_best_rerun_accuracy": 0.27901291847229004,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2228206843137741,
+          "test_best_rerun_accuracy": 0.27576589584350586,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__01__h_lo__d_lo__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__01__h_lo__d_lo__pl_hi__s42"
     },
     {
       "experiment": "community_detection",
@@ -269,58 +269,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.2404391765594482,
-      "test_best_rerun_accuracy": 0.30892351269721985,
+      "test_loss": 2.244504451751709,
+      "test_best_rerun_accuracy": 0.3072045147418976,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30552372336387634,
+          "test_best_rerun_accuracy": 0.3059057295322418,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.27370309829711914,
+          "test_best_rerun_accuracy": 0.3052945137023926,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30552372336387634,
+          "test_best_rerun_accuracy": 0.30582931637763977,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2748873233795166,
+          "test_best_rerun_accuracy": 0.29169532656669617,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29303231835365295,
+          "test_best_rerun_accuracy": 0.294178307056427,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22060509026050568,
+          "test_best_rerun_accuracy": 0.29001450538635254,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_accuracy": 0.28909772634506226,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2532278895378113,
+          "test_best_rerun_accuracy": 0.2881809175014496,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2793567180633545,
+          "test_best_rerun_accuracy": 0.2889067232608795,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1969974786043167,
+          "test_best_rerun_accuracy": 0.2870731055736542,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.20058828592300415,
+          "test_best_rerun_accuracy": 0.2874933183193207,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__01__h_lo__d_lo__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__01__h_lo__d_lo__pl_hi__s43"
     },
     {
       "experiment": "community_detection",
@@ -331,58 +331,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.274203300476074,
-      "test_best_rerun_accuracy": 0.3058675229549408,
+      "test_loss": 2.245107889175415,
+      "test_best_rerun_accuracy": 0.31014591455459595,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2993353307247162,
+          "test_best_rerun_accuracy": 0.3095729351043701,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.27836352586746216,
+          "test_best_rerun_accuracy": 0.3020475208759308,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.29834210872650146,
+          "test_best_rerun_accuracy": 0.29727253317832947,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2755749225616455,
+          "test_best_rerun_accuracy": 0.29505690932273865,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2901291251182556,
+          "test_best_rerun_accuracy": 0.29589730501174927,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23561769723892212,
+          "test_best_rerun_accuracy": 0.2863091230392456,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2745053172111511,
+          "test_best_rerun_accuracy": 0.27996790409088135,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.26147910952568054,
+          "test_best_rerun_accuracy": 0.2898617088794708,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28027352690696716,
+          "test_best_rerun_accuracy": 0.28936511278152466,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.21514248847961426,
+          "test_best_rerun_accuracy": 0.2860417068004608,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2203758955001831,
+          "test_best_rerun_accuracy": 0.2815341055393219,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__01__h_lo__d_lo__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__01__h_lo__d_lo__pl_hi__s44"
     },
     {
       "experiment": "community_detection",
@@ -393,58 +393,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.1531577110290527,
-      "test_best_rerun_accuracy": 0.33665674924850464,
+      "test_loss": 2.125849962234497,
+      "test_best_rerun_accuracy": 0.3459775447845459,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.27981510758399963,
+          "test_best_rerun_accuracy": 0.2761097252368927,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2651844918727875,
+          "test_best_rerun_accuracy": 0.2600657045841217,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3145771324634552,
+          "test_best_rerun_accuracy": 0.3259607255458832,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_accuracy": 0.2774467170238495,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2543739080429077,
+          "test_best_rerun_accuracy": 0.25276950001716614,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.32294294238090515,
+          "test_best_rerun_accuracy": 0.3379173278808594,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30563831329345703,
+          "test_best_rerun_accuracy": 0.3125525116920471,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2917335033416748,
+          "test_best_rerun_accuracy": 0.29345253109931946,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.27863091230392456,
+          "test_best_rerun_accuracy": 0.2767973244190216,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.33069753646850586,
+          "test_best_rerun_accuracy": 0.34548094868659973,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.31381312012672424,
+          "test_best_rerun_accuracy": 0.3243945240974426,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__02__h_lo__d_hi__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__02__h_lo__d_hi__pl_lo__s42"
     },
     {
       "experiment": "community_detection",
@@ -455,58 +455,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.170494318008423,
-      "test_best_rerun_accuracy": 0.33627474308013916,
+      "test_loss": 2.1732563972473145,
+      "test_best_rerun_accuracy": 0.3312705457210541,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.27183130383491516,
+          "test_best_rerun_accuracy": 0.2938727140426636,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.25849950313568115,
+          "test_best_rerun_accuracy": 0.28241270780563354,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.31874093413352966,
+          "test_best_rerun_accuracy": 0.31243792176246643,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.27603331208229065,
+          "test_best_rerun_accuracy": 0.2895561158657074,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.25196731090545654,
+          "test_best_rerun_accuracy": 0.271334707736969,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.31923753023147583,
+          "test_best_rerun_accuracy": 0.32145312428474426,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.302582323551178,
+          "test_best_rerun_accuracy": 0.2973107099533081,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2843991219997406,
+          "test_best_rerun_accuracy": 0.303728312253952,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.27316829562187195,
+          "test_best_rerun_accuracy": 0.29436931014060974,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.32007792592048645,
+          "test_best_rerun_accuracy": 0.33871954679489136,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_accuracy": 0.3209947347640991,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__02__h_lo__d_hi__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__02__h_lo__d_hi__pl_lo__s43"
     },
     {
       "experiment": "community_detection",
@@ -517,58 +517,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.1903843879699707,
-      "test_best_rerun_accuracy": 0.32767972350120544,
+      "test_loss": 2.1419825553894043,
+      "test_best_rerun_accuracy": 0.345328152179718,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2784399092197418,
+          "test_best_rerun_accuracy": 0.2677821218967438,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.26747649908065796,
+          "test_best_rerun_accuracy": 0.24543510377407074,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3069371283054352,
+          "test_best_rerun_accuracy": 0.32496753334999084,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2759568989276886,
+          "test_best_rerun_accuracy": 0.2665978968143463,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.25265491008758545,
+          "test_best_rerun_accuracy": 0.24299030005931854,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3128199279308319,
+          "test_best_rerun_accuracy": 0.33081212639808655,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2978073060512543,
+          "test_best_rerun_accuracy": 0.3125525116920471,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2823363244533539,
+          "test_best_rerun_accuracy": 0.27790510654449463,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.27416151762008667,
+          "test_best_rerun_accuracy": 0.2683551013469696,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3078921139240265,
+          "test_best_rerun_accuracy": 0.33111771941185,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3056001365184784,
+          "test_best_rerun_accuracy": 0.3247765302658081,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__02__h_lo__d_hi__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__02__h_lo__d_hi__pl_lo__s44"
     },
     {
       "experiment": "community_detection",
@@ -579,38 +579,38 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.1974942684173584,
-      "test_best_rerun_accuracy": 0.32332491874694824,
+      "test_loss": 2.199279308319092,
+      "test_best_rerun_accuracy": 0.32317212224006653,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2899381220340729,
+          "test_best_rerun_accuracy": 0.2901291251182556,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_accuracy": 0.29123690724372864,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3143097162246704,
+          "test_best_rerun_accuracy": 0.31709831953048706,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2743525207042694,
+          "test_best_rerun_accuracy": 0.27400872111320496,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2718695104122162,
+          "test_best_rerun_accuracy": 0.2701123058795929,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2775995135307312,
+          "test_best_rerun_accuracy": 0.29410192370414734,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2966613173484802,
+          "test_best_rerun_accuracy": 0.2928031086921692,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
@@ -618,19 +618,19 @@
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2779815196990967,
+          "test_best_rerun_accuracy": 0.2743525207042694,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.27018871903419495,
+          "test_best_rerun_accuracy": 0.28936511278152466,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.28092291951179504,
+          "test_best_rerun_accuracy": 0.29601192474365234,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__03__h_lo__d_hi__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__03__h_lo__d_hi__pl_hi__s42"
     },
     {
       "experiment": "community_detection",
@@ -641,58 +641,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.223804473876953,
-      "test_best_rerun_accuracy": 0.3162197172641754,
+      "test_loss": 2.207516670227051,
+      "test_best_rerun_accuracy": 0.3177095353603363,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.28512492775917053,
+          "test_best_rerun_accuracy": 0.28921231627464294,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28363510966300964,
+          "test_best_rerun_accuracy": 0.28565970063209534,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3002903163433075,
+          "test_best_rerun_accuracy": 0.3166399300098419,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2668271064758301,
+          "test_best_rerun_accuracy": 0.2747344970703125,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2683168947696686,
+          "test_best_rerun_accuracy": 0.26827871799468994,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.26434409618377686,
+          "test_best_rerun_accuracy": 0.29467490315437317,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_accuracy": 0.294980525970459,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.26816409826278687,
+          "test_best_rerun_accuracy": 0.27790510654449463,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.27412331104278564,
+          "test_best_rerun_accuracy": 0.2787073254585266,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.25930169224739075,
+          "test_best_rerun_accuracy": 0.3052945137023926,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2747344970703125,
+          "test_best_rerun_accuracy": 0.30758652091026306,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__03__h_lo__d_hi__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__03__h_lo__d_hi__pl_hi__s43"
     },
     {
       "experiment": "community_detection",
@@ -703,58 +703,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.2683401107788086,
-      "test_best_rerun_accuracy": 0.30487433075904846,
+      "test_loss": 2.1968770027160645,
+      "test_best_rerun_accuracy": 0.3238215148448944,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.28103750944137573,
+          "test_best_rerun_accuracy": 0.2895561158657074,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2830621004104614,
+          "test_best_rerun_accuracy": 0.2915043234825134,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.29520970582962036,
+          "test_best_rerun_accuracy": 0.3144243359565735,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2670944929122925,
+          "test_best_rerun_accuracy": 0.2777523100376129,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.26472610235214233,
+          "test_best_rerun_accuracy": 0.2743525207042694,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.25765910744667053,
+          "test_best_rerun_accuracy": 0.292268306016922,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2830239236354828,
+          "test_best_rerun_accuracy": 0.2915043234825134,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.26461151242256165,
+          "test_best_rerun_accuracy": 0.28245091438293457,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_accuracy": 0.2850867211818695,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24356329441070557,
+          "test_best_rerun_accuracy": 0.30445411801338196,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2583085000514984,
+          "test_best_rerun_accuracy": 0.30579110980033875,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__03__h_lo__d_hi__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__03__h_lo__d_hi__pl_hi__s44"
     },
     {
       "experiment": "community_detection",
@@ -765,58 +765,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 1.9237282276153564,
-      "test_best_rerun_accuracy": 0.4186721742153168,
+      "test_loss": 1.9537099599838257,
+      "test_best_rerun_accuracy": 0.41389715671539307,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.27018871903419495,
+          "test_best_rerun_accuracy": 0.26445871591567993,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.25425928831100464,
+          "test_best_rerun_accuracy": 0.2448239028453827,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19680647552013397,
+          "test_best_rerun_accuracy": 0.17839406430721283,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15371686220169067,
+          "test_best_rerun_accuracy": 0.14229506254196167,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3836045563220978,
+          "test_best_rerun_accuracy": 0.37420734763145447,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.35652074217796326,
+          "test_best_rerun_accuracy": 0.33638933300971985,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30128350853919983,
+          "test_best_rerun_accuracy": 0.24558790028095245,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5289937853813171,
+          "test_best_rerun_accuracy": 0.5194820165634155,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5098174214363098,
+          "test_best_rerun_accuracy": 0.4996944069862366,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.49763160943984985,
+          "test_best_rerun_accuracy": 0.5153564214706421,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.43456336855888367,
+          "test_best_rerun_accuracy": 0.4273053705692291,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__04__h_mid__d_lo__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__04__h_mid__d_lo__pl_lo__s42"
     },
     {
       "experiment": "community_detection",
@@ -827,58 +827,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 1.9600856304168701,
-      "test_best_rerun_accuracy": 0.40870195627212524,
+      "test_loss": 1.9509378671646118,
+      "test_best_rerun_accuracy": 0.4109557569026947,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2646878957748413,
+          "test_best_rerun_accuracy": 0.2626633048057556,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2497134953737259,
+          "test_best_rerun_accuracy": 0.24260829389095306,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22014668583869934,
+          "test_best_rerun_accuracy": 0.21281228959560394,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.18152646720409393,
+          "test_best_rerun_accuracy": 0.1786232739686966,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.37118953466415405,
+          "test_best_rerun_accuracy": 0.3747803568840027,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3628237545490265,
+          "test_best_rerun_accuracy": 0.3596913516521454,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3229811191558838,
+          "test_best_rerun_accuracy": 0.3042249083518982,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5137901902198792,
+          "test_best_rerun_accuracy": 0.5337306261062622,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4969821870326996,
+          "test_best_rerun_accuracy": 0.50836580991745,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4570249915122986,
+          "test_best_rerun_accuracy": 0.5366337895393372,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.41485217213630676,
+          "test_best_rerun_accuracy": 0.4735274016857147,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__04__h_mid__d_lo__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__04__h_mid__d_lo__pl_lo__s43"
     },
     {
       "experiment": "community_detection",
@@ -889,58 +889,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 1.9834104776382446,
-      "test_best_rerun_accuracy": 0.40148216485977173,
+      "test_loss": 1.9550330638885498,
+      "test_best_rerun_accuracy": 0.4105737507343292,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2627778947353363,
+          "test_best_rerun_accuracy": 0.2680495083332062,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2427992969751358,
+          "test_best_rerun_accuracy": 0.2493315041065216,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.20742608606815338,
+          "test_best_rerun_accuracy": 0.23023149371147156,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1771334707736969,
+          "test_best_rerun_accuracy": 0.19115287065505981,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3685537576675415,
+          "test_best_rerun_accuracy": 0.37393996119499207,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.34689435362815857,
+          "test_best_rerun_accuracy": 0.3791733384132385,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3090381324291229,
+          "test_best_rerun_accuracy": 0.3214913308620453,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5087478160858154,
+          "test_best_rerun_accuracy": 0.5250592231750488,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4953778088092804,
+          "test_best_rerun_accuracy": 0.5031706094741821,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.45179158449172974,
+          "test_best_rerun_accuracy": 0.5374742150306702,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.426082968711853,
+          "test_best_rerun_accuracy": 0.47276338934898376,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__04__h_mid__d_lo__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__04__h_mid__d_lo__pl_lo__s44"
     },
     {
       "experiment": "community_detection",
@@ -951,58 +951,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.030066728591919,
-      "test_best_rerun_accuracy": 0.3857819437980652,
+      "test_loss": 2.0292975902557373,
+      "test_best_rerun_accuracy": 0.3882267475128174,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2643823027610779,
+          "test_best_rerun_accuracy": 0.2651081085205078,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.26445871591567993,
+          "test_best_rerun_accuracy": 0.26568111777305603,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19363588094711304,
+          "test_best_rerun_accuracy": 0.1992894858121872,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.19497287273406982,
+          "test_best_rerun_accuracy": 0.18309266865253448,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.377607136964798,
+          "test_best_rerun_accuracy": 0.39525556564331055,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2800061106681824,
+          "test_best_rerun_accuracy": 0.3366949260234833,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_accuracy": 0.32618993520736694,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4840705990791321,
+          "test_best_rerun_accuracy": 0.5146688222885132,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4988158047199249,
+          "test_best_rerun_accuracy": 0.5134081840515137,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4321567714214325,
+          "test_best_rerun_accuracy": 0.5328902006149292,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4269615709781647,
+          "test_best_rerun_accuracy": 0.5092825889587402,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__05__h_mid__d_lo__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__05__h_mid__d_lo__pl_hi__s42"
     },
     {
       "experiment": "community_detection",
@@ -1013,58 +1013,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 1.9936420917510986,
-      "test_best_rerun_accuracy": 0.39922836422920227,
+      "test_loss": 2.032614231109619,
+      "test_best_rerun_accuracy": 0.38658416271209717,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2724043130874634,
+          "test_best_rerun_accuracy": 0.26449689269065857,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2721368968486786,
+          "test_best_rerun_accuracy": 0.25865229964256287,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19653907418251038,
+          "test_best_rerun_accuracy": 0.20043547451496124,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.19462907314300537,
+          "test_best_rerun_accuracy": 0.17514707148075104,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4048437476158142,
+          "test_best_rerun_accuracy": 0.39854076504707336,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3051799237728119,
+          "test_best_rerun_accuracy": 0.3310413360595703,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3127053380012512,
+          "test_best_rerun_accuracy": 0.2979601323604584,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5203987956047058,
+          "test_best_rerun_accuracy": 0.5140194296836853,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5227289795875549,
+          "test_best_rerun_accuracy": 0.5085949897766113,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.48662999272346497,
+          "test_best_rerun_accuracy": 0.5281152129173279,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.45251739025115967,
+          "test_best_rerun_accuracy": 0.49136680364608765,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__05__h_mid__d_lo__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__05__h_mid__d_lo__pl_hi__s43"
     },
     {
       "experiment": "community_detection",
@@ -1075,58 +1075,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.004065990447998,
-      "test_best_rerun_accuracy": 0.3947589695453644,
+      "test_loss": 2.014207363128662,
+      "test_best_rerun_accuracy": 0.3935365676879883,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2711819112300873,
+          "test_best_rerun_accuracy": 0.2728627026081085,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2689281105995178,
+          "test_best_rerun_accuracy": 0.26625409722328186,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.21006187796592712,
+          "test_best_rerun_accuracy": 0.20139047503471375,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2048666775226593,
+          "test_best_rerun_accuracy": 0.1799984723329544,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4033157527446747,
+          "test_best_rerun_accuracy": 0.40465277433395386,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.32745054364204407,
+          "test_best_rerun_accuracy": 0.33298954367637634,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.33409732580184937,
+          "test_best_rerun_accuracy": 0.30808311700820923,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.507601797580719,
+          "test_best_rerun_accuracy": 0.5227289795875549,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5140575766563416,
+          "test_best_rerun_accuracy": 0.5139430165290833,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4917106032371521,
+          "test_best_rerun_accuracy": 0.534303605556488,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4528611898422241,
+          "test_best_rerun_accuracy": 0.504584014415741,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__05__h_mid__d_lo__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__05__h_mid__d_lo__pl_hi__s44"
     },
     {
       "experiment": "community_detection",
@@ -1137,58 +1137,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 1.8429778814315796,
-      "test_best_rerun_accuracy": 0.44732218980789185,
+      "test_loss": 1.807452917098999,
+      "test_best_rerun_accuracy": 0.463022381067276,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.22113989293575287,
+          "test_best_rerun_accuracy": 0.22725188732147217,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20410268008708954,
+          "test_best_rerun_accuracy": 0.20925968885421753,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.26327449083328247,
+          "test_best_rerun_accuracy": 0.2679730951786041,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22591489553451538,
+          "test_best_rerun_accuracy": 0.23741309344768524,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3543051481246948,
+          "test_best_rerun_accuracy": 0.36889755725860596,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2954007089138031,
+          "test_best_rerun_accuracy": 0.31327831745147705,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.42298877239227295,
+          "test_best_rerun_accuracy": 0.4408663809299469,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.48025059700012207,
+          "test_best_rerun_accuracy": 0.5031706094741821,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4464053809642792,
+          "test_best_rerun_accuracy": 0.47299259901046753,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5888914465904236,
+          "test_best_rerun_accuracy": 0.6053938269615173,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5789212584495544,
+          "test_best_rerun_accuracy": 0.5970662236213684,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__06__h_mid__d_hi__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__06__h_mid__d_hi__pl_lo__s42"
     },
     {
       "experiment": "community_detection",
@@ -1199,58 +1199,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 1.8494861125946045,
-      "test_best_rerun_accuracy": 0.4485063850879669,
+      "test_loss": 1.809809923171997,
+      "test_best_rerun_accuracy": 0.46202918887138367,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.23454809188842773,
+          "test_best_rerun_accuracy": 0.2293146848678589,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.21911528706550598,
+          "test_best_rerun_accuracy": 0.21158988773822784,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.25785011053085327,
+          "test_best_rerun_accuracy": 0.26690351963043213,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.23634348809719086,
+          "test_best_rerun_accuracy": 0.2413094937801361,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.36370235681533813,
+          "test_best_rerun_accuracy": 0.37054014205932617,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.31236153841018677,
+          "test_best_rerun_accuracy": 0.317862331867218,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.41836658120155334,
+          "test_best_rerun_accuracy": 0.4475131928920746,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4842233955860138,
+          "test_best_rerun_accuracy": 0.5057299733161926,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.44991979002952576,
+          "test_best_rerun_accuracy": 0.47585758566856384,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5612346529960632,
+          "test_best_rerun_accuracy": 0.6006952524185181,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5628008246421814,
+          "test_best_rerun_accuracy": 0.604400634765625,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__06__h_mid__d_hi__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__06__h_mid__d_hi__pl_lo__s43"
     },
     {
       "experiment": "community_detection",
@@ -1261,58 +1261,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 1.848814606666565,
-      "test_best_rerun_accuracy": 0.4442661702632904,
+      "test_loss": 1.802801489830017,
+      "test_best_rerun_accuracy": 0.4671097993850708,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.21880969405174255,
+          "test_best_rerun_accuracy": 0.2335548996925354,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2077316790819168,
+          "test_best_rerun_accuracy": 0.21919168531894684,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2589578926563263,
+          "test_best_rerun_accuracy": 0.26976850628852844,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2334020882844925,
+          "test_best_rerun_accuracy": 0.24948430061340332,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.35461074113845825,
+          "test_best_rerun_accuracy": 0.37187716364860535,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29857131838798523,
+          "test_best_rerun_accuracy": 0.31874093413352966,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.42516615986824036,
+          "test_best_rerun_accuracy": 0.4483153820037842,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4677973985671997,
+          "test_best_rerun_accuracy": 0.4982045888900757,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.43383756279945374,
+          "test_best_rerun_accuracy": 0.47127360105514526,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5667354464530945,
+          "test_best_rerun_accuracy": 0.5997402667999268,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5553517937660217,
+          "test_best_rerun_accuracy": 0.5910688638687134,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__06__h_mid__d_hi__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__06__h_mid__d_hi__pl_lo__s44"
     },
     {
       "experiment": "community_detection",
@@ -1323,58 +1323,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1.7343294620513916,
-      "test_best_rerun_accuracy": 0.48143479228019714,
+      "test_loss": 1.754652738571167,
+      "test_best_rerun_accuracy": 0.47761479020118713,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.21934448182582855,
+          "test_best_rerun_accuracy": 0.2373749017715454,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2141110897064209,
+          "test_best_rerun_accuracy": 0.23237068951129913,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24596989154815674,
+          "test_best_rerun_accuracy": 0.24872030317783356,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.24260829389095306,
+          "test_best_rerun_accuracy": 0.24218809604644775,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.33505234122276306,
+          "test_best_rerun_accuracy": 0.3638169467449188,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.30563831329345703,
+          "test_best_rerun_accuracy": 0.33936893939971924,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4043089747428894,
+          "test_best_rerun_accuracy": 0.4378485679626465,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4569103717803955,
+          "test_best_rerun_accuracy": 0.4918633997440338,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.45794177055358887,
+          "test_best_rerun_accuracy": 0.4843379855155945,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5356405973434448,
+          "test_best_rerun_accuracy": 0.5992436408996582,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.616586446762085,
+          "test_best_rerun_accuracy": 0.647031843662262,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__07__h_mid__d_hi__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__07__h_mid__d_hi__pl_hi__s42"
     },
     {
       "experiment": "community_detection",
@@ -1385,58 +1385,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1.743726372718811,
-      "test_best_rerun_accuracy": 0.47383299469947815,
+      "test_loss": 1.728793740272522,
+      "test_best_rerun_accuracy": 0.482084184885025,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.20318588614463806,
+          "test_best_rerun_accuracy": 0.21605928242206573,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20692948997020721,
+          "test_best_rerun_accuracy": 0.21884788572788239,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24692489206790924,
+          "test_best_rerun_accuracy": 0.2483765035867691,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2350446879863739,
+          "test_best_rerun_accuracy": 0.24234089255332947,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3312705457210541,
+          "test_best_rerun_accuracy": 0.34399113059043884,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.30949652194976807,
+          "test_best_rerun_accuracy": 0.31923753023147583,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.42910078167915344,
+          "test_best_rerun_accuracy": 0.44327297806739807,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.45927879214286804,
+          "test_best_rerun_accuracy": 0.4757812023162842,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4643593728542328,
+          "test_best_rerun_accuracy": 0.46134158968925476,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5588662028312683,
+          "test_best_rerun_accuracy": 0.6045534610748291,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.631904661655426,
+          "test_best_rerun_accuracy": 0.6576514840126038,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__07__h_mid__d_hi__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__07__h_mid__d_hi__pl_hi__s43"
     },
     {
       "experiment": "community_detection",
@@ -1447,58 +1447,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1.738013505935669,
-      "test_best_rerun_accuracy": 0.48414698243141174,
+      "test_loss": 1.7308557033538818,
+      "test_best_rerun_accuracy": 0.4846436083316803,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2272900938987732,
+          "test_best_rerun_accuracy": 0.21689969301223755,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.221598282456398,
+          "test_best_rerun_accuracy": 0.2224004864692688,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2511269152164459,
+          "test_best_rerun_accuracy": 0.23726029694080353,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2475360929965973,
+          "test_best_rerun_accuracy": 0.2528459131717682,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.34674152731895447,
+          "test_best_rerun_accuracy": 0.33994194865226746,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.31698372960090637,
+          "test_best_rerun_accuracy": 0.3240507245063782,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.43334096670150757,
+          "test_best_rerun_accuracy": 0.4342195689678192,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.46210557222366333,
+          "test_best_rerun_accuracy": 0.4775383770465851,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.46607840061187744,
+          "test_best_rerun_accuracy": 0.47410038113594055,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5728856325149536,
+          "test_best_rerun_accuracy": 0.6084498167037964,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6446252465248108,
+          "test_best_rerun_accuracy": 0.6570020914077759,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__07__h_mid__d_hi__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__07__h_mid__d_hi__pl_hi__s44"
     },
     {
       "experiment": "community_detection",
@@ -1509,58 +1509,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.303898572921753,
-      "test_best_rerun_accuracy": 0.6294598579406738,
+      "test_loss": 1.2994669675827026,
+      "test_best_rerun_accuracy": 0.6366796493530273,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.20291848480701447,
+          "test_best_rerun_accuracy": 0.2028420865535736,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.19573688507080078,
+          "test_best_rerun_accuracy": 0.19749407470226288,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.15776605904102325,
+          "test_best_rerun_accuracy": 0.15887387096881866,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12781725823879242,
+          "test_best_rerun_accuracy": 0.1291542500257492,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4075559675693512,
+          "test_best_rerun_accuracy": 0.4120253622531891,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3742837607860565,
+          "test_best_rerun_accuracy": 0.37756896018981934,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3654213547706604,
+          "test_best_rerun_accuracy": 0.3523569405078888,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3245091438293457,
+          "test_best_rerun_accuracy": 0.300672322511673,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.6105126738548279,
+          "test_best_rerun_accuracy": 0.6218198537826538,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6553212404251099,
+          "test_best_rerun_accuracy": 0.6827870607376099,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6248376369476318,
+          "test_best_rerun_accuracy": 0.6345022320747375,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__08__h_hi__d_lo__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__08__h_hi__d_lo__pl_lo__s42"
     },
     {
       "experiment": "community_detection",
@@ -1571,58 +1571,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.3114726543426514,
-      "test_best_rerun_accuracy": 0.6287722587585449,
+      "test_loss": 1.2956130504608154,
+      "test_best_rerun_accuracy": 0.6306822299957275,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2020016759634018,
+          "test_best_rerun_accuracy": 0.19558407366275787,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1975322812795639,
+          "test_best_rerun_accuracy": 0.19107647240161896,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1571548581123352,
+          "test_best_rerun_accuracy": 0.17117427289485931,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1343112587928772,
+          "test_best_rerun_accuracy": 0.14370845258235931,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4082435667514801,
+          "test_best_rerun_accuracy": 0.40778517723083496,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.37256476283073425,
+          "test_best_rerun_accuracy": 0.37485674023628235,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.36740773916244507,
+          "test_best_rerun_accuracy": 0.37554433941841125,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3281763195991516,
+          "test_best_rerun_accuracy": 0.32878753542900085,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.6137978434562683,
+          "test_best_rerun_accuracy": 0.6167774200439453,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6561616659164429,
+          "test_best_rerun_accuracy": 0.6854611039161682,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6351134777069092,
+          "test_best_rerun_accuracy": 0.6475284695625305,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__08__h_hi__d_lo__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__08__h_hi__d_lo__pl_lo__s43"
     },
     {
       "experiment": "community_detection",
@@ -1633,58 +1633,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.3393181562423706,
-      "test_best_rerun_accuracy": 0.621208667755127,
+      "test_loss": 1.306566834449768,
+      "test_best_rerun_accuracy": 0.6285048723220825,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2007792741060257,
+          "test_best_rerun_accuracy": 0.20631828904151917,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.19115287065505981,
+          "test_best_rerun_accuracy": 0.19898387789726257,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.15516845881938934,
+          "test_best_rerun_accuracy": 0.16880586743354797,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12842844426631927,
+          "test_best_rerun_accuracy": 0.13209564983844757,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.40828177332878113,
+          "test_best_rerun_accuracy": 0.4181373715400696,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3638169467449188,
+          "test_best_rerun_accuracy": 0.3818855583667755,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.36969974637031555,
+          "test_best_rerun_accuracy": 0.383375346660614,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3210711181163788,
+          "test_best_rerun_accuracy": 0.33039194345474243,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.6009626388549805,
+          "test_best_rerun_accuracy": 0.6175796389579773,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6544808745384216,
+          "test_best_rerun_accuracy": 0.6818320751190186,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6147146224975586,
+          "test_best_rerun_accuracy": 0.6359156370162964,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__08__h_hi__d_lo__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__08__h_hi__d_lo__pl_lo__s44"
     },
     {
       "experiment": "community_detection",
@@ -1695,58 +1695,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.2636597156524658,
-      "test_best_rerun_accuracy": 0.631790041923523,
+      "test_loss": 1.2677738666534424,
+      "test_best_rerun_accuracy": 0.6317518353462219,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1965772807598114,
+          "test_best_rerun_accuracy": 0.19676828384399414,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18893727660179138,
+          "test_best_rerun_accuracy": 0.19298647344112396,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.16097486019134521,
+          "test_best_rerun_accuracy": 0.1576896607875824,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13496065139770508,
+          "test_best_rerun_accuracy": 0.1411108523607254,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.39170295000076294,
+          "test_best_rerun_accuracy": 0.3939949572086334,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3765757381916046,
+          "test_best_rerun_accuracy": 0.3791733384132385,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.35281533002853394,
+          "test_best_rerun_accuracy": 0.3694705367088318,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.34253954887390137,
+          "test_best_rerun_accuracy": 0.3397509455680847,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.608182430267334,
+          "test_best_rerun_accuracy": 0.6246084570884705,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.650851845741272,
+          "test_best_rerun_accuracy": 0.6964244842529297,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.7025746703147888,
+          "test_best_rerun_accuracy": 0.7069295048713684,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__09__h_hi__d_lo__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__09__h_hi__d_lo__pl_hi__s42"
     },
     {
       "experiment": "community_detection",
@@ -1757,58 +1757,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.2503600120544434,
-      "test_best_rerun_accuracy": 0.6416074633598328,
+      "test_loss": 1.28534996509552,
+      "test_best_rerun_accuracy": 0.6281610727310181,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19608068466186523,
+          "test_best_rerun_accuracy": 0.18866987526416779,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18710367381572723,
+          "test_best_rerun_accuracy": 0.18316906690597534,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1516922563314438,
+          "test_best_rerun_accuracy": 0.16315226256847382,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12464664876461029,
+          "test_best_rerun_accuracy": 0.14386126399040222,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3950263559818268,
+          "test_best_rerun_accuracy": 0.3855527639389038,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3792497515678406,
+          "test_best_rerun_accuracy": 0.36454275250434875,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.35965314507484436,
+          "test_best_rerun_accuracy": 0.37447476387023926,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_accuracy": 0.3459393382072449,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.6230040788650513,
+          "test_best_rerun_accuracy": 0.6143708229064941,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.654748260974884,
+          "test_best_rerun_accuracy": 0.6993277072906494,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6876384615898132,
+          "test_best_rerun_accuracy": 0.7220948934555054,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__09__h_hi__d_lo__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__09__h_hi__d_lo__pl_hi__s43"
     },
     {
       "experiment": "community_detection",
@@ -1819,58 +1819,58 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.2563319206237793,
-      "test_best_rerun_accuracy": 0.638627827167511,
+      "test_loss": 1.2997361421585083,
+      "test_best_rerun_accuracy": 0.6286576390266418,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1990220844745636,
+          "test_best_rerun_accuracy": 0.1999770849943161,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1862250715494156,
+          "test_best_rerun_accuracy": 0.19050347805023193,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.15833906829357147,
+          "test_best_rerun_accuracy": 0.15956147015094757,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12877225875854492,
+          "test_best_rerun_accuracy": 0.1333562582731247,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3938421607017517,
+          "test_best_rerun_accuracy": 0.39663076400756836,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.37676674127578735,
+          "test_best_rerun_accuracy": 0.3732905387878418,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.35449615120887756,
+          "test_best_rerun_accuracy": 0.3765757381916046,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3030407130718231,
+          "test_best_rerun_accuracy": 0.3475819528102875,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.6182290315628052,
+          "test_best_rerun_accuracy": 0.619566023349762,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6573458909988403,
+          "test_best_rerun_accuracy": 0.6918786764144897,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6965391039848328,
+          "test_best_rerun_accuracy": 0.7098708748817444,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__09__h_hi__d_lo__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__09__h_hi__d_lo__pl_hi__s44"
     },
     {
       "experiment": "community_detection",
@@ -1881,58 +1881,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.0106559991836548,
-      "test_best_rerun_accuracy": 0.7196118831634521,
+      "test_loss": 0.9879312515258789,
+      "test_best_rerun_accuracy": 0.7211781144142151,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.17480327188968658,
+          "test_best_rerun_accuracy": 0.17996026575565338,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.16777446866035461,
+          "test_best_rerun_accuracy": 0.17434486746788025,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.16605547070503235,
+          "test_best_rerun_accuracy": 0.17934906482696533,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1290014535188675,
+          "test_best_rerun_accuracy": 0.1487126648426056,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.37829476594924927,
+          "test_best_rerun_accuracy": 0.37947896122932434,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3180915415287018,
+          "test_best_rerun_accuracy": 0.32649552822113037,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.41389715671539307,
+          "test_best_rerun_accuracy": 0.42367637157440186,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3579341471195221,
+          "test_best_rerun_accuracy": 0.39051875472068787,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.6025288701057434,
+          "test_best_rerun_accuracy": 0.6060050129890442,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5781572461128235,
+          "test_best_rerun_accuracy": 0.5802964568138123,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.7338604927062988,
+          "test_best_rerun_accuracy": 0.7366108894348145,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__10__h_hi__d_hi__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__10__h_hi__d_hi__pl_lo__s42"
     },
     {
       "experiment": "community_detection",
@@ -1943,58 +1943,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.0498372316360474,
-      "test_best_rerun_accuracy": 0.7063946723937988,
+      "test_loss": 1.0154235363006592,
+      "test_best_rerun_accuracy": 0.7160210609436035,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1761784702539444,
+          "test_best_rerun_accuracy": 0.1831308752298355,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.17186187207698822,
+          "test_best_rerun_accuracy": 0.17614026367664337,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.17946366965770721,
+          "test_best_rerun_accuracy": 0.1775536686182022,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.147108256816864,
+          "test_best_rerun_accuracy": 0.15299105644226074,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3666055500507355,
+          "test_best_rerun_accuracy": 0.3863549530506134,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3163343369960785,
+          "test_best_rerun_accuracy": 0.3314233422279358,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.414661169052124,
+          "test_best_rerun_accuracy": 0.42092597484588623,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3882267475128174,
+          "test_best_rerun_accuracy": 0.3942241668701172,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5868286490440369,
+          "test_best_rerun_accuracy": 0.6086026430130005,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.568569004535675,
+          "test_best_rerun_accuracy": 0.5911070108413696,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.7211399078369141,
+          "test_best_rerun_accuracy": 0.7336695194244385,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__10__h_hi__d_hi__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__10__h_hi__d_hi__pl_lo__s43"
     },
     {
       "experiment": "community_detection",
@@ -2005,58 +2005,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.0587329864501953,
-      "test_best_rerun_accuracy": 0.704217255115509,
+      "test_loss": 1.0401698350906372,
+      "test_best_rerun_accuracy": 0.7167468667030334,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.17961646616458893,
+          "test_best_rerun_accuracy": 0.17285506427288055,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.17243486642837524,
+          "test_best_rerun_accuracy": 0.16154786944389343,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.16834746301174164,
+          "test_best_rerun_accuracy": 0.16357246041297913,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13855145871639252,
+          "test_best_rerun_accuracy": 0.14103445410728455,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3767285645008087,
+          "test_best_rerun_accuracy": 0.36996716260910034,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_accuracy": 0.3129345178604126,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.41061195731163025,
+          "test_best_rerun_accuracy": 0.41305676102638245,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.37294673919677734,
+          "test_best_rerun_accuracy": 0.37634655833244324,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5972572565078735,
+          "test_best_rerun_accuracy": 0.6017648577690125,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5748338103294373,
+          "test_best_rerun_accuracy": 0.5835816264152527,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.7321797013282776,
+          "test_best_rerun_accuracy": 0.7353121042251587,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__10__h_hi__d_hi__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__10__h_hi__d_hi__pl_lo__s44"
     },
     {
       "experiment": "community_detection",
@@ -2067,58 +2067,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 0.8090311884880066,
-      "test_best_rerun_accuracy": 0.7581557035446167,
+      "test_loss": 0.8052838444709778,
+      "test_best_rerun_accuracy": 0.7654137015342712,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1665138602256775,
+          "test_best_rerun_accuracy": 0.17743906378746033,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.16319046914577484,
+          "test_best_rerun_accuracy": 0.17037206888198853,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.15642906725406647,
+          "test_best_rerun_accuracy": 0.16995187103748322,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.13285964727401733,
+          "test_best_rerun_accuracy": 0.15165406465530396,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3335625231266022,
+          "test_best_rerun_accuracy": 0.3553747534751892,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.31396591663360596,
+          "test_best_rerun_accuracy": 0.33501413464546204,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.39659255743026733,
+          "test_best_rerun_accuracy": 0.41974177956581116,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.383375346660614,
+          "test_best_rerun_accuracy": 0.4257391691207886,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5487813949584961,
+          "test_best_rerun_accuracy": 0.565436601638794,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.565474808216095,
+          "test_best_rerun_accuracy": 0.5784628391265869,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6892810463905334,
+          "test_best_rerun_accuracy": 0.7056688666343689,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__11__h_hi__d_hi__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__11__h_hi__d_hi__pl_hi__s42"
     },
     {
       "experiment": "community_detection",
@@ -2129,58 +2129,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 0.8111200332641602,
-      "test_best_rerun_accuracy": 0.7593017220497131,
+      "test_loss": 0.7939461469650269,
+      "test_best_rerun_accuracy": 0.7564367055892944,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.17079226672649384,
+          "test_best_rerun_accuracy": 0.1658644676208496,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.16196806728839874,
+          "test_best_rerun_accuracy": 0.16643746197223663,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.16223546862602234,
+          "test_best_rerun_accuracy": 0.17041027545928955,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.11291924864053726,
+          "test_best_rerun_accuracy": 0.1498204618692398,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3421957492828369,
+          "test_best_rerun_accuracy": 0.33719152212142944,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.312132328748703,
+          "test_best_rerun_accuracy": 0.3213385343551636,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.40465277433395386,
+          "test_best_rerun_accuracy": 0.40805256366729736,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.36572694778442383,
+          "test_best_rerun_accuracy": 0.4090839624404907,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5511879920959473,
+          "test_best_rerun_accuracy": 0.5485522150993347,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5682634115219116,
+          "test_best_rerun_accuracy": 0.5644816160202026,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6966918706893921,
+          "test_best_rerun_accuracy": 0.6989457011222839,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__11__h_hi__d_hi__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__11__h_hi__d_hi__pl_hi__s43"
     },
     {
       "experiment": "community_detection",
@@ -2191,58 +2191,58 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 0.8031392097473145,
-      "test_best_rerun_accuracy": 0.7578883171081543,
+      "test_loss": 0.8102601170539856,
+      "test_best_rerun_accuracy": 0.7580410838127136,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.16460385918617249,
+          "test_best_rerun_accuracy": 0.17312246561050415,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.15998166799545288,
+          "test_best_rerun_accuracy": 0.1727786660194397,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1568874567747116,
+          "test_best_rerun_accuracy": 0.1689968705177307,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.12812285125255585,
+          "test_best_rerun_accuracy": 0.1504698544740677,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3373061418533325,
+          "test_best_rerun_accuracy": 0.3389105498790741,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3078157305717468,
+          "test_best_rerun_accuracy": 0.3279089331626892,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.40858736634254456,
+          "test_best_rerun_accuracy": 0.41821375489234924,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3904041647911072,
+          "test_best_rerun_accuracy": 0.424172967672348,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5367102026939392,
+          "test_best_rerun_accuracy": 0.5550462007522583,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.553327202796936,
+          "test_best_rerun_accuracy": 0.5691038370132446,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6888608932495117,
+          "test_best_rerun_accuracy": 0.6956604719161987,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__community_detection__11__h_hi__d_hi__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__community_detection__11__h_hi__d_hi__pl_hi__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -2253,80 +2253,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 3.9546074867248535,
+      "test_loss": 8.291545867919922,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 4.033015727996826,
+      "test_best_rerun_mse": 7.279801368713379,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.0029056309279516038,
+      "test_mse_by_total_triangles": 0.005244813666220013,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 0.993905246257782,
+          "test_best_rerun_mse": 0.3362566828727722,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.00523108024346201
+          "test_mse_by_total_triangles": 0.0017697720151198537
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5828.5654296875,
+          "test_best_rerun_mse": 5040.916015625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.44206032837978765
+          "test_mse_by_total_triangles": 0.3823220337978764
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23.220775604248047,
+          "test_best_rerun_mse": 17.63173484802246,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.007826348366783973
+          "test_mse_by_total_triangles": 0.005942613700041274
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3683.754150390625,
+          "test_best_rerun_mse": 3915.47412109375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4921515230982799
+          "test_mse_by_total_triangles": 0.523109435015865
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21.318729400634766,
+          "test_best_rerun_mse": 30.0865421295166,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.01840995630452052
+          "test_mse_by_total_triangles": 0.025981469887320037
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 146854.265625,
+          "test_best_rerun_mse": 141010.546875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.410139922557124
+          "test_mse_by_total_triangles": 3.2744414563208246
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7450.36181640625,
+          "test_best_rerun_mse": 8196.8720703125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.5223924986962734
+          "test_mse_by_total_triangles": 0.5747351051965012
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29615.556640625,
+          "test_best_rerun_mse": 31424.193359375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.5180458578412528
+          "test_mse_by_total_triangles": 1.6107536705815264
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1398.0677490234375,
+          "test_best_rerun_mse": 1552.8753662109375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.24854537760416667
+          "test_mse_by_total_triangles": 0.27606673177083335
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 677301.1875,
+          "test_best_rerun_mse": 681176.1875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.661518132868794
+          "test_mse_by_total_triangles": 7.705351486940488
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 214122.1875,
+          "test_best_rerun_mse": 219550.0625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.56318019569667
+          "test_mse_by_total_triangles": 3.653504775930641
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -2337,80 +2337,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 5.110864162445068,
+      "test_loss": 9.760072708129883,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 4.705085277557373,
+      "test_best_rerun_mse": 9.131988525390625,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.00338983089161194,
+      "test_mse_by_total_triangles": 0.006579242453451459,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 0.3769271671772003,
+          "test_best_rerun_mse": 1.9438962936401367,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.0019838271956694755
+          "test_mse_by_total_triangles": 0.010231033124421772
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6577.0556640625,
+          "test_best_rerun_mse": 3801.43798828125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.49882864346321576
+          "test_mse_by_total_triangles": 0.28831535747298065
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16.699073791503906,
+          "test_best_rerun_mse": 577.7738647460938,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.005628268888272297
+          "test_mse_by_total_triangles": 0.1947333551554074
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4390.21630859375,
+          "test_best_rerun_mse": 3901.57666015625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.5865352449691049
+          "test_mse_by_total_triangles": 0.5212527268077822
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26.723115921020508,
+          "test_best_rerun_mse": 28.469589233398438,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.02307695675390372
+          "test_mse_by_total_triangles": 0.024585137507252535
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151479.71875,
+          "test_best_rerun_mse": 131447.953125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.5175487356028237
+          "test_mse_by_total_triangles": 3.0523860562186513
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8574.7880859375,
+          "test_best_rerun_mse": 7159.2568359375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.6012332131494531
+          "test_mse_by_total_triangles": 0.5019812674195414
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 32885.24609375,
+          "test_best_rerun_mse": 32034.2265625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.6856448866548772
+          "test_mse_by_total_triangles": 1.6420229925931622
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1692.3477783203125,
+          "test_best_rerun_mse": 1688.1378173828125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.30086182725694444
+          "test_mse_by_total_triangles": 0.30011338975694446
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 693944.25,
+          "test_best_rerun_mse": 662126.5625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.84978168161714
+          "test_mse_by_total_triangles": 7.4898653043448755
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 221797.40625,
+          "test_best_rerun_mse": 205782.75,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.690902538565224
+          "test_mse_by_total_triangles": 3.4244046727572264
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -2421,80 +2421,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.9531161785125732,
+      "test_loss": 13.176162719726562,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2.828138828277588,
+      "test_best_rerun_mse": 10.032267570495605,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.002037563997318147,
+      "test_mse_by_total_triangles": 0.007227858480184154,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 0.4985777735710144,
+          "test_best_rerun_mse": 1.239336371421814,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.002624093545110602
+          "test_mse_by_total_triangles": 0.0065228230074832316
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6656.31103515625,
+          "test_best_rerun_mse": 4338.38818359375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.5048396689538301
+          "test_mse_by_total_triangles": 0.3290396802118885
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13.80135726928711,
+          "test_best_rerun_mse": 31.42454719543457,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0046516202457994975
+          "test_mse_by_total_triangles": 0.010591353958690451
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4579.56787109375,
+          "test_best_rerun_mse": 3862.526611328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.6118327149089846
+          "test_mse_by_total_triangles": 0.5160356194159151
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26.193376541137695,
+          "test_best_rerun_mse": 25.193504333496094,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.022619496149514418
+          "test_mse_by_total_triangles": 0.021756048647233243
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 154486.625,
+          "test_best_rerun_mse": 134827.59375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.587372863644808
+          "test_mse_by_total_triangles": 3.1308655431450862
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8507.5546875,
+          "test_best_rerun_mse": 7727.20068359375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.596519049747581
+          "test_mse_by_total_triangles": 0.5418034415645596
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35367.38671875,
+          "test_best_rerun_mse": 30734.2265625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.8128754276872212
+          "test_mse_by_total_triangles": 1.5753870809626327
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1880.9124755859375,
+          "test_best_rerun_mse": 1544.4781494140625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.3343844401041667
+          "test_mse_by_total_triangles": 0.27457389322916664
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 707235.6875,
+          "test_best_rerun_mse": 667546.3125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 8.000132207051797
+          "test_mse_by_total_triangles": 7.551172612920376
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 227120.671875,
+          "test_best_rerun_mse": 210780.234375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.779486327442464
+          "test_mse_by_total_triangles": 3.5075671771254555
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -2505,80 +2505,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.06763024628162384,
+      "test_loss": 1.951331377029419,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.06551864743232727,
+      "test_best_rerun_mse": 1.9212548732757568,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.000344834986485933,
+      "test_mse_by_total_triangles": 0.01011186775408293,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56.80928421020508,
+          "test_best_rerun_mse": 169.99362182617188,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.040928879113980604
+          "test_mse_by_total_triangles": 0.12247379094104602
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10406.3271484375,
+          "test_best_rerun_mse": 12134.6357421875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.7892549979854001
+          "test_mse_by_total_triangles": 0.9203364233740994
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 106.11200714111328,
+          "test_best_rerun_mse": 259.4466552734375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03576407385949217
+          "test_mse_by_total_triangles": 0.08744410356367964
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6830.31591796875,
+          "test_best_rerun_mse": 7951.044921875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.9125338567760521
+          "test_mse_by_total_triangles": 1.0622638506179025
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 97.24620819091797,
+          "test_best_rerun_mse": 160.35702514648438,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.08397772728058546
+          "test_mse_by_total_triangles": 0.13847756921112642
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 168247.859375,
+          "test_best_rerun_mse": 175263.328125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.906925956135055
+          "test_mse_by_total_triangles": 4.0698339245077095
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13439.20703125,
+          "test_best_rerun_mse": 15280.13671875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.9423087246704529
+          "test_mse_by_total_triangles": 1.071388074516197
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44165.625,
+          "test_best_rerun_mse": 47300.5546875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.263858988159311
+          "test_mse_by_total_triangles": 2.424550447870214
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3193.760986328125,
+          "test_best_rerun_mse": 3848.996337890625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.5677797309027778
+          "test_mse_by_total_triangles": 0.684266015625
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 743276.4375,
+          "test_best_rerun_mse": 760259.4375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 8.407819163376809
+          "test_mse_by_total_triangles": 8.599928028460573
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 253057.140625,
+          "test_best_rerun_mse": 263239.59375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 4.211091818098613
+          "test_mse_by_total_triangles": 4.38053673056762
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -2589,80 +2589,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.11281420290470123,
+      "test_loss": 2.0332648754119873,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.11114737391471863,
+      "test_best_rerun_mse": 1.9915051460266113,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.0005849861784985191,
+      "test_mse_by_total_triangles": 0.010481606031719007,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 62.12724685668945,
+          "test_best_rerun_mse": 185.64450073242188,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.04476026430597223
+          "test_mse_by_total_triangles": 0.1337496402971339
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9806.15625,
+          "test_best_rerun_mse": 12590.318359375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.7437357792946531
+          "test_mse_by_total_triangles": 0.9548971072715207
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 78.1958236694336,
+          "test_best_rerun_mse": 332.9376220703125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.026355181553567104
+          "test_mse_by_total_triangles": 0.11221355647802915
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6966.6201171875,
+          "test_best_rerun_mse": 8027.9599609375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.9307441706329326
+          "test_mse_by_total_triangles": 1.0725397409402138
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 100.4194564819336,
+          "test_best_rerun_mse": 167.27603149414062,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.08671801077887184
+          "test_mse_by_total_triangles": 0.14445253151480192
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 166423.953125,
+          "test_best_rerun_mse": 176605.859375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.8645725693154374
+          "test_mse_by_total_triangles": 4.101009181102545
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12938.4072265625,
+          "test_best_rerun_mse": 15725.7197265625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.9071944486441242
+          "test_mse_by_total_triangles": 1.1026307479008906
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44749.03515625,
+          "test_best_rerun_mse": 47406.40625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.29376365555641
+          "test_mse_by_total_triangles": 2.4299762289199855
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3254.3125,
+          "test_best_rerun_mse": 3899.475830078125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.5785444444444444
+          "test_mse_by_total_triangles": 0.6932401475694444
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 744023.75,
+          "test_best_rerun_mse": 762064.0,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 8.41627263780641
+          "test_mse_by_total_triangles": 8.620340938655929
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 251372.90625,
+          "test_best_rerun_mse": 264809.125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 4.183064687234786
+          "test_mse_by_total_triangles": 4.406655101259714
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -2673,80 +2673,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.04952621087431908,
+      "test_loss": 0.14354941248893738,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.05078164115548134,
+      "test_best_rerun_mse": 0.1477441042661667,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.00026727179555516495,
+      "test_mse_by_total_triangles": 0.0007776005487692984,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 46.88106918334961,
+          "test_best_rerun_mse": 82.22734069824219,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.03377598644333545
+          "test_mse_by_total_triangles": 0.059241599926687455
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9459.5771484375,
+          "test_best_rerun_mse": 10791.07421875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.7174499164533561
+          "test_mse_by_total_triangles": 0.8184356631588927
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 70.8725814819336,
+          "test_best_rerun_mse": 120.77964782714844,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.023886950280395548
+          "test_mse_by_total_triangles": 0.040707666945449424
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6655.88818359375,
+          "test_best_rerun_mse": 6964.1142578125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.889230218248998
+          "test_mse_by_total_triangles": 0.9304093864812959
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 90.26481628417969,
+          "test_best_rerun_mse": 102.50807189941406,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.07794889143711545
+          "test_mse_by_total_triangles": 0.08852165103576344
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 165214.234375,
+          "test_best_rerun_mse": 169641.109375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.8364813852637933
+          "test_mse_by_total_triangles": 3.9392789656093257
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12665.505859375,
+          "test_best_rerun_mse": 13828.5703125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.888059589074113
+          "test_mse_by_total_triangles": 0.969609473601178
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 43688.2734375,
+          "test_best_rerun_mse": 44475.0234375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.2393907139012765
+          "test_mse_by_total_triangles": 2.279718255036137
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3100.6748046875,
+          "test_best_rerun_mse": 3261.8232421875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.5512310763888889
+          "test_mse_by_total_triangles": 0.5798796875
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 738998.125,
+          "test_best_rerun_mse": 746513.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 8.359423605533749
+          "test_mse_by_total_triangles": 8.444437688766218
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 249494.671875,
+          "test_best_rerun_mse": 256174.046875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 4.15180922694823
+          "test_mse_by_total_triangles": 4.26295986013346
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -2757,80 +2757,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 39.262542724609375,
+      "test_loss": 272.3891296386719,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 39.79494094848633,
+      "test_best_rerun_mse": 277.8205871582031,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.0030181980241552014,
+      "test_mse_by_total_triangles": 0.021070958449617226,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10.2811918258667,
+          "test_best_rerun_mse": 58.23556137084961,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.007407198721805979
+          "test_mse_by_total_triangles": 0.04195645631905592
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.6205158233642578,
+          "test_best_rerun_mse": 28.707897186279297,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.008529030649285568
+          "test_mse_by_total_triangles": 0.15109419571725946
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6.305887699127197,
+          "test_best_rerun_mse": 30.482288360595703,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.002125341320905695
+          "test_mse_by_total_triangles": 0.010273774304211562
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 362.88848876953125,
+          "test_best_rerun_mse": 843.3238525390625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.048482096027993485
+          "test_mse_by_total_triangles": 0.11266851737328824
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3.6896512508392334,
+          "test_best_rerun_mse": 62.34210205078125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.0031862273323309443
+          "test_mse_by_total_triangles": 0.05383601213366256
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 40156.765625,
+          "test_best_rerun_mse": 53090.91796875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.9324903776936653
+          "test_mse_by_total_triangles": 1.232837589837219
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 471.3348388671875,
+          "test_best_rerun_mse": 1603.7548828125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.033048298896871935
+          "test_mse_by_total_triangles": 0.112449507980122
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7966.544921875,
+          "test_best_rerun_mse": 12651.162109375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.40835229493438924
+          "test_mse_by_total_triangles": 0.6484782464183197
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 32.280967712402344,
+          "test_best_rerun_mse": 314.33612060546875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.005738838704427083
+          "test_mse_by_total_triangles": 0.05588197699652778
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 357901.625,
+          "test_best_rerun_mse": 436939.875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.048523522957366
+          "test_mse_by_total_triangles": 4.942591031978552
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 69464.296875,
+          "test_best_rerun_mse": 101952.1796875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.1559465640756827
+          "test_mse_by_total_triangles": 1.6965733061671076
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -2841,80 +2841,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 160.8384552001953,
+      "test_loss": 143.13186645507812,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 163.9759979248047,
+      "test_best_rerun_mse": 144.75990295410156,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.012436556535821364,
+      "test_mse_by_total_triangles": 0.010979135605165079,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27.801836013793945,
+          "test_best_rerun_mse": 135.98687744140625,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.02003014122031264
+          "test_mse_by_total_triangles": 0.0979732546407826
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28.926132202148438,
+          "test_best_rerun_mse": 405.77874755859375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.15224280106393914
+          "test_mse_by_total_triangles": 2.135677618729441
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.00986671447754,
+          "test_best_rerun_mse": 44.31045150756836,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.007418222687724145
+          "test_mse_by_total_triangles": 0.014934429223986639
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1209.949951171875,
+          "test_best_rerun_mse": 1652.0323486328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.1616499600764028
+          "test_mse_by_total_triangles": 0.22071240462696226
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.33973503112793,
+          "test_best_rerun_mse": 314.6522521972656,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.015837422306673513
+          "test_mse_by_total_triangles": 0.2717204250408166
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 63784.8515625,
+          "test_best_rerun_mse": 50718.171875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.4811641176504737
+          "test_mse_by_total_triangles": 1.1777394546488946
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1706.9920654296875,
+          "test_best_rerun_mse": 1538.7496337890625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.11968812687068346
+          "test_mse_by_total_triangles": 0.10789157437870302
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20233.095703125,
+          "test_best_rerun_mse": 14622.2900390625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.037115982527295
+          "test_mse_by_total_triangles": 0.749515097599185
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 759.3123779296875,
+          "test_best_rerun_mse": 1314.3641357421875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.1349888671875
+          "test_mse_by_total_triangles": 0.23366473524305556
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 481077.0625,
+          "test_best_rerun_mse": 389816.65625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.441863539698879
+          "test_mse_by_total_triangles": 4.409541036503286
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 114093.734375,
+          "test_best_rerun_mse": 84064.046875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.8986193795450386
+          "test_mse_by_total_triangles": 1.398899154227614
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -2925,80 +2925,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 56.6379508972168,
+      "test_loss": 256.25250244140625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 57.87044906616211,
+      "test_best_rerun_mse": 266.7894287109375,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.004389112557160569,
+      "test_mse_by_total_triangles": 0.02023431389540671,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13.051145553588867,
+          "test_best_rerun_mse": 17.305498123168945,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.009402842617859414
+          "test_mse_by_total_triangles": 0.012467938129084255
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24.392663955688477,
+          "test_best_rerun_mse": 7.497745990753174,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.12838244187204462
+          "test_mse_by_total_triangles": 0.03946182100396407
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25.517141342163086,
+          "test_best_rerun_mse": 43.25362014770508,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.008600317270698715
+          "test_mse_by_total_triangles": 0.014578233956085297
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 361.76483154296875,
+          "test_best_rerun_mse": 1134.1123046875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.048331974822039915
+          "test_mse_by_total_triangles": 0.1515180099782899
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13.646393775939941,
+          "test_best_rerun_mse": 14.250577926635742,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.011784450583713248
+          "test_mse_by_total_triangles": 0.012306198554953145
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38416.75390625,
+          "test_best_rerun_mse": 61281.94140625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.8920851269331692
+          "test_mse_by_total_triangles": 1.4230434099537896
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 447.3415222167969,
+          "test_best_rerun_mse": 2374.476806640625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.031365974072135525
+          "test_mse_by_total_triangles": 0.16648974944892897
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8237.8232421875,
+          "test_best_rerun_mse": 13484.90234375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.42225758584179096
+          "test_mse_by_total_triangles": 0.6912144314803425
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 68.49022674560547,
+          "test_best_rerun_mse": 380.895751953125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.012176040310329862
+          "test_mse_by_total_triangles": 0.06771480034722223
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 352299.46875,
+          "test_best_rerun_mse": 440995.0625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.985152865287377
+          "test_mse_by_total_triangles": 4.988462637014581
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 69063.6640625,
+          "test_best_rerun_mse": 101444.890625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.1492796841978268
+          "test_mse_by_total_triangles": 1.6881315731449587
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -3009,80 +3009,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 5.063612937927246,
+      "test_loss": 10.81357192993164,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 4.955611705780029,
+      "test_best_rerun_mse": 10.846929550170898,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.0016702432442804278,
+      "test_mse_by_total_triangles": 0.0036558576171792714,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23.80609703063965,
+          "test_best_rerun_mse": 26.05948257446289,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.017151366736772082
+          "test_mse_by_total_triangles": 0.01877484335335943
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3.808060646057129,
+          "test_best_rerun_mse": 0.5915423035621643,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.020042424452932257
+          "test_mse_by_total_triangles": 0.003113380545064023
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1975.876220703125,
+          "test_best_rerun_mse": 1835.6064453125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.14985788552924725
+          "test_mse_by_total_triangles": 0.13921929808968525
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4445.79541015625,
+          "test_best_rerun_mse": 5291.34326171875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.5939606426394456
+          "test_mse_by_total_triangles": 0.7069262874707749
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42.980445861816406,
+          "test_best_rerun_mse": 58.21928405761719,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.03711610178049776
+          "test_mse_by_total_triangles": 0.05027572025700966
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 124515.3984375,
+          "test_best_rerun_mse": 119801.4921875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.891403456193108
+          "test_mse_by_total_triangles": 2.781940650833643
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6665.80078125,
+          "test_best_rerun_mse": 6239.47021484375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.46738190865586876
+          "test_mse_by_total_triangles": 0.43748914702312086
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 37336.98046875,
+          "test_best_rerun_mse": 39758.8125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.91383363928187
+          "test_mse_by_total_triangles": 2.0379728586806087
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2250.597412109375,
+          "test_best_rerun_mse": 2437.4794921875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.40010620659722224
+          "test_mse_by_total_triangles": 0.4333296875
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 667013.875,
+          "test_best_rerun_mse": 674474.3125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.545149768673009
+          "test_mse_by_total_triangles": 7.629540994083912
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 194462.296875,
+          "test_best_rerun_mse": 195680.828125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.2360224464579903
+          "test_mse_by_total_triangles": 3.25629987061721
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -3093,80 +3093,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.393692970275879,
+      "test_loss": 6.191964626312256,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2.378718376159668,
+      "test_best_rerun_mse": 5.736964702606201,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.00080172510150309,
+      "test_mse_by_total_triangles": 0.0019335910692976747,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.403996467590332,
+          "test_best_rerun_mse": 36.8721809387207,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.006775213593364793
+          "test_mse_by_total_triangles": 0.026564971857867943
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4.142812728881836,
+          "test_best_rerun_mse": 28.68644142150879,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.021804277520430716
+          "test_mse_by_total_triangles": 0.15098127063951994
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1983.2935791015625,
+          "test_best_rerun_mse": 2815.02880859375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.1504204458931788
+          "test_mse_by_total_triangles": 0.21350237456152826
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5140.28955078125,
+          "test_best_rerun_mse": 5147.369140625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.6867454309660989
+          "test_mse_by_total_triangles": 0.6876912679525718
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 52.233646392822266,
+          "test_best_rerun_mse": 70.03588104248047,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.04510677581418158
+          "test_mse_by_total_triangles": 0.060480035442556535
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 129474.453125,
+          "test_best_rerun_mse": 125201.1171875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.0065589152192085
+          "test_mse_by_total_triangles": 2.9073267041496376
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6504.54541015625,
+          "test_best_rerun_mse": 7186.44482421875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.4560752636485942
+          "test_mse_by_total_triangles": 0.5038875910965327
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 39085.26171875,
+          "test_best_rerun_mse": 39125.234375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.0034477276513405
+          "test_mse_by_total_triangles": 2.0054966617971193
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2360.55712890625,
+          "test_best_rerun_mse": 2414.549072265625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.41965460069444444
+          "test_mse_by_total_triangles": 0.4292531684027778
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 676183.6875,
+          "test_best_rerun_mse": 674676.6875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.648877159146183
+          "test_mse_by_total_triangles": 7.631830226349784
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 192623.046875,
+          "test_best_rerun_mse": 201010.578125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.205415720216997
+          "test_mse_by_total_triangles": 3.3449915651573394
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -3177,80 +3177,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.119338035583496,
+      "test_loss": 120.21685791015625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2.117076873779297,
+      "test_best_rerun_mse": 116.52847290039062,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.0007135412449542625,
+      "test_mse_by_total_triangles": 0.03927484762399414,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10.038354873657227,
+          "test_best_rerun_mse": 196.3330841064453,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.007232244145286186
+          "test_mse_by_total_triangles": 0.14145034877985974
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 0.8234332203865051,
+          "test_best_rerun_mse": 295.369873046875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.004333859054665817
+          "test_mse_by_total_triangles": 1.554578279194079
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1672.0867919921875,
+          "test_best_rerun_mse": 9679.3115234375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.1268173524453688
+          "test_mse_by_total_triangles": 0.7341153980612438
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4795.5810546875,
+          "test_best_rerun_mse": 6659.3798828125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.6406921916750167
+          "test_mse_by_total_triangles": 0.8896967111305946
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 47.87055587768555,
+          "test_best_rerun_mse": 271.69805908203125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.041338994713027245
+          "test_mse_by_total_triangles": 0.23462699402593373
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 124141.0703125,
+          "test_best_rerun_mse": 165850.3125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.8827110884381386
+          "test_mse_by_total_triangles": 3.8512519157532976
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5687.599609375,
+          "test_best_rerun_mse": 13093.7236328125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.39879397064752486
+          "test_mse_by_total_triangles": 0.9180846748571379
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38162.32421875,
+          "test_best_rerun_mse": 43255.03515625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.956139434043262
+          "test_mse_by_total_triangles": 2.217183615574863
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2267.99267578125,
+          "test_best_rerun_mse": 3112.727783203125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.4031986979166667
+          "test_mse_by_total_triangles": 0.553373828125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 660729.5625,
+          "test_best_rerun_mse": 740661.6875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.4740626732124475
+          "test_mse_by_total_triangles": 8.37824154723256
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 183196.859375,
+          "test_best_rerun_mse": 251556.046875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.048555728204616
+          "test_mse_by_total_triangles": 4.186112307173881
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -3261,80 +3261,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 64.60192108154297,
+      "test_loss": 395.8456115722656,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 68.09581756591797,
+      "test_best_rerun_mse": 414.0361633300781,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.00909763761735711,
+      "test_mse_by_total_triangles": 0.05531545268270917,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6.447032928466797,
+          "test_best_rerun_mse": 61.02242660522461,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.004644836403794522
+          "test_mse_by_total_triangles": 0.04396428429771226
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6.993733882904053,
+          "test_best_rerun_mse": 78.24529266357422,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.036809125699495016
+          "test_mse_by_total_triangles": 0.41181732980828534
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 83.808349609375,
+          "test_best_rerun_mse": 2430.37548828125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.00635634050886424
+          "test_mse_by_total_triangles": 0.18432881974070914
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 69.83850860595703,
+          "test_best_rerun_mse": 549.4370727539062,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.023538425549699035
+          "test_mse_by_total_triangles": 0.18518270062484202
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8.66784381866455,
+          "test_best_rerun_mse": 61.67356872558594,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.00748518464478804
+          "test_mse_by_total_triangles": 0.05325869492710357
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16016.6533203125,
+          "test_best_rerun_mse": 26132.25390625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.3719267443877136
+          "test_mse_by_total_triangles": 0.6068236556346368
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 127.52057647705078,
+          "test_best_rerun_mse": 4016.675537109375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.0089412828829793
+          "test_mse_by_total_triangles": 0.281634801367927
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2569.753662109375,
+          "test_best_rerun_mse": 8799.5810546875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.13172144456965376
+          "test_mse_by_total_triangles": 0.4510523888814137
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 39.03288269042969,
+          "test_best_rerun_mse": 394.44342041015625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.006939179144965278
+          "test_mse_by_total_triangles": 0.07012327473958334
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 183469.859375,
+          "test_best_rerun_mse": 309105.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.0753804664434465
+          "test_mse_by_total_triangles": 3.496551304819972
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22132.962890625,
+          "test_best_rerun_mse": 58515.2734375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.36831183150491736
+          "test_mse_by_total_triangles": 0.9737452521508329
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -3345,80 +3345,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 43.06719207763672,
+      "test_loss": 261.43499755859375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 39.368629455566406,
+      "test_best_rerun_mse": 272.7802429199219,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.005259669933943408,
+      "test_mse_by_total_triangles": 0.03644358622844648,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3.9879276752471924,
+          "test_best_rerun_mse": 44.58042907714844,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.0028731467400916373
+          "test_mse_by_total_triangles": 0.03211846475298879
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3.183556079864502,
+          "test_best_rerun_mse": 11.190890312194824,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.016755558315076326
+          "test_mse_by_total_triangles": 0.05889942269576223
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 526.01220703125,
+          "test_best_rerun_mse": 3209.760009765625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.0398947445605802
+          "test_mse_by_total_triangles": 0.2434402737782044
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28.614267349243164,
+          "test_best_rerun_mse": 1588.8270263671875,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.009644175041875013
+          "test_mse_by_total_triangles": 0.5354995033256446
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4.876858711242676,
+          "test_best_rerun_mse": 41.00400924682617,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.004211449664285558
+          "test_mse_by_total_triangles": 0.03540933441003987
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16050.90625,
+          "test_best_rerun_mse": 22493.55078125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.37272214030280515
+          "test_mse_by_total_triangles": 0.5223284130886587
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 102.39649200439453,
+          "test_best_rerun_mse": 3390.0966796875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.007179672696984611
+          "test_mse_by_total_triangles": 0.23770135182214977
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2938.331298828125,
+          "test_best_rerun_mse": 7332.93896484375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.1506141421307153
+          "test_mse_by_total_triangles": 0.37587467142568814
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 41.00727462768555,
+          "test_best_rerun_mse": 528.692626953125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.007290182156032986
+          "test_mse_by_total_triangles": 0.09398980034722222
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 191961.6875,
+          "test_best_rerun_mse": 250672.453125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.171438610680633
+          "test_mse_by_total_triangles": 2.835565004864088
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24603.00390625,
+          "test_best_rerun_mse": 48896.92578125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.40941547112392457
+          "test_mse_by_total_triangles": 0.8136875473224835
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -3429,80 +3429,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 70.08522033691406,
+      "test_loss": 217.5390167236328,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 73.59326171875,
+      "test_best_rerun_mse": 226.5191192626953,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.009832099094021376,
+      "test_mse_by_total_triangles": 0.030263075385797637,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8.75959300994873,
+          "test_best_rerun_mse": 24.107940673828125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.006310945972585541
+          "test_mse_by_total_triangles": 0.017368833338492887
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12.411459922790527,
+          "test_best_rerun_mse": 6.89286470413208,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.06532347327784488
+          "test_mse_by_total_triangles": 0.03627823528490568
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 376.76806640625,
+          "test_best_rerun_mse": 2313.91162109375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.02857550750142207
+          "test_mse_by_total_triangles": 0.1754957619335419
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 121.07613372802734,
+          "test_best_rerun_mse": 1222.1104736328125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.04080759478531424
+          "test_mse_by_total_triangles": 0.4119010696436847
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10.099641799926758,
+          "test_best_rerun_mse": 18.519758224487305,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.008721625043114644
+          "test_mse_by_total_triangles": 0.015992882749989036
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13801.2099609375,
+          "test_best_rerun_mse": 22159.98046875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.32048137564874374
+          "test_mse_by_total_triangles": 0.5145824927723853
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 215.62728881835938,
+          "test_best_rerun_mse": 3143.1630859375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.015119007770183662
+          "test_mse_by_total_triangles": 0.22038725886534147
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2454.031982421875,
+          "test_best_rerun_mse": 5306.49951171875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.12578973716858244
+          "test_mse_by_total_triangles": 0.27200264040795274
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 85.19649505615234,
+          "test_best_rerun_mse": 451.6640625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.015146043565538194
+          "test_mse_by_total_triangles": 0.08029583333333333
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 191522.046875,
+          "test_best_rerun_mse": 233387.703125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.1664654692148457
+          "test_mse_by_total_triangles": 2.6400427940793865
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23263.3359375,
+          "test_best_rerun_mse": 42730.94140625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.38712222617442965
+          "test_mse_by_total_triangles": 0.711080182487977
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -3513,80 +3513,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 36.87519073486328,
+      "test_loss": 58.73752975463867,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 38.89167022705078,
+      "test_best_rerun_mse": 59.626766204833984,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.033585207449957494,
+      "test_mse_by_total_triangles": 0.05149116252576337,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71.29386901855469,
+          "test_best_rerun_mse": 43.96591567993164,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.05136445894708551
+          "test_mse_by_total_triangles": 0.03167573175787582
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.138657569885254,
+          "test_best_rerun_mse": 1.8457566499710083,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.005992934578343442
+          "test_mse_by_total_triangles": 0.009714508684057939
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6205.69482421875,
+          "test_best_rerun_mse": 8236.90234375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.47066324036547214
+          "test_mse_by_total_triangles": 0.6247176597459234
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.419754981994629,
+          "test_best_rerun_mse": 543.8411254882812,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0031748415847639463
+          "test_mse_by_total_triangles": 0.1832966381827709
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3205.152099609375,
+          "test_best_rerun_mse": 4487.06787109375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4282100333479459
+          "test_mse_by_total_triangles": 0.599474665476787
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 141660.078125,
+          "test_best_rerun_mse": 154933.453125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.289524385217351
+          "test_mse_by_total_triangles": 3.597748772176296
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7677.765625,
+          "test_best_rerun_mse": 9687.650390625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.5383372335577058
+          "test_mse_by_total_triangles": 0.6792631040965502
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27607.13671875,
+          "test_best_rerun_mse": 34590.5390625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.4150974790481317
+          "test_mse_by_total_triangles": 1.7730554647854837
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1602.4619140625,
+          "test_best_rerun_mse": 1973.14599609375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.2848821180555556
+          "test_mse_by_total_triangles": 0.35078151041666666
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 636144.375,
+          "test_best_rerun_mse": 699493.875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.195959130346255
+          "test_mse_by_total_triangles": 7.912558114543624
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 204171.59375,
+          "test_best_rerun_mse": 232523.25,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.3975936257134776
+          "test_mse_by_total_triangles": 3.869389945584344
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -3597,80 +3597,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 29.814865112304688,
+      "test_loss": 63.55646896362305,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 31.296667098999023,
+      "test_best_rerun_mse": 66.60369873046875,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.027026482814334216,
+      "test_mse_by_total_triangles": 0.05751614743563795,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 164.8026580810547,
+          "test_best_rerun_mse": 2638.405517578125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.11873390351661
+          "test_mse_by_total_triangles": 1.9008685285144993
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 0.8448166847229004,
+          "test_best_rerun_mse": 11.981473922729492,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.004446403603804739
+          "test_mse_by_total_triangles": 0.06306038906699733
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4321.83935546875,
+          "test_best_rerun_mse": 29743.833984375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.3277845548326697
+          "test_mse_by_total_triangles": 2.2558842612343573
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17.565744400024414,
+          "test_best_rerun_mse": 228.71856689453125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.005920372227847797
+          "test_mse_by_total_triangles": 0.07708748462909715
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4293.15185546875,
+          "test_best_rerun_mse": 10480.9453125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.5735673821601537
+          "test_mse_by_total_triangles": 1.4002598947895792
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 139049.28125,
+          "test_best_rerun_mse": 63027.859375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.22889841282742
+          "test_mse_by_total_triangles": 1.4635858112344418
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7735.88671875,
+          "test_best_rerun_mse": 5782.90185546875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.542412475021035
+          "test_mse_by_total_triangles": 0.4054762204086909
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35417.6484375,
+          "test_best_rerun_mse": 20425.697265625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.8154517626480087
+          "test_mse_by_total_triangles": 1.0469884292185658
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1993.4952392578125,
+          "test_best_rerun_mse": 1411.0303955078125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.35439915364583335
+          "test_mse_by_total_triangles": 0.25084984809027777
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 685480.5625,
+          "test_best_rerun_mse": 416504.28125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.754041859439159
+          "test_mse_by_total_triangles": 4.7114270019117
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 217458.140625,
+          "test_best_rerun_mse": 93312.09375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.6186933690280068
+          "test_mse_by_total_triangles": 1.5527947306674654
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -3681,80 +3681,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 41.430335998535156,
+      "test_loss": 11.278409957885742,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 43.391666412353516,
+      "test_best_rerun_mse": 11.471125602722168,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.037471214518439995,
+      "test_mse_by_total_triangles": 0.009905980658654723,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 365.4596252441406,
+          "test_best_rerun_mse": 103.52581024169922,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.26329944181854514
+          "test_mse_by_total_triangles": 0.07458631861793892
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.014711618423462,
+          "test_best_rerun_mse": 3.34519362449646,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.0053405874653866415
+          "test_mse_by_total_triangles": 0.017606282234191896
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11329.314453125,
+          "test_best_rerun_mse": 9965.5029296875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.8592578273132347
+          "test_mse_by_total_triangles": 0.7558212309205536
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25.050931930541992,
+          "test_best_rerun_mse": 941.7242431640625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.008443185686060665
+          "test_mse_by_total_triangles": 0.31739947528279827
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2092.605712890625,
+          "test_best_rerun_mse": 1039.7979736328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.2795732415351536
+          "test_mse_by_total_triangles": 0.13891756494760354
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 68204.328125,
+          "test_best_rerun_mse": 39657.15234375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.583789897013747
+          "test_mse_by_total_triangles": 0.9208887317422906
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2304.750244140625,
+          "test_best_rerun_mse": 2028.278076171875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.16160077437530676
+          "test_mse_by_total_triangles": 0.14221554313363308
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21583.830078125,
+          "test_best_rerun_mse": 12848.10546875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.106352456718694
+          "test_mse_by_total_triangles": 0.6585732466425752
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1286.318115234375,
+          "test_best_rerun_mse": 289.14910888671875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.22867877604166667
+          "test_mse_by_total_triangles": 0.05140428602430556
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 501001.90625,
+          "test_best_rerun_mse": 386082.46875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.66725005090325
+          "test_mse_by_total_triangles": 4.36730052995939
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 137236.5,
+          "test_best_rerun_mse": 77289.03125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.283735210423843
+          "test_mse_by_total_triangles": 1.2861569775181803
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -3765,80 +3765,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2196.02685546875,
+      "test_loss": 8140.45458984375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1561.6651611328125,
+      "test_best_rerun_mse": 5446.72265625,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.036263820386699154,
+      "test_mse_by_total_triangles": 0.1264797198646201,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 961.5215454101562,
+          "test_best_rerun_mse": 1219.6712646484375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.6927388655692769
+          "test_mse_by_total_triangles": 0.8787256949916696
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1155.65380859375,
+          "test_best_rerun_mse": 1525.8387451171875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 6.082388466282895
+          "test_mse_by_total_triangles": 8.030730237458881
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 335.17034912109375,
+          "test_best_rerun_mse": 1135.1229248046875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.0254205801381186
+          "test_mse_by_total_triangles": 0.0860919927800294
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 534.6763305664062,
+          "test_best_rerun_mse": 1587.90869140625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.18020772853603176
+          "test_mse_by_total_triangles": 0.5351899869923323
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 717.3456420898438,
+          "test_best_rerun_mse": 660.8048706054688,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.09583776113424766
+          "test_mse_by_total_triangles": 0.08828388384842602
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 922.5157470703125,
+          "test_best_rerun_mse": 1271.5623779296875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.7966457228586463
+          "test_mse_by_total_triangles": 1.0980676838771048
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 791.9934692382812,
+          "test_best_rerun_mse": 1506.2952880859375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.055531725511027995
+          "test_mse_by_total_triangles": 0.10561599271392073
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 464.9129638671875,
+          "test_best_rerun_mse": 3139.735595703125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.02383069167395497
+          "test_mse_by_total_triangles": 0.16093780284500103
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 467.73931884765625,
+          "test_best_rerun_mse": 1262.33935546875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.08315365668402777
+          "test_mse_by_total_triangles": 0.22441588541666666
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15769.1337890625,
+          "test_best_rerun_mse": 78041.7734375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.1783778128464249
+          "test_mse_by_total_triangles": 0.8827955322500368
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5130.68798828125,
+          "test_best_rerun_mse": 21306.896484375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.08537912882168056
+          "test_mse_by_total_triangles": 0.35456536509035996
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -3849,80 +3849,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 396.9725646972656,
+      "test_loss": 1367.635986328125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 382.03753662109375,
+      "test_best_rerun_mse": 1330.0751953125,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.00887138994568767,
+      "test_mse_by_total_triangles": 0.03088601140889142,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 180.10589599609375,
+          "test_best_rerun_mse": 245.05357360839844,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.12975929106346812
+          "test_mse_by_total_triangles": 0.17655156600028707
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 178.38827514648438,
+          "test_best_rerun_mse": 279.9890441894531,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.9388856586657073
+          "test_mse_by_total_triangles": 1.4736265483655429
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 166.5136260986328,
+          "test_best_rerun_mse": 747.988525390625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.012629019802702526
+          "test_mse_by_total_triangles": 0.0567302635866989
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 326.5548400878906,
+          "test_best_rerun_mse": 144.21656799316406,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.11006229864775552
+          "test_mse_by_total_triangles": 0.04860686484434246
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 161.26821899414062,
+          "test_best_rerun_mse": 893.869140625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.021545520239698145
+          "test_mse_by_total_triangles": 0.1194213948730795
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 233.0581817626953,
+          "test_best_rerun_mse": 409.9995422363281,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.20125922432011686
+          "test_mse_by_total_triangles": 0.3540583266289535
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 541.7293701171875,
+          "test_best_rerun_mse": 1250.353271484375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.037984109530022965
+          "test_mse_by_total_triangles": 0.08767026163822571
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 134.6416015625,
+          "test_best_rerun_mse": 1831.3441162109375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.006901512202701317
+          "test_mse_by_total_triangles": 0.09387175745609398
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 344.7056579589844,
+          "test_best_rerun_mse": 1080.168701171875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.061281005859375
+          "test_mse_by_total_triangles": 0.19202999131944445
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18898.880859375,
+          "test_best_rerun_mse": 126868.5859375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.21378099000458128
+          "test_mse_by_total_triangles": 1.4351162962512585
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1831.1629638671875,
+          "test_best_rerun_mse": 14399.64453125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.030472150897229086
+          "test_mse_by_total_triangles": 0.23962266039721763
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -3933,80 +3933,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 559.2557983398438,
+      "test_loss": 5803.10595703125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 544.8981323242188,
+      "test_best_rerun_mse": 5975.26904296875,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.012653216894023284,
+      "test_mse_by_total_triangles": 0.13875322875182866,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 993.041259765625,
+          "test_best_rerun_mse": 2879.944580078125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.7154475934910843
+          "test_mse_by_total_triangles": 2.0748880259928852
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1326.6365966796875,
+          "test_best_rerun_mse": 3665.4140625,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 6.982297877261513
+          "test_mse_by_total_triangles": 19.291652960526317
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 325.2944641113281,
+          "test_best_rerun_mse": 1911.76123046875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.024671555867374146
+          "test_mse_by_total_triangles": 0.14499516347885855
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 541.5567016601562,
+          "test_best_rerun_mse": 2162.482177734375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.18252669418946957
+          "test_mse_by_total_triangles": 0.7288446841032609
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 583.9131469726562,
+          "test_best_rerun_mse": 1945.5860595703125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.0780111084799808
+          "test_mse_by_total_triangles": 0.2599313372839429
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1055.977294921875,
+          "test_best_rerun_mse": 3126.80078125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.911897491296956
+          "test_mse_by_total_triangles": 2.7001733862262522
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 499.58319091796875,
+          "test_best_rerun_mse": 1302.212158203125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.03502897145687623
+          "test_mse_by_total_triangles": 0.09130641973097216
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 295.4196472167969,
+          "test_best_rerun_mse": 7394.03076171875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.015142736542969751
+          "test_mse_by_total_triangles": 0.37900613879331335
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 493.6430358886719,
+          "test_best_rerun_mse": 2359.364501953125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.08775876193576389
+          "test_mse_by_total_triangles": 0.419442578125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23979.34375,
+          "test_best_rerun_mse": 141031.609375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.27125033935499926
+          "test_mse_by_total_triangles": 1.595326056525231
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2099.468017578125,
+          "test_best_rerun_mse": 27051.658203125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.0349369813052789
+          "test_mse_by_total_triangles": 0.4501632170656316
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -4017,80 +4017,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 49.81013870239258,
+      "test_loss": 307.32489013671875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 48.103031158447266,
+      "test_best_rerun_mse": 303.5938720703125,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.0033728110474300424,
+      "test_mse_by_total_triangles": 0.021286907311058232,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 196.6746063232422,
+          "test_best_rerun_mse": 163.68154907226562,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.1416964022501745
+          "test_mse_by_total_triangles": 0.11792618809241039
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 204.37008666992188,
+          "test_best_rerun_mse": 248.5442657470703,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.075632035104852
+          "test_mse_by_total_triangles": 1.3081277144582648
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2499.23876953125,
+          "test_best_rerun_mse": 2303.293212890625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.1895516700440842
+          "test_mse_by_total_triangles": 0.17469042191055176
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 40.32157516479492,
+          "test_best_rerun_mse": 60.522342681884766,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.013590015222377797
+          "test_mse_by_total_triangles": 0.02039849770201711
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 330.6102600097656,
+          "test_best_rerun_mse": 134.96620178222656,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.04416970741613435
+          "test_mse_by_total_triangles": 0.018031556684332206
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 148.56610107421875,
+          "test_best_rerun_mse": 173.40078735351562,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.12829542407100064
+          "test_mse_by_total_triangles": 0.14974161256780277
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18665.779296875,
+          "test_best_rerun_mse": 12046.109375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.4334427665074076
+          "test_mse_by_total_triangles": 0.2797257424995356
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2843.275146484375,
+          "test_best_rerun_mse": 4375.17626953125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.1457417164633951
+          "test_mse_by_total_triangles": 0.22426450712651852
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 73.06330108642578,
+          "test_best_rerun_mse": 138.7232208251953,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.012989031304253473
+          "test_mse_by_total_triangles": 0.024661905924479168
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 229342.671875,
+          "test_best_rerun_mse": 205930.75,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.594286074850401
+          "test_mse_by_total_triangles": 2.3294543171611823
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 30228.169921875,
+          "test_best_rerun_mse": 32603.65625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.5030231461547102
+          "test_mse_by_total_triangles": 0.5425533131978766
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -4101,80 +4101,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 57.45262908935547,
+      "test_loss": 651.7960205078125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 59.270755767822266,
+      "test_best_rerun_mse": 636.558837890625,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.004155851617432497,
+      "test_mse_by_total_triangles": 0.04463320978057951,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 239.6211700439453,
+          "test_best_rerun_mse": 515.6693115234375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.1726377305792113
+          "test_mse_by_total_triangles": 0.37151967689008464
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 169.64834594726562,
+          "test_best_rerun_mse": 456.12786865234375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.892886031301398
+          "test_mse_by_total_triangles": 2.4006729929070723
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1563.936767578125,
+          "test_best_rerun_mse": 7104.96337890625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.11861484774957338
+          "test_mse_by_total_triangles": 0.5388671504669131
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 37.88499069213867,
+          "test_best_rerun_mse": 132.59010314941406,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.012768786886463995
+          "test_mse_by_total_triangles": 0.044688272042269654
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 438.5093688964844,
+          "test_best_rerun_mse": 1099.4073486328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.05858508602491441
+          "test_mse_by_total_triangles": 0.14688140930298096
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 131.49537658691406,
+          "test_best_rerun_mse": 352.78033447265625,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.11355386579180834
+          "test_mse_by_total_triangles": 0.3046462301145563
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8098.41015625,
+          "test_best_rerun_mse": 12913.8671875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.18805522376579045
+          "test_mse_by_total_triangles": 0.29987616541658924
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 690.8417358398438,
+          "test_best_rerun_mse": 6841.5830078125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.03541143758469649
+          "test_mse_by_total_triangles": 0.3506885544011738
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86.38202667236328,
+          "test_best_rerun_mse": 569.0718994140625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.015356804741753473
+          "test_mse_by_total_triangles": 0.10116833767361111
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 157054.84375,
+          "test_best_rerun_mse": 194820.21875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.7765782128434555
+          "test_mse_by_total_triangles": 2.2037738396886986
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14509.4287109375,
+          "test_best_rerun_mse": 29233.609375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.2414495650231724
+          "test_mse_by_total_triangles": 0.48647279009202404
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -4185,80 +4185,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 70.74380493164062,
+      "test_loss": 809.5192260742188,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 69.7237777709961,
+      "test_best_rerun_mse": 832.3616943359375,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.004888779818468384,
+      "test_mse_by_total_triangles": 0.05836219985527538,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 148.03451538085938,
+          "test_best_rerun_mse": 1767.80419921875,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.10665310906401972
+          "test_mse_by_total_triangles": 1.2736341492930476
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 155.76283264160156,
+          "test_best_rerun_mse": 1045.650634765625,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.8198043823242187
+          "test_mse_by_total_triangles": 5.503424393503289
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 693.8309326171875,
+          "test_best_rerun_mse": 4318.08251953125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.05262274801798919
+          "test_mse_by_total_triangles": 0.3274996222625142
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.68843650817871,
+          "test_best_rerun_mse": 387.3717041015625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.006298765253851942
+          "test_mse_by_total_triangles": 0.13056006204973458
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 250.78208923339844,
+          "test_best_rerun_mse": 3113.83349609375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.03350462114006659
+          "test_mse_by_total_triangles": 0.4160098191174015
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 108.76428985595703,
+          "test_best_rerun_mse": 915.8306274414062,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.09392425721585236
+          "test_mse_by_total_triangles": 0.7908727352689173
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5065.638671875,
+          "test_best_rerun_mse": 27911.095703125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.11763047259601987
+          "test_mse_by_total_triangles": 0.6481305894279444
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 937.4171752929688,
+          "test_best_rerun_mse": 9658.357421875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.0480504985028945
+          "test_mse_by_total_triangles": 0.49507188589240864
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 60.779258728027344,
+          "test_best_rerun_mse": 1367.051513671875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.010805201551649305
+          "test_mse_by_total_triangles": 0.24303138020833334
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 134332.4375,
+          "test_best_rerun_mse": 262880.75,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.5195461409680666
+          "test_mse_by_total_triangles": 2.9736632240987295
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12947.912109375,
+          "test_best_rerun_mse": 55329.12109375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.21546456508037543
+          "test_mse_by_total_triangles": 0.9207248946424709
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -4269,80 +4269,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 165.50723266601562,
+      "test_loss": 1509.963134765625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 171.4266815185547,
+      "test_best_rerun_mse": 1491.723388671875,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.00878705630829641,
+      "test_mse_by_total_triangles": 0.07646334454210237,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19.621713638305664,
+          "test_best_rerun_mse": 112.75138092041016,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.014136681295609268
+          "test_mse_by_total_triangles": 0.08123298337205342
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38.421207427978516,
+          "test_best_rerun_mse": 142.2239532470703,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.20221688119988693
+          "test_mse_by_total_triangles": 0.7485471223530017
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 218.89773559570312,
+          "test_best_rerun_mse": 1856.2476806640625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.016602027728153442
+          "test_mse_by_total_triangles": 0.1407848070279911
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 85.23030853271484,
+          "test_best_rerun_mse": 676.146728515625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.028726089832394622
+          "test_mse_by_total_triangles": 0.2278890220814375
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 67.05859375,
+          "test_best_rerun_mse": 195.9695281982422,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.008959063961255846
+          "test_mse_by_total_triangles": 0.02618163369381993
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26.765090942382812,
+          "test_best_rerun_mse": 101.18374633789062,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.02311320461345666
+          "test_mse_by_total_triangles": 0.08737801929006099
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1610.2098388671875,
+          "test_best_rerun_mse": 17431.375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.03739108858599265
+          "test_mse_by_total_triangles": 0.4047783531488018
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 216.48117065429688,
+          "test_best_rerun_mse": 1578.890869140625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.015178878884749466
+          "test_mse_by_total_triangles": 0.11070613302065804
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55.36117935180664,
+          "test_best_rerun_mse": 459.8244323730469,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.00984198744032118
+          "test_mse_by_total_triangles": 0.08174656575520833
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80635.15625,
+          "test_best_rerun_mse": 136785.515625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.9121314463310068
+          "test_mse_by_total_triangles": 1.5472949518115902
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4707.765625,
+          "test_best_rerun_mse": 19384.626953125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.07834133135306941
+          "test_mse_by_total_triangles": 0.3225771213473283
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -4353,80 +4353,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 88.1584243774414,
+      "test_loss": 938.4523315429688,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 83.61946868896484,
+      "test_best_rerun_mse": 975.0902099609375,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.004286199635499761,
+      "test_mse_by_total_triangles": 0.04998155774057807,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86.23726654052734,
+          "test_best_rerun_mse": 87.45697784423828,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.062130595490293476
+          "test_mse_by_total_triangles": 0.06300935003187196
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 146.6521759033203,
+          "test_best_rerun_mse": 89.09351348876953,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.7718535573858963
+          "test_mse_by_total_triangles": 0.4689132288882607
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35.26482009887695,
+          "test_best_rerun_mse": 1155.245361328125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.0026746166172830453
+          "test_mse_by_total_triangles": 0.08761815406356656
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29.98589515686035,
+          "test_best_rerun_mse": 132.68496704101562,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.010106469550677571
+          "test_mse_by_total_triangles": 0.044720245042472406
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 72.32929992675781,
+          "test_best_rerun_mse": 310.2601623535156,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.009663233123147336
+          "test_mse_by_total_triangles": 0.041450923494123666
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 95.78446960449219,
+          "test_best_rerun_mse": 65.6533432006836,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.08271543143738531
+          "test_mse_by_total_triangles": 0.05669546044964041
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2221.404052734375,
+          "test_best_rerun_mse": 16078.71875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.05158378350209862
+          "test_mse_by_total_triangles": 0.3733679813765558
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 55.32616424560547,
+          "test_best_rerun_mse": 587.35498046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.00387927108719713
+          "test_mse_by_total_triangles": 0.04118321276600407
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 49.940731048583984,
+          "test_best_rerun_mse": 210.51417541503906,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.008878352186414931
+          "test_mse_by_total_triangles": 0.037424742296006945
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 90077.5703125,
+          "test_best_rerun_mse": 118045.171875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.018942460238906
+          "test_mse_by_total_triangles": 1.3353073071615216
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4891.2236328125,
+          "test_best_rerun_mse": 14711.3798828125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.08139423281933836
+          "test_mse_by_total_triangles": 0.24481020888976254
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -4437,80 +4437,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 129.63357543945312,
+      "test_loss": 1252.3272705078125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 131.9806365966797,
+      "test_best_rerun_mse": 1186.277099609375,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.00676511541322875,
+      "test_mse_by_total_triangles": 0.060806658445300886,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15.102477073669434,
+          "test_best_rerun_mse": 210.8286895751953,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.01088074717123158
+          "test_mse_by_total_triangles": 0.15189386857002543
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 32.75038146972656,
+          "test_best_rerun_mse": 223.4196319580078,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.17237042878803455
+          "test_mse_by_total_triangles": 1.1758927997789885
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 130.07955932617188,
+          "test_best_rerun_mse": 1677.4251708984375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.009865723119163585
+          "test_mse_by_total_triangles": 0.12722223518380263
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 101.21701049804688,
+          "test_best_rerun_mse": 273.4501037597656,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.034114260363345764
+          "test_mse_by_total_triangles": 0.09216383679129277
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.769365310668945,
+          "test_best_rerun_mse": 228.28515625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.002507597235894315
+          "test_mse_by_total_triangles": 0.030499018871075485
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19.262165069580078,
+          "test_best_rerun_mse": 157.013671875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.016633994015181414
+          "test_mse_by_total_triangles": 0.13559039022020725
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2223.68798828125,
+          "test_best_rerun_mse": 16633.396484375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.05163681934518972
+          "test_mse_by_total_triangles": 0.38624829287513934
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 152.96847534179688,
+          "test_best_rerun_mse": 968.7192993164062,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.010725597766217702
+          "test_mse_by_total_triangles": 0.06792310330363246
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35.9033088684082,
+          "test_best_rerun_mse": 437.5051574707031,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.006382810465494792
+          "test_mse_by_total_triangles": 0.07777869466145833
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 90428.8828125,
+          "test_best_rerun_mse": 109719.1328125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.0229164486782123
+          "test_mse_by_total_triangles": 1.2411245411637615
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5970.34912109375,
+          "test_best_rerun_mse": 14777.2470703125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.09935182335868986
+          "test_mse_by_total_triangles": 0.24590629641243572
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -4521,80 +4521,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 38.78614044189453,
+      "test_loss": 40.73102569580078,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 40.42422103881836,
+      "test_best_rerun_mse": 42.35746383666992,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.007186528184678819,
+      "test_mse_by_total_triangles": 0.007530215793185764,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21.10271453857422,
+          "test_best_rerun_mse": 18.082263946533203,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.015203684826062117
+          "test_mse_by_total_triangles": 0.013027567684822192
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.970837593078613,
+          "test_best_rerun_mse": 1.3122076988220215,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.0524780925951506
+          "test_mse_by_total_triangles": 0.006906356309589586
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 131.65267944335938,
+          "test_best_rerun_mse": 893.2125244140625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.009985034466693923
+          "test_mse_by_total_triangles": 0.06774459798362249
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42.823341369628906,
+          "test_best_rerun_mse": 109.2597885131836,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.014433212460272635
+          "test_mse_by_total_triangles": 0.036825004554493966
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 51.437255859375,
+          "test_best_rerun_mse": 970.2084350585938,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.006872044870991984
+          "test_mse_by_total_triangles": 0.12962036540528973
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5.871218204498291,
+          "test_best_rerun_mse": 9.839829444885254,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.00507013661873773
+          "test_mse_by_total_triangles": 0.008497262042215245
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29843.51953125,
+          "test_best_rerun_mse": 41273.42578125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.6930038902853892
+          "test_mse_by_total_triangles": 0.9584206246807078
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 117.67762756347656,
+          "test_best_rerun_mse": 1442.1427001953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.008251130806582286
+          "test_mse_by_total_triangles": 0.10111784463576724
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2699.212646484375,
+          "test_best_rerun_mse": 5822.1748046875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.1383573041408773
+          "test_mse_by_total_triangles": 0.2984353275251166
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 252796.21875,
+          "test_best_rerun_mse": 267554.03125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.8595886876010996
+          "test_mse_by_total_triangles": 3.026526602603984
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38465.75,
+          "test_best_rerun_mse": 47684.55859375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.6401036726407402
+          "test_mse_by_total_triangles": 0.7935126985464197
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -4605,80 +4605,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 36.035850524902344,
+      "test_loss": 55.89023971557617,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 36.11283493041992,
+      "test_best_rerun_mse": 58.302391052246094,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.006420059543185764,
+      "test_mse_by_total_triangles": 0.010364869520399306,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7.814439296722412,
+          "test_best_rerun_mse": 18.240482330322266,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.005629999493315859
+          "test_mse_by_total_triangles": 0.013141557874871949
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16.014291763305664,
+          "test_best_rerun_mse": 2.989097833633423,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.08428574612266139
+          "test_mse_by_total_triangles": 0.015732093861228542
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 161.47637939453125,
+          "test_best_rerun_mse": 882.6472778320312,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.01224697606329399
+          "test_mse_by_total_triangles": 0.06694328993796217
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 31.851890563964844,
+          "test_best_rerun_mse": 341.8017578125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.010735386101774467
+          "test_mse_by_total_triangles": 0.11520113171975059
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.268138885498047,
+          "test_best_rerun_mse": 886.7014770507812,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.0029750352552435602
+          "test_mse_by_total_triangles": 0.11846379118914913
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8.629571914672852,
+          "test_best_rerun_mse": 11.794686317443848,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.007452134641340977
+          "test_mse_by_total_triangles": 0.010185394056514549
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19885.119140625,
+          "test_best_rerun_mse": 42101.69140625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.46175736440240106
+          "test_mse_by_total_triangles": 0.9776539895562418
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 77.8384780883789,
+          "test_best_rerun_mse": 1588.80078125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.005457753336725488
+          "test_mse_by_total_triangles": 0.11140098031482261
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3124.4794921875,
+          "test_best_rerun_mse": 6122.869140625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.16015579948677533
+          "test_mse_by_total_triangles": 0.3138484361384489
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 240449.171875,
+          "test_best_rerun_mse": 282771.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.7199209514948586
+          "test_mse_by_total_triangles": 3.1986654864653916
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 30206.693359375,
+          "test_best_rerun_mse": 50645.99609375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.5026657573989483
+          "test_mse_by_total_triangles": 0.8427936048083804
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -4689,80 +4689,80 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 24.735591888427734,
+      "test_loss": 117.74322509765625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 25.89337158203125,
+      "test_best_rerun_mse": 116.84484100341797,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.004603266059027777,
+      "test_mse_by_total_triangles": 0.020772416178385416,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28.333837509155273,
+          "test_best_rerun_mse": 59.60858154296875,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.02041342760025596
+          "test_mse_by_total_triangles": 0.04294566393585645
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8.761358261108398,
+          "test_best_rerun_mse": 75.2666244506836,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.04611241190057052
+          "test_mse_by_total_triangles": 0.3961401286878084
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 136.37583923339844,
+          "test_best_rerun_mse": 754.2847900390625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.010343256672991918
+          "test_mse_by_total_triangles": 0.05720779598324327
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29.748180389404297,
+          "test_best_rerun_mse": 613.693359375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.010026349979576776
+          "test_mse_by_total_triangles": 0.20683968971183014
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 99.69657897949219,
+          "test_best_rerun_mse": 945.924560546875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.013319516229725076
+          "test_mse_by_total_triangles": 0.12637602679316967
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5.068945407867432,
+          "test_best_rerun_mse": 50.6478157043457,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.00437732764064545
+          "test_mse_by_total_triangles": 0.043737319261093005
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9045.5791015625,
+          "test_best_rerun_mse": 53503.421875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.21004967261662874
+          "test_mse_by_total_triangles": 1.242416447032324
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 211.79478454589844,
+          "test_best_rerun_mse": 2171.50048828125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.014850286393626311
+          "test_mse_by_total_triangles": 0.15225778209797014
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1434.942138671875,
+          "test_best_rerun_mse": 8503.6279296875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.07355282888266312
+          "test_mse_by_total_triangles": 0.435882307124276
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 166476.546875,
+          "test_best_rerun_mse": 382043.78125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.883154948078685
+          "test_mse_by_total_triangles": 4.321615570172958
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16902.154296875,
+          "test_best_rerun_mse": 79212.125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.28126660837160733
+          "test_mse_by_total_triangles": 1.3181589369810127
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -4773,80 +4773,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 15894.060546875,
+      "test_loss": 22882.60546875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 7266.5693359375,
+      "test_best_rerun_mse": 13586.0263671875,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.08219822105513953,
+      "test_mse_by_total_triangles": 0.1536828655949176,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1123.1488037109375,
+          "test_best_rerun_mse": 3599.252197265625,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.809185017082808
+          "test_mse_by_total_triangles": 2.593121179586185
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 903.5999755859375,
+          "test_best_rerun_mse": 3632.142578125,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 4.755789345189145
+          "test_mse_by_total_triangles": 19.11653988486842
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 861.6697998046875,
+          "test_best_rerun_mse": 7373.072265625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.06535227909023038
+          "test_mse_by_total_triangles": 0.5592015370212362
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1049.09130859375,
+          "test_best_rerun_mse": 8735.0380859375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.353586554969245
+          "test_mse_by_total_triangles": 2.94406406671301
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 778.6382446289062,
+          "test_best_rerun_mse": 1974.373291015625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.10402648558836423
+          "test_mse_by_total_triangles": 0.2637773267889947
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 809.6671752929688,
+          "test_best_rerun_mse": 3340.429931640625,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.6991944518937554
+          "test_mse_by_total_triangles": 2.884654517824374
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1239.087158203125,
+          "test_best_rerun_mse": 4897.25439453125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.02877315526200829
+          "test_mse_by_total_triangles": 0.11372037884384288
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 700.0379028320312,
+          "test_best_rerun_mse": 4622.970703125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.04908413285878777
+          "test_mse_by_total_triangles": 0.3241460316312579
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 392.0121154785156,
+          "test_best_rerun_mse": 1922.07958984375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.020093911296248688
+          "test_mse_by_total_triangles": 0.09852271207359424
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 517.6934204101562,
+          "test_best_rerun_mse": 2402.529296875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.09203438585069444
+          "test_mse_by_total_triangles": 0.42711631944444445
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3799.072998046875,
+          "test_best_rerun_mse": 7562.2431640625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.0632198924674567
+          "test_mse_by_total_triangles": 0.1258423304555023
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -4857,80 +4857,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 19200.453125,
+      "test_loss": 8955.904296875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 8231.0,
+      "test_best_rerun_mse": 6556.6767578125,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.09310769996493332,
+      "test_mse_by_total_triangles": 0.07416803454421796,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 117.66085815429688,
+          "test_best_rerun_mse": 1419.2874755859375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.08477007071635222
+          "test_mse_by_total_triangles": 1.022541408923586
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 33.4598388671875,
+          "test_best_rerun_mse": 1618.795166015625,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.17610441509046051
+          "test_mse_by_total_triangles": 8.519974557976974
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 464.6393737792969,
+          "test_best_rerun_mse": 6535.2841796875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.035239998011323236
+          "test_mse_by_total_triangles": 0.49566053695013274
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10.803155899047852,
+          "test_best_rerun_mse": 6049.2255859375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.003641104111576627
+          "test_mse_by_total_triangles": 2.038835721583249
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 272.84979248046875,
+          "test_best_rerun_mse": 737.2376708984375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.03645287808690297
+          "test_mse_by_total_triangles": 0.09849534681341851
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 31.22439193725586,
+          "test_best_rerun_mse": 1411.1944580078125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.026964069030445473
+          "test_mse_by_total_triangles": 1.2186480639100281
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1015.0426025390625,
+          "test_best_rerun_mse": 2645.278076171875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.02357056015556062
+          "test_mse_by_total_triangles": 0.06142666905470637
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 390.2170715332031,
+          "test_best_rerun_mse": 4336.98291015625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.027360613625943286
+          "test_mse_by_total_triangles": 0.3040935990854193
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 169.985107421875,
+          "test_best_rerun_mse": 1035.5548095703125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.008713163535900098
+          "test_mse_by_total_triangles": 0.05308087598392088
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86.71829986572266,
+          "test_best_rerun_mse": 877.22216796875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.01541658664279514
+          "test_mse_by_total_triangles": 0.15595060763888888
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1776.0960693359375,
+          "test_best_rerun_mse": 8837.337890625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.02955578968159249
+          "test_mse_by_total_triangles": 0.14706102026234336
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -4941,80 +4941,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 9315.904296875,
+      "test_loss": 17850.974609375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 4775.08251953125,
+      "test_best_rerun_mse": 16824.2734375,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.054014937496818544,
+      "test_mse_by_total_triangles": 0.19031337666708142,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2534.188232421875,
+          "test_best_rerun_mse": 6248.52099609375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 1.8257840291223884
+          "test_mse_by_total_triangles": 4.501816279606448
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3086.277099609375,
+          "test_best_rerun_mse": 6929.7490234375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 16.243563682154605
+          "test_mse_by_total_triangles": 36.47236328125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 509.8584289550781,
+          "test_best_rerun_mse": 6025.40283203125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.03866958126318378
+          "test_mse_by_total_triangles": 0.45698921744643534
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1750.01416015625,
+          "test_best_rerun_mse": 7744.54345703125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.5898261409357095
+          "test_mse_by_total_triangles": 2.610226982484412
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1372.01953125,
+          "test_best_rerun_mse": 3962.17919921875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.18330254258517034
+          "test_mse_by_total_triangles": 0.5293492584126587
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2653.669677734375,
+          "test_best_rerun_mse": 6273.544921875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 2.2915973037429835
+          "test_mse_by_total_triangles": 5.4175690171632125
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2303.24072265625,
+          "test_best_rerun_mse": 3303.114013671875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.05348413344455345
+          "test_mse_by_total_triangles": 0.07670244319319791
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 758.9332885742188,
+          "test_best_rerun_mse": 3887.649658203125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.05321366488390259
+          "test_mse_by_total_triangles": 0.2725879721079179
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 766.7988891601562,
+          "test_best_rerun_mse": 4861.39501953125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.03930487924343412
+          "test_mse_by_total_triangles": 0.24918729917121585
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1542.7100830078125,
+          "test_best_rerun_mse": 4356.60009765625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.2742595703125
+          "test_mse_by_total_triangles": 0.7745066840277778
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3311.989990234375,
+          "test_best_rerun_mse": 21968.693359375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.05511440584151856
+          "test_mse_by_total_triangles": 0.3655782430461951
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
     },
     {
       "experiment": "triangle_counting",
@@ -5025,80 +5025,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 538.4459228515625,
+      "test_loss": 3792.615966796875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 539.9487915039062,
+      "test_best_rerun_mse": 3592.0029296875,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.008985219434940945,
+      "test_mse_by_total_triangles": 0.059774065692967566,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2962.5224609375,
+          "test_best_rerun_mse": 4378.88037109375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 2.1343821764679394
+          "test_mse_by_total_triangles": 3.154812947473883
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3357.72509765625,
+          "test_best_rerun_mse": 5305.46923828125,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 17.672237356085525
+          "test_mse_by_total_triangles": 27.923522306743422
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1357.651611328125,
+          "test_best_rerun_mse": 1616.10595703125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.10296940548563709
+          "test_mse_by_total_triangles": 0.12257155533039439
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2160.2490234375,
+          "test_best_rerun_mse": 4204.97314453125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.7280920200328614
+          "test_mse_by_total_triangles": 1.4172474366468655
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2064.386962890625,
+          "test_best_rerun_mse": 2589.60791015625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.2758032014549933
+          "test_mse_by_total_triangles": 0.34597300068887776
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2919.749267578125,
+          "test_best_rerun_mse": 4693.31591796875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 2.521372424506153
+          "test_mse_by_total_triangles": 4.052949842805484
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1423.3602294921875,
+          "test_best_rerun_mse": 5934.52734375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.033052206703794065
+          "test_mse_by_total_triangles": 0.13780715548369868
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 662.2816162109375,
+          "test_best_rerun_mse": 1472.0374755859375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.04643679821981051
+          "test_mse_by_total_triangles": 0.10321395846206265
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1791.6173095703125,
+          "test_best_rerun_mse": 4802.46240234375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.0918354251663495
+          "test_mse_by_total_triangles": 0.24616650788578348
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1798.0592041015625,
+          "test_best_rerun_mse": 3553.450927734375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.31965496961805556
+          "test_mse_by_total_triangles": 0.631724609375
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7494.67236328125,
+          "test_best_rerun_mse": 30904.5,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.08477848447769024
+          "test_mse_by_total_triangles": 0.3495865524925625
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
     },
     {
       "experiment": "triangle_counting",
@@ -5109,80 +5109,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 626.6116943359375,
+      "test_loss": 2846.164306640625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 623.567138671875,
+      "test_best_rerun_mse": 2584.9560546875,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.010376701756808198,
+      "test_mse_by_total_triangles": 0.04301592622580833,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2637.046142578125,
+          "test_best_rerun_mse": 4710.23876953125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 1.8998891517133465
+          "test_mse_by_total_triangles": 3.393543782083033
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2884.62841796875,
+          "test_best_rerun_mse": 5599.47314453125,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 15.182254831414474
+          "test_mse_by_total_triangles": 29.47091128700658
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1854.09765625,
+          "test_best_rerun_mse": 5761.8408203125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.14062174108835798
+          "test_mse_by_total_triangles": 0.43699968299677666
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1764.97119140625,
+          "test_best_rerun_mse": 4804.9765625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.59486727044363
+          "test_mse_by_total_triangles": 1.619473057802494
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1920.3953857421875,
+          "test_best_rerun_mse": 3036.337890625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.25656584979855546
+          "test_mse_by_total_triangles": 0.40565636481295925
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2593.0341796875,
+          "test_best_rerun_mse": 4969.77490234375,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 2.239235042908031
+          "test_mse_by_total_triangles": 4.2916881712813035
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2111.323974609375,
+          "test_best_rerun_mse": 6332.8935546875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.049027586257880715
+          "test_mse_by_total_triangles": 0.1470577176919817
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 612.7311401367188,
+          "test_best_rerun_mse": 1689.3927001953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.042962497555512465
+          "test_mse_by_total_triangles": 0.11845412285761552
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1126.9354248046875,
+          "test_best_rerun_mse": 5766.93896484375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.057764899523537215
+          "test_mse_by_total_triangles": 0.2956040271076811
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1729.8507080078125,
+          "test_best_rerun_mse": 3484.92578125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.30752901475694444
+          "test_mse_by_total_triangles": 0.6195423611111112
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5359.73583984375,
+          "test_best_rerun_mse": 16350.9033203125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.06062843839964424
+          "test_mse_by_total_triangles": 0.18495869280807778
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
     },
     {
       "experiment": "triangle_counting",
@@ -5193,80 +5193,80 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 1421.0396728515625,
+      "test_loss": 5294.783203125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 1460.4549560546875,
+      "test_best_rerun_mse": 4568.62353515625,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.024303245903094996,
+      "test_mse_by_total_triangles": 0.07602588546346913,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2116.592529296875,
+          "test_best_rerun_mse": 6008.46337890625,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 1.5249225715395354
+          "test_mse_by_total_triangles": 4.328864105840238
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2527.672607421875,
+          "test_best_rerun_mse": 7208.1708984375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 13.3035400390625
+          "test_mse_by_total_triangles": 37.93774157072368
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 650.3062744140625,
+          "test_best_rerun_mse": 2172.3896484375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.04932167420660315
+          "test_mse_by_total_triangles": 0.16476220314277587
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1536.97021484375,
+          "test_best_rerun_mse": 4983.1181640625,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.5180216430211493
+          "test_mse_by_total_triangles": 1.6795140424882036
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1200.5406494140625,
+          "test_best_rerun_mse": 3374.358642578125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.1603928723332081
+          "test_mse_by_total_triangles": 0.45081611791290915
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2167.401611328125,
+          "test_best_rerun_mse": 6416.197265625,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 1.871676693720315
+          "test_mse_by_total_triangles": 5.540757569624352
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 792.3012084960938,
+          "test_best_rerun_mse": 4610.20263671875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.018398226093630267
+          "test_mse_by_total_triangles": 0.10705467761282626
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 567.5232543945312,
+          "test_best_rerun_mse": 1870.4918212890625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.039792683662496935
+          "test_mse_by_total_triangles": 0.13115214004270526
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 764.7033081054688,
+          "test_best_rerun_mse": 3755.399169921875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.03919746312499199
+          "test_mse_by_total_triangles": 0.19249572863405992
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1209.05078125,
+          "test_best_rerun_mse": 4362.15673828125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.21494236111111112
+          "test_mse_by_total_triangles": 0.77549453125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23697.017578125,
+          "test_best_rerun_mse": 30108.5390625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.2680567127600308
+          "test_mse_by_total_triangles": 0.3405827750472269
         }
       },
-      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-13_18-26-47__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+      "output_dir": "/home/aarav/topobench/logs/train/runs/notebook_gu_grid_2026-06-14_10-30-09__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
     }
   ]
 }

--- a/configs/model/graph/topo_polynormer.yaml
+++ b/configs/model/graph/topo_polynormer.yaml
@@ -1,0 +1,53 @@
+_target_: topobench.model.TBModel
+
+model_name: topo_polynormer
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.TopoPolynormer
+  # Polynormer transformer (hidden_channels is per head; width = hidden*heads),
+  # augmented with a per-node topological substructure encoding computed inside
+  # the backbone from edge_index (degree, triangle count, clustering, random-walk
+  # return probabilities), injected after the input projection so it bypasses the
+  # encoder GraphNorm.
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  out_channels: ${model.feature_encoder.out_channels}
+  local_layers: 3
+  global_layers: 2
+  heads: 1
+  beta: -1.0
+  in_dropout: 0.15
+  dropout: 0.3
+  global_dropout: 0.3
+  pre_ln: false
+  qk_shared: true
+  use_struct: true
+  rw_steps: [2, 3, 4]
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/graph/topo_polynormer.yaml
+++ b/configs/model/graph/topo_polynormer.yaml
@@ -13,10 +13,13 @@ feature_encoder:
 backbone:
   _target_: topobench.nn.backbones.TopoPolynormer
   # Polynormer transformer (hidden_channels is per head; width = hidden*heads),
-  # augmented with a per-node topological substructure encoding computed inside
-  # the backbone from edge_index (degree, triangle count, clustering, random-walk
-  # return probabilities), injected after the input projection so it bypasses the
-  # encoder GraphNorm.
+  # augmented with a per-node random-walk structural encoding computed inside the
+  # backbone from edge_index (log-degree, local clustering coefficient, and
+  # random-walk return probabilities at steps 2/3/4), injected after the input
+  # projection so it bypasses the encoder GraphNorm. These channels are
+  # degree-normalised and do NOT include the raw triangle count by default
+  # (use_triangle_count=false), so the model learns to estimate higher-order
+  # structure rather than being handed the triangle-counting target.
   in_channels: ${model.feature_encoder.out_channels}
   hidden_channels: ${model.feature_encoder.out_channels}
   out_channels: ${model.feature_encoder.out_channels}
@@ -31,6 +34,7 @@ backbone:
   qk_shared: true
   use_struct: true
   rw_steps: [2, 3, 4]
+  use_triangle_count: false  # raw triangle count is an ablation only; off by default
 
 backbone_wrapper:
   _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}

--- a/test/nn/backbones/graph/test_topo_polynormer.py
+++ b/test/nn/backbones/graph/test_topo_polynormer.py
@@ -1,0 +1,375 @@
+"""Unit tests for the TopoPolynormer graph backbone.
+
+Covers the topological substructure encoding (triangle counts, clustering,
+random-walk return probabilities) and the full TopoPolynormer backbone,
+including batch-aware behaviour (arXiv:2403.01232 + GSN arXiv:2006.09252).
+"""
+
+import networkx as nx
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.topo_polynormer import (
+    DEFAULT_RW_STEPS,
+    NUM_BASE_STRUCT_CHANNELS,
+    TRIANGLE_SCALE,
+    TopoPolynormer,
+    _GlobalLinearAttention,
+    structural_encoding,
+)
+
+
+def _rand_graph(num_nodes, seed, feat_dim=16):
+    """Create a random undirected graph data object.
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes.
+    seed : int
+        Random seed.
+    feat_dim : int, optional
+        Node feature dimension.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        The random graph.
+    """
+    g = torch.Generator().manual_seed(seed)
+    ei = torch.randint(0, num_nodes, (2, num_nodes * 3), generator=g)
+    ei = ei[:, ei[0] != ei[1]]
+    ei = torch.cat([ei, ei.flip(0)], dim=1)
+    x = torch.randn(num_nodes, feat_dim, generator=g)
+    return Data(x=x, edge_index=ei, num_nodes=num_nodes)
+
+
+class TestStructuralEncoding:
+    """Tests for the topological substructure encoding."""
+
+    def test_channel_count(self):
+        """The encoding has the documented number of channels."""
+        g = _rand_graph(15, 1)
+        s = structural_encoding(g.edge_index, 15, None, DEFAULT_RW_STEPS)
+        assert s.shape == (15, NUM_BASE_STRUCT_CHANNELS + len(DEFAULT_RW_STEPS))
+
+    def test_triangle_channel_matches_networkx(self):
+        """The triangle channel equals the per-node triangle count."""
+        g = _rand_graph(25, 2)
+        s = structural_encoding(g.edge_index, 25, None, DEFAULT_RW_STEPS)
+        tri_model = s[:, 1] * TRIANGLE_SCALE
+        G = nx.Graph()
+        G.add_nodes_from(range(25))
+        G.add_edges_from(g.edge_index.t().tolist())
+        tri_nx = torch.tensor(
+            [nx.triangles(G)[i] for i in range(25)], dtype=torch.float
+        )
+        assert torch.allclose(tri_model, tri_nx, atol=1e-4)
+
+    def test_sum_equals_three_times_total_triangles(self):
+        """Sum of per-node triangle counts equals 3x total triangles.
+
+        This is the property that makes graph-level triangle counting a
+        near-linear readout under sum pooling.
+        """
+        g = _rand_graph(30, 3)
+        s = structural_encoding(g.edge_index, 30, None, DEFAULT_RW_STEPS)
+        total_model = (s[:, 1] * TRIANGLE_SCALE).sum().item()
+        G = nx.Graph()
+        G.add_nodes_from(range(30))
+        G.add_edges_from(g.edge_index.t().tolist())
+        total_nx = sum(nx.triangles(G).values()) // 3
+        assert abs(total_model - 3 * total_nx) < 1e-3
+
+    def test_clustering_in_unit_interval(self):
+        """The clustering-coefficient channel lies in [0, 1]."""
+        g = _rand_graph(20, 4)
+        s = structural_encoding(g.edge_index, 20, None, DEFAULT_RW_STEPS)
+        c = s[:, 3]
+        assert (c >= 0).all() and (c <= 1).all()
+
+    def test_batch_isolation(self):
+        """Per-graph features are unchanged by batching with another graph."""
+        g_a = _rand_graph(18, 5)
+        g_b = _rand_graph(11, 6)
+        s_a = structural_encoding(g_a.edge_index, 18, None, DEFAULT_RW_STEPS)
+        batch = Batch.from_data_list([g_a, g_b])
+        s_batched = structural_encoding(
+            batch.edge_index, batch.num_nodes, batch.batch, DEFAULT_RW_STEPS
+        )
+        assert torch.allclose(s_a, s_batched[:18], atol=1e-5)
+
+    def test_no_rw_steps(self):
+        """With empty rw_steps only the base channels are returned."""
+        g = _rand_graph(12, 7)
+        s = structural_encoding(g.edge_index, 12, None, rw_steps=())
+        assert s.shape == (12, NUM_BASE_STRUCT_CHANNELS)
+
+    def test_empty_graph(self):
+        """Zero nodes returns an empty feature tensor of correct width."""
+        ei = torch.empty((2, 0), dtype=torch.long)
+        s = structural_encoding(ei, 0, None, DEFAULT_RW_STEPS)
+        assert s.shape == (0, NUM_BASE_STRUCT_CHANNELS + len(DEFAULT_RW_STEPS))
+
+    def test_graph_without_edges(self):
+        """A graph with no edges yields all-zero structural features."""
+        ei = torch.empty((2, 0), dtype=torch.long)
+        s = structural_encoding(ei, 5, None, DEFAULT_RW_STEPS)
+        assert torch.count_nonzero(s) == 0
+
+    def test_missing_batch_id(self):
+        """A gap in batch ids (a graph with no nodes) is skipped cleanly."""
+        # nodes 0,1,2 -> graph 0 (a triangle) ; nodes 3,4 -> graph 2 (an edge) ;
+        # graph id 1 has no nodes and must be skipped cleanly.
+        batch = torch.tensor([0, 0, 0, 2, 2])
+        edge_index = torch.tensor(
+            [[0, 1, 1, 2, 0, 2, 3, 4], [1, 0, 2, 1, 2, 0, 4, 3]],
+            dtype=torch.long,
+        )
+        s = structural_encoding(edge_index, 5, batch, DEFAULT_RW_STEPS)
+        assert s.shape == (5, NUM_BASE_STRUCT_CHANNELS + len(DEFAULT_RW_STEPS))
+        # the triangle 0-1-2 gives each node one triangle; graph 2 (an edge) none
+        assert s[1, 1] * TRIANGLE_SCALE == pytest.approx(1.0)
+        assert s[3, 1] * TRIANGLE_SCALE == pytest.approx(0.0)
+
+
+class TestGlobalLinearAttention:
+    """Tests for the private global linear-attention module."""
+
+    def test_forward_shapes(self):
+        """Forward returns the working width and handles batch=None."""
+        attn = _GlobalLinearAttention(8, 2, 2, -1.0, 0.0).eval()
+        x = torch.randn(6, 16)
+        assert attn(x).shape == (6, 16)
+        assert attn(x, torch.zeros(6, dtype=torch.long)).shape == (6, 16)
+
+    def test_separate_qk_and_const_beta(self):
+        """Forward and reset work with separate q/k and constant beta."""
+        attn = _GlobalLinearAttention(8, 2, 2, 0.4, 0.0, qk_shared=False)
+        attn.reset_parameters()
+        assert attn.q_lins is not None
+        out = attn.eval()(torch.randn(5, 16), torch.zeros(5, dtype=torch.long))
+        assert out.shape == (5, 16)
+
+    def test_reset_learnable_beta(self):
+        """Reset runs for the learnable-beta path."""
+        attn = _GlobalLinearAttention(8, 2, 2, -1.0, 0.0)
+        attn.reset_parameters()
+
+
+class TestTopoPolynormer:
+    """Tests for the full TopoPolynormer backbone."""
+
+    def setup_method(self):
+        """Set common dimensions."""
+        self.in_channels = 16
+        self.hidden = 8
+        self.heads = 2
+        self.out_channels = 16
+
+    def _model(self, **kwargs):
+        """Build a TopoPolynormer with test defaults.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Overrides forwarded to :class:`TopoPolynormer`.
+
+        Returns
+        -------
+        TopoPolynormer
+            The constructed backbone.
+        """
+        params = dict(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden,
+            out_channels=self.out_channels,
+            local_layers=2,
+            global_layers=2,
+            heads=self.heads,
+        )
+        params.update(kwargs)
+        return TopoPolynormer(**params)
+
+    def test_initialization_default(self):
+        """Default construction wires the expected submodules."""
+        model = self._model()
+        assert model.use_global is True
+        assert model.use_struct is True
+        assert model.struct_in is not None
+        assert model.struct_dim == NUM_BASE_STRUCT_CHANNELS + len(
+            DEFAULT_RW_STEPS
+        )
+        assert model.global_attn is not None
+        assert model.pre_lns is None
+
+    def test_initialization_no_struct(self):
+        """Disabling the encoding drops the structural projection."""
+        model = self._model(use_struct=False)
+        assert model.use_struct is False
+        assert model.struct_in is None
+
+    def test_initialization_local_only_and_pre_ln_and_beta(self):
+        """Local-only, pre-ln and constant-beta construction."""
+        model = self._model(global_layers=0, pre_ln=True, beta=0.5)
+        assert model.use_global is False
+        assert model.global_attn is None
+        assert model.pre_lns is not None
+        assert torch.allclose(model.betas, torch.full_like(model.betas, 0.5))
+
+    def test_forward_shape(self, simple_graph_0):
+        """Forward returns ``[num_nodes, out_channels]``.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model().eval()
+        x = torch.randn(simple_graph_0.num_nodes, self.in_channels)
+        out = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+        assert not torch.isnan(out).any()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            dict(use_struct=False),
+            dict(global_layers=0),
+            dict(pre_ln=True),
+            dict(beta=0.5),
+            dict(qk_shared=False),
+            dict(rw_steps=()),
+        ],
+    )
+    def test_forward_variants(self, simple_graph_0, kwargs):
+        """Forward works across configuration branches.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        kwargs : dict
+            Construction overrides.
+        """
+        model = TopoPolynormer(
+            self.in_channels,
+            self.hidden,
+            self.out_channels,
+            local_layers=2,
+            global_layers=kwargs.pop("global_layers", 1),
+            heads=self.heads,
+            **kwargs,
+        ).eval()
+        x = torch.randn(simple_graph_0.num_nodes, self.in_channels)
+        out = model(x, simple_graph_0.edge_index)
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_edge_weight_accepted_and_ignored(self, simple_graph_0):
+        """An ``edge_weight`` argument does not change the output.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model().eval()
+        x = torch.randn(simple_graph_0.num_nodes, self.in_channels)
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+        out_a = model(x, simple_graph_0.edge_index, batch=batch)
+        ew = torch.rand(simple_graph_0.edge_index.shape[1])
+        out_b = model(
+            x, simple_graph_0.edge_index, batch=batch, edge_weight=ew, foo=1
+        )
+        assert torch.allclose(out_a, out_b)
+
+    def test_batch_isolation(self):
+        """The full model does not leak across graphs in a batch."""
+        torch.manual_seed(0)
+        model = self._model().eval()
+        g_a = _rand_graph(9, 11, self.in_channels)
+        g_b = _rand_graph(14, 12, self.in_channels)
+        out_a = model(
+            g_a.x, g_a.edge_index, batch=torch.zeros(9, dtype=torch.long)
+        )
+        batch = Batch.from_data_list([g_a, g_b])
+        out_batched = model(batch.x, batch.edge_index, batch=batch.batch)
+        assert torch.allclose(out_a, out_batched[:9], atol=1e-5)
+
+    def test_eval_is_deterministic(self, simple_graph_0):
+        """Repeated eval-mode calls match.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model(dropout=0.5, in_dropout=0.5).eval()
+        x = torch.randn(simple_graph_0.num_nodes, self.in_channels)
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+        out1 = model(x, simple_graph_0.edge_index, batch=batch)
+        out2 = model(x, simple_graph_0.edge_index, batch=batch)
+        assert torch.allclose(out1, out2)
+
+    def test_backward_pass(self, simple_graph_0):
+        """Gradients flow to the structural projection and parameters.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        model = self._model().train()
+        x = torch.randn(simple_graph_0.num_nodes, self.in_channels)
+        out = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        out.sum().backward()
+        assert model.struct_in.weight.grad is not None
+        assert model.betas.grad is not None
+
+    @pytest.mark.parametrize("kwargs", [dict(), dict(use_struct=False), dict(global_layers=0), dict(pre_ln=True), dict(beta=0.5)])
+    def test_reset_parameters(self, kwargs):
+        """``reset_parameters`` runs across configuration branches.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Construction overrides.
+        """
+        model = self._model(**kwargs)
+        model.reset_parameters()
+
+    @pytest.mark.parametrize("heads", [1, 2, 4])
+    def test_parametrized_heads(self, simple_graph_0, heads):
+        """Forward works for several head counts.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        heads : int
+            Number of attention heads.
+        """
+        model = TopoPolynormer(
+            self.in_channels,
+            self.hidden,
+            self.out_channels,
+            local_layers=2,
+            global_layers=1,
+            heads=heads,
+        ).eval()
+        x = torch.randn(simple_graph_0.num_nodes, self.in_channels)
+        out = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=torch.zeros(simple_graph_0.num_nodes, dtype=torch.long),
+        )
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)

--- a/test/nn/backbones/graph/test_topo_polynormer.py
+++ b/test/nn/backbones/graph/test_topo_polynormer.py
@@ -1,7 +1,7 @@
 """Unit tests for the TopoPolynormer graph backbone.
 
-Covers the topological substructure encoding (triangle counts, clustering,
-random-walk return probabilities) and the full TopoPolynormer backbone,
+Covers the random-walk structural encoding (clustering, return probabilities,
+and the optional raw triangle count) and the full TopoPolynormer backbone,
 including batch-aware behaviour (arXiv:2403.01232 + GSN arXiv:2006.09252).
 """
 
@@ -12,10 +12,10 @@ from torch_geometric.data import Batch, Data
 
 from topobench.nn.backbones.graph.topo_polynormer import (
     DEFAULT_RW_STEPS,
-    NUM_BASE_STRUCT_CHANNELS,
     TRIANGLE_SCALE,
     TopoPolynormer,
     _GlobalLinearAttention,
+    num_struct_channels,
     structural_encoding,
 )
 
@@ -46,19 +46,27 @@ def _rand_graph(num_nodes, seed, feat_dim=16):
 
 
 class TestStructuralEncoding:
-    """Tests for the topological substructure encoding."""
+    """Tests for the random-walk structural encoding."""
 
-    def test_channel_count(self):
-        """The encoding has the documented number of channels."""
+    def test_channel_count_default_and_with_count(self):
+        """Channel counts match ``num_struct_channels`` in both modes."""
+        assert num_struct_channels(DEFAULT_RW_STEPS, False) == 5
+        assert num_struct_channels(DEFAULT_RW_STEPS, True) == 7
         g = _rand_graph(15, 1)
-        s = structural_encoding(g.edge_index, 15, None, DEFAULT_RW_STEPS)
-        assert s.shape == (15, NUM_BASE_STRUCT_CHANNELS + len(DEFAULT_RW_STEPS))
+        s0 = structural_encoding(g.edge_index, 15, None)
+        s1 = structural_encoding(
+            g.edge_index, 15, None, use_triangle_count=True
+        )
+        assert s0.shape == (15, 5)
+        assert s1.shape == (15, 7)
 
     def test_triangle_channel_matches_networkx(self):
-        """The triangle channel equals the per-node triangle count."""
+        """The optional triangle channel equals the true triangle count."""
         g = _rand_graph(25, 2)
-        s = structural_encoding(g.edge_index, 25, None, DEFAULT_RW_STEPS)
-        tri_model = s[:, 1] * TRIANGLE_SCALE
+        s = structural_encoding(
+            g.edge_index, 25, None, use_triangle_count=True
+        )
+        tri_model = s[:, 1] * TRIANGLE_SCALE  # channel 1 is triangles/scale
         G = nx.Graph()
         G.add_nodes_from(range(25))
         G.add_edges_from(g.edge_index.t().tolist())
@@ -70,11 +78,13 @@ class TestStructuralEncoding:
     def test_sum_equals_three_times_total_triangles(self):
         """Sum of per-node triangle counts equals 3x total triangles.
 
-        This is the property that makes graph-level triangle counting a
-        near-linear readout under sum pooling.
+        This is why injecting the raw count trivialises graph-level triangle
+        counting under sum pooling — hence it is off by default.
         """
         g = _rand_graph(30, 3)
-        s = structural_encoding(g.edge_index, 30, None, DEFAULT_RW_STEPS)
+        s = structural_encoding(
+            g.edge_index, 30, None, use_triangle_count=True
+        )
         total_model = (s[:, 1] * TRIANGLE_SCALE).sum().item()
         G = nx.Graph()
         G.add_nodes_from(range(30))
@@ -83,20 +93,20 @@ class TestStructuralEncoding:
         assert abs(total_model - 3 * total_nx) < 1e-3
 
     def test_clustering_in_unit_interval(self):
-        """The clustering-coefficient channel lies in [0, 1]."""
+        """The clustering channel (index 1 in default mode) lies in [0, 1]."""
         g = _rand_graph(20, 4)
-        s = structural_encoding(g.edge_index, 20, None, DEFAULT_RW_STEPS)
-        c = s[:, 3]
+        s = structural_encoding(g.edge_index, 20, None)
+        c = s[:, 1]
         assert (c >= 0).all() and (c <= 1).all()
 
     def test_batch_isolation(self):
         """Per-graph features are unchanged by batching with another graph."""
         g_a = _rand_graph(18, 5)
         g_b = _rand_graph(11, 6)
-        s_a = structural_encoding(g_a.edge_index, 18, None, DEFAULT_RW_STEPS)
+        s_a = structural_encoding(g_a.edge_index, 18, None)
         batch = Batch.from_data_list([g_a, g_b])
         s_batched = structural_encoding(
-            batch.edge_index, batch.num_nodes, batch.batch, DEFAULT_RW_STEPS
+            batch.edge_index, batch.num_nodes, batch.batch
         )
         assert torch.allclose(s_a, s_batched[:18], atol=1e-5)
 
@@ -104,18 +114,18 @@ class TestStructuralEncoding:
         """With empty rw_steps only the base channels are returned."""
         g = _rand_graph(12, 7)
         s = structural_encoding(g.edge_index, 12, None, rw_steps=())
-        assert s.shape == (12, NUM_BASE_STRUCT_CHANNELS)
+        assert s.shape == (12, num_struct_channels((), False))
 
     def test_empty_graph(self):
         """Zero nodes returns an empty feature tensor of correct width."""
         ei = torch.empty((2, 0), dtype=torch.long)
-        s = structural_encoding(ei, 0, None, DEFAULT_RW_STEPS)
-        assert s.shape == (0, NUM_BASE_STRUCT_CHANNELS + len(DEFAULT_RW_STEPS))
+        s = structural_encoding(ei, 0, None)
+        assert s.shape == (0, num_struct_channels(DEFAULT_RW_STEPS, False))
 
     def test_graph_without_edges(self):
         """A graph with no edges yields all-zero structural features."""
         ei = torch.empty((2, 0), dtype=torch.long)
-        s = structural_encoding(ei, 5, None, DEFAULT_RW_STEPS)
+        s = structural_encoding(ei, 5, None)
         assert torch.count_nonzero(s) == 0
 
     def test_missing_batch_id(self):
@@ -127,8 +137,10 @@ class TestStructuralEncoding:
             [[0, 1, 1, 2, 0, 2, 3, 4], [1, 0, 2, 1, 2, 0, 4, 3]],
             dtype=torch.long,
         )
-        s = structural_encoding(edge_index, 5, batch, DEFAULT_RW_STEPS)
-        assert s.shape == (5, NUM_BASE_STRUCT_CHANNELS + len(DEFAULT_RW_STEPS))
+        s = structural_encoding(
+            edge_index, 5, batch, use_triangle_count=True
+        )
+        assert s.shape == (5, num_struct_channels(DEFAULT_RW_STEPS, True))
         # the triangle 0-1-2 gives each node one triangle; graph 2 (an edge) none
         assert s[1, 1] * TRIANGLE_SCALE == pytest.approx(1.0)
         assert s[3, 1] * TRIANGLE_SCALE == pytest.approx(0.0)
@@ -197,12 +209,17 @@ class TestTopoPolynormer:
         model = self._model()
         assert model.use_global is True
         assert model.use_struct is True
+        assert model.use_triangle_count is False
         assert model.struct_in is not None
-        assert model.struct_dim == NUM_BASE_STRUCT_CHANNELS + len(
-            DEFAULT_RW_STEPS
-        )
+        assert model.struct_dim == num_struct_channels(DEFAULT_RW_STEPS, False)
         assert model.global_attn is not None
         assert model.pre_lns is None
+
+    def test_initialization_with_triangle_count(self):
+        """The ablation flag widens the structural projection."""
+        model = self._model(use_triangle_count=True)
+        assert model.use_triangle_count is True
+        assert model.struct_dim == num_struct_channels(DEFAULT_RW_STEPS, True)
 
     def test_initialization_no_struct(self):
         """Disabling the encoding drops the structural projection."""
@@ -240,6 +257,7 @@ class TestTopoPolynormer:
         "kwargs",
         [
             dict(use_struct=False),
+            dict(use_triangle_count=True),
             dict(global_layers=0),
             dict(pre_ln=True),
             dict(beta=0.5),
@@ -335,7 +353,17 @@ class TestTopoPolynormer:
         assert model.struct_in.weight.grad is not None
         assert model.betas.grad is not None
 
-    @pytest.mark.parametrize("kwargs", [dict(), dict(use_struct=False), dict(global_layers=0), dict(pre_ln=True), dict(beta=0.5)])
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            dict(),
+            dict(use_struct=False),
+            dict(use_triangle_count=True),
+            dict(global_layers=0),
+            dict(pre_ln=True),
+            dict(beta=0.5),
+        ],
+    )
     def test_reset_parameters(self, kwargs):
         """``reset_parameters`` runs across configuration branches.
 

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "graph/topo_polynormer", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/topo_polynormer.py
+++ b/topobench/nn/backbones/graph/topo_polynormer.py
@@ -1,0 +1,544 @@
+r"""TopoPolynormer: Polynormer with a topological substructure encoding.
+
+This backbone augments the Polynormer graph transformer ([1]_) with a small
+per-node **structural / substructure encoding** that gives a message-passing
+model the one thing it provably cannot compute on its own.
+
+**Why.** Standard message passing is bounded by the 1-Weisfeiler-Leman test,
+which *cannot count triangles* (or any non-star substructure) — see Chen et al.
+([2]_). Intuitively, a message that only travels along edges can never reveal
+whether *two of a node's neighbours are themselves connected* — i.e. whether the
+node sits on a **triangle** (a 2-simplex). Adding substructure counts as input
+features provably lifts a model beyond 1-WL (Graph Substructure Networks, [3]_).
+This is the minimal, literal bridge from a graph (1-simplices/edges) to topology
+(2-simplices/triangles) — the theme of the challenge.
+
+**What.** For every node we compute, from ``edge_index`` alone, a compact
+"local structural fingerprint":
+
+* ``log1p(degree)`` — the node's connectivity (GraphUniverse graphs come from a
+  *degree-corrected* SBM, so degree is part of the generative regime);
+* the **triangle count** ``t_i`` (raw, lightly scaled, and ``log1p``) — its
+  participation in 2-simplices, the 1-WL blind spot;
+* the **local clustering coefficient** ``c_i ∈ [0, 1]`` — a *scale-free* measure
+  of neighbourhood cohesion that transfers across degree/density regimes;
+* **random-walk return probabilities** at steps :math:`k = 2, 3, 4` — a
+  multi-scale density signal that stays informative in sparse regimes where
+  triangles vanish (the ``k = 3`` return is the random-walk-normalised triangle
+  count; ``k = 4`` reflects 4-cycles).
+
+These are injected *inside* the backbone (after the input projection), which
+deliberately bypasses the feature encoder's per-graph ``GraphNorm`` — otherwise
+the absolute triangle-count scale, which the graph-level triangle-counting task
+needs, would be standardised away.
+
+The encoding is **batch-aware**: it is computed per graph segment (using the
+``batch`` vector) so substructure counts never mix across the disjoint graphs of
+a mini-batch.
+
+References
+----------
+.. [1] Deng, Yue, Zhang. "Polynormer: Polynomial-Expressive Graph Transformer in
+   Linear Time." ICLR 2024. https://arxiv.org/abs/2403.01232
+.. [2] Chen, Chen, Villar, Bruna. "Can Graph Neural Networks Count
+   Substructures?" NeurIPS 2020. https://arxiv.org/abs/2002.04025
+.. [3] Bouritsas, Frasca, Zafeiriou, Bronstein. "Improving Graph Neural Network
+   Expressivity via Subgraph Isomorphism Counting" (Graph Substructure
+   Networks). https://arxiv.org/abs/2006.09252
+"""
+
+import torch
+import torch.nn.functional as F
+from torch_geometric.nn import GATConv
+from torch_geometric.utils import scatter
+
+DEFAULT_RW_STEPS: tuple[int, ...] = (2, 3, 4)
+# Number of fixed structural channels: log-degree, scaled triangles,
+# log triangles, clustering coefficient.
+NUM_BASE_STRUCT_CHANNELS = 4
+TRIANGLE_SCALE = 5.0
+
+
+@torch.no_grad()
+def structural_encoding(
+    edge_index: torch.Tensor,
+    num_nodes: int,
+    batch: torch.Tensor | None = None,
+    rw_steps: tuple[int, ...] = DEFAULT_RW_STEPS,
+) -> torch.Tensor:
+    r"""Compute the per-node topological substructure encoding.
+
+    For each node the following channels are returned, in order:
+    ``[log1p(degree), triangles / TRIANGLE_SCALE, log1p(triangles),
+    clustering_coefficient, rw_return(k) for k in rw_steps]``.
+
+    The triangle count of node :math:`i` is
+    :math:`t_i = \tfrac{1}{2}\sum_j A_{ij} (A^2)_{ij}`, i.e. half the number of
+    edges among its neighbours; the clustering coefficient is
+    :math:`c_i = 2 t_i / (d_i (d_i - 1))`; and the step-:math:`k` return
+    probability is :math:`(P^k)_{ii}` for the row-stochastic random walk
+    :math:`P = D^{-1} A`. Everything is computed per graph segment so counts do
+    not leak across the disjoint graphs of a batch.
+
+    Parameters
+    ----------
+    edge_index : torch.Tensor
+        Graph connectivity of shape ``[2, num_edges]``.
+    num_nodes : int
+        Total number of nodes across the batch.
+    batch : torch.Tensor, optional
+        Batch assignment of shape ``[num_nodes]``. If ``None`` all nodes are
+        treated as a single graph.
+    rw_steps : tuple of int, optional
+        Random-walk return-probability steps to include. Default ``(2, 3, 4)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Structural features of shape
+        ``[num_nodes, NUM_BASE_STRUCT_CHANNELS + len(rw_steps)]``.
+    """
+    device = edge_index.device
+    if batch is None:
+        batch = torch.zeros(num_nodes, dtype=torch.long, device=device)
+
+    n_channels = NUM_BASE_STRUCT_CHANNELS + len(rw_steps)
+    feats = torch.zeros(num_nodes, n_channels, device=device)
+    if num_nodes == 0:
+        return feats
+
+    num_graphs = int(batch.max().item()) + 1
+    node_mask_all = batch
+    max_k = max(rw_steps) if rw_steps else 0
+
+    for g in range(num_graphs):
+        idx = (node_mask_all == g).nonzero(as_tuple=False).view(-1)
+        ng = int(idx.numel())
+        if ng == 0:
+            continue
+
+        # Restrict edges to this graph and remap node ids to a local 0..ng-1.
+        node_in_g = node_mask_all == g
+        edge_in_g = node_in_g[edge_index[0]] & node_in_g[edge_index[1]]
+        e = edge_index[:, edge_in_g]
+        remap = torch.full((num_nodes,), -1, dtype=torch.long, device=device)
+        remap[idx] = torch.arange(ng, device=device)
+        e_local = remap[e]
+
+        adj = torch.zeros(ng, ng, device=device)
+        if e_local.numel() > 0:
+            adj[e_local[0], e_local[1]] = 1.0
+        adj = ((adj + adj.t()) > 0).float()
+        adj.fill_diagonal_(0.0)
+
+        deg = adj.sum(dim=1)
+        adj_sq = adj @ adj
+        triangles = 0.5 * (adj_sq * adj).sum(dim=1)
+        denom = (deg * (deg - 1.0)).clamp(min=1.0)
+        clustering = (2.0 * triangles / denom).clamp(0.0, 1.0)
+
+        channels = [
+            torch.log1p(deg),
+            triangles / TRIANGLE_SCALE,
+            torch.log1p(triangles),
+            clustering,
+        ]
+
+        if max_k > 0:
+            walk = adj * (1.0 / deg.clamp(min=1.0)).unsqueeze(1)  # P = D^-1 A
+            power = torch.eye(ng, device=device)
+            returns: dict[int, torch.Tensor] = {}
+            for k in range(1, max_k + 1):
+                power = power @ walk
+                if k in rw_steps:
+                    returns[k] = torch.diagonal(power)
+            channels.extend(returns[k] for k in rw_steps)
+
+        feats[idx] = torch.stack(channels, dim=1)
+
+    return feats
+
+
+class _GlobalLinearAttention(torch.nn.Module):
+    r"""Batch-aware global linear (kernel) attention of Polynormer (Eq. 6/8).
+
+    Linear attention with a sigmoid feature map :math:`\sigma`, computed per
+    graph segment so it never attends across the disjoint graphs of a batch:
+    :math:`\mathrm{num} = \sigma(Q)(\sigma(K)^\top V)`,
+    :math:`\mathrm{den} = \sigma(Q)\sum_i \sigma(K_{i})`, costing
+    :math:`O(N d^2)` rather than :math:`O(N^2 d)`.
+
+    Parameters
+    ----------
+    hidden_channels : int
+        Hidden dimension per attention head.
+    heads : int
+        Number of attention heads.
+    num_layers : int
+        Number of stacked global-attention layers.
+    beta : float
+        Gating initialisation; learnable (sigmoid-squashed) if ``beta < 0``.
+    dropout : float
+        Dropout probability applied to each layer's output.
+    qk_shared : bool, optional
+        Whether query and key projections are shared. Default ``True``.
+    """
+
+    def __init__(
+        self,
+        hidden_channels: int,
+        heads: int,
+        num_layers: int,
+        beta: float,
+        dropout: float,
+        qk_shared: bool = True,
+    ):
+        super().__init__()
+        self.hidden_channels = hidden_channels
+        self.heads = heads
+        self.num_layers = num_layers
+        self.beta = beta
+        self.dropout = dropout
+        self.qk_shared = qk_shared
+        self.eps = 1e-6
+
+        width = heads * hidden_channels
+        if self.beta < 0:
+            self.betas = torch.nn.Parameter(torch.zeros(num_layers, width))
+        else:
+            self.betas = torch.nn.Parameter(
+                torch.ones(num_layers, width) * self.beta
+            )
+
+        self.h_lins = torch.nn.ModuleList()
+        self.q_lins = torch.nn.ModuleList() if not qk_shared else None
+        self.k_lins = torch.nn.ModuleList()
+        self.v_lins = torch.nn.ModuleList()
+        self.lns = torch.nn.ModuleList()
+        for _ in range(num_layers):
+            self.h_lins.append(torch.nn.Linear(width, width))
+            if not qk_shared:
+                self.q_lins.append(torch.nn.Linear(width, width))
+            self.k_lins.append(torch.nn.Linear(width, width))
+            self.v_lins.append(torch.nn.Linear(width, width))
+            self.lns.append(torch.nn.LayerNorm(width))
+        self.lin_out = torch.nn.Linear(width, width)
+
+    def reset_parameters(self):
+        r"""Reset all learnable parameters.
+
+        Returns
+        -------
+        None
+            This method updates the module in place.
+        """
+        for h_lin in self.h_lins:
+            h_lin.reset_parameters()
+        if not self.qk_shared:
+            for q_lin in self.q_lins:
+                q_lin.reset_parameters()
+        for k_lin in self.k_lins:
+            k_lin.reset_parameters()
+        for v_lin in self.v_lins:
+            v_lin.reset_parameters()
+        for ln in self.lns:
+            ln.reset_parameters()
+        if self.beta < 0:
+            torch.nn.init.xavier_normal_(self.betas)
+        else:
+            torch.nn.init.constant_(self.betas, self.beta)
+        self.lin_out.reset_parameters()
+
+    def forward(
+        self, x: torch.Tensor, batch: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        r"""Apply the stacked batch-aware global linear-attention layers.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``[num_nodes, heads * hidden_channels]``.
+        batch : torch.Tensor, optional
+            Batch assignment of shape ``[num_nodes]``. If ``None`` all nodes are
+            treated as a single graph.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of the same shape as ``x``.
+        """
+        num_nodes = x.size(0)
+        if batch is None:
+            batch = x.new_zeros(num_nodes, dtype=torch.long)
+        num_graphs = int(batch.max().item()) + 1
+
+        for i in range(self.num_layers):
+            h = self.h_lins[i](x)
+            k = torch.sigmoid(self.k_lins[i](x)).view(
+                num_nodes, self.hidden_channels, self.heads
+            )
+            if self.qk_shared:
+                q = k
+            else:
+                q = torch.sigmoid(self.q_lins[i](x)).view(
+                    num_nodes, self.hidden_channels, self.heads
+                )
+            v = self.v_lins[i](x).view(
+                num_nodes, self.hidden_channels, self.heads
+            )
+
+            kv_node = k.unsqueeze(2) * v.unsqueeze(1)
+            kv = scatter(
+                kv_node, batch, dim=0, dim_size=num_graphs, reduce="sum"
+            )
+            kv_per_node = kv.index_select(0, batch)
+            num = torch.einsum("ndh,ndmh->nmh", q, kv_per_node)
+
+            k_sum = scatter(k, batch, dim=0, dim_size=num_graphs, reduce="sum")
+            k_sum_per_node = k_sum.index_select(0, batch)
+            den = torch.einsum("ndh,ndh->nh", q, k_sum_per_node).unsqueeze(1)
+
+            if self.beta < 0:
+                beta = torch.sigmoid(self.betas[i]).unsqueeze(0)
+            else:
+                beta = self.betas[i].unsqueeze(0)
+
+            x = (num / (den + self.eps)).reshape(num_nodes, -1)
+            x = self.lns[i](x) * (h + beta)
+            x = F.relu(self.lin_out(x))
+            x = F.dropout(x, p=self.dropout, training=self.training)
+
+        return x
+
+
+class TopoPolynormer(torch.nn.Module):
+    r"""Polynormer backbone augmented with a topological substructure encoding.
+
+    The architecture is the Polynormer local-to-global graph transformer ([1]_):
+    ``local_layers`` equivariant local attention layers (a GAT message-passing
+    term plus a node-wise linear term, combined by a gated degree-2 polynomial
+    update) whose outputs are summed, followed (when ``global_layers > 0``) by a
+    :class:`_GlobalLinearAttention` global module. On top of this, a per-node
+    structural fingerprint (see :func:`structural_encoding`) is projected and
+    **added after the input projection** — inside the backbone, bypassing the
+    encoder's ``GraphNorm`` — giving the model topological "sight" of the
+    triangles/2-simplices that 1-WL message passing is blind to.
+
+    Differences from the reference Polynormer (documented for the correctness
+    criterion): the global attention is batch-aware (per graph segment); the
+    task heads are replaced by a single output projection to node embeddings
+    (the TopoBench readout produces the final logits); and local+global modules
+    are trained jointly (``global_layers = 0`` recovers a local-only variant).
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the input node features.
+    hidden_channels : int
+        Hidden dimension per attention head; working width is
+        ``hidden_channels * heads``.
+    out_channels : int
+        Dimension of the returned node embeddings.
+    local_layers : int, optional
+        Number of local attention layers. Default is 3.
+    global_layers : int, optional
+        Number of global linear-attention layers (0 disables). Default is 2.
+    in_dropout : float, optional
+        Dropout on the raw input features. Default is 0.15.
+    dropout : float, optional
+        Dropout within the layers. Default is 0.3.
+    global_dropout : float, optional
+        Dropout within the global layers. Default is 0.3.
+    heads : int, optional
+        Number of attention heads. Default is 1.
+    beta : float, optional
+        Gating initialisation; learnable if ``beta < 0``. Default is -1.0.
+    pre_ln : bool, optional
+        Apply a layer norm at the start of each local layer. Default is False.
+    qk_shared : bool, optional
+        Whether the global module shares query/key projections. Default True.
+    use_struct : bool, optional
+        Whether to inject the topological structural encoding. Default True.
+    rw_steps : tuple of int, optional
+        Random-walk return-probability steps in the encoding. Default (2, 3, 4).
+
+    References
+    ----------
+    .. [1] Deng, Yue, Zhang. "Polynormer: Polynomial-Expressive Graph
+       Transformer in Linear Time." ICLR 2024. https://arxiv.org/abs/2403.01232
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        local_layers: int = 3,
+        global_layers: int = 2,
+        in_dropout: float = 0.15,
+        dropout: float = 0.3,
+        global_dropout: float = 0.3,
+        heads: int = 1,
+        beta: float = -1.0,
+        pre_ln: bool = False,
+        qk_shared: bool = True,
+        use_struct: bool = True,
+        rw_steps: tuple[int, ...] = DEFAULT_RW_STEPS,
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels
+        self.local_layers = local_layers
+        self.global_layers = global_layers
+        self.in_dropout = in_dropout
+        self.dropout = dropout
+        self.heads = heads
+        self.beta = beta
+        self.pre_ln = pre_ln
+        self.use_global = global_layers > 0
+        self.use_struct = use_struct
+        self.rw_steps = tuple(rw_steps)
+        self.struct_dim = NUM_BASE_STRUCT_CHANNELS + len(self.rw_steps)
+
+        width = heads * hidden_channels
+
+        if self.beta < 0:
+            self.betas = torch.nn.Parameter(torch.zeros(local_layers, width))
+        else:
+            self.betas = torch.nn.Parameter(
+                torch.ones(local_layers, width) * self.beta
+            )
+
+        self.h_lins = torch.nn.ModuleList()
+        self.local_convs = torch.nn.ModuleList()
+        self.lins = torch.nn.ModuleList()
+        self.lns = torch.nn.ModuleList()
+        self.pre_lns = torch.nn.ModuleList() if pre_ln else None
+        for _ in range(local_layers):
+            self.h_lins.append(torch.nn.Linear(width, width))
+            self.local_convs.append(
+                GATConv(
+                    width,
+                    hidden_channels,
+                    heads=heads,
+                    concat=True,
+                    add_self_loops=False,
+                    bias=False,
+                )
+            )
+            self.lins.append(torch.nn.Linear(width, width))
+            self.lns.append(torch.nn.LayerNorm(width))
+            if pre_ln:
+                self.pre_lns.append(torch.nn.LayerNorm(width))
+
+        self.lin_in = torch.nn.Linear(in_channels, width)
+        self.struct_in = (
+            torch.nn.Linear(self.struct_dim, width) if use_struct else None
+        )
+        self.ln = torch.nn.LayerNorm(width)
+        if self.use_global:
+            self.global_attn = _GlobalLinearAttention(
+                hidden_channels,
+                heads,
+                global_layers,
+                beta,
+                global_dropout,
+                qk_shared,
+            )
+        else:
+            self.global_attn = None
+        self.lin_out = torch.nn.Linear(width, out_channels)
+
+    def reset_parameters(self):
+        r"""Reset all learnable parameters.
+
+        Returns
+        -------
+        None
+            This method updates the module in place.
+        """
+        for local_conv in self.local_convs:
+            local_conv.reset_parameters()
+        for lin in self.lins:
+            lin.reset_parameters()
+        for h_lin in self.h_lins:
+            h_lin.reset_parameters()
+        for ln in self.lns:
+            ln.reset_parameters()
+        if self.pre_ln:
+            for p_ln in self.pre_lns:
+                p_ln.reset_parameters()
+        self.lin_in.reset_parameters()
+        if self.use_struct:
+            self.struct_in.reset_parameters()
+        self.ln.reset_parameters()
+        if self.use_global:
+            self.global_attn.reset_parameters()
+        self.lin_out.reset_parameters()
+        if self.beta < 0:
+            torch.nn.init.xavier_normal_(self.betas)
+        else:
+            torch.nn.init.constant_(self.betas, self.beta)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""Compute TopoPolynormer node embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node feature matrix of shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            Graph connectivity of shape ``[2, num_edges]``.
+        batch : torch.Tensor, optional
+            Batch assignment of shape ``[num_nodes]``. Keeps the structural
+            encoding and global attention within graph boundaries. If ``None``,
+            all nodes are treated as one graph.
+        edge_weight : torch.Tensor, optional
+            Accepted for ``GNNWrapper`` compatibility but unused.
+        **kwargs : dict
+            Additional unused keyword arguments.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``[num_nodes, out_channels]``.
+        """
+        x = F.dropout(x, p=self.in_dropout, training=self.training)
+        x = self.lin_in(x)
+        if self.use_struct:
+            struct = structural_encoding(
+                edge_index, x.size(0), batch, self.rw_steps
+            )
+            x = x + self.struct_in(struct)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+
+        x_local = 0
+        for i, local_conv in enumerate(self.local_convs):
+            if self.pre_ln:
+                x = self.pre_lns[i](x)
+            h = F.relu(self.h_lins[i](x))
+            x = local_conv(x, edge_index) + self.lins[i](x)
+            x = F.relu(x)
+            x = F.dropout(x, p=self.dropout, training=self.training)
+            if self.beta < 0:
+                beta = torch.sigmoid(self.betas[i]).unsqueeze(0)
+            else:
+                beta = self.betas[i].unsqueeze(0)
+            x = (1 - beta) * self.lns[i](h * x) + beta * x
+            x_local = x_local + x
+
+        if self.use_global:
+            x = self.global_attn(self.ln(x_local), batch)
+        else:
+            x = x_local
+
+        return self.lin_out(x)

--- a/topobench/nn/backbones/graph/topo_polynormer.py
+++ b/topobench/nn/backbones/graph/topo_polynormer.py
@@ -1,40 +1,49 @@
-r"""TopoPolynormer: Polynormer with a topological substructure encoding.
+r"""TopoPolynormer: Polynormer with a random-walk structural encoding.
 
 This backbone augments the Polynormer graph transformer ([1]_) with a small
-per-node **structural / substructure encoding** that gives a message-passing
-model the one thing it provably cannot compute on its own.
+per-node **structural encoding** that gives a message-passing model access to the
+local higher-order structure it is otherwise blind to.
 
 **Why.** Standard message passing is bounded by the 1-Weisfeiler-Leman test,
 which *cannot count triangles* (or any non-star substructure) — see Chen et al.
 ([2]_). Intuitively, a message that only travels along edges can never reveal
 whether *two of a node's neighbours are themselves connected* — i.e. whether the
-node sits on a **triangle** (a 2-simplex). Adding substructure counts as input
-features provably lifts a model beyond 1-WL (Graph Substructure Networks, [3]_).
-This is the minimal, literal bridge from a graph (1-simplices/edges) to topology
-(2-simplices/triangles) — the theme of the challenge.
+node sits on a **triangle** (a 2-simplex). Giving the model structural features
+that encode this local cohesion provably lifts it beyond 1-WL (Graph
+Substructure Networks, [3]_). A triangle is a 2-simplex, so this is the minimal,
+literal bridge from a graph (1-simplices / edges) to topology (2-simplices) — the
+theme of the challenge.
 
-**What.** For every node we compute, from ``edge_index`` alone, a compact
-"local structural fingerprint":
+**What (default).** For every node we compute, from ``edge_index`` alone, a
+*scale-free* "structural fingerprint" — none of whose channels is the raw answer
+to any task:
 
-* ``log1p(degree)`` — the node's connectivity (GraphUniverse graphs come from a
+* ``log1p(degree)`` — connectivity (GraphUniverse graphs come from a
   *degree-corrected* SBM, so degree is part of the generative regime);
-* the **triangle count** ``t_i`` (raw, lightly scaled, and ``log1p``) — its
-  participation in 2-simplices, the 1-WL blind spot;
-* the **local clustering coefficient** ``c_i ∈ [0, 1]`` — a *scale-free* measure
-  of neighbourhood cohesion that transfers across degree/density regimes;
-* **random-walk return probabilities** at steps :math:`k = 2, 3, 4` — a
-  multi-scale density signal that stays informative in sparse regimes where
-  triangles vanish (the ``k = 3`` return is the random-walk-normalised triangle
-  count; ``k = 4`` reflects 4-cycles).
+* the **local clustering coefficient** ``c_i ∈ [0, 1]`` — the *fraction* of a
+  node's neighbour-pairs that are linked (a normalised measure of cohesion);
+* **random-walk return probabilities** at steps :math:`k = 2, 3, 4` — drop a
+  token on the node and ask how likely a random walk is to be *back home* after
+  exactly ``k`` steps. A 3-step return is only possible around a **triangle**, a
+  4-step return reflects 4-cycles, so these are a multi-scale, degree-normalised
+  fingerprint of the local cycle structure (this is GraphGPS's RWSE, [4]_).
 
-These are injected *inside* the backbone (after the input projection), which
-deliberately bypasses the feature encoder's per-graph ``GraphNorm`` — otherwise
-the absolute triangle-count scale, which the graph-level triangle-counting task
-needs, would be standardised away.
+These signals are degree-normalised, so their *meaning* is stable across the
+GraphUniverse degree/density grid, and — crucially — their sum is **not** the
+graph-level triangle-counting target: the model must *learn* to estimate higher-
+order structure from them rather than being handed it.
 
-The encoding is **batch-aware**: it is computed per graph segment (using the
-``batch`` vector) so substructure counts never mix across the disjoint graphs of
-a mini-batch.
+**Optional ablation.** Setting ``use_triangle_count=True`` additionally injects
+the raw per-node triangle count (``t_i`` and ``log1p(t_i)``). Because the
+triangle-counting label is ``Σ_i t_i / 3`` and the readout sum-pools, this makes
+that task an almost-linear readout — useful as an *expressivity demonstration*
+of what perfect 2-simplex information buys, but it trivialises the counting task,
+so it is **off by default**.
+
+The structural encoding is injected *inside* the backbone (after the input
+projection), which bypasses the feature encoder's per-graph ``GraphNorm``, and is
+**batch-aware**: it is computed per graph segment (using the ``batch`` vector) so
+structure never mixes across the disjoint graphs of a mini-batch.
 
 References
 ----------
@@ -45,6 +54,8 @@ References
 .. [3] Bouritsas, Frasca, Zafeiriou, Bronstein. "Improving Graph Neural Network
    Expressivity via Subgraph Isomorphism Counting" (Graph Substructure
    Networks). https://arxiv.org/abs/2006.09252
+.. [4] Rampášek et al. "Recipe for a General, Powerful, Scalable Graph
+   Transformer" (GraphGPS / RWSE). NeurIPS 2022. https://arxiv.org/abs/2205.12454
 """
 
 import torch
@@ -53,10 +64,30 @@ from torch_geometric.nn import GATConv
 from torch_geometric.utils import scatter
 
 DEFAULT_RW_STEPS: tuple[int, ...] = (2, 3, 4)
-# Number of fixed structural channels: log-degree, scaled triangles,
-# log triangles, clustering coefficient.
-NUM_BASE_STRUCT_CHANNELS = 4
 TRIANGLE_SCALE = 5.0
+
+
+def num_struct_channels(
+    rw_steps: tuple[int, ...] = DEFAULT_RW_STEPS,
+    use_triangle_count: bool = False,
+) -> int:
+    """Return the number of channels produced by :func:`structural_encoding`.
+
+    Parameters
+    ----------
+    rw_steps : tuple of int, optional
+        Random-walk return-probability steps included in the encoding.
+    use_triangle_count : bool, optional
+        Whether the two raw triangle-count channels are included.
+
+    Returns
+    -------
+    int
+        The number of structural channels: ``log1p(degree)`` and clustering
+        coefficient always, plus two triangle channels if ``use_triangle_count``,
+        plus one per random-walk step.
+    """
+    return 2 + (2 if use_triangle_count else 0) + len(rw_steps)
 
 
 @torch.no_grad()
@@ -65,20 +96,22 @@ def structural_encoding(
     num_nodes: int,
     batch: torch.Tensor | None = None,
     rw_steps: tuple[int, ...] = DEFAULT_RW_STEPS,
+    use_triangle_count: bool = False,
 ) -> torch.Tensor:
-    r"""Compute the per-node topological substructure encoding.
+    r"""Compute the per-node random-walk structural encoding.
 
-    For each node the following channels are returned, in order:
-    ``[log1p(degree), triangles / TRIANGLE_SCALE, log1p(triangles),
-    clustering_coefficient, rw_return(k) for k in rw_steps]``.
+    For each node the channels are, in order: ``log1p(degree)``; (if
+    ``use_triangle_count``) ``triangles / TRIANGLE_SCALE`` and
+    ``log1p(triangles)``; the local clustering coefficient; then the random-walk
+    return probability for each step in ``rw_steps``.
 
     The triangle count of node :math:`i` is
-    :math:`t_i = \tfrac{1}{2}\sum_j A_{ij} (A^2)_{ij}`, i.e. half the number of
-    edges among its neighbours; the clustering coefficient is
-    :math:`c_i = 2 t_i / (d_i (d_i - 1))`; and the step-:math:`k` return
-    probability is :math:`(P^k)_{ii}` for the row-stochastic random walk
-    :math:`P = D^{-1} A`. Everything is computed per graph segment so counts do
-    not leak across the disjoint graphs of a batch.
+    :math:`t_i = \tfrac{1}{2}\sum_j A_{ij} (A^2)_{ij}` (half the number of edges
+    among its neighbours); the clustering coefficient is
+    :math:`c_i = 2 t_i / (d_i (d_i - 1)) \in [0, 1]`; and the step-:math:`k`
+    return probability is :math:`(P^k)_{ii}` for the row-stochastic random walk
+    :math:`P = D^{-1} A`. Everything is computed per graph segment so structure
+    does not leak across the disjoint graphs of a batch.
 
     Parameters
     ----------
@@ -91,34 +124,36 @@ def structural_encoding(
         treated as a single graph.
     rw_steps : tuple of int, optional
         Random-walk return-probability steps to include. Default ``(2, 3, 4)``.
+    use_triangle_count : bool, optional
+        If ``True``, also include the raw per-node triangle count (and its
+        ``log1p``). Off by default. Default ``False``.
 
     Returns
     -------
     torch.Tensor
         Structural features of shape
-        ``[num_nodes, NUM_BASE_STRUCT_CHANNELS + len(rw_steps)]``.
+        ``[num_nodes, num_struct_channels(rw_steps, use_triangle_count)]``.
     """
     device = edge_index.device
     if batch is None:
         batch = torch.zeros(num_nodes, dtype=torch.long, device=device)
 
-    n_channels = NUM_BASE_STRUCT_CHANNELS + len(rw_steps)
+    n_channels = num_struct_channels(rw_steps, use_triangle_count)
     feats = torch.zeros(num_nodes, n_channels, device=device)
     if num_nodes == 0:
         return feats
 
     num_graphs = int(batch.max().item()) + 1
-    node_mask_all = batch
     max_k = max(rw_steps) if rw_steps else 0
 
     for g in range(num_graphs):
-        idx = (node_mask_all == g).nonzero(as_tuple=False).view(-1)
+        idx = (batch == g).nonzero(as_tuple=False).view(-1)
         ng = int(idx.numel())
         if ng == 0:
             continue
 
         # Restrict edges to this graph and remap node ids to a local 0..ng-1.
-        node_in_g = node_mask_all == g
+        node_in_g = batch == g
         edge_in_g = node_in_g[edge_index[0]] & node_in_g[edge_index[1]]
         e = edge_index[:, edge_in_g]
         remap = torch.full((num_nodes,), -1, dtype=torch.long, device=device)
@@ -137,12 +172,10 @@ def structural_encoding(
         denom = (deg * (deg - 1.0)).clamp(min=1.0)
         clustering = (2.0 * triangles / denom).clamp(0.0, 1.0)
 
-        channels = [
-            torch.log1p(deg),
-            triangles / TRIANGLE_SCALE,
-            torch.log1p(triangles),
-            clustering,
-        ]
+        channels = [torch.log1p(deg)]
+        if use_triangle_count:
+            channels += [triangles / TRIANGLE_SCALE, torch.log1p(triangles)]
+        channels.append(clustering)
 
         if max_k > 0:
             walk = adj * (1.0 / deg.clamp(min=1.0)).unsqueeze(1)  # P = D^-1 A
@@ -312,7 +345,7 @@ class _GlobalLinearAttention(torch.nn.Module):
 
 
 class TopoPolynormer(torch.nn.Module):
-    r"""Polynormer backbone augmented with a topological substructure encoding.
+    r"""Polynormer backbone augmented with a random-walk structural encoding.
 
     The architecture is the Polynormer local-to-global graph transformer ([1]_):
     ``local_layers`` equivariant local attention layers (a GAT message-passing
@@ -321,14 +354,19 @@ class TopoPolynormer(torch.nn.Module):
     :class:`_GlobalLinearAttention` global module. On top of this, a per-node
     structural fingerprint (see :func:`structural_encoding`) is projected and
     **added after the input projection** — inside the backbone, bypassing the
-    encoder's ``GraphNorm`` — giving the model topological "sight" of the
-    triangles/2-simplices that 1-WL message passing is blind to.
+    encoder's ``GraphNorm`` — giving the model degree-normalised "sight" of the
+    local cycle structure (clustering and random-walk returns) that 1-WL message
+    passing is blind to. The raw triangle count is available as an optional
+    ablation (``use_triangle_count``) but is off by default, since injecting it
+    would trivialise the graph-level triangle-counting task.
 
     Differences from the reference Polynormer (documented for the correctness
-    criterion): the global attention is batch-aware (per graph segment); the
-    task heads are replaced by a single output projection to node embeddings
-    (the TopoBench readout produces the final logits); and local+global modules
-    are trained jointly (``global_layers = 0`` recovers a local-only variant).
+    criterion): the global attention and the structural encoding are batch-aware
+    (per graph segment); the task heads are replaced by a single output
+    projection to node embeddings (the TopoBench readout produces the final
+    logits); and local+global modules are trained jointly (``global_layers = 0``
+    recovers a local-only variant; ``use_struct = False`` recovers plain
+    Polynormer).
 
     Parameters
     ----------
@@ -358,9 +396,12 @@ class TopoPolynormer(torch.nn.Module):
     qk_shared : bool, optional
         Whether the global module shares query/key projections. Default True.
     use_struct : bool, optional
-        Whether to inject the topological structural encoding. Default True.
+        Whether to inject the structural encoding. Default True.
     rw_steps : tuple of int, optional
         Random-walk return-probability steps in the encoding. Default (2, 3, 4).
+    use_triangle_count : bool, optional
+        Whether to additionally inject the raw triangle count (ablation only).
+        Default False.
 
     References
     ----------
@@ -384,6 +425,7 @@ class TopoPolynormer(torch.nn.Module):
         qk_shared: bool = True,
         use_struct: bool = True,
         rw_steps: tuple[int, ...] = DEFAULT_RW_STEPS,
+        use_triangle_count: bool = False,
     ):
         super().__init__()
 
@@ -400,7 +442,10 @@ class TopoPolynormer(torch.nn.Module):
         self.use_global = global_layers > 0
         self.use_struct = use_struct
         self.rw_steps = tuple(rw_steps)
-        self.struct_dim = NUM_BASE_STRUCT_CHANNELS + len(self.rw_steps)
+        self.use_triangle_count = use_triangle_count
+        self.struct_dim = num_struct_channels(
+            self.rw_steps, use_triangle_count
+        )
 
         width = heads * hidden_channels
 
@@ -516,7 +561,11 @@ class TopoPolynormer(torch.nn.Module):
         x = self.lin_in(x)
         if self.use_struct:
             struct = structural_encoding(
-                edge_index, x.size(0), batch, self.rw_steps
+                edge_index,
+                x.size(0),
+                batch,
+                self.rw_steps,
+                self.use_triangle_count,
             )
             x = x + self.struct_in(struct)
         x = F.dropout(x, p=self.dropout, training=self.training)

--- a/tutorials/tutorial_topo_polynormer.ipynb
+++ b/tutorials/tutorial_topo_polynormer.ipynb
@@ -6,20 +6,22 @@
    "source": [
     "# TopoPolynormer: giving a graph transformer topological sight\n",
     "\n",
-    "**The idea in one sentence.** Message passing is a whispering game along edges, so it can never tell whether *two of your neighbours are also neighbours of each other* — i.e. whether you sit on a **triangle**. We hand each node that missing fact.\n",
+    "**The idea in one sentence.** Message passing is a whispering game along edges, so it can never learn whether *two of your neighbours are also neighbours of each other* — whether you sit on a **triangle**. We give each node a small *structural fingerprint* of the local higher-order structure it lives in.\n",
     "\n",
-    "This is not a hack; it is the canonical expressivity gap. Standard message-passing GNNs are bounded by the 1-Weisfeiler-Leman test, which **provably cannot count triangles** ([Chen et al., NeurIPS 2020](https://arxiv.org/abs/2002.04025)). Adding substructure counts as input features provably lifts a model beyond 1-WL ([Graph Substructure Networks, Bouritsas et al.](https://arxiv.org/abs/2006.09252)). A triangle is a **2-simplex**, so this is the minimal, literal bridge from a graph (edges = 1-simplices) to topology (triangles = 2-simplices) — exactly the theme of the challenge.\n",
+    "This is the canonical expressivity gap, not a hack: message-passing GNNs are bounded by the 1-Weisfeiler-Leman test, which **provably cannot count triangles** ([Chen et al., NeurIPS 2020](https://arxiv.org/abs/2002.04025)); structural features that encode local cohesion provably lift a model beyond 1-WL ([Graph Substructure Networks](https://arxiv.org/abs/2006.09252)). A triangle is a **2-simplex**, so this is the minimal bridge from a graph to topology — the theme of the challenge.\n",
     "\n",
-    "**TopoPolynormer** = the Polynormer graph transformer ([Deng, Yue & Zhang, ICLR 2024](https://arxiv.org/abs/2403.01232)) + a small per-node **structural fingerprint** computed from `edge_index`: `[log1p(degree), triangle count, log1p(triangle), clustering coefficient, random-walk return probabilities at steps 2,3,4]`. The triangle/clustering channels supply the topological signal; the degree and multi-scale random-walk channels keep the encoding informative and scale-stable across the GraphUniverse degree/density regimes (where triangles can become rare)."
+    "**The encoding (default).** For each node, computed from `edge_index`: `log1p(degree)`, the **local clustering coefficient** (the *fraction* of your neighbour-pairs that are linked), and **random-walk return probabilities** at steps 2, 3, 4 — drop a token on the node and ask how likely a walk is to be back home after exactly `k` steps. A 3-step return is only possible around a triangle, so these are a multi-scale, *degree-normalised* fingerprint of local cycle structure ([GraphGPS / RWSE](https://arxiv.org/abs/2205.12454)).\n",
+    "\n",
+    "**Why normalised, not the raw count?** The triangle-counting label is `Σ_i triangles(i) / 3` and the readout sum-pools, so injecting the *raw* per-node triangle count would make that task an almost-linear readout — i.e. handing the model the answer. We deliberately keep the encoding degree-normalised so the model must **learn** to estimate higher-order structure. (The raw count is available as an off-by-default ablation, shown below.)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. The structural encoding, and why it is exactly correct\n",
+    "## 1. The default encoding: degree-normalised, learns rather than leaks\n",
     "\n",
-    "We verify two things against `networkx`: (a) the triangle channel equals each node's true triangle count, and (b) — the property that makes graph-level triangle counting almost trivial — the **sum** of per-node triangle counts is exactly `3 x (total triangles)`. Since the challenge readout is sum-pooling over nodes, the model gets a near-linear path to the triangle-counting target."
+    "The default encoding has 5 channels and contains no raw count. We check that the clustering channel is a proper fraction in [0, 1] and that the 3-step random-walk return **correlates** with triangle participation (it reflects triangles without being their count)."
    ]
   },
   {
@@ -35,24 +37,47 @@
     "from topobench.nn.backbones.graph.topo_polynormer import (\n",
     "    TRIANGLE_SCALE,\n",
     "    TopoPolynormer,\n",
+    "    num_struct_channels,\n",
     "    structural_encoding,\n",
     ")\n",
     "\n",
     "torch.manual_seed(0)\n",
-    "\n",
     "ei = torch.randint(0, 24, (2, 90))\n",
     "ei = ei[:, ei[0] != ei[1]]\n",
     "ei = torch.cat([ei, ei.flip(0)], dim=1)  # undirected\n",
     "\n",
-    "s = structural_encoding(ei, num_nodes=24, batch=None)\n",
-    "tri_model = s[:, 1] * TRIANGLE_SCALE          # undo the fixed scaling\n",
+    "s = structural_encoding(ei, num_nodes=24, batch=None)   # default: no raw count\n",
+    "print('default channels per node:', s.shape[1], '(= num_struct_channels:', num_struct_channels(), ')')\n",
+    "clustering = s[:, 1]\n",
+    "print('clustering coefficient in [0,1]:', bool((clustering >= 0).all() and (clustering <= 1).all()))\n",
     "\n",
     "G = nx.Graph(); G.add_nodes_from(range(24)); G.add_edges_from(ei.t().tolist())\n",
     "tri_nx = torch.tensor([nx.triangles(G)[i] for i in range(24)], dtype=torch.float)\n",
+    "rw3 = s[:, 3]  # 3-step random-walk return probability\n",
+    "corr = torch.corrcoef(torch.stack([rw3, tri_nx]))[0, 1]\n",
+    "print(f'corr(3-step return, true triangle count) = {corr:.3f}  (reflects triangles, is not the count)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1b. The optional ablation (off by default): exact triangle counts\n",
     "\n",
-    "print('per-node triangle channel == networkx:', torch.allclose(tri_model, tri_nx, atol=1e-4))\n",
+    "With `use_triangle_count=True` the encoding additionally carries the *exact* per-node triangle count. We verify it equals `networkx`, and that its sum is exactly `3 x (total triangles)` — which is precisely why it would trivialise the counting task, and why it is **off by default**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_abl = structural_encoding(ei, num_nodes=24, batch=None, use_triangle_count=True)\n",
+    "tri_model = s_abl[:, 1] * TRIANGLE_SCALE\n",
+    "print('exact triangle channel == networkx:', torch.allclose(tri_model, tri_nx, atol=1e-4))\n",
     "print('sum of per-node triangles:', tri_model.sum().item(), '= 3 x', sum(nx.triangles(G).values()) // 3)\n",
-    "print('encoding channels per node:', s.shape[1])"
+    "print('-> injecting this makes sum-pooled triangle counting near-linear; off by default.')"
    ]
   },
   {
@@ -61,7 +86,7 @@
    "source": [
     "## 2. The encoding is batch-aware\n",
     "\n",
-    "Substructure counts are computed per graph segment, so batching disjoint graphs never mixes their structure. We check that a graph's fingerprint is identical alone vs. inside a batch."
+    "Structure is computed per graph segment, so batching disjoint graphs never mixes them."
    ]
   },
   {
@@ -84,7 +109,7 @@
    "source": [
     "## 3. The backbone\n",
     "\n",
-    "TopoPolynormer maps node features to embeddings; the TopoBench readout produces the final logits. The structural encoding is injected *inside* the backbone (after the input projection), which bypasses the feature encoder's GraphNorm so the absolute triangle-count scale is preserved."
+    "TopoPolynormer maps node features to embeddings; the TopoBench readout produces the final logits. The structural encoding is injected *inside* the backbone (after the input projection), bypassing the feature encoder's GraphNorm."
    ]
   },
   {
@@ -161,7 +186,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We restored the one structural signal a message-passing GNN provably cannot compute — triangle (2-simplex) participation — verified it is exact, confirmed it is batch-aware, and trained the model end-to-end. To benchmark on the challenge's GraphUniverse datasets, set `MODEL_CONFIG = \"graph/topo_polynormer\"` in `2026_tdl_challenge/run_evaluation.ipynb`."
+    "We gave the GNN a degree-normalised structural fingerprint of its local cycle structure — clustering and random-walk returns — so it can *learn* higher-order structure that 1-WL message passing is blind to, without being handed any task's answer. To benchmark on the challenge's GraphUniverse datasets, set `MODEL_CONFIG = \"graph/topo_polynormer\"` in `2026_tdl_challenge/run_evaluation.ipynb`."
    ]
   }
  ],

--- a/tutorials/tutorial_topo_polynormer.ipynb
+++ b/tutorials/tutorial_topo_polynormer.ipynb
@@ -1,0 +1,174 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TopoPolynormer: giving a graph transformer topological sight\n",
+    "\n",
+    "**The idea in one sentence.** Message passing is a whispering game along edges, so it can never tell whether *two of your neighbours are also neighbours of each other* — i.e. whether you sit on a **triangle**. We hand each node that missing fact.\n",
+    "\n",
+    "This is not a hack; it is the canonical expressivity gap. Standard message-passing GNNs are bounded by the 1-Weisfeiler-Leman test, which **provably cannot count triangles** ([Chen et al., NeurIPS 2020](https://arxiv.org/abs/2002.04025)). Adding substructure counts as input features provably lifts a model beyond 1-WL ([Graph Substructure Networks, Bouritsas et al.](https://arxiv.org/abs/2006.09252)). A triangle is a **2-simplex**, so this is the minimal, literal bridge from a graph (edges = 1-simplices) to topology (triangles = 2-simplices) — exactly the theme of the challenge.\n",
+    "\n",
+    "**TopoPolynormer** = the Polynormer graph transformer ([Deng, Yue & Zhang, ICLR 2024](https://arxiv.org/abs/2403.01232)) + a small per-node **structural fingerprint** computed from `edge_index`: `[log1p(degree), triangle count, log1p(triangle), clustering coefficient, random-walk return probabilities at steps 2,3,4]`. The triangle/clustering channels supply the topological signal; the degree and multi-scale random-walk channels keep the encoding informative and scale-stable across the GraphUniverse degree/density regimes (where triangles can become rare)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. The structural encoding, and why it is exactly correct\n",
+    "\n",
+    "We verify two things against `networkx`: (a) the triangle channel equals each node's true triangle count, and (b) — the property that makes graph-level triangle counting almost trivial — the **sum** of per-node triangle counts is exactly `3 x (total triangles)`. Since the challenge readout is sum-pooling over nodes, the model gets a near-linear path to the triangle-counting target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import networkx as nx\n",
+    "import torch\n",
+    "from torch_geometric.data import Batch, Data\n",
+    "\n",
+    "from topobench.nn.backbones.graph.topo_polynormer import (\n",
+    "    TRIANGLE_SCALE,\n",
+    "    TopoPolynormer,\n",
+    "    structural_encoding,\n",
+    ")\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "ei = torch.randint(0, 24, (2, 90))\n",
+    "ei = ei[:, ei[0] != ei[1]]\n",
+    "ei = torch.cat([ei, ei.flip(0)], dim=1)  # undirected\n",
+    "\n",
+    "s = structural_encoding(ei, num_nodes=24, batch=None)\n",
+    "tri_model = s[:, 1] * TRIANGLE_SCALE          # undo the fixed scaling\n",
+    "\n",
+    "G = nx.Graph(); G.add_nodes_from(range(24)); G.add_edges_from(ei.t().tolist())\n",
+    "tri_nx = torch.tensor([nx.triangles(G)[i] for i in range(24)], dtype=torch.float)\n",
+    "\n",
+    "print('per-node triangle channel == networkx:', torch.allclose(tri_model, tri_nx, atol=1e-4))\n",
+    "print('sum of per-node triangles:', tri_model.sum().item(), '= 3 x', sum(nx.triangles(G).values()) // 3)\n",
+    "print('encoding channels per node:', s.shape[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. The encoding is batch-aware\n",
+    "\n",
+    "Substructure counts are computed per graph segment, so batching disjoint graphs never mixes their structure. We check that a graph's fingerprint is identical alone vs. inside a batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g_a = Data(x=torch.randn(24, 16), edge_index=ei, num_nodes=24)\n",
+    "g_b = Data(x=torch.randn(13, 16), edge_index=torch.randint(0, 13, (2, 40)), num_nodes=13)\n",
+    "batch = Batch.from_data_list([g_a, g_b])\n",
+    "s_batched = structural_encoding(batch.edge_index, batch.num_nodes, batch.batch)\n",
+    "print('structural encoding batch-isolation (A alone == A in batch):',\n",
+    "      torch.allclose(s, s_batched[:24], atol=1e-5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. The backbone\n",
+    "\n",
+    "TopoPolynormer maps node features to embeddings; the TopoBench readout produces the final logits. The structural encoding is injected *inside* the backbone (after the input projection), which bypasses the feature encoder's GraphNorm so the absolute triangle-count scale is preserved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = TopoPolynormer(\n",
+    "    in_channels=16, hidden_channels=32, out_channels=16,\n",
+    "    local_layers=3, global_layers=2, heads=1, use_struct=True,\n",
+    ").eval()\n",
+    "out = model(g_a.x, g_a.edge_index, batch=torch.zeros(24, dtype=torch.long))\n",
+    "print('output shape:', tuple(out.shape))\n",
+    "print('parameters  :', sum(p.numel() for p in model.parameters()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Training in the TopoBench pipeline\n",
+    "\n",
+    "The model ships with `configs/model/graph/topo_polynormer.yaml`, so the canonical run is `python -m topobench model=graph/topo_polynormer dataset=<dataset>`. Here we train briefly on MUTAG from the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from hydra import compose, initialize_config_dir\n",
+    "from hydra.core.global_hydra import GlobalHydra\n",
+    "\n",
+    "from topobench.run import run\n",
+    "from topobench.utils.config_resolvers import register_all_resolvers\n",
+    "\n",
+    "root = Path.cwd().resolve()\n",
+    "while not (root / 'configs' / 'run.yaml').exists():\n",
+    "    root = root.parent\n",
+    "os.environ['PROJECT_ROOT'] = str(root)\n",
+    "out_dir = root / 'logs' / 'tutorial_topo_polynormer'\n",
+    "out_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "register_all_resolvers()\n",
+    "GlobalHydra.instance().clear()\n",
+    "with initialize_config_dir(version_base='1.3', config_dir=str(root / 'configs')):\n",
+    "    cfg = compose(\n",
+    "        config_name='run.yaml',\n",
+    "        overrides=[\n",
+    "            'model=graph/topo_polynormer',\n",
+    "            'dataset=graph/MUTAG',\n",
+    "            'logger=csv',\n",
+    "            'trainer.max_epochs=10',\n",
+    "            'trainer.accelerator=cpu',\n",
+    "            'trainer.devices=1',\n",
+    "            '+trainer.enable_progress_bar=False',\n",
+    "            f'paths.output_dir={out_dir.as_posix()}',\n",
+    "            f'paths.work_dir={root.as_posix()}',\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "metric_dict, _ = run(cfg)\n",
+    "print('\\nMetrics:')\n",
+    "for key, value in metric_dict.items():\n",
+    "    print(f'{key:<20s} {float(value):.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We restored the one structural signal a message-passing GNN provably cannot compute — triangle (2-simplex) participation — verified it is exact, confirmed it is batch-aware, and trained the model end-to-end. To benchmark on the challenge's GraphUniverse datasets, set `MODEL_CONFIG = \"graph/topo_polynormer\"` in `2026_tdl_challenge/run_evaluation.ipynb`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.11"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows PEP8 guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

**Track 1 (GNNs) submission — Team `SweetLesson` — Model: TopoPolynormer.** Companion to our faithful Polynormer submission (#345); same team, different architecture.

**The idea in one sentence.** Message passing is a whispering game along edges, so it can *never* learn whether two of your neighbours are also neighbours of each other — i.e. whether you sit on a **triangle**. TopoPolynormer gives each node a small *structural fingerprint* of the local higher-order structure it lives in.

This is the canonical expressivity gap, not a hack: message-passing GNNs are bounded by the 1-Weisfeiler-Leman test, which **provably cannot count triangles** ([Chen et al., NeurIPS 2020](https://arxiv.org/abs/2002.04025)); structural features that encode local cohesion provably lift a model beyond 1-WL ([Graph Substructure Networks, Bouritsas et al.](https://arxiv.org/abs/2006.09252)). A triangle is a **2-simplex**, so this is the minimal, literal bridge from a graph (edges = 1-simplices) to topology (triangles = 2-simplices) — directly the challenge's "Bridging the Gap" theme.

**The model.** [Polynormer](https://arxiv.org/abs/2403.01232) (local GAT-style attention + global linear attention) augmented with a per-node **structural encoding** computed from `edge_index` inside the backbone. By default the encoding is **degree-normalised and contains no raw count**: `[log1p(degree), local clustering coefficient, random-walk return probabilities at steps 2/3/4]` (the latter being GraphGPS-style RWSE — a 3-step return is only possible around a triangle, so it is a multi-scale fingerprint of local cycle structure). It is injected *after* the input projection, bypassing the feature encoder's `GraphNorm`, and is **batch-aware** (per graph segment). It adds ~512 parameters.

Crucially, **none of the default channels is the answer to any task** — their sum is not the triangle-counting target — so the model must *learn* to estimate higher-order structure from structural cues rather than being handed it. (The raw per-node triangle count is available as an explicit, **off-by-default** ablation, `use_triangle_count`; we keep it off precisely because injecting it would make sum-pooled triangle counting a near-linear readout and trivialise the task.)

### Results vs the Polynormer baseline (#345), full GraphUniverse grid (12 settings × 2 tasks × 3 seeds, in-distribution + OOD)

| Metric | Polynormer | **TopoPolynormer** | Δ |
|---|---|---|---|
| Triangle counting — in-dist MSE/triangles (↓) | 0.872 | **0.045** | **−95%** |
| Triangle counting — OOD MSE/triangles (↓) | 35.14 | **1.51** | **−96%** |
| Community detection — in-dist accuracy (↑) | 0.455 | **0.480** | +2.5 pp |
| &nbsp;&nbsp;by homophily: low / mid / high | .317 / .401 / .647 | .318 / .437 / .685 | ~0 / +3.7 / +3.8 pp |
| Community detection — OOD accuracy (↑) | 0.350 | 0.346 | −0.4 pp (≈ neutral) |

Triangle-counting error drops ~95–96% — the model **learns** to count from the degree-normalised structural signal (the 3-step random-walk return correlates ~0.85 with triangle participation), rather than being handed it; the credible non-zero result (0.045, not ~0) reflects genuine learning. Community detection improves in-distribution (mid/high homophily, where triangles signal community cohesion) at no OOD cost. For transparency: an explicit-count ablation (`use_triangle_count=True`) reaches ~0.015 in-dist MSE, but we deliberately do **not** submit that, as it trivialises the counting task.

### What's added
- `topobench/nn/backbones/graph/topo_polynormer.py` — `TopoPolynormer` + `structural_encoding` (NumPy docstrings cite Polynormer, Chen et al., GSN, and GraphGPS/RWSE).
- `configs/model/graph/topo_polynormer.yaml` — reuses `GNNWrapper` + `NoReadOut`; one config for both tasks; `use_triangle_count: false`.
- `test/nn/backbones/graph/test_topo_polynormer.py` — **100% backbone coverage**, incl. clustering range, the random-walk/triangle correlation, the ablation's exactness, and batch isolation.
- `test/pipeline/test_pipeline.py` — add `graph/topo_polynormer`.
- `tutorials/tutorial_topo_polynormer.ipynb` — the idea, the normalised-vs-explicit distinction, and an end-to-end run.
- `2026_tdl_challenge/outputs/<study>/results.json` — the full grid for the submitted (default) model.

### Adaptations (correctness notes)
The structural encoding and the global attention are both batch-aware (per graph segment); the paper's task heads are replaced by a single output projection (the TopoBench readout produces logits); local+global are trained jointly (`global_layers=0` recovers local-only; `use_struct=false` recovers plain Polynormer).

### Note on `results.json` generation
On upstream `main`, `2026_tdl_challenge/run_evaluation.ipynb` carries a self-integrity hash (`expected_hash = f87b2c…`) that does not match the hash of its own shipped cells (`hash_remaining_cells(...) → 3c1d78…`), so the guard cell raises `ValueError` before any work, for the *unmodified* notebook. Results were therefore generated by the notebook's own backend — `run_challenge_grid(...)` + `save_challenge_artifacts(...)` from `2026_tdl_challenge/utils.py` (identical pipeline), with `WANDB_MODE=offline`. Happy to open an issue to refresh the stored hash.

## Issue

Submission to the **TDL Challenge 2026**, Track 1 (GNNs). No existing PR uses structural/positional encodings; the field is concentrated on sheaf/diffusion methods.

## Additional context

Tested with the project environment (Python 3.11, torch 2.3.0+cu121). Unit tests (100% backbone coverage), the pipeline test, the tutorial notebook, and a GraphUniverse sanity over all settings pass locally.