### PR TITLE
Track: Track1; Team name: PushparajD; Model: Graph Attention with self/neighbour-separated attention

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-13_20-55-59/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-13_20-55-59/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-13_20-55-59",
+    "model_config": "graph/gate",
+    "generated_at_utc": "2026-06-14T00:06:12.525096+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1885271072387695,
+      "test_best_rerun_accuracy": 0.319772332906723,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31652534008026123,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3252731263637543,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32699212431907654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3389105498790741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3353961408138275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34062954783439636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3418901264667511,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37130415439605713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36969974637031555,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38543814420700073,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39281076192855835,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1701104640960693,
+      "test_best_rerun_accuracy": 0.32538771629333496,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32145312428474426,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3300863206386566,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3284055292606354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3424631357192993,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3400183320045471,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3449079394340515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3447551429271698,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3726029396057129,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3727557361125946,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3864695429801941,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3954465687274933,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1803979873657227,
+      "test_best_rerun_accuracy": 0.3232867419719696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3193521201610565,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32821452617645264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3277561366558075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3409351408481598,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3379173278808594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34376195073127747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34441134333610535,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37118953466415405,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3724501430988312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38559094071388245,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39346015453338623,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1945583820343018,
+      "test_best_rerun_accuracy": 0.31587591767311096,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3172511160373688,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3231339156627655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3240507245063782,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3350905478000641,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3326457440853119,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33409732580184937,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33696234226226807,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3594621419906616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3618687391281128,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37225914001464844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37810376286506653,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1966795921325684,
+      "test_best_rerun_accuracy": 0.31450071930885315,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3170219361782074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3228283226490021,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3205745220184326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3335625231266022,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3299717307090759,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3342501223087311,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3348231315612793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35839253664016724,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3594239354133606,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3693559467792511,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3768431544303894,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.186208486557007,
+      "test_best_rerun_accuracy": 0.3188937306404114,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32023072242736816,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32554054260253906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32496753334999084,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33650392293930054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3341355323791504,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3375353217124939,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33856675028800964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36179235577583313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36183053255081177,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3723737597465515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3786385655403137,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1165809631347656,
+      "test_best_rerun_accuracy": 0.3407823443412781,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32252272963523865,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3142715394496918,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3382229208946228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35652074217796326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3505615293979645,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.371915340423584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37351974844932556,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4328825771808624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43143096566200256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4766598045825958,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4952250123023987,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.105832576751709,
+      "test_best_rerun_accuracy": 0.34372374415397644,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3256933391094208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3193139135837555,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3402475416660309,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3601497411727905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35350292921066284,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.376537561416626,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37592634558677673,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.43208035826683044,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4312399625778198,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47719457745552063,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49736419320106506,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1078076362609863,
+      "test_best_rerun_accuracy": 0.34414392709732056,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3261135220527649,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32007792592048645,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33952173590660095,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35950034856796265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3504851460456848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37665215134620667,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3774161636829376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4368935823440552,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4331117868423462,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4797157943248749,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49747881293296814,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1208019256591797,
+      "test_best_rerun_accuracy": 0.33967453241348267,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32317212224006653,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3164871335029602,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3405531346797943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35445794463157654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3489571511745453,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36996716260910034,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3739781379699707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4268851578235626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.426044762134552,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47165557742118835,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4947283864021301,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1177639961242676,
+      "test_best_rerun_accuracy": 0.33936893939971924,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32481473684310913,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3183589279651642,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3405149281024933,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35571855306625366,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3504851460456848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3709603548049927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.371915340423584,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42436397075653076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42298877239227295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.46676599979400635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4918251931667328,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.118675947189331,
+      "test_best_rerun_accuracy": 0.34131714701652527,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32592251896858215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3203835189342499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3427305519580841,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35407593846321106,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34888073801994324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37187716364860535,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37607914209365845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4264267683029175,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4273053705692291,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4691725969314575,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49411720037460327,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9918991327285767,
+      "test_best_rerun_accuracy": 0.39185574650764465,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30632591247558594,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3003285229206085,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32114753127098083,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32279011607170105,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37909695506095886,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.401291161775589,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4045763611793518,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48441439867019653,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4805561900138855,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5344564318656921,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5528306365013123,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.015587329864502,
+      "test_best_rerun_accuracy": 0.3832225501537323,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29902970790863037,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.290396511554718,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31698372960090637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31736573576927185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36981433629989624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4010237455368042,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40312474966049194,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48403239250183105,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4811291992664337,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.543433427810669,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5640614032745361,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0032215118408203,
+      "test_best_rerun_accuracy": 0.38956376910209656,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30147451162338257,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2947131097316742,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3217969238758087,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32072731852531433,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3748949468135834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4014439582824707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4056841731071472,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.484758198261261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4813583791255951,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5385820269584656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5619222521781921,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0294899940490723,
+      "test_best_rerun_accuracy": 0.37279394268989563,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3076247274875641,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30307891964912415,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3229811191558838,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32550233602523804,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38070136308670044,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39105355739593506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3984643518924713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.465734601020813,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4667277932167053,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5096645951271057,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5339980125427246,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.066990852355957,
+      "test_best_rerun_accuracy": 0.3620215356349945,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29711970686912537,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2925357222557068,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3134693205356598,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3160669207572937,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37076935172080994,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38276416063308716,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39132094383239746,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4593169689178467,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4593551754951477,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5081366300582886,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5321261882781982,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0402112007141113,
+      "test_best_rerun_accuracy": 0.3706929385662079,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3054855167865753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3012453317642212,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3228283226490021,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3242035210132599,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37718695402145386,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39170295000076294,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39636334776878357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46516159176826477,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46485599875450134,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5085185766220093,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5336924195289612,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9031636714935303,
+      "test_best_rerun_accuracy": 0.4280693829059601,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2832913100719452,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27347391843795776,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31259071826934814,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31316372752189636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3969745635986328,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38058674335479736,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43250057101249695,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5203223824501038,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5161585807800293,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5959202647209167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6228894591331482,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9318315982818604,
+      "test_best_rerun_accuracy": 0.42123156785964966,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2725571095943451,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2641149163246155,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3028879165649414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3873099684715271,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3697761595249176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4273053705692291,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.51146000623703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5092825889587402,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5939720273017883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6205592751502991,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9130874872207642,
+      "test_best_rerun_accuracy": 0.4273817837238312,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27863091230392456,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26965391635894775,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3098403215408325,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3081977367401123,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3941095471382141,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37691953778266907,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42936816811561584,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5189090371131897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5132172107696533,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.596760630607605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6236916780471802,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8630081415176392,
+      "test_best_rerun_accuracy": 0.43872717022895813,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27714112401008606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2670181095600128,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30663153529167175,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30705171823501587,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3934219479560852,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3802047371864319,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4270379841327667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5200549960136414,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5215066075325012,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5996256470680237,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6353044509887695,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8659484386444092,
+      "test_best_rerun_accuracy": 0.4407517910003662,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27591872215270996,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2691573202610016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30567651987075806,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3093819320201874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3926961421966553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37905874848365784,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4274199604988098,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5200932025909424,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5205516219139099,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6015356183052063,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6377874612808228,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.867460012435913,
+      "test_best_rerun_accuracy": 0.4396821856498718,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2761097252368927,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2665597200393677,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3065169155597687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30563831329345703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3927725553512573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3791351616382599,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4280693829059601,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5223851799964905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5201314091682434,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.600657045841217,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.636450469493866,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6006762981414795,
+      "test_best_rerun_accuracy": 0.5405684113502502,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2740468978881836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26373291015625,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29776912927627563,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3003285229206085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3943387567996979,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37921154499053955,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4178699553012848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4294445812702179,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5406830310821533,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6170066595077515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6526090502738953,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6143745183944702,
+      "test_best_rerun_accuracy": 0.5361372232437134,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2704178988933563,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26040950417518616,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29803651571273804,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2993353307247162,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3878447413444519,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37279394268989563,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4185575544834137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43116357922554016,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.534188985824585,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6173504590988159,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6553976535797119,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5990394353866577,
+      "test_best_rerun_accuracy": 0.5420200228691101,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2750401198863983,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2640002965927124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2989533245563507,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3028879165649414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39540836215019226,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37947896122932434,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4210405647754669,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4309725761413574,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5394605994224548,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6165100336074829,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6533348560333252,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5822350978851318,
+      "test_best_rerun_accuracy": 0.53892582654953,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27305370569229126,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26487889885902405,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30063411593437195,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30143633484840393,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39143556356430054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3784857392311096,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4162273705005646,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43062877655029297,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5344182252883911,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6139506697654724,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6557796597480774,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5703994035720825,
+      "test_best_rerun_accuracy": 0.5413706302642822,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2762625217437744,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2684697210788727,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30349913239479065,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30510351061820984,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39338377118110657,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37963175773620605,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41920697689056396,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43047598004341125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5383909940719604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6174650192260742,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6561616659164429,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5702635049819946,
+      "test_best_rerun_accuracy": 0.5422492027282715,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2748491168022156,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26598671078681946,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30132171511650085,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3052945137023926,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3939949572086334,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3802047371864319,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41798457503318787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43276798725128174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5372068285942078,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6170830726623535,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6571548581123352,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3267314434051514,
+      "test_best_rerun_accuracy": 0.634884238243103,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2601802945137024,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2491786926984787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2894033193588257,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29165711998939514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39185574650764465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3766903579235077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4307815730571747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4434639811515808,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5473679900169373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5504240393638611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6772480607032776,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.328214406967163,
+      "test_best_rerun_accuracy": 0.6364122629165649,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25456491112709045,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24436549842357635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28978532552719116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2897089123725891,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3883795440196991,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37011995911598206,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4310871660709381,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4434639811515808,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5481702089309692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5469860434532166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6788524985313416,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3294073343276978,
+      "test_best_rerun_accuracy": 0.6367942690849304,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25823211669921875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24558790028095245,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29123690724372864,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2943311035633087,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3904041647911072,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37462756037712097,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4285277724266052,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4433111846446991,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5474061965942383,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5480174422264099,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6788906455039978,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1634540557861328,
+      "test_best_rerun_accuracy": 0.6900832653045654,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25318971276283264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24230270087718964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28688210248947144,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2877607047557831,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3908243477344513,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3750477433204651,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4324241876602173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45301398634910583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5530980229377747,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5565742254257202,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6431736350059509,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1793733835220337,
+      "test_best_rerun_accuracy": 0.6886316537857056,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24478569626808167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23741309344768524,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28229811787605286,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2840934991836548,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3820001482963562,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3666055500507355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4268851578235626,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4480861723423004,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5458018183708191,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5478264093399048,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6399266719818115,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1909465789794922,
+      "test_best_rerun_accuracy": 0.6854611039161682,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24409809708595276,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2350446879863739,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2837115228176117,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2852395176887512,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38299334049224854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3666437566280365,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4263121783733368,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44774237275123596,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.542669415473938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5454580187797546,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6358392834663391,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 193.65249633789062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 190.93492126464844,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.13756118246732596,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243.8753662109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2835545590049342
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10209.513671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7743279235400076
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140.73080444335938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.047432020371877104
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6748.59423828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9016157966975618
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245.45726013183594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.21196654588241445
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168079.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.903017529142671
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13513.849609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9475423930286776
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43701.5859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2400730912655695
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3202.41796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.56931875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744181.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.418061321448366
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254356.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.232711172682342
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 98.63712310791016,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 99.21099090576172,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.071477659154007,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84.3233871459961,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.44380730076840047
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9073.6962890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6881832604522184
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.11154174804688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05463820079138756
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6991.419921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9340574377922511
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143.35923767089844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12379899626157033
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165129.03125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.83450286201932
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12880.6904296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9031475550194573
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44746.4921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2936333070634065
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3322.974609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5907510416666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743469.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.410006589142903
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252475.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.201412290116985
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 133.27220153808594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 127.778076171875,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09205913268867075,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114.8979721069336,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.604726168983861
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10352.0009765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7851346967434585
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.07762145996094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04417850403099459
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7146.0849609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9547207696643286
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.09654235839844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.139979742969256
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169113.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9270301179639606
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13697.2275390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9604001920531833
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44963.8984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3047772021887334
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3376.309326171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6002327690972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 748425.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.466064500073527
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256070.21875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.261232069459005
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 5.908016204833984,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5.957378387451172,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.03135462309184827,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212.7343292236328,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15326680779800636
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12971.3203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.983793728668942
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 394.1270446777344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13283688731976218
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8170.97021484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.091645987287074
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184.822265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15960471988341968
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178165.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.137227440553595
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16126.138671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1307066801202497
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47801.8828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.450247722205136
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4008.882568359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.712690234375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764964.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.653155860095247
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266763.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.439177088013579
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.8891215324401855,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.800124168395996,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.014737495623136821,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195.91781616210938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14115116438192318
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12931.990234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9808107875900645
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 380.2248229980469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12815127165421195
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8134.24169921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.086739037971777
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174.39703369140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15060192892176705
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177971.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.132730499953557
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16061.6669921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1261861584761954
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47660.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4430070736583116
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3960.695068359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7041235677083333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764575.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.648749901021459
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266440.4375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.433801565906179
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 4.0186872482299805,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.9264631271362305,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.02066559540598016,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189.19984436035156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13631112706077203
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12756.060546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9674676182688662
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 352.85595703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11892684766809909
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8089.03076171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0806988325609552
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170.42298889160156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1471701113053554
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177373.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.11884237704347
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15897.0048828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.11464064526802
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47560.22265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4378606108078325
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3934.938232421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6995445746527778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 763592.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.637631782858048
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 265808.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.4232886941906715
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 4071.36083984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3956.4609375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3000728811149033,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2377.966552734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.7132323866962356
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2363.669921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 12.44036800986842
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5517.84423828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.8597385366637176
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4710.01025390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6292598869614229
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1845.9779052734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.594108726488288
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128974.2109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9949426652772617
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8333.6650390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5843265347821133
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34848.90234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7862987515377518
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2888.034912109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5134284288194444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 673912.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.62319081366017
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211589.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5210369240177726
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 4163.19873046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3989.544921875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.30258209494690935,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1881.5301513671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.3555692733192994
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1759.3062744140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.259506707442434
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4785.234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.6128191354903942
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4836.5654296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6461677260771543
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1463.4307861328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2637571555551057
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131533.78125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.054379092745681
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8401.212890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5890627465029449
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35617.76171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8257092479752934
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2580.669189453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4587856336805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 679392.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.685171176317546
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 213918.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5597849375135207
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 4129.4990234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4040.7333984375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.30646442157281,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3242.44677734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.3360567560113474
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3315.2822265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.44885382401316
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6722.546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.2657724553420966
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4927.8212890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6583595576569806
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2762.4052734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.3854967818976682
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126263.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9319893066134126
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8236.037109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5774812164755995
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33170.078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7002449190117381
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3152.16455078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5603848090277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 662927.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.498922547877335
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204895.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.409647598305959
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 147.27952575683594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 148.5501251220703,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.05006745032762734,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.43576049804688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11774910698706548
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233.56817626953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2293061908922698
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9537.791015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7233819503697383
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6698.2021484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8948833865647963
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 220.3284149169922,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.19026633412520913
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165846.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8511706413709828
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12941.0810546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9073819278283201
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43626.55859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2362273101517247
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3156.0986328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5610842013888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741884.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.392078040337998
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252493.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.201715466027657
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 134.55686950683594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 131.69017028808594,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04438495796699897,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.68980407714844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10496383579045276
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184.2470245361328,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.96972118176912
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10115.7529296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7672167561386045
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6904.9345703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9225029486055444
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200.01998901367188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.17272883334513978
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168120.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9039696004783577
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13504.6474609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.946897171570432
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44187.03125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2649562381464965
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3231.03076171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.57440546875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 745929.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.437832285103447
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254826.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.240537063385086
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 149.6332550048828,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 148.15550231933594,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04993444634962452,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170.7594757080078,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12302555886744079
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243.5839080810547,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2820205688476562
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9636.060546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7308350812950323
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6741.68212890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9006923351912157
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225.4053192138672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.19465053472700103
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166151.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8582436896247447
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13030.7041015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9136659726239307
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43697.83984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.239881072517812
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3143.273193359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5588041232638888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742534.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.399422955103333
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252610.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.203662188191636
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5063.3330078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5241.9658203125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7003294349114897,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1459.7978515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.051727558762608
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1979.64453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 10.419181743421053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5878.013671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4458106690841866
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1598.4942626953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5387577562168225
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1562.518798828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.3493253875890545
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147438.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4237091160830393
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9498.3369140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6659891259334245
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36987.9453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8959426578758523
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2789.005859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.49582326388888887
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 703411.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.956875049489271
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229698.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8223846787479405
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 4205.58642578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4324.216796875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.5777176749331997,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2808.82470703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.0236489243740996
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2403.911865234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 12.65216771175987
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5384.107421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4083509610826697
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12806.2421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.316225880519043
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1959.2794189453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.6919511389855895
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114945.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.669186051574401
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9160.845703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6423254594814892
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33356.02734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.709776377248962
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2727.8173828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4849453125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 652699.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.383225823784261
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 193006.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2117930749005708
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 4919.8681640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5089.4306640625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.6799506565213761,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1323.7152099609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9536853097701279
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1707.6480712890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.98762142783717
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5064.48583984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.38410965793278345
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2396.210693359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8076207257699275
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1284.64404296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.1093644585222366
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143050.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.321807005271224
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8938.6259765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.626744213754207
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37343.1953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9141522021887334
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2625.4267578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4667425347222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 699813.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.916172952275375
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225847.515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.75829989557852
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 140.90658569335938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 148.19747924804688,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12797709779624084,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.17041015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10170778829701009
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.6069278717041,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.16635225195633738
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11384.0029296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8634056071056124
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.86343383789062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06028427160023277
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7610.47900390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0167640619781229
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172972.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.016646372259892
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14663.58984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.028158031394615
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46396.1015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.378189633630632
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3674.09716796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6531728298611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 756375.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.555991453909936
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261006.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.343377660459621
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 141.72662353515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 148.8637237548828,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12855243847571918,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.0531463623047,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09441869334459992
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.978668212890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.19988772743626645
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11539.5654296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8752040523084945
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.72695922851562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0673161305118017
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7604.880859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0160161468770874
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173551.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.030091477219952
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14846.7666015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0410017249728298
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46264.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3714503562458353
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3620.88427734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6437127604166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 756945.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.562444147823038
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261382.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.349632288702511
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 144.8751220703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 151.61959838867188,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13093229567242823,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134.56858825683594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09695143246169736
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66.35773468017578,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3492512351588199
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11205.46875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8498649032992036
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172.03402709960938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05798248301301293
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7409.408203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9899008955410822
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171990.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.993824235440275
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14466.138671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0143134673871126
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45743.77734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.344752542095956
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3521.46533203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.62603828125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753873.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.527692781919166
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259448.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.317445199524071
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112302.5625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78753.359375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8287516109743638,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65025.0,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 46.84798270893372
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68934.609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 362.81373355263156
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36615.75390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.7770765192453544
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64772.375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 21.83093191776205
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49180.0625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.570482631930528
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65857.2734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 56.8715660082038
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40511.01171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.840486027117515
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41276.77734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.115781298054744
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54128.328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.622813888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 482014.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.452462374014456
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125403.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.08682791672907
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 109151.6015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 77005.875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.7881728357793052,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82354.4375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 59.33316822766571
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86417.9765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 454.83145559210527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51292.16796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.8901909722222223
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84990.3515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 28.64521454752275
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63449.578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 8.47689754509018
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82674.8359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 71.39450426381693
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54947.03125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.8526876489973354
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49819.98828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.5536925665718386
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69123.9375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 12.2887
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 457532.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.1755366757915455
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117946.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9627275639425557
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 111771.8125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78334.4765625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8190246275891697,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64944.953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 46.790312049711815
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68604.3359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 361.07545230263156
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38408.69921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9130602365377323
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67158.375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.63511122345804
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48989.65625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.545044255177021
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65241.140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 56.3394996761658
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41964.51953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.9424007524365448
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41178.01171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1107187307781023
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53672.2421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.541731944444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 480615.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.436647017069556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124564.6640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0728647939443863
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8449.205078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8185.6923828125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5739512258317557,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3279.1142578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.3624742491444524
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3673.6103515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 19.334791324013157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4742.55322265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3596930771828783
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6302.44140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.1241797796595887
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5232.14794921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6990177620866733
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3082.81884765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.6621924418447755
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129517.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0075534379063718
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33728.19140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7288529092341995
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3449.6474609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6132706597222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 670383.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.583260749069602
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207523.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.453374873113341
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8555.650390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8172.71337890625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5730411848903555,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2190.91796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.5784711590417868
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2196.799560546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 11.562102950246711
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4683.68603515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3552283682333144
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4421.4404296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.490205739699191
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5190.251953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6934204346192385
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1920.014404296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.6580435270266622
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133890.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1091152122422443
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35981.5078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8443542884053514
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2922.404052734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5195384982638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 681940.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.713991606619685
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212745.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5402654531309805
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8611.2529296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8341.783203125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.584895751165685,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1709.7432861328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.2318035202685969
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1739.8779296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.157252261513158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4775.47900390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3621902922947478
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4506.59326171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5189057167909505
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5152.41015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6883647503340014
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1499.72509765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2950993934855355
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134766.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1294548520806242
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37189.984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9062988556563638
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2894.21630859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.51452734375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 685639.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.75584326889359
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214898.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.576101833824239
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26215.416015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 26902.837890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.3789962525308832,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17180.94140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 12.378199860410662
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18961.80859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 99.79899259868421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8622.80859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6539862414675768
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19819.365234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.679934356041456
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12284.6123046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.6412307688293253
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17244.470703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 14.891598189227116
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103680.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4075841334989785
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12316.9990234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8636235467281937
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12994.009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.3100461805555557
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 592564.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.7029887277581075
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170621.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.839290505965753
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26641.068359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27235.462890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.3960460756894253,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18573.92578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 13.381790908681555
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20487.75,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 107.83026315789473
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8850.125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6712267728479333
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19974.7890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.732318524603977
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13393.14453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.7893312667000667
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18765.138671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 16.204782963622627
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103911.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4129580391974734
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12556.185546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8803944430567242
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14116.408203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.5095836805555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 590862.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.683742350372725
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169975.21875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.828536081573561
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 28424.978515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 26678.314453125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.3674875418076273,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22991.24609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 16.5642983384366
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17737.91015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 93.357421875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113919.84375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.640109499431171
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197885.46875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 66.69547312099765
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14121.712890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.8866683888610554
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18791.64453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 16.227672306778928
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79195.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8390106875812744
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123516.7890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 8.660551750280465
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19072.9296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.3907430555555558
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 502501.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.684211791455041
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130815.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1768805226898307
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2581.16064453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2723.90673828125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.48425008680555554,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 994.066650390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7161863475436779
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1407.6876220703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.408882221422697
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6555.18603515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.49716996853668943
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1056.1658935546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.35597097861634225
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5455.00830078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7287920241524716
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1094.247802734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9449462890625
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151732.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.523428792030466
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10121.689453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7096963576724863
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38415.953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9691400443385105
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 712264.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.057014467834803
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234785.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.907031341004776
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2516.857421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2665.78662109375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4739176215277778,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 407.49749755859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2935860933419263
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 548.395751953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.886293431332237
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6045.2216796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.458492353408229
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1278.9644775390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.4310631875763608
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5888.56689453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7867156839721109
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 409.0005798339844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.35319566479618686
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151240.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.51199377670444
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9979.3798828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.69971812388252
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41078.68359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.105627330655082
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 719721.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.141374585704105
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236293.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9321260379744727
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2558.65771484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2712.811767578125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.48227764756944447,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 605.9459228515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4365604631495407
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 898.580322265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.7293701171875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6913.77587890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5243667712481039
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 811.2655639648438,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.27342958003533663
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5729.27392578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7654340582206078
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 671.5225219726562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5798985509263007
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154133.453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5791717705043657
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10524.34375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7379290246809704
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40003.25390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.050502532485007
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 719537.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.139290380416954
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 238143.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9629189339856556
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 488860.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 336347.78125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.8047100352929197,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612094.75,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 440.9904538904899
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 624841.1875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3288.6378289473682
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 502017.125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 38.074867273416764
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610465.25,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 205.75168520390966
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 548852.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 73.32692050768203
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 615441.625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 531.46945164076
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 303046.46875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 7.037118445801598
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 508180.21875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 35.63176404080774
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 445294.28125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 22.82506951919627
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 572321.25,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 101.746
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263718.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.388510309021018
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 487676.90625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 331482.78125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.7496779662454895,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 575942.4375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 414.9441192363112
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 588568.0625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3097.726644736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 470716.90625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 35.700940936670456
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 576640.9375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 194.35151247050894
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 514402.34375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 68.72442802271209
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 579029.3125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 500.02531303972364
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282497.875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 6.559954370239644
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 477325.71875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 33.468357786425464
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415444.9375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 21.295040109692962
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 537191.0625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 95.50063333333334
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 246358.984375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.099628648511474
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 485726.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 329372.3125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.7258046955420063,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 563370.125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 405.88625720461096
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 575987.4375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3031.5128289473682
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 457611.09375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 34.706946814562
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 560881.4375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 189.03991826761037
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 503196.96875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 67.22738393453574
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 566738.8125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 489.41175518134713
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 273931.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 6.3610266115548955
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 463596.96875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 32.50574735310616
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 405974.90625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 20.809621520836536
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 525742.5,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 93.46533333333333
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239495.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9854082942272813
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111303.203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107870.0859375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7950524343517549,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140064.0,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 100.91066282420749
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145085.375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 763.6072368421053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99515.2734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.547612699089875
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147922.546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 49.8559308645096
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112921.828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 15.086416583166333
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140185.546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 121.05833063471502
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82036.4609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9049893399939626
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103600.6796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 7.264105994075165
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82820.4140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.245241378978933
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121452.375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 21.591533333333334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 399017.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.513622982251734
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 113899.7109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108943.3671875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8129127716622568,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107184.5390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 77.22229039085015
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103176.5625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 543.0345394736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106160.546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.051615235115662
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147916.890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 49.85402447758679
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83899.8671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 11.20906709251837
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98414.703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 84.98679026338515
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86433.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0071020748188744
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99206.90625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.9560304480437525
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61181.89453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.13608562874827
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87202.3046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 15.502631944444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 424659.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.803678890987863
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gate_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111360.5,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107923.6015625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7959429810876475,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142193.40625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 102.44481718299711
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146108.765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 768.9935032894737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116324.65625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.822499525976488
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170902.921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 57.601254423660265
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113039.3828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 15.102121952237809
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139223.953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 120.22793879533678
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86739.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.014204875301876
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119132.265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 8.35312478088627
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81672.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.186391537239223
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120432.34375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 21.410194444444443
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 396469.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.484801137970431
+        }
+      },
+      "output_dir": "C:\\Users\\HP\\Projects\\topobench\\logs\\train\\runs\\notebook_gu_grid_2026-06-13_20-55-59__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/graph/gate.yaml
+++ b/configs/model/graph/gate.yaml
@@ -1,0 +1,42 @@
+_target_: topobench.model.TBModel
+
+model_name: GATE
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  # Full path required: backbone auto-discovery loads this file under a
+  # synthetic module name, which breaks PyG MessagePassing's inspector.
+  _target_: topobench.nn.backbones.graph.gate.GATE
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_layers: 2
+  heads: 4
+  dropout: 0.5
+  share_att: false
+  has_omega: true
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/graph/gate.yaml
+++ b/configs/model/graph/gate.yaml
@@ -20,7 +20,6 @@ backbone:
   heads: 4
   dropout: 0.5
   share_att: false
-  has_omega: true
 
 backbone_wrapper:
   _target_: topobench.nn.wrappers.GNNWrapper

--- a/test/nn/backbones/graph/test_gate.py
+++ b/test/nn/backbones/graph/test_gate.py
@@ -2,6 +2,7 @@
 
 import pytest
 import torch
+import torch.nn.functional as F
 import torch_geometric
 from torch_geometric.utils import add_self_loops, remove_self_loops
 
@@ -12,9 +13,9 @@ from topobench.nn.wrappers.graph import GNNWrapper
 def _dense_gate_reference(conv, x, edge_index):
     """Recompute GATEConv's output with explicit dense per-node loops.
 
-    This is an independent implementation of the documented GATE update
-    (no ``MessagePassing``/``propagate``); agreement with the layer is the
-    parity check on attention, masking, softmax scope, and aggregation.
+    Independent implementation of the GATE update (Eq. 1/2/4, no
+    ``MessagePassing``); agreement with the layer is the parity check on
+    attention, the self/neighbour split, softmax scope, and aggregation.
 
     Parameters
     ----------
@@ -23,8 +24,7 @@ def _dense_gate_reference(conv, x, edge_index):
     x : torch.Tensor
         Node features.
     edge_index : torch.Tensor
-        Graph connectivity (self-loops are added internally, matching
-        ``GATEConv.forward``).
+        Graph connectivity (self-loops added internally, as in forward).
 
     Returns
     -------
@@ -35,44 +35,27 @@ def _dense_gate_reference(conv, x, edge_index):
     h, c = conv.heads, conv.out_channels
     x_l = conv.lin_l(x).view(-1, h, c)
     x_r = conv.lin_r(x).view(-1, h, c)
-    x_s = conv.lin_s(x).view(-1, h, c)
-
     ei, _ = remove_self_loops(edge_index)
     ei, _ = add_self_loops(ei, num_nodes=x.size(0))
     src, dst = ei[0], ei[1]
 
-    e = torch.nn.functional.leaky_relu(
-        x_l[dst] + x_r[src], conv.negative_slope
-    )  # (E, H, C)
-    att = conv.att.squeeze(0)
-    att2 = conv.att2.squeeze(0)
+    pre = F.leaky_relu(x_l[dst] + x_r[src], conv.negative_slope)
+    att, att2 = conv.att.squeeze(0), conv.att2.squeeze(0)
     is_self = (src == dst).view(-1, 1)
-    logit = torch.where(
-        is_self, (e * att2).sum(-1), (e * att).sum(-1)
-    )  # (E, H)
+    logit = torch.where(is_self, (pre * att2).sum(-1), (pre * att).sum(-1))
 
     out = torch.zeros(x.size(0), h, c)
     for i in range(x.size(0)):
-        mask = dst == i
-        a = torch.softmax(logit[mask], dim=0)  # (deg, H)
-        s = src[mask]
-        self_e = (s == i).view(-1, 1, 1).to(x.dtype)
-        val = torch.where(self_e.bool(), x_s[s], x_r[s])  # (deg, H, C)
-        if conv.has_omega:
-            omega = conv.omega.view(h, c)
-            contrib = val * (self_e - omega * (self_e - a.unsqueeze(-1)))
-        else:
-            contrib = val * a.unsqueeze(-1)
-        out[i] = contrib.sum(0)
+        m = dst == i
+        a = torch.softmax(logit[m], dim=0)  # (deg, H)
+        out[i] = (x_r[src[m]] * a.unsqueeze(-1)).sum(0)  # value = U h_u
     return out.reshape(x.size(0), h * c) if conv.concat else out.mean(1)
 
 
 @pytest.mark.parametrize(
-    "share_att,has_omega,concat",
-    [(False, True, True), (False, False, True), (True, True, True),
-     (False, True, False)],
+    "share_att,concat", [(False, True), (True, True), (False, False)]
 )
-def test_gate_parity_dense(random_graph_input, share_att, has_omega, concat):
+def test_gate_parity_dense(random_graph_input, share_att, concat):
     """GATEConv matches an independent dense recomputation (fidelity).
 
     Parameters
@@ -81,31 +64,34 @@ def test_gate_parity_dense(random_graph_input, share_att, has_omega, concat):
         Fixture providing random node features and edge indices.
     share_att : bool
         Whether self/neighbour edges share one attention vector.
-    has_omega : bool
-        Whether the learned self/neighbour gate is active.
     concat : bool
         Whether heads are concatenated.
     """
     x, _, _, edges_1, _ = random_graph_input
     conv = GATEConv(
         x.shape[1], 5, heads=2, share_att=share_att,
-        has_omega=has_omega, concat=concat, dropout=0.0,
+        concat=concat, dropout=0.0,
     )
+    # Random (non-zero) attention so the test exercises real coefficients.
+    with torch.no_grad():
+        conv.att.normal_()
+        if not share_att:
+            conv.att2.normal_()
     conv.eval()
-    ours = conv(x, edges_1)
-    ref = _dense_gate_reference(conv, x, edges_1)
-    torch.testing.assert_close(ours, ref, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(
+        conv(x, edges_1), _dense_gate_reference(conv, x, edges_1),
+        rtol=1e-5, atol=1e-5,
+    )
 
 
 def test_gate_reduces_to_pyg_gatv2(random_graph_input):
     """In its GATv2 special case, GATEConv matches PyG's official GATv2Conv.
 
-    This is an external fidelity check: with one shared attention vector,
-    no omega, and the self-value tied to ``lin_r``, GATE collapses to
-    standard GATv2. Copying PyG's weights and asserting bit-for-bit
-    agreement validates our attention routing (the i/j assignment,
-    softmax scope, self-loop handling, and aggregation) against a trusted
-    reference implementation.
+    With one shared attention vector, GATE collapses to standard GATv2
+    (the value is already the source transform for every edge). Copying
+    PyG's weights and asserting bit-for-bit agreement validates our
+    attention routing (i/j assignment, softmax scope, self-loop handling,
+    aggregation) against a trusted reference implementation.
 
     Parameters
     ----------
@@ -123,19 +109,17 @@ def test_gate_reduces_to_pyg_gatv2(random_graph_input):
     ).eval()
     ours = GATEConv(
         x.shape[1], c, heads=heads, concat=True,
-        share_att=True, has_omega=False, dropout=0.0,
+        share_att=True, dropout=0.0,
     ).eval()
 
-    # Copy by ROLE, not by name: PyG's lin_l is the source transform (and
+    # Copy by ROLE, not name: PyG's lin_l is the source transform (and
     # value), lin_r the target transform; ours uses the paper's opposite
     # naming (lin_r = source = value, lin_l = target).
     with torch.no_grad():
-        ours.lin_r.weight.copy_(ref.lin_l.weight)  # source / neighbour value
-        ours.lin_s.weight.copy_(ref.lin_l.weight)  # self value (= source W)
-        ours.lin_l.weight.copy_(ref.lin_r.weight)  # target
+        ours.lin_r.weight.copy_(ref.lin_l.weight)  # source / value (U)
+        ours.lin_l.weight.copy_(ref.lin_r.weight)  # target (V)
         ours.lin_l.bias.zero_()
         ours.lin_r.bias.zero_()
-        ours.lin_s.bias.zero_()
         ours.att.copy_(ref.att)  # att2 is att (share_att=True)
 
     torch.testing.assert_close(
@@ -143,14 +127,14 @@ def test_gate_reduces_to_pyg_gatv2(random_graph_input):
     )
 
 
-def test_gate_omega_zero_switches_off_neighbours(random_graph_input):
-    """omega=0 fully gates off neighbours (GATE's defining claim).
+def test_gate_uniform_attention_at_init(random_graph_input):
+    """At init (zero attention) GATE is uniform mean aggregation (Thm 4.3).
 
-    With ``omega = 0`` the gate zeroes every neighbour message and passes
-    the self-value through unchanged, so each node's output collapses
-    exactly to its own value transform ``lin_s(x)``. This is a direct,
-    closed-form check of the paper's "keep out intrusive neighbours"
-    mechanism, independent of the formula-level parity tests.
+    Zero-initialized attention vectors make every logit zero, so softmax
+    is uniform over the closed neighbourhood and the layer reduces to a
+    mean of the source transform ``U h_u`` -- the paper's "no initial
+    inductive bias" property. (Also covers isolated nodes: a node whose
+    only edge is its self-loop returns its own transform.)
 
     Parameters
     ----------
@@ -158,21 +142,26 @@ def test_gate_omega_zero_switches_off_neighbours(random_graph_input):
         Fixture providing random node features and edge indices.
     """
     x, _, _, edges_1, _ = random_graph_input
-    conv = GATEConv(x.shape[1], 6, heads=1, has_omega=True, dropout=0.0)
+    conv = GATEConv(x.shape[1], 6, heads=1, dropout=0.0)  # att zero at init
     conv.eval()
-    with torch.no_grad():
-        conv.omega.zero_()
-    torch.testing.assert_close(
-        conv(x, edges_1), conv.lin_s(x), rtol=1e-5, atol=1e-5
+    out = conv(x, edges_1)
+
+    x_r = conv.lin_r(x)
+    ei, _ = remove_self_loops(edges_1)
+    ei, _ = add_self_loops(ei, num_nodes=x.shape[0])
+    src, dst = ei[0], ei[1]
+    expected = torch.stack(
+        [x_r[src[dst == i]].mean(0) for i in range(x.shape[0])]
     )
+    torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
 
 
 def test_gate_share_att_ties_vectors():
-    """With share_att=True the two attention vectors are the same object."""
-    conv = GATEConv(8, 4, share_att=True)
-    assert conv.att2 is conv.att
-    conv2 = GATEConv(8, 4, share_att=False)
-    assert conv2.att2 is not conv2.att
+    """share_att=True ties the two attention vectors; False keeps them apart."""
+    tied = GATEConv(8, 4, share_att=True)
+    assert tied.att2 is tied.att
+    untied = GATEConv(8, 4, share_att=False)
+    assert untied.att2 is not untied.att
 
 
 def test_gate_wrapper_forward(random_graph_input):
@@ -208,6 +197,11 @@ def test_gate_permutation_equivariance(random_graph_input):
     """
     x, _, _, edges_1, _ = random_graph_input
     model = GATE(x.shape[1], x.shape[1], num_layers=2, heads=2, dropout=0.0)
+    # Non-zero attention so equivariance is tested on real attention.
+    for conv in model.convs:
+        with torch.no_grad():
+            conv.att.normal_()
+            conv.att2.normal_()
     model.eval()
     perm = torch.randperm(x.shape[0])
     inv = torch.empty_like(perm)
@@ -218,7 +212,7 @@ def test_gate_permutation_equivariance(random_graph_input):
 
 
 def test_gate_parameters_learnable(random_graph_input):
-    """A backward pass populates gradients, including omega.
+    """A backward pass populates gradients for weights and attention.
 
     Parameters
     ----------
@@ -226,8 +220,8 @@ def test_gate_parameters_learnable(random_graph_input):
         Fixture providing random node features and edge indices.
     """
     x, _, _, edges_1, _ = random_graph_input
-    model = GATE(x.shape[1], 8, num_layers=2, heads=2, has_omega=True)
+    model = GATE(x.shape[1], 8, num_layers=2, heads=2)
     model(x, edges_1).sum().backward()
-    assert model.convs[0].omega.grad is not None
     assert model.convs[0].att.grad is not None
+    assert model.convs[0].lin_l.weight.grad is not None
     model.reset_parameters()

--- a/test/nn/backbones/graph/test_gate.py
+++ b/test/nn/backbones/graph/test_gate.py
@@ -1,0 +1,163 @@
+"""Unit tests for the GATE backbone."""
+
+import pytest
+import torch
+import torch_geometric
+from torch_geometric.utils import add_self_loops, remove_self_loops
+
+from topobench.nn.backbones.graph.gate import GATE, GATEConv
+from topobench.nn.wrappers.graph import GNNWrapper
+
+
+def _dense_gate_reference(conv, x, edge_index):
+    """Recompute GATEConv's output with explicit dense per-node loops.
+
+    This is an independent implementation of the documented GATE update
+    (no ``MessagePassing``/``propagate``); agreement with the layer is the
+    parity check on attention, masking, softmax scope, and aggregation.
+
+    Parameters
+    ----------
+    conv : GATEConv
+        The layer under test (used for its weights and flags).
+    x : torch.Tensor
+        Node features.
+    edge_index : torch.Tensor
+        Graph connectivity (self-loops are added internally, matching
+        ``GATEConv.forward``).
+
+    Returns
+    -------
+    torch.Tensor
+        The reference output, same shape as ``conv(x, edge_index)``.
+    """
+    conv.eval()
+    h, c = conv.heads, conv.out_channels
+    x_l = conv.lin_l(x).view(-1, h, c)
+    x_r = conv.lin_r(x).view(-1, h, c)
+    x_s = conv.lin_s(x).view(-1, h, c)
+
+    ei, _ = remove_self_loops(edge_index)
+    ei, _ = add_self_loops(ei, num_nodes=x.size(0))
+    src, dst = ei[0], ei[1]
+
+    e = torch.nn.functional.leaky_relu(
+        x_l[dst] + x_r[src], conv.negative_slope
+    )  # (E, H, C)
+    att = conv.att.squeeze(0)
+    att2 = conv.att2.squeeze(0)
+    is_self = (src == dst).view(-1, 1)
+    logit = torch.where(
+        is_self, (e * att2).sum(-1), (e * att).sum(-1)
+    )  # (E, H)
+
+    out = torch.zeros(x.size(0), h, c)
+    for i in range(x.size(0)):
+        mask = dst == i
+        a = torch.softmax(logit[mask], dim=0)  # (deg, H)
+        s = src[mask]
+        self_e = (s == i).view(-1, 1, 1).to(x.dtype)
+        val = torch.where(self_e.bool(), x_s[s], x_r[s])  # (deg, H, C)
+        if conv.has_omega:
+            omega = conv.omega.view(h, c)
+            contrib = val * (self_e - omega * (self_e - a.unsqueeze(-1)))
+        else:
+            contrib = val * a.unsqueeze(-1)
+        out[i] = contrib.sum(0)
+    return out.reshape(x.size(0), h * c) if conv.concat else out.mean(1)
+
+
+@pytest.mark.parametrize(
+    "share_att,has_omega,concat",
+    [(False, True, True), (False, False, True), (True, True, True),
+     (False, True, False)],
+)
+def test_gate_parity_dense(random_graph_input, share_att, has_omega, concat):
+    """GATEConv matches an independent dense recomputation (fidelity).
+
+    Parameters
+    ----------
+    random_graph_input : tuple
+        Fixture providing random node features and edge indices.
+    share_att : bool
+        Whether self/neighbour edges share one attention vector.
+    has_omega : bool
+        Whether the learned self/neighbour gate is active.
+    concat : bool
+        Whether heads are concatenated.
+    """
+    x, _, _, edges_1, _ = random_graph_input
+    conv = GATEConv(
+        x.shape[1], 5, heads=2, share_att=share_att,
+        has_omega=has_omega, concat=concat, dropout=0.0,
+    )
+    conv.eval()
+    ours = conv(x, edges_1)
+    ref = _dense_gate_reference(conv, x, edges_1)
+    torch.testing.assert_close(ours, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_gate_share_att_ties_vectors():
+    """With share_att=True the two attention vectors are the same object."""
+    conv = GATEConv(8, 4, share_att=True)
+    assert conv.att2 is conv.att
+    conv2 = GATEConv(8, 4, share_att=False)
+    assert conv2.att2 is not conv2.att
+
+
+def test_gate_wrapper_forward(random_graph_input):
+    """GATE returns node embeddings of the hidden dimension via the wrapper.
+
+    Parameters
+    ----------
+    random_graph_input : tuple
+        Fixture providing random node features and edge indices.
+    """
+    x, _, _, edges_1, _ = random_graph_input
+    hidden = x.shape[1]
+    model = GATE(x.shape[1], hidden, num_layers=2, heads=2)
+    wrapper = GNNWrapper(model, out_channels=hidden, num_cell_dimensions=1)
+    _ = wrapper.__repr__()
+    _ = model.convs[0].__repr__()
+    batch = torch_geometric.data.Data(
+        x_0=x, x=x, y=torch.randint(0, 2, (x.shape[0],)),
+        edge_index=edges_1,
+        batch_0=torch.zeros(x.shape[0], dtype=torch.long),
+    )
+    out = wrapper(batch)
+    assert out["x_0"].shape == (x.shape[0], hidden)
+
+
+def test_gate_permutation_equivariance(random_graph_input):
+    """Relabeling nodes permutes the GATE outputs identically.
+
+    Parameters
+    ----------
+    random_graph_input : tuple
+        Fixture providing random node features and edge indices.
+    """
+    x, _, _, edges_1, _ = random_graph_input
+    model = GATE(x.shape[1], x.shape[1], num_layers=2, heads=2, dropout=0.0)
+    model.eval()
+    perm = torch.randperm(x.shape[0])
+    inv = torch.empty_like(perm)
+    inv[perm] = torch.arange(x.shape[0])
+    out = model(x, edges_1)
+    out_perm = model(x[perm], inv[edges_1])
+    torch.testing.assert_close(out_perm, out[perm], rtol=1e-4, atol=1e-4)
+
+
+def test_gate_parameters_learnable(random_graph_input):
+    """A backward pass populates gradients, including omega.
+
+    Parameters
+    ----------
+    random_graph_input : tuple
+        Fixture providing random node features and edge indices.
+    """
+    x, _, _, edges_1, _ = random_graph_input
+    model = GATE(x.shape[1], 8, num_layers=2, heads=2, has_omega=True)
+    model(x, edges_1).sum().backward()
+    assert model.convs[0].omega.grad is not None
+    assert model.convs[0].att.grad is not None
+    model.reset_parameters()

--- a/test/nn/backbones/graph/test_gate.py
+++ b/test/nn/backbones/graph/test_gate.py
@@ -164,6 +164,17 @@ def test_gate_share_att_ties_vectors():
     assert untied.att2 is not untied.att
 
 
+def test_gate_rejects_indivisible_hidden():
+    """hidden_channels not divisible by heads raises at construction.
+
+    Guards the invariant that concatenated head outputs must equal
+    ``hidden_channels``; otherwise the width silently drifts and breaks
+    the wrapper's residual downstream.
+    """
+    with pytest.raises(ValueError, match="divisible"):
+        GATE(8, 10, num_layers=1, heads=4)
+
+
 def test_gate_wrapper_forward(random_graph_input):
     """GATE returns node embeddings of the hidden dimension via the wrapper.
 

--- a/test/nn/backbones/graph/test_gate.py
+++ b/test/nn/backbones/graph/test_gate.py
@@ -97,6 +97,76 @@ def test_gate_parity_dense(random_graph_input, share_att, has_omega, concat):
     torch.testing.assert_close(ours, ref, rtol=1e-5, atol=1e-5)
 
 
+def test_gate_reduces_to_pyg_gatv2(random_graph_input):
+    """In its GATv2 special case, GATEConv matches PyG's official GATv2Conv.
+
+    This is an external fidelity check: with one shared attention vector,
+    no omega, and the self-value tied to ``lin_r``, GATE collapses to
+    standard GATv2. Copying PyG's weights and asserting bit-for-bit
+    agreement validates our attention routing (the i/j assignment,
+    softmax scope, self-loop handling, and aggregation) against a trusted
+    reference implementation.
+
+    Parameters
+    ----------
+    random_graph_input : tuple
+        Fixture providing random node features and edge indices.
+    """
+    from torch_geometric.nn import GATv2Conv
+
+    x, _, _, edges_1, _ = random_graph_input
+    ei, _ = remove_self_loops(edges_1)  # both add their own self-loops
+    heads, c = 2, 5
+    ref = GATv2Conv(
+        x.shape[1], c, heads=heads, concat=True,
+        add_self_loops=True, bias=False, share_weights=False,
+    ).eval()
+    ours = GATEConv(
+        x.shape[1], c, heads=heads, concat=True,
+        share_att=True, has_omega=False, dropout=0.0,
+    ).eval()
+
+    # Copy by ROLE, not by name: PyG's lin_l is the source transform (and
+    # value), lin_r the target transform; ours uses the paper's opposite
+    # naming (lin_r = source = value, lin_l = target).
+    with torch.no_grad():
+        ours.lin_r.weight.copy_(ref.lin_l.weight)  # source / neighbour value
+        ours.lin_s.weight.copy_(ref.lin_l.weight)  # self value (= source W)
+        ours.lin_l.weight.copy_(ref.lin_r.weight)  # target
+        ours.lin_l.bias.zero_()
+        ours.lin_r.bias.zero_()
+        ours.lin_s.bias.zero_()
+        ours.att.copy_(ref.att)  # att2 is att (share_att=True)
+
+    torch.testing.assert_close(
+        ours(x, ei), ref(x, ei), rtol=1e-5, atol=1e-5
+    )
+
+
+def test_gate_omega_zero_switches_off_neighbours(random_graph_input):
+    """omega=0 fully gates off neighbours (GATE's defining claim).
+
+    With ``omega = 0`` the gate zeroes every neighbour message and passes
+    the self-value through unchanged, so each node's output collapses
+    exactly to its own value transform ``lin_s(x)``. This is a direct,
+    closed-form check of the paper's "keep out intrusive neighbours"
+    mechanism, independent of the formula-level parity tests.
+
+    Parameters
+    ----------
+    random_graph_input : tuple
+        Fixture providing random node features and edge indices.
+    """
+    x, _, _, edges_1, _ = random_graph_input
+    conv = GATEConv(x.shape[1], 6, heads=1, has_omega=True, dropout=0.0)
+    conv.eval()
+    with torch.no_grad():
+        conv.omega.zero_()
+    torch.testing.assert_close(
+        conv(x, edges_1), conv.lin_s(x), rtol=1e-5, atol=1e-5
+    )
+
+
 def test_gate_share_att_ties_vectors():
     """With share_att=True the two attention vectors are the same object."""
     conv = GATEConv(8, 4, share_att=True)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "graph/gate"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/gate.py
+++ b/topobench/nn/backbones/graph/gate.py
@@ -1,20 +1,32 @@
 """GATE backbone: graph attention that separates self from neighbours.
 
-GATE extends GATv2 by giving a node's self-loop its own attention vector
-and value transform, plus an optional learned gate ``omega`` that controls
-how much a node retains its own signal versus aggregating (potentially
-heterophilic, "intrusive") neighbours. This self/neighbour separation is
-what makes the model robust on heterophilic graphs.
+GATE extends GATv2 with a single change (paper Eq. 4): the attention
+logit uses a *separate* learnable vector for self-loops (``a_t``) versus
+genuine neighbours (``a_s``). This lets a node parameterize its own
+self-attention independently of its neighbours, so it can suppress
+aggregation from unrelated ("intrusive") neighbours -- which is what
+makes the model robust on heterophilic graphs. Apart from the extra
+attention vector, GATE adds no parameters over GATv2: the value and the
+source/target transforms are the same as GATv2.
 
 Notes
 -----
-The exact message routing (value transform, i/j assignment) is validated
-by a numerical parity test against the official ``GATv2Conv`` reference;
-see ``test/nn/backbones/graph/test_gate.py``.
+Faithful to the paper's GATE (Eq. 1, 2, 4), not to the optional knobs in
+the reference repo: the repo's ``omega`` gate and separate self-loop value
+transform are *not* part of the published model (the paper adds only the
+``d``-dimensional ``a_t`` vector and never uses ``omega``), so they are
+intentionally omitted here. Initialization follows the paper: attention
+vectors zero (no initial inductive bias, Thm. 4.3) and weight matrices
+random-orthogonal. (The paper's full "looks-linear" channel-mirroring
+construction is not applied; orthogonal init captures the random-orthogonal
+specification, and the zero attention init provides the Thm. 4.3
+aggregation property.) The base mechanism is validated against PyG's
+``GATv2Conv`` in ``test/nn/backbones/graph/test_gate.py``.
 
 References
 ----------
-.. [1] "GATE: How to Keep Out Intrusive Neighbors." ICML 2024.
+.. [1] Nimrah Mustafa, Rebekka Burkholz. "GATE: How to Keep Out
+   Intrusive Neighbors." ICML 2024. https://arxiv.org/abs/2406.00418
    Official code: https://github.com/RelationalML/GATE
 """
 
@@ -26,14 +38,21 @@ from torch_geometric.utils import add_self_loops, remove_self_loops, softmax
 
 
 class GATEConv(MessagePassing):
-    r"""Single GATE attention layer.
+    r"""Single GATE attention layer (Mustafa & Burkholz, 2024).
 
-    The attention logit for an edge :math:`(i, j)` follows GATv2,
-    :math:`\alpha_{ij} \propto a^\top \mathrm{LeakyReLU}(W_l x_i + W_r x_j)`,
-    but self-loops are parameterized separately: they use a distinct
-    attention vector ``att2`` and a distinct value transform ``lin_s``,
-    and an optional gate :math:`\omega` rescales the per-edge contribution
-    as :math:`x_j (\mathbb{1}_{ii} - \omega(\mathbb{1}_{ii} - \alpha))`.
+    Implements the GATE update. For an edge :math:`(u \to v)` the logit is
+    (Eq. 4)
+
+    .. math::
+        e_{uv} = (\mathbb{1}_{u \neq v}\, a_s
+                  + \mathbb{1}_{u = v}\, a_t)^\top
+                 \,\phi(U h_u + V h_v),
+
+    i.e. a GATv2-style additive score whose attention vector switches
+    between ``a_s`` (neighbours) and ``a_t`` (self-loops). Coefficients are
+    normalized by softmax over the neighbourhood (Eq. 2) and aggregated as
+    :math:`h_v = \sum_u \alpha_{uv} U h_u` (Eq. 1) -- the value transform is
+    the same source matrix :math:`U` for every edge, self-loops included.
 
     Parameters
     ----------
@@ -46,18 +65,13 @@ class GATEConv(MessagePassing):
     concat : bool, optional
         Concatenate heads if True, else average them (default: True).
     negative_slope : float, optional
-        LeakyReLU negative slope (default: 0.2).
+        LeakyReLU negative slope for :math:`\phi` (default: 0.2).
     dropout : float, optional
         Dropout rate on attention coefficients (default: 0.0).
     share_att : bool, optional
-        If True, self and neighbour edges share one attention vector
-        (recovers GATv2); if False, self-loops get a separate ``att2``
-        (the GATE variant) (default: False).
-    has_omega : bool, optional
-        If True, apply the learned self/neighbour gate ``omega``
-        (default: True).
-    omega_init : float, optional
-        Initial value for ``omega`` (default: 1.0).
+        If True, tie ``a_s`` and ``a_t`` into one vector (the paper's
+        weight-sharing "GATES" variant / standard GATv2); if False, use the
+        separate self/neighbour vectors of GATE (default: False).
     **kwargs
         Additional arguments forwarded to
         :class:`torch_geometric.nn.MessagePassing`.
@@ -72,8 +86,6 @@ class GATEConv(MessagePassing):
         negative_slope=0.2,
         dropout=0.0,
         share_att=False,
-        has_omega=True,
-        omega_init=1.0,
         **kwargs,
     ):
         super().__init__(node_dim=0, aggr="add", **kwargs)
@@ -84,31 +96,31 @@ class GATEConv(MessagePassing):
         self.negative_slope = negative_slope
         self.dropout = dropout
         self.share_att = share_att
-        self.has_omega = has_omega
-        self.omega_init = omega_init
 
         h, c = heads, out_channels
-        self.lin_l = Linear(in_channels, h * c)  # query / target transform
-        self.lin_r = Linear(in_channels, h * c)  # key / source transform
-        self.lin_s = Linear(in_channels, h * c)  # self-loop value transform
-        self.att = Parameter(torch.empty(1, h, c))  # neighbour attention
+        self.lin_l = Linear(in_channels, h * c)  # V: target transform
+        self.lin_r = Linear(in_channels, h * c)  # U: source transform & value
+        self.att = Parameter(torch.empty(1, h, c))  # a_s (neighbours)
         self.att2 = (
             self.att if share_att else Parameter(torch.empty(1, h, c))
-        )  # self-loop attention
-        if has_omega:
-            self.omega = Parameter(torch.empty(h * c))
+        )  # a_t (self-loops)
         self.reset_parameters()
 
     def reset_parameters(self):
-        """Reset all learnable parameters."""
-        self.lin_l.reset_parameters()
-        self.lin_r.reset_parameters()
-        self.lin_s.reset_parameters()
-        torch.nn.init.xavier_uniform_(self.att)
+        """Reset parameters following the paper's initialization scheme.
+
+        Weight matrices use random orthogonal initialization; attention
+        vectors and biases start at zero (zero ``a`` gives no initial
+        inductive bias, Thm. 4.3).
+        """
+        torch.nn.init.orthogonal_(self.lin_l.weight)
+        torch.nn.init.orthogonal_(self.lin_r.weight)
+        if self.lin_l.bias is not None:
+            torch.nn.init.zeros_(self.lin_l.bias)
+            torch.nn.init.zeros_(self.lin_r.bias)
+        torch.nn.init.zeros_(self.att)
         if not self.share_att:
-            torch.nn.init.xavier_uniform_(self.att2)
-        if self.has_omega:
-            torch.nn.init.constant_(self.omega, self.omega_init)
+            torch.nn.init.zeros_(self.att2)
 
     def forward(self, x, edge_index):
         """Compute one round of GATE attention.
@@ -130,29 +142,24 @@ class GATEConv(MessagePassing):
         h, c = self.heads, self.out_channels
         x_l = self.lin_l(x).view(-1, h, c)
         x_r = self.lin_r(x).view(-1, h, c)
-        x_s = self.lin_s(x).view(-1, h, c)
 
         edge_index, _ = remove_self_loops(edge_index)
         edge_index, _ = add_self_loops(edge_index, num_nodes=x.size(0))
 
-        out = self.propagate(
-            edge_index, x_l=x_l, x_r=x_r, x_s=x_s, ei=edge_index
-        )
+        out = self.propagate(edge_index, x_l=x_l, x_r=x_r, ei=edge_index)
         return out.reshape(-1, h * c) if self.concat else out.mean(dim=1)
 
-    def message(self, x_l_i, x_r_j, x_s_j, ei, index, ptr, size_i):
-        """Build attention-weighted messages with the self/neighbour split.
+    def message(self, x_l_i, x_r_j, ei, index, ptr, size_i):
+        """Build attention-weighted messages (Eq. 4 logit, Eq. 1 value).
 
         Parameters
         ----------
         x_l_i : torch.Tensor
-            Target-node query features per edge.
+            Target-node transform :math:`V h_v` per edge.
         x_r_j : torch.Tensor
-            Source-node key/value features per edge.
-        x_s_j : torch.Tensor
-            Source-node self-value features per edge (used on self-loops).
+            Source-node transform :math:`U h_u` per edge (also the value).
         ei : torch.Tensor
-            Edge index (to identify self-loops).
+            Edge index, used to flag self-loops (:math:`u = v`).
         index : torch.Tensor
             Target index per edge, for softmax normalization.
         ptr : torch.Tensor
@@ -165,27 +172,17 @@ class GATEConv(MessagePassing):
         torch.Tensor
             Messages of shape ``(num_edges, heads, out_channels)``.
         """
-        x = F.leaky_relu(x_l_i + x_r_j, self.negative_slope)
-        self_mask = (ei[0] == ei[1]).to(x.dtype).unsqueeze(-1)
+        # phi(U h_u + V h_v), then the self/neighbour attention split.
+        pre = F.leaky_relu(x_l_i + x_r_j, self.negative_slope)
+        self_mask = (ei[0] == ei[1]).to(pre.dtype).unsqueeze(-1)
         nbr_mask = 1.0 - self_mask
-
-        alpha = (x * self.att).sum(-1) * nbr_mask + (x * self.att2).sum(
-            -1
-        ) * self_mask
+        alpha = (pre * self.att).sum(-1) * nbr_mask + (
+            pre * self.att2
+        ).sum(-1) * self_mask
         alpha = softmax(alpha, index, ptr, size_i)
         alpha = F.dropout(alpha, p=self.dropout, training=self.training)
-
-        # Neighbours contribute their source value; self-loops contribute
-        # the dedicated self transform.
-        value = x_r_j * nbr_mask.unsqueeze(-1) + x_s_j * self_mask.unsqueeze(
-            -1
-        )
-        if self.has_omega:
-            omega = self.omega.view(self.heads, self.out_channels)
-            sm = self_mask.unsqueeze(-1)
-            a = alpha.unsqueeze(-1)
-            return value * (sm - omega * (sm - a))
-        return value * alpha.unsqueeze(-1)
+        # Value is U h_u for every edge (self-loops use U h_v with u = v).
+        return x_r_j * alpha.unsqueeze(-1)
 
     def __repr__(self):
         """Return a string representation of the layer."""
@@ -198,16 +195,18 @@ class GATEConv(MessagePassing):
 class GATE(torch.nn.Module):
     r"""Stacked GATE backbone.
 
-    Stacks :class:`GATEConv` layers with ELU activations and dropout,
-    returning node embeddings of dimension ``hidden_channels``; the
-    TopoBench readout produces the task logits.
+    Stacks :class:`GATEConv` layers with a homogeneous activation
+    (LeakyReLU, consistent with the paper's :math:`\phi`) and dropout
+    between layers, returning node embeddings of dimension
+    ``hidden_channels``; the TopoBench readout produces the task logits.
 
     Parameters
     ----------
     in_channels : int
         Number of input features.
     hidden_channels : int
-        Hidden width; also the returned embedding dimension.
+        Hidden width; also the returned embedding dimension. Must be
+        divisible by ``heads``.
     num_layers : int, optional
         Number of GATE layers (default: 2).
     heads : int, optional
@@ -215,10 +214,8 @@ class GATE(torch.nn.Module):
     dropout : float, optional
         Dropout rate between layers (default: 0.0).
     share_att : bool, optional
-        Whether self/neighbour edges share an attention vector
+        Whether self/neighbour edges share one attention vector
         (default: False).
-    has_omega : bool, optional
-        Whether to use the learned self/neighbour gate (default: True).
     **kwargs
         Additional arguments (ignored), kept for config compatibility.
     """
@@ -231,11 +228,11 @@ class GATE(torch.nn.Module):
         heads=1,
         dropout=0.0,
         share_att=False,
-        has_omega=True,
         **kwargs,
     ):
         super().__init__()
         self.dropout = dropout
+        self.negative_slope = 0.2
         self.out_channels = hidden_channels
         self.convs = torch.nn.ModuleList()
         for layer in range(num_layers):
@@ -248,7 +245,6 @@ class GATE(torch.nn.Module):
                     concat=True,
                     dropout=dropout,
                     share_att=share_att,
-                    has_omega=has_omega,
                 )
             )
 
@@ -279,6 +275,6 @@ class GATE(torch.nn.Module):
         for i, conv in enumerate(self.convs):
             x = conv(x, edge_index)
             if i < len(self.convs) - 1:
-                x = F.elu(x)
+                x = F.leaky_relu(x, self.negative_slope)
                 x = F.dropout(x, p=self.dropout, training=self.training)
         return x

--- a/topobench/nn/backbones/graph/gate.py
+++ b/topobench/nn/backbones/graph/gate.py
@@ -176,9 +176,9 @@ class GATEConv(MessagePassing):
         pre = F.leaky_relu(x_l_i + x_r_j, self.negative_slope)
         self_mask = (ei[0] == ei[1]).to(pre.dtype).unsqueeze(-1)
         nbr_mask = 1.0 - self_mask
-        alpha = (pre * self.att).sum(-1) * nbr_mask + (
-            pre * self.att2
-        ).sum(-1) * self_mask
+        alpha = (pre * self.att).sum(-1) * nbr_mask + (pre * self.att2).sum(
+            -1
+        ) * self_mask
         alpha = softmax(alpha, index, ptr, size_i)
         alpha = F.dropout(alpha, p=self.dropout, training=self.training)
         # Value is U h_u for every edge (self-loops use U h_v with u = v).

--- a/topobench/nn/backbones/graph/gate.py
+++ b/topobench/nn/backbones/graph/gate.py
@@ -1,0 +1,284 @@
+"""GATE backbone: graph attention that separates self from neighbours.
+
+GATE extends GATv2 by giving a node's self-loop its own attention vector
+and value transform, plus an optional learned gate ``omega`` that controls
+how much a node retains its own signal versus aggregating (potentially
+heterophilic, "intrusive") neighbours. This self/neighbour separation is
+what makes the model robust on heterophilic graphs.
+
+Notes
+-----
+The exact message routing (value transform, i/j assignment) is validated
+by a numerical parity test against the official ``GATv2Conv`` reference;
+see ``test/nn/backbones/graph/test_gate.py``.
+
+References
+----------
+.. [1] "GATE: How to Keep Out Intrusive Neighbors." ICML 2024.
+   Official code: https://github.com/RelationalML/GATE
+"""
+
+import torch
+import torch.nn.functional as F
+from torch.nn import Linear, Parameter
+from torch_geometric.nn import MessagePassing
+from torch_geometric.utils import add_self_loops, remove_self_loops, softmax
+
+
+class GATEConv(MessagePassing):
+    r"""Single GATE attention layer.
+
+    The attention logit for an edge :math:`(i, j)` follows GATv2,
+    :math:`\alpha_{ij} \propto a^\top \mathrm{LeakyReLU}(W_l x_i + W_r x_j)`,
+    but self-loops are parameterized separately: they use a distinct
+    attention vector ``att2`` and a distinct value transform ``lin_s``,
+    and an optional gate :math:`\omega` rescales the per-edge contribution
+    as :math:`x_j (\mathbb{1}_{ii} - \omega(\mathbb{1}_{ii} - \alpha))`.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features.
+    out_channels : int
+        Number of output features per head.
+    heads : int, optional
+        Number of attention heads (default: 1).
+    concat : bool, optional
+        Concatenate heads if True, else average them (default: True).
+    negative_slope : float, optional
+        LeakyReLU negative slope (default: 0.2).
+    dropout : float, optional
+        Dropout rate on attention coefficients (default: 0.0).
+    share_att : bool, optional
+        If True, self and neighbour edges share one attention vector
+        (recovers GATv2); if False, self-loops get a separate ``att2``
+        (the GATE variant) (default: False).
+    has_omega : bool, optional
+        If True, apply the learned self/neighbour gate ``omega``
+        (default: True).
+    omega_init : float, optional
+        Initial value for ``omega`` (default: 1.0).
+    **kwargs
+        Additional arguments forwarded to
+        :class:`torch_geometric.nn.MessagePassing`.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        heads=1,
+        concat=True,
+        negative_slope=0.2,
+        dropout=0.0,
+        share_att=False,
+        has_omega=True,
+        omega_init=1.0,
+        **kwargs,
+    ):
+        super().__init__(node_dim=0, aggr="add", **kwargs)
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.heads = heads
+        self.concat = concat
+        self.negative_slope = negative_slope
+        self.dropout = dropout
+        self.share_att = share_att
+        self.has_omega = has_omega
+        self.omega_init = omega_init
+
+        h, c = heads, out_channels
+        self.lin_l = Linear(in_channels, h * c)  # query / target transform
+        self.lin_r = Linear(in_channels, h * c)  # key / source transform
+        self.lin_s = Linear(in_channels, h * c)  # self-loop value transform
+        self.att = Parameter(torch.empty(1, h, c))  # neighbour attention
+        self.att2 = (
+            self.att if share_att else Parameter(torch.empty(1, h, c))
+        )  # self-loop attention
+        if has_omega:
+            self.omega = Parameter(torch.empty(h * c))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Reset all learnable parameters."""
+        self.lin_l.reset_parameters()
+        self.lin_r.reset_parameters()
+        self.lin_s.reset_parameters()
+        torch.nn.init.xavier_uniform_(self.att)
+        if not self.share_att:
+            torch.nn.init.xavier_uniform_(self.att2)
+        if self.has_omega:
+            torch.nn.init.constant_(self.omega, self.omega_init)
+
+    def forward(self, x, edge_index):
+        """Compute one round of GATE attention.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``(num_nodes, in_channels)``.
+        edge_index : torch.Tensor
+            Graph connectivity of shape ``(2, num_edges)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of shape
+            ``(num_nodes, heads * out_channels)`` if ``concat`` else
+            ``(num_nodes, out_channels)``.
+        """
+        h, c = self.heads, self.out_channels
+        x_l = self.lin_l(x).view(-1, h, c)
+        x_r = self.lin_r(x).view(-1, h, c)
+        x_s = self.lin_s(x).view(-1, h, c)
+
+        edge_index, _ = remove_self_loops(edge_index)
+        edge_index, _ = add_self_loops(edge_index, num_nodes=x.size(0))
+
+        out = self.propagate(
+            edge_index, x_l=x_l, x_r=x_r, x_s=x_s, ei=edge_index
+        )
+        return out.reshape(-1, h * c) if self.concat else out.mean(dim=1)
+
+    def message(self, x_l_i, x_r_j, x_s_j, ei, index, ptr, size_i):
+        """Build attention-weighted messages with the self/neighbour split.
+
+        Parameters
+        ----------
+        x_l_i : torch.Tensor
+            Target-node query features per edge.
+        x_r_j : torch.Tensor
+            Source-node key/value features per edge.
+        x_s_j : torch.Tensor
+            Source-node self-value features per edge (used on self-loops).
+        ei : torch.Tensor
+            Edge index (to identify self-loops).
+        index : torch.Tensor
+            Target index per edge, for softmax normalization.
+        ptr : torch.Tensor
+            Optional CSR pointer for softmax.
+        size_i : int
+            Number of target nodes.
+
+        Returns
+        -------
+        torch.Tensor
+            Messages of shape ``(num_edges, heads, out_channels)``.
+        """
+        x = F.leaky_relu(x_l_i + x_r_j, self.negative_slope)
+        self_mask = (ei[0] == ei[1]).to(x.dtype).unsqueeze(-1)
+        nbr_mask = 1.0 - self_mask
+
+        alpha = (x * self.att).sum(-1) * nbr_mask + (x * self.att2).sum(
+            -1
+        ) * self_mask
+        alpha = softmax(alpha, index, ptr, size_i)
+        alpha = F.dropout(alpha, p=self.dropout, training=self.training)
+
+        # Neighbours contribute their source value; self-loops contribute
+        # the dedicated self transform.
+        value = x_r_j * nbr_mask.unsqueeze(-1) + x_s_j * self_mask.unsqueeze(
+            -1
+        )
+        if self.has_omega:
+            omega = self.omega.view(self.heads, self.out_channels)
+            sm = self_mask.unsqueeze(-1)
+            a = alpha.unsqueeze(-1)
+            return value * (sm - omega * (sm - a))
+        return value * alpha.unsqueeze(-1)
+
+    def __repr__(self):
+        """Return a string representation of the layer."""
+        return (
+            f"{self.__class__.__name__}({self.in_channels}, "
+            f"{self.out_channels}, heads={self.heads})"
+        )
+
+
+class GATE(torch.nn.Module):
+    r"""Stacked GATE backbone.
+
+    Stacks :class:`GATEConv` layers with ELU activations and dropout,
+    returning node embeddings of dimension ``hidden_channels``; the
+    TopoBench readout produces the task logits.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features.
+    hidden_channels : int
+        Hidden width; also the returned embedding dimension.
+    num_layers : int, optional
+        Number of GATE layers (default: 2).
+    heads : int, optional
+        Number of attention heads (default: 1).
+    dropout : float, optional
+        Dropout rate between layers (default: 0.0).
+    share_att : bool, optional
+        Whether self/neighbour edges share an attention vector
+        (default: False).
+    has_omega : bool, optional
+        Whether to use the learned self/neighbour gate (default: True).
+    **kwargs
+        Additional arguments (ignored), kept for config compatibility.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels,
+        num_layers=2,
+        heads=1,
+        dropout=0.0,
+        share_att=False,
+        has_omega=True,
+        **kwargs,
+    ):
+        super().__init__()
+        self.dropout = dropout
+        self.out_channels = hidden_channels
+        self.convs = torch.nn.ModuleList()
+        for layer in range(num_layers):
+            in_dim = in_channels if layer == 0 else hidden_channels
+            self.convs.append(
+                GATEConv(
+                    in_dim,
+                    hidden_channels // heads,
+                    heads=heads,
+                    concat=True,
+                    dropout=dropout,
+                    share_att=share_att,
+                    has_omega=has_omega,
+                )
+            )
+
+    def reset_parameters(self):
+        """Reset all learnable parameters."""
+        for conv in self.convs:
+            conv.reset_parameters()
+
+    def forward(self, x, edge_index, edge_weight=None, **kwargs):
+        """Compute node embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``(num_nodes, in_channels)``.
+        edge_index : torch.Tensor
+            Graph connectivity of shape ``(2, num_edges)``.
+        edge_weight : torch.Tensor, optional
+            Unused; accepted for wrapper compatibility (default: None).
+        **kwargs
+            Additional arguments (e.g. ``batch``) ignored by this backbone.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``(num_nodes, hidden_channels)``.
+        """
+        for i, conv in enumerate(self.convs):
+            x = conv(x, edge_index)
+            if i < len(self.convs) - 1:
+                x = F.elu(x)
+                x = F.dropout(x, p=self.dropout, training=self.training)
+        return x

--- a/topobench/nn/backbones/graph/gate.py
+++ b/topobench/nn/backbones/graph/gate.py
@@ -231,6 +231,13 @@ class GATE(torch.nn.Module):
         **kwargs,
     ):
         super().__init__()
+        if hidden_channels % heads != 0:
+            raise ValueError(
+                f"hidden_channels ({hidden_channels}) must be divisible "
+                f"by heads ({heads}); otherwise the concatenated output "
+                f"width drifts from hidden_channels and breaks the "
+                f"wrapper's residual."
+            )
         self.dropout = dropout
         self.negative_slope = 0.2
         self.out_channels = hidden_channels


### PR DESCRIPTION
## Checklist
- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

Adds **GATE** (Graph Attention with self/neighbour-separated attention) as a Track 1 graph backbone.

- Nimrah Mustafa, Rebekka Burkholz. *GATE: How to Keep Out Intrusive Neighbors.* ICML 2024 - [arXiv:2406.00418](https://arxiv.org/abs/2406.00418)
- code: [RelationalML/GATE](https://github.com/RelationalML/GATE).

GATE is GATv2 with one targeted change (Eq. 4): the attention logit uses a *separate* learnable vector for a node's self-loop (`a_t`) versus its neighbours (`a_s`), so a node can parameterize its own self-attention independently and suppress aggregation from unrelated ("intrusive") neighbours. That's what makes it robust on heterophilic graphs - the axis GraphUniverse sweeps.     

**Files**
- `topobench/nn/backbones/graph/gate.py` : `GATEConv` (the attention layer) and `GATE` (stacked backbone). Docstrings cite the paper's Eq. 1/2/4.
- `configs/model/graph/gate.yaml` : Hydra config on `GNNWrapper` + `NoReadOut`; one config serves both challenge tasks.
- `test/nn/backbones/graph/test_gate.py` : 10 tests, 100% backbone coverage.
- `test/pipeline/test_pipeline.py` : registers `graph/gate` for the CI MUTAG integration test.
- `2026_tdl_challenge/outputs/.../results.json` : GraphUniverse grid output 

**Fidelity**
The reference repo doesn't run under modern PyG (it ships a modified, older-PyG `MessagePassing` base), so I implemented a clean standalone version directly from the paper's equations, and validated it three ways:
1. an independent dense reimplementation of the GATE update (parity across configurations);
2. **reduction to PyG's official `GATv2Conv`** : in the shared-attention special case our layer matches PyG bit-for-bit (external reference for the routing/softmax/aggregation);
3. a property test of Thm. 4.3 - with zero-initialized attention the layer is exactly uniform mean-aggregation at init.

I follow the paper's GATE (Eq. 1/2/4), **not** the reference repo's optional `omega` gate or separate self-loop value transform,  neither is part of the published model (the paper adds only the `d`-dimensional `a_t`). Init follows the paper: zero attention (Thm. 4.3) + random-orthogonal weights.

**Initialization**
 I apply the paper's prescription where it bears on the GATE mechanism: zero attention vectors (Thm. 4.3 - no initial inductive bias, so the layer starts as uniform mean-aggregation) and random-orthogonal weight matrices. I deliberately do not reproduce the paper's full looks-linear (channel-mirroring) weight construction: zero-attention already delivers the at-init uniform-aggregation property that looks-linear is there to support, and orthogonal init captures the random-orthogonal specification it builds on. The mirroring would add implementation surface without changing the attention mechanism this PR contributes. This is documented in the module docstring.

**TopoBench integration**
- Backbone returns node embeddings; the readout owns the classification head.
- `forward(x, edge_index, edge_weight=None, **kwargs)` accepts the `GNNWrapper` arguments; hidden width matches the encoder so the wrapper's residual is consistent.
- The config uses the fully-qualified `_target_` (`topobench.nn.backbones.graph.gate.GATE`): the backbone auto-discovery loads files under a synthetic module name, which otherwise breaks PyG `MessagePassing`'s inspector.

**Cost.** Attention is `O(E·H·d)`; the benchmarked config (hidden 64, 4 heads, 2 layers) has **16,896** trainable parameters.

**Results (72 runs, seeds 42/43/44).** In-distribution community-detection accuracy 0.31–0.69 (mean 0.45; chance ≈ 0.05 over 20 communities); triangle-count MSE/triangles 0.015–3.80, all finite. Per-setting/per-seed/OOD values are in `results.json`. Run on CPU (no CUDA device) under `WANDB_MODE=offline`, so the optional W&B fields are empty; metrics are seeded and
device-independent.

**On `results.json` generation.** The shipped evaluation notebook can't run as-is (its integrity-check cell's stored hash doesn't match its own cells, so it aborts). Without modifying the notebook or `utils.py`, I called the functions it wraps i.e., `run_challenge_grid` + `save_challenge_artifacts` - which run the identical pipeline.

## Issue
Track 1 entry for the TDL Challenge 2026.

## Additional context
Python 3.11, torch 2.3.0. `pre-commit` (ruff-format, ruff, numpydoc-validation, standard hooks) passes; 10 unit tests at 100% backbone coverage; MUTAG pipeline test passes.