### PR TITLE
Track: Track1; Team name: AdamGohain; Model: SGFormer

### DIFF
--- a/2026_tdl_challenge/results.json
+++ b/2026_tdl_challenge/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-19_20-21-23",
+    "model_config": "graph/sgformer",
+    "generated_at_utc": "2026-06-20T01:22:14.289818+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.316493034362793,
+      "test_best_rerun_accuracy": 0.29929712414741516,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2993353307247162,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30636411905288696,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3072427213191986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3054473102092743,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30552372336387634,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3067079186439514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3084269165992737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32019251585006714,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3224463164806366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3322255313396454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33787912130355835,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2989532947540283,
+      "test_best_rerun_accuracy": 0.2998701333999634,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30009931325912476,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30678433179855347,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30949652194976807,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3105279207229614,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30907630920410156,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3117121160030365,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31259071826934814,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3265337347984314,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32809993624687195,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3374207317829132,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.343379944562912,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.3039474487304688,
+      "test_best_rerun_accuracy": 0.3051799237728119,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3039957284927368,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31205591559410095,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3130873143672943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30850332975387573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3078921139240265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3126671314239502,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3096493184566498,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32363054156303406,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3246619403362274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3333333432674408,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.337649941444397,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.302400827407837,
+      "test_best_rerun_accuracy": 0.30132171511650085,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3022003173828125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3077775239944458,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3091145157814026,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3081977367401123,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3079303205013275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3092673122882843,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3091145157814026,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32049813866615295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32294294238090515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3307357430458069,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3350905478000641,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3110175132751465,
+      "test_best_rerun_accuracy": 0.30296432971954346,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30403393507003784,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3084269165992737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30972573161125183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.308312326669693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3079303205013275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30987852811813354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30991673469543457,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3227519392967224,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32359233498573303,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3322637379169464,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33665674924850464,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3114099502563477,
+      "test_best_rerun_accuracy": 0.2994881272315979,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3001375198364258,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30441591143608093,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3051799237728119,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30433952808380127,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3050653338432312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30701351165771484,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30605852603912354,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31927573680877686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31996333599090576,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3257315158843994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33054473996162415,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2758407592773438,
+      "test_best_rerun_accuracy": 0.3084651231765747,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29047292470932007,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2855069041252136,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30827412009239197,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3096493184566498,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30567651987075806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31992512941360474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3223317265510559,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3524715304374695,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35407593846321106,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3811979591846466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39579036831855774,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.233903646469116,
+      "test_best_rerun_accuracy": 0.3259607255458832,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30556192994117737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30090153217315674,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3239361345767975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3230193257331848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3228665292263031,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3380701243877411,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3322637379169464,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3690885603427887,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37405455112457275,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40174955129623413,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4166475534439087,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.263378620147705,
+      "test_best_rerun_accuracy": 0.3146153390407562,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29631751775741577,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2920391261577606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31094813346862793,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31641072034835815,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31014591455459595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32565513253211975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32592251896858215,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35762855410575867,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3616013526916504,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38952556252479553,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4046909511089325,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.257920742034912,
+      "test_best_rerun_accuracy": 0.3174039125442505,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2957063317298889,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2971961200237274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3111773133277893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3198869228363037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3147299289703369,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3224845230579376,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3243945240974426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3630911409854889,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36477193236351013,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.387997567653656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40667736530303955,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.241642951965332,
+      "test_best_rerun_accuracy": 0.32359233498573303,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30758652091026306,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3210711181163788,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32508212327957153,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32034534215927124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3318435251712799,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3299717307090759,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37038734555244446,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37172433733940125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3992665708065033,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4148903787136078,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.25390625,
+      "test_best_rerun_accuracy": 0.3095729351043701,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29520970582962036,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28974711894989014,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3093055188655853,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31694552302360535,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3120177388191223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3244709372520447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32401251792907715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3601497411727905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3633967339992523,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3942241668701172,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41267475485801697,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.1433281898498535,
+      "test_best_rerun_accuracy": 0.37638476490974426,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27714112401008606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2696920931339264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28963252902030945,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2845519185066223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36496293544769287,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39567574858665466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40938955545425415,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47192299365997314,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4747498035430908,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5483994483947754,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5790358185768127,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.1400299072265625,
+      "test_best_rerun_accuracy": 0.3671785593032837,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2712201178073883,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26464971899986267,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27973872423171997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2785544991493225,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.358659952878952,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3924669623374939,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4039269685745239,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4626403748989105,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46745359897613525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5362899899482727,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5760180354118347,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.141462802886963,
+      "test_best_rerun_accuracy": 0.3684009611606598,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2787073254585266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2677057087421417,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2841317057609558,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28405532240867615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3618687391281128,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39200854301452637,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4015967547893524,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4684467911720276,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4719993770122528,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5392696261405945,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5756742358207703,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1700968742370605,
+      "test_best_rerun_accuracy": 0.3590419292449951,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27725571393966675,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2716020941734314,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2838643193244934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28367331624031067,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36427533626556396,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3824203610420227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3945297598838806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4524027705192566,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46214377880096436,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5166934132575989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.557873010635376,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1759064197540283,
+      "test_best_rerun_accuracy": 0.35132554173469543,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2671326994895935,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26205211877822876,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27278631925582886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2740468978881836,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35694095492362976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3799373507499695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3954847455024719,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.439376562833786,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4473985731601715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5058445930480957,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5506532192230225,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1782777309417725,
+      "test_best_rerun_accuracy": 0.3559095561504364,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2744289040565491,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26950111985206604,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2816869020462036,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2801971137523651,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3604171574115753,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3786003589630127,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3920849561691284,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.442050576210022,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4517151713371277,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5059974193572998,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5459927916526794,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0068857669830322,
+      "test_best_rerun_accuracy": 0.42065855860710144,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2604477107524872,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2512032985687256,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2850867211818695,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28176331520080566,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37386354804039,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35747575759887695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4303995668888092,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49098479747772217,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4887309968471527,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5859118103981018,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.623500645160675,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9922010898590088,
+      "test_best_rerun_accuracy": 0.42650318145751953,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26189929246902466,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25005730986595154,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28883031010627747,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2837115228176117,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3713805377483368,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3568263351917267,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43250057101249695,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48972418904304504,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4855603873729706,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5831232070922852,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6219726204872131,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9696714878082275,
+      "test_best_rerun_accuracy": 0.43005576729774475,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.265604704618454,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25796470046043396,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2920391261577606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28798991441726685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3831843435764313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3671785593032837,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.438268780708313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.50382000207901,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5004202127456665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5974482297897339,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6309496760368347,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9694814682006836,
+      "test_best_rerun_accuracy": 0.43632057309150696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25914889574050903,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2513178884983063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2813049256801605,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27752310037612915,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3732905387878418,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36534494161605835,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41427916288375854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4977079927921295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5058827996253967,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5903048515319824,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.639506459236145,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.919100046157837,
+      "test_best_rerun_accuracy": 0.4491557776927948,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.266750693321228,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.255328893661499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2895561158657074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28741690516471863,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38272595405578613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37149515748023987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4284513592720032,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5077546238899231,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5162349939346313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6046298146247864,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.653907835483551,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9600245952606201,
+      "test_best_rerun_accuracy": 0.4327297806739807,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.256131112575531,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24814729392528534,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2815723121166229,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28065550327301025,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37348154187202454,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36396974325180054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41439375281333923,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4915578067302704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5016807913780212,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5871724486351013,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6365650296211243,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6809173822402954,
+      "test_best_rerun_accuracy": 0.5461456179618835,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2487584948539734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24081289768218994,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27007409930229187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26231950521469116,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3853999674320221,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36370235681533813,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41019177436828613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43032318353652954,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5423638224601746,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6346168518066406,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.674535870552063,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.681902527809143,
+      "test_best_rerun_accuracy": 0.5496982336044312,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24990449845790863,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24150049686431885,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26396211981773376,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38872334361076355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36740773916244507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41699135303497314,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.431774765253067,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5478264093399048,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6374054551124573,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6805332899093628,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.7000799179077148,
+      "test_best_rerun_accuracy": 0.5421727895736694,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24547329545021057,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23500649631023407,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26541370153427124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2563984990119934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3808923661708832,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.366261750459671,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4062189757823944,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42757275700569153,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.543433427810669,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6317518353462219,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6732752919197083,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6660785675048828,
+      "test_best_rerun_accuracy": 0.5463365912437439,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2442891001701355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23607610166072845,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2672473192214966,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2607533037662506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37756896018981934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36778974533081055,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4063717722892761,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4303995668888092,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5387347936630249,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6337382793426514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6818702816963196,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6724531650543213,
+      "test_best_rerun_accuracy": 0.5448468327522278,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24730689823627472,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23580870032310486,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26312169432640076,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2551760971546173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3748185634613037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3669493496417999,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4079761505126953,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42948275804519653,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5377416014671326,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6347314715385437,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6835510730743408,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.6900522708892822,
+      "test_best_rerun_accuracy": 0.5397661924362183,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24367789924144745,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2312246859073639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25960731506347656,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25452670454978943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3749331533908844,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3636641502380371,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39876994490623474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42165178060531616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5307509899139404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6265948414802551,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6761020421981812,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.4021271467208862,
+      "test_best_rerun_accuracy": 0.6460768580436707,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2327526956796646,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21812207996845245,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2622049152851105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24807089567184448,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37584996223449707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3523569405078888,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4218427538871765,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4310489594936371,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5390022397041321,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5393460392951965,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.686721682548523,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3877182006835938,
+      "test_best_rerun_accuracy": 0.6430208683013916,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2323324978351593,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22251509130001068,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25907251238822937,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2543739080429077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3697761595249176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3522041440010071,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4185575544834137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4362441599369049,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.538008987903595,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5360990166664124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6905034780502319,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.4415571689605713,
+      "test_best_rerun_accuracy": 0.6347314715385437,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22832149267196655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22018489241600037,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2569715082645416,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25105050206184387,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36450454592704773,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34941554069519043,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.408892959356308,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.426006555557251,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5250592231750488,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5324318408966064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6817938685417175,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.2368910312652588,
+      "test_best_rerun_accuracy": 0.6952020525932312,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2243104875087738,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2149132788181305,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25372451543807983,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2467339038848877,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36790433526039124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35174575448036194,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41607457399368286,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43819236755371094,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5315914154052734,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5385056138038635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6388188600540161,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.258815884590149,
+      "test_best_rerun_accuracy": 0.6892810463905334,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22068148851394653,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2128886878490448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24669569730758667,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24146229028701782,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36347314715385437,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3497975468635559,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41038277745246887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4332263767719269,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5246390104293823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5369394421577454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.631866455078125,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.2274326086044312,
+      "test_best_rerun_accuracy": 0.6901214718818665,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22599129378795624,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21739628911018372,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2541064918041229,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2505156993865967,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36221253871917725,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35159292817115784,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4078233540058136,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4334173798561096,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5272747874259949,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5369012355804443,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6335854530334473,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 137.7327423095703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.27125549316406,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09673721577317296,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.27220153808594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.40669579756887336
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11702.3095703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8875471801526356
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207.9357147216797,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07008281588192777
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7367.59326171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9843143970232131
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.2426300048828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1331974352373772
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173360.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.025640616292031
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14812.2978515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0385849005442784
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45461.62109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3302896659874928
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3474.039306640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6176069878472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754389.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.533525445969028
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260499.515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.334939437621687
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 137.55795288085938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.4442901611328,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09686188051954814,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81.51161193847656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.42900848388671875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11650.888671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8836472257773985
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202.61146545410156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06828832674556844
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7344.79931640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.98126911374833
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.98785400390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13470453713636119
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173168.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.02117959606632
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14755.0869140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0345734759544594
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45391.09375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.326674547644677
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3460.396240234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6151815538194444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753968.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.528770941031413
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260247.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.330746457574094
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 139.05178833007812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 135.29861450195312,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09747738796970687,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.980613708496094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3367400721499794
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11845.3232421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8983938750237012
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225.41012573242188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07597240503283514
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7439.46923828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9939170659026386
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.05126953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1304415108214594
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173879.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.037702605424484
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14960.693359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.048989858321063
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45672.796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3411141972935567
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3518.333740234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6254815538194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755449.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.545520938203454
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261154.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.345833229327875
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3250136375427246,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.2880730628967285,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012042489804719624,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207.6129150390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14957702812612572
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13171.1845703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9989521858409177
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 421.1925354003906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14195906147637027
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8182.4482421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0931794578740814
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177.64898681640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15341017859793285
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178635.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.1481443316923645
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16243.76953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1389545317101388
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47774.03125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.448820095853196
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3985.483642578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7085304253472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765474.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.65891429023902
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267099.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.444762181119265
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3717288970947266,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.3241968154907227,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012232614818372225,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209.39697265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15086237223072765
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13188.7392578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.000283599379029
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 425.40972900390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14338042770606885
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8193.5751953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.094666024757849
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.45701599121094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15497151640000945
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178691.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.1494461731376555
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16265.662109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1404895603263918
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47803.16015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4503131967937875
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3995.111572265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7102420572916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765595.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.660288677986042
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267195.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.446364385202935
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.355281352996826,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.3014976978302,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012113145778053684,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211.03253173828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15204072891807008
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13209.517578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0018595053564656
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 429.8475036621094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14487613874691924
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8203.458984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.095986504258517
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.6345977783203,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1559884264061488
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178759.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.1510215899591305
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16286.9462890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.141981930238571
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47829.3671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.45165652711569
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4001.825439453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7114356336805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765725.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.661759216316188
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267278.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.447753378097283
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5061.82666015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4832.32861328125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.36650198052948424,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8982.283203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.471385593029539
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10594.7529296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 55.76185752467105
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7474.80517578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.519314181254213
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7861.6240234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0503171707999333
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9560.09375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 8.25569408462867
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123617.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.87055857270574
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8337.375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.584586663862011
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29068.8828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.490024235609206
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7373.27099609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.3108037326388888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 639142.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.22986776466862
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195715.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2568719006373454
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5028.7509765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4725.046875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3583653299203641,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7068.83349609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.092819521681376
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8501.26953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 44.74352384868421
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5802.5009765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.9556794663169867
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6903.623046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9223277283734135
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7590.23828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.554609914723661
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128333.8828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9800734444663757
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8183.205078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5737768249982471
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30035.505859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.539571780171972
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6023.8984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.0709152777777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 651293.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.3673263350791265
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202112.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.363326687384554
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5071.138671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4850.05859375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3678466889457717,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9161.66796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.600625337716139
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10786.2470703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 56.769721422697366
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7622.21435546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.568997086440428
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7959.0556640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0633340900551103
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9743.515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 8.414089486183075
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123199.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8608539034924765
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8361.482421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5862769893335437
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28993.50390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4861604339663745
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7505.36181640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.3342865451388888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 638056.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.217593718538963
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195165.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.247728780806417
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 138.11485290527344,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.72036743164062,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.045406257981678674,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 220.49435424804688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1588576039251058
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 331.5348815917969,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7449204294305098
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10205.4404296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.774018993529579
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6614.19287109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8836597022169339
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 296.4579162597656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2560085632640463
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167545.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8906112123815717
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13350.4580078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9360859632458631
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43009.203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.204582660566918
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3061.74365234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5443099826388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741967.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.393010559596394
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253155.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.212731204133593
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 138.17498779296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.8118133544922,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0454370789870213,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209.25302124023438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15075866083590372
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 310.6447448730469,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.634972341437089
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10262.65625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7783584565794464
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6657.59521484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8894582785362392
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281.8763122558594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.24341650453873867
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167802.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8965924989550436
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13394.1162109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.939147118983137
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43163.65234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2124994794069406
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3082.4140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5479847222222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742626.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.400465764736492
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253479.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.218113486595777
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 137.7272186279297,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.31790161132812,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.045270610586898595,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215.07611083984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15495397034570876
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 322.1838073730469,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.6957042493318257
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10230.162109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7758939787163444
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6633.2373046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8862040487224448
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 289.65106201171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2501304507873219
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167660.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8932979838147874
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13369.9130859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9374500831536601
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43073.5546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.207881218283869
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3069.8037109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5457428819444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742267.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.396401988620296
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253294.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.215035965087448
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5220.1259765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5404.19287109375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7220030555903474,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1710.5445556640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.2323808037925523
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2366.654052734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 12.456073961759868
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6598.3974609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5004472856228669
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1145.7032470703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3861487182576045
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1969.0020751953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.7003472151945704
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149998.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4831486276240016
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9868.0771484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6919139775934301
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36342.23046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8628443522861244
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2951.894287109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5247812065972223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 703219.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.954701056525231
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230723.328125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8394376736891154
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5254.40185546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5430.8251953125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7255611483383434,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1515.794921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.092071269362392
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2129.965087890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 11.210342567845395
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6797.47119140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5155457862272469
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1021.87939453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.34441503017568253
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1760.3204345703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.5201385445339486
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151220.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5115181038686605
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10051.3095703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.704761574134939
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36819.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8873148290532575
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2888.724609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5135510416666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706128.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.987608593599765
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232317.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.865967385968416
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5231.43505859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5412.29150390625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.723085037262024,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1633.0191650390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1765267759647424
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2274.791748046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 11.97258814761513
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6660.12939453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5051292676929275
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1109.892578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.37407906239467476
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1887.3172607421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.6298076517635471
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150405.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4926091108582575
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9927.1357421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6960549531753961
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36518.3671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8718728375365217
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2926.06689453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5201896701388888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 704243.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.966279424906395
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231243.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8480893677300183
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 138.1960906982422,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.06610107421875,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12613652942505937,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.54286193847656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10918073626691395
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.319669723510742,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1279982617026881
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12274.9755859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9309803250616231
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 265.6343994140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08952962568724722
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7736.640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.033619321977288
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175519.96875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.075793441157347
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15331.876953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0750159131345534
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46550.765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3861174650161465
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3695.787109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6570288194444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759283.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.588883437213669
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263241.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.38056169187759
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 139.21144104003906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 147.22398376464844,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12713642812145806,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.43470764160156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10189820435273887
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.060646057128906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.21610866345857319
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12107.9345703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9183113060532803
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254.01841735839844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08561456601226776
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7592.61328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0143771918837676
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174852.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.060298335036225
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15205.6513671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.066165430317452
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46124.83203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.364284793236455
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3611.433349609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6420325954861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757570.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.569509801703562
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262388.9375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.366381067678431
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 138.84561157226562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.83277893066406,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12679860011283597,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144.52455139160156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10412431656455444
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34.4353141784668,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18123849567614103
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12206.453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9257833238528631
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267.26275634765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09007844838141431
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7643.982421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0212401365230461
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175213.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.068671410574958
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15302.61328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0729640500105175
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46274.6953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.371966544287252
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3642.274658203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6475154947916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758314.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.577925805685327
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262829.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3737082522090756
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 106252.5234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 77942.421875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8099206268577002,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119393.6796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 86.0185012157781
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125516.3828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 660.6125411184211
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73629.703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.584353668941979
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114193.4140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 38.48783756740816
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95986.2578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 12.823815339011356
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121481.7578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 104.90652660837651
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78259.796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.487294690436124
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72189.125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.700298580142498
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104594.6484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 18.594604166666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 418670.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.7359280793638225
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109846.0703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8279345400046594
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 107771.890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 81589.3984375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.894607988981516,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144455.75,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 104.07474783861672
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151289.484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 796.2604440789473
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93177.3046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.066917306598407
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139275.953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 46.94167614593866
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117959.8671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 15.759501294255177
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146806.03125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 126.77550194300518
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98115.8984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.879532915264339
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87949.0234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.508125656748168
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127828.1875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 22.72501111111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 398183.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.504183257355519
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107974.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.7967897155242707
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 106752.2265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 76698.6875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.7810395574029352,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100192.2109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 72.18459001260807
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105910.75,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 557.425
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59718.40625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.529268581721653
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96507.9921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 32.52712914981463
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79319.171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 10.597083750835003
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102188.0234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 88.24527067141624
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64443.6328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.518555098338242
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60711.83984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.1119913805807577
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86923.4765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 15.4530625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 437128.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.944720484598939
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113137.1171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8827004341187825
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8504.76953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8174.822265625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5731890524207685,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6475.05126953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.665022528480728
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7839.99169921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 41.26311420641447
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4732.0673828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3588977916429655
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5249.2939453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7692261359327603
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6630.33837890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8858167506888778
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6970.74267578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.019639616391408
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130027.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0193919224874604
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30419.40625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.559249897483213
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5621.26025390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.99933515625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 655540.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.415367691141704
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204391.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.401250977651307
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8530.5185546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8185.990234375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.573972110109031,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6110.5810546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.402435918362752
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7434.05419921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 39.12660104851974
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4756.171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3607259670079636
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4925.80908203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.6601985446684362
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6473.19091796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8648217659276887
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6593.10595703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.693528460303325
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131092.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0441330780930707
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30677.82421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.572495987428879
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5378.81640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9562340277777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 658204.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.445504536045157
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205819.71875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4250198650425174
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8490.3896484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8161.89990234375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5722829829157026,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6436.52197265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.637263669060699
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7799.9267578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 41.05224609375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4730.2705078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.35876150988339023
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5265.6396484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7747353044952814
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6606.11767578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8825808518077822
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6930.69482421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.985055979463515
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130016.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.019148825004644
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30429.263671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5597551730931878
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5588.14013671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9934471354166666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 655618.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.416247186181464
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204341.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4004225741766927
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26807.48046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27455.90234375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4073454479342868,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17703.076171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 12.754377645443084
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20027.5,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 105.40789473684211
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7199.05517578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5460034263011946
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15792.89453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.32284952182339
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13158.91015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.758037429024716
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18523.107421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 15.995774975712436
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108244.65625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.513576450167193
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10893.7353515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7638294314656079
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14067.5712890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.5009015625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 596896.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.751990175672772
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174140.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8978437588404637
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26724.32421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27483.720703125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.408771372347378,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21944.74609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 15.810335802413544
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24738.568359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 130.20299136513157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9593.6337890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7276172763794084
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21930.556640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 7.3914919584175935
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15933.388671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.1287092413994655
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22844.25,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 19.727331606217618
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101878.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.3657350832481887
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13535.70703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9490749566154817
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17330.140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.080913888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 579092.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.550594295442463
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165111.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.747602934201987
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26833.171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27459.244140625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4075167430737097,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16980.59765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 12.233859982889049
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19346.353515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 101.82291324013158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7098.7998046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5383996818117178
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15742.93359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.3060106483822045
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12647.490234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.6897114541583167
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17817.3671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 15.386327450345423
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108870.0703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.528099347773082
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10857.294921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7612743599687982
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13479.994140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.396443402777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 599159.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.777597338325623
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175065.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9132347465594997
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2706.02001953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2870.625732421875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5103334635416666,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 399.6314697265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2879189263159672
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 637.4923095703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.355222681949013
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9190.326171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6970289095089116
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202.2775421142578,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06817578096200129
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6169.6318359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8242661103456914
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 518.086181640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4473973934720423
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163276.875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7914934748281626
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12357.7744140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8664825700506591
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41303.71484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.117162071031319
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 732784.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.289133287331877
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247735.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.122530130381242
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2726.302001953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2892.09619140625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5141504340277778,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 357.104736328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.25728006940066644
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 574.951904296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.026062654194079
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9282.2470703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7040005362390974
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196.36892700195312,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06618433670439944
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6236.80517578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8332405044463927
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 467.4497375488281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.40366989425632827
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163719.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8017823036643135
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12421.3154296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.870937836887358
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41601.9296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1324480848582708
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 734023.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.303153597728583
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 248336.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.132542215815486
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2634.518310546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2792.2080078125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4963925347222222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 600.19091796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4324142060293588
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 933.8703002929688,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.915106843647204
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8490.9208984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6439833825132727
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 324.8351135253906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10948268066241679
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5899.67919921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7882002938168002
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 751.3915405273438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6488700695400205
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160106.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7178806543748837
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11679.4521484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8189210593491446
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40075.6875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0542153621405506
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 725884.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.21108941438639
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243675.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.054980145358028
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 501090.3125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 357720.34375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 4.046472899675351,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 721487.25,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 519.8034942363113
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 736956.9375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3878.7207236842105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 593505.9375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 45.01372298065984
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 711171.9375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 239.6939459049545
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 653314.75,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 87.28319973279893
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 726720.5625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 627.5652525906736
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 367955.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 8.544389600362251
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 601040.9375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 42.14282271069976
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 539239.875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 27.64056973704444
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 680252.5,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 120.93377777777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 319510.21875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 5.316929072437722
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 516033.6875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 379636.4375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 4.294384098955918,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 809535.9375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 583.239148054755
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 826272.0,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4348.8
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 674471.75,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 51.15447478194918
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 800815.625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 269.9075244354567
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 736687.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 98.42177688710755
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 815220.375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 703.9899611398964
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 425444.125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 9.879345276797325
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 682751.875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 47.87209893423082
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 613529.8125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 31.448552591111795
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765478.375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 136.08504444444443
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368869.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 6.1383074983775145
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 492126.6875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 342407.5,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.8732565636912772,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 644123.875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 464.0661923631124
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 660141.6875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3474.4299342105264
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 530251.1875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 40.216244785741374
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 646331.1875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 217.83996882372767
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 579453.9375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 77.41535571142285
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 649676.25,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 561.0330310880829
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 323080.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 7.502338089819803
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 540230.375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 37.87900539896228
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 473878.5,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 24.29025065354452
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 605094.75,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 107.5724
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281634.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.686636754696886
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111643.8984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 109453.5078125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8214019571747124,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185520.84375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 133.66055025216139
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 193164.1875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1016.6536184210527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125568.5703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.523592742700037
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178950.5,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 60.31361644759016
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154579.46875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 20.651899632598532
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188133.171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 162.4638789939551
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91158.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1168039865084527
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130590.3203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 9.156522248808022
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115499.5625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 5.920322030857553
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166262.140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 29.557713888888888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 372649.15625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.215345138174044
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 113306.6015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 111522.4765625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8558314040320836,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203169.046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 146.37539400216139
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211280.234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1112.0012335526317
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140278.609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 10.639257442169132
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197103.046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 66.43176504044489
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170386.1875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 22.76368570474282
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205932.796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 177.8348850388601
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96468.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.2401255253808285
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145565.84375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 10.206551938718272
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127702.3828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 6.545818997001384
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182794.8125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 32.496855555555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 363834.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.1156309740619665
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "sgformer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111530.0234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 109345.6171875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8196065629524238,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185150.359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 133.39363067363112
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 192855.40625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1015.0284539473685
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125761.8125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.538248957148275
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179450.171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 60.4820262470509
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154202.203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 20.601496743486972
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 187778.3125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 162.15743739205527
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91133.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1162401454811444
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130862.5703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 9.175611436860187
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115190.5625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 5.904483187246912
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165865.859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 29.48726388888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 372530.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.213998323020712
+        }
+      },
+      "output_dir": "/orcd/data/edboyden/002/gohain/projects/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-19_20-21-23__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/graph/sgformer.yaml
+++ b/configs/model/graph/sgformer.yaml
@@ -1,0 +1,50 @@
+_target_: topobench.model.TBModel
+
+model_name: sgformer
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.SGFormer
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  out_channels: ${model.feature_encoder.out_channels}
+  trans_num_layers: 1
+  trans_num_heads: 1
+  trans_dropout: 0.2
+  gnn_num_layers: 2
+  gnn_dropout: 0.2
+  graph_weight: 0.5
+  aggregate: add
+  gnn_use_bn: false
+  gnn_use_edge_weight: false
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: MLPReadout
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_layers: [16]
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+  dropout: 0.2
+  act: relu
+  norm: null
+  final_act: null
+
+compile: false

--- a/test/nn/backbones/graph/test_sgformer.py
+++ b/test/nn/backbones/graph/test_sgformer.py
@@ -1,0 +1,193 @@
+"""Unit tests for the SGFormer graph backbone."""
+
+import pytest
+import torch
+from torch_geometric.data import Batch
+
+from topobench.nn.backbones import MODEL_CLASSES, SGFormer
+
+
+class TestSGFormer:
+    """Test SGFormer model behavior."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.in_channels = 8
+        self.hidden_channels = 16
+        self.out_channels = 16
+
+    def _features(self, num_nodes):
+        return torch.randn(num_nodes, self.in_channels)
+
+    def test_model_export(self):
+        """Test dynamic model discovery."""
+        assert SGFormer is MODEL_CLASSES["SGFormer"]
+
+    def test_initialization_default(self):
+        """Test default initialization."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+        )
+
+        assert model.in_channels == self.in_channels
+        assert model.hidden_channels == self.hidden_channels
+        assert model.out_channels == self.hidden_channels
+        assert model.aggregate == "add"
+
+    def test_initialization_custom(self):
+        """Test custom initialization."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            trans_num_layers=2,
+            trans_num_heads=2,
+            aggregate="cat",
+            gnn_use_bn=False,
+        )
+
+        assert model.out_channels == self.out_channels
+        assert model.aggregate == "cat"
+
+    def test_invalid_aggregate(self):
+        """Test invalid aggregate type."""
+        with pytest.raises(ValueError, match="Invalid aggregate type"):
+            SGFormer(
+                in_channels=self.in_channels,
+                hidden_channels=self.hidden_channels,
+                aggregate="mean",
+            )
+
+    def test_forward_basic(self, simple_graph_0):
+        """Test a basic forward pass."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            gnn_use_bn=False,
+        )
+        x = self._features(simple_graph_0.num_nodes)
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+
+        out = model(x, simple_graph_0.edge_index, batch=batch)
+
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+
+    def test_forward_without_batch(self, simple_graph_0):
+        """Test forward pass without a batch vector."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            gnn_use_bn=False,
+        )
+        out = model(self._features(simple_graph_0.num_nodes), simple_graph_0.edge_index)
+
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_forward_cat_aggregate(self, simple_graph_0):
+        """Test concatenation branch aggregation."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            aggregate="cat",
+            gnn_use_bn=False,
+        )
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+        out = model(
+            self._features(simple_graph_0.num_nodes),
+            simple_graph_0.edge_index,
+            batch=batch,
+        )
+
+        assert out.shape == (simple_graph_0.num_nodes, self.out_channels)
+
+    def test_batched_graphs(self, simple_graph_0, simple_graph_1):
+        """Test forward pass on a batch of graphs."""
+        data = Batch.from_data_list([simple_graph_0, simple_graph_1])
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            trans_num_layers=2,
+            gnn_use_bn=False,
+        )
+        out = model(
+            self._features(data.num_nodes),
+            data.edge_index,
+            batch=data.batch,
+        )
+
+        assert out.shape == (data.num_nodes, self.out_channels)
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+
+    def test_backward_pass(self, simple_graph_0):
+        """Test gradient computation."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            gnn_use_bn=False,
+        )
+        x = self._features(simple_graph_0.num_nodes).requires_grad_(True)
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+
+        loss = model(x, simple_graph_0.edge_index, batch=batch).sum()
+        loss.backward()
+
+        assert x.grad is not None
+        assert any(
+            param.grad is not None
+            for param in model.parameters()
+            if param.requires_grad
+        )
+
+    def test_single_node_training_batch_with_layer_norm(self):
+        """Test the LayerNorm graph branch on a one-node training batch."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            gnn_use_bn=False,
+        )
+        model.train()
+        x = self._features(1)
+        edge_index = torch.empty((2, 0), dtype=torch.long)
+        batch = torch.zeros(1, dtype=torch.long)
+
+        out = model(x, edge_index, batch=batch)
+
+        assert out.shape == (1, self.out_channels)
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+
+    def test_edge_weight_reference_path_ignored(self, simple_graph_0):
+        """Test that edge weights are ignored unless explicitly enabled."""
+        model = SGFormer(
+            in_channels=self.in_channels,
+            hidden_channels=self.hidden_channels,
+            out_channels=self.out_channels,
+            gnn_use_bn=False,
+            gnn_use_edge_weight=False,
+            trans_dropout=0.0,
+            gnn_dropout=0.0,
+        )
+        model.eval()
+        x = self._features(simple_graph_0.num_nodes)
+        batch = torch.zeros(simple_graph_0.num_nodes, dtype=torch.long)
+        edge_weight = torch.rand(simple_graph_0.edge_index.size(1))
+
+        unweighted = model(x, simple_graph_0.edge_index, batch=batch)
+        weighted = model(
+            x,
+            simple_graph_0.edge_index,
+            batch=batch,
+            edge_weight=edge_weight,
+        )
+
+        assert torch.allclose(unweighted, weighted)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/sgformer"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/sgformer.py
+++ b/topobench/nn/backbones/graph/sgformer.py
@@ -1,0 +1,435 @@
+"""SGFormer backbone for graph representation learning.
+
+This implementation adapts the SGFormer architecture for TopoBench by
+returning node embeddings instead of classifier log-probabilities.
+
+References
+----------
+Wu, Q., Zhao, W., Yang, C., Zhang, H., Nie, F., Jiang, H., Bian, Y.,
+and Yan, J. "SGFormer: Simplifying and Empowering Transformers for
+Large-Graph Representations." NeurIPS 2023.
+"""
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch_geometric.nn import GCNConv
+from torch_geometric.utils import to_dense_batch
+
+
+class _SGFormerAttention(nn.Module):
+    """Linear-complexity global attention used by SGFormer.
+
+    Parameters
+    ----------
+    channels : int
+        Input feature dimension.
+    heads : int, optional
+        Number of attention heads.
+    head_channels : int, optional
+        Hidden dimension per attention head. Defaults to ``channels``.
+    qkv_bias : bool, optional
+        Whether query, key, and value projections use bias terms.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        heads: int = 1,
+        head_channels: int | None = None,
+        qkv_bias: bool = False,
+    ) -> None:
+        super().__init__()
+        self.heads = heads
+        self.head_channels = head_channels or channels
+
+        inner_channels = self.heads * self.head_channels
+        self.q = nn.Linear(channels, inner_channels, bias=qkv_bias)
+        self.k = nn.Linear(channels, inner_channels, bias=qkv_bias)
+        self.v = nn.Linear(channels, inner_channels, bias=qkv_bias)
+
+    def reset_parameters(self) -> None:
+        """Reset learnable parameters."""
+        self.q.reset_parameters()
+        self.k.reset_parameters()
+        self.v.reset_parameters()
+
+    def forward(self, x: Tensor, mask: Tensor | None = None) -> Tensor:
+        """Run SGFormer attention over a dense graph batch.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Dense node features with shape ``[batch_size, num_nodes, channels]``.
+        mask : torch.Tensor, optional
+            Boolean mask indicating valid nodes in each graph.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated dense node features.
+        """
+        batch_size, num_nodes, _ = x.shape
+        query, key, value = self.q(x), self.k(x), self.v(x)
+        query, key, value = (
+            tensor.view(
+                batch_size,
+                num_nodes,
+                self.heads,
+                self.head_channels,
+            )
+            for tensor in (query, key, value)
+        )
+
+        if mask is None:
+            mask = x.new_ones((batch_size, num_nodes), dtype=torch.bool)
+
+        valid_mask = mask[:, :, None, None]
+        key = key.masked_fill(~valid_mask, 0.0)
+        value = value.masked_fill(~valid_mask, 0.0)
+
+        eps = torch.finfo(x.dtype).eps
+        query = query / torch.linalg.norm(
+            query, ord=2, dim=-1, keepdim=True
+        ).clamp_min(eps)
+        key = key / torch.linalg.norm(
+            key, ord=2, dim=-1, keepdim=True
+        ).clamp_min(eps)
+
+        kv = torch.einsum("bnhc,bnhd->bhcd", key, value)
+        numerator = torch.einsum("bnhc,bhcd->bnhd", query, kv)
+
+        valid_counts = mask.sum(dim=1).clamp_min(1).view(batch_size, 1, 1, 1)
+        numerator = numerator + valid_counts * value
+
+        key_sum = key.sum(dim=1)
+        denominator = torch.einsum("bnhc,bhc->bnh", query, key_sum)
+        denominator = denominator.unsqueeze(-1) + valid_counts
+        denominator = torch.where(
+            denominator.abs() > eps,
+            denominator,
+            denominator.new_full(denominator.shape, eps),
+        )
+
+        return (numerator / denominator).mean(dim=2)
+
+
+class _SGModule(nn.Module):
+    """Global SGFormer attention branch.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input node feature dimension.
+    hidden_channels : int
+        Hidden embedding dimension.
+    num_layers : int, optional
+        Number of global attention layers.
+    num_heads : int, optional
+        Number of attention heads.
+    dropout : float, optional
+        Dropout probability.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_layers: int = 1,
+        num_heads: int = 1,
+        dropout: float = 0.5,
+    ) -> None:
+        super().__init__()
+        self.input_proj = nn.Linear(in_channels, hidden_channels)
+        self.input_norm = nn.LayerNorm(hidden_channels)
+        self.attns = nn.ModuleList(
+            [
+                _SGFormerAttention(
+                    hidden_channels,
+                    heads=num_heads,
+                    head_channels=hidden_channels,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.norms = nn.ModuleList(
+            [nn.LayerNorm(hidden_channels) for _ in range(num_layers)]
+        )
+        self.dropout = dropout
+
+    def reset_parameters(self) -> None:
+        """Reset learnable parameters."""
+        self.input_proj.reset_parameters()
+        self.input_norm.reset_parameters()
+        for attn in self.attns:
+            attn.reset_parameters()
+        for norm in self.norms:
+            norm.reset_parameters()
+
+    def forward(self, x: Tensor, batch: Tensor | None = None) -> Tensor:
+        """Run the global branch.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features with shape ``[num_nodes, in_channels]``.
+        batch : torch.Tensor, optional
+            Graph assignment vector for each node.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings with shape ``[num_nodes, hidden_channels]``.
+        """
+        if batch is None:
+            batch = x.new_zeros(x.size(0), dtype=torch.long)
+
+        batch, indices = batch.sort(stable=True)
+        reverse = torch.empty_like(indices)
+        reverse[indices] = torch.arange(indices.numel(), device=indices.device)
+
+        x = x[indices]
+        x, mask = to_dense_batch(x, batch)
+        x = self.input_proj(x)
+        x = self.input_norm(x)
+        x = F.relu(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+
+        for attn, norm in zip(self.attns, self.norms, strict=True):
+            residual = x
+            x = attn(x, mask)
+            x = (x + residual) / 2.0
+            x = norm(x)
+            x = F.relu(x)
+            x = F.dropout(x, p=self.dropout, training=self.training)
+
+        return x[mask][reverse]
+
+
+class _GraphModule(nn.Module):
+    """Local GCN branch used by SGFormer.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input node feature dimension.
+    hidden_channels : int
+        Hidden embedding dimension.
+    num_layers : int, optional
+        Number of graph convolution layers.
+    dropout : float, optional
+        Dropout probability.
+    use_bn : bool, optional
+        Whether to use ``BatchNorm1d`` instead of ``LayerNorm``.
+    use_edge_weight : bool, optional
+        Whether to pass edge weights to the local graph convolutions.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_layers: int = 2,
+        dropout: float = 0.5,
+        use_bn: bool = True,
+        use_edge_weight: bool = False,
+    ) -> None:
+        super().__init__()
+        self.input_proj = nn.Linear(in_channels, hidden_channels)
+        self.input_norm = (
+            nn.BatchNorm1d(hidden_channels)
+            if use_bn
+            else nn.LayerNorm(hidden_channels)
+        )
+        self.convs = nn.ModuleList(
+            [
+                GCNConv(hidden_channels, hidden_channels)
+                for _ in range(num_layers)
+            ]
+        )
+        norm_cls = nn.BatchNorm1d if use_bn else nn.LayerNorm
+        self.norms = nn.ModuleList(
+            [norm_cls(hidden_channels) for _ in range(num_layers)]
+        )
+        self.dropout = dropout
+        self.use_edge_weight = use_edge_weight
+
+    def reset_parameters(self) -> None:
+        """Reset learnable parameters."""
+        self.input_proj.reset_parameters()
+        self.input_norm.reset_parameters()
+        for conv in self.convs:
+            conv.reset_parameters()
+        for norm in self.norms:
+            norm.reset_parameters()
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        edge_weight: Tensor | None = None,
+    ) -> Tensor:
+        """Run the local graph branch.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features with shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            Edge indices with shape ``[2, num_edges]``.
+        edge_weight : torch.Tensor, optional
+            Optional scalar weights for each edge.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings with shape ``[num_nodes, hidden_channels]``.
+        """
+        x = self.input_proj(x)
+        x = self.input_norm(x)
+        x = F.relu(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+
+        for conv, norm in zip(self.convs, self.norms, strict=True):
+            residual = x
+            if self.use_edge_weight:
+                x = conv(x, edge_index, edge_weight=edge_weight)
+            else:
+                x = conv(x, edge_index)
+            x = norm(x)
+            x = F.relu(x)
+            x = F.dropout(x, p=self.dropout, training=self.training)
+            x = x + residual
+
+        return x
+
+
+class SGFormer(nn.Module):
+    """SGFormer backbone returning node embeddings for TopoBench readouts.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input node feature dimension.
+    hidden_channels : int
+        Hidden dimension for both SGFormer branches.
+    out_channels : int, optional
+        Output embedding dimension. Defaults to ``hidden_channels``.
+    trans_num_layers : int, optional
+        Number of global attention layers.
+    trans_num_heads : int, optional
+        Number of heads in the global attention branch.
+    trans_dropout : float, optional
+        Dropout rate in the global attention branch.
+    gnn_num_layers : int, optional
+        Number of local graph convolution layers.
+    gnn_dropout : float, optional
+        Dropout rate in the local graph branch.
+    graph_weight : float, optional
+        Weight assigned to the local graph branch when ``aggregate="add"``.
+    aggregate : {"add", "cat"}, optional
+        How to combine global and local branches.
+    gnn_use_bn : bool, optional
+        Whether to use BatchNorm1d in the local branch. LayerNorm is used when
+        false, which is robust to one-node training batches.
+    gnn_use_edge_weight : bool, optional
+        Whether to pass ``edge_weight`` to the local GCN branch. Disabled by
+        default to match the reference SGFormer path.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int | None = None,
+        trans_num_layers: int = 1,
+        trans_num_heads: int = 1,
+        trans_dropout: float = 0.5,
+        gnn_num_layers: int = 2,
+        gnn_dropout: float = 0.5,
+        graph_weight: float = 0.5,
+        aggregate: Literal["add", "cat"] = "add",
+        gnn_use_bn: bool = True,
+        gnn_use_edge_weight: bool = False,
+    ) -> None:
+        super().__init__()
+        if aggregate not in {"add", "cat"}:
+            raise ValueError(f"Invalid aggregate type: {aggregate}")
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels or hidden_channels
+        self.graph_weight = graph_weight
+        self.aggregate = aggregate
+
+        self.trans_conv = _SGModule(
+            in_channels,
+            hidden_channels,
+            trans_num_layers,
+            trans_num_heads,
+            trans_dropout,
+        )
+        self.graph_conv = _GraphModule(
+            in_channels,
+            hidden_channels,
+            gnn_num_layers,
+            gnn_dropout,
+            use_bn=gnn_use_bn,
+            use_edge_weight=gnn_use_edge_weight,
+        )
+
+        fc_in_channels = (
+            hidden_channels if aggregate == "add" else 2 * hidden_channels
+        )
+        self.fc = nn.Linear(fc_in_channels, self.out_channels)
+
+    def reset_parameters(self) -> None:
+        """Reset learnable parameters."""
+        self.trans_conv.reset_parameters()
+        self.graph_conv.reset_parameters()
+        self.fc.reset_parameters()
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        batch: Tensor | None = None,
+        edge_weight: Tensor | None = None,
+        **kwargs,
+    ) -> Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features with shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            Edge indices with shape ``[2, num_edges]``.
+        batch : torch.Tensor, optional
+            Graph assignment vector for each node.
+        edge_weight : torch.Tensor, optional
+            Optional edge weights for the GCN branch. Ignored unless
+            ``gnn_use_edge_weight`` is enabled.
+        **kwargs : dict
+            Extra keyword arguments ignored for wrapper compatibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings with shape ``[num_nodes, out_channels]``.
+        """
+        del kwargs
+        x_trans = self.trans_conv(x, batch)
+        x_graph = self.graph_conv(x, edge_index, edge_weight=edge_weight)
+
+        if self.aggregate == "add":
+            x = (
+                self.graph_weight * x_graph
+                + (1.0 - self.graph_weight) * x_trans
+            )
+        else:
+            x = torch.cat((x_trans, x_graph), dim=-1)
+
+        return self.fc(x)


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

Adds **SGFormer** as a Track 1 graph backbone for TopoBench.

- Qitian Wu, Wentao Zhao, Chenxiao Yang, Hengrui Zhang, Fan Nie, Haitian Jiang, Yatao Bian, Junchi Yan. *SGFormer: Simplifying and Empowering Transformers for Large-Graph Representations*. NeurIPS 2023. [arXiv:2306.10759](https://arxiv.org/abs/2306.10759)
- Official implementation: [qitianwu/SGFormer](https://github.com/qitianwu/SGFormer)

**TopoBench integration notes**

- The backbone exposes `out_channels` and returns node embeddings for the wrapper/readout stack.
- `gnn_use_bn: false` uses LayerNorm in the graph branch, avoiding BatchNorm failures on one-node training batches.
- `gnn_use_edge_weight: false` matches the SGFormer reference path, which does not use edge weights by default; the code keeps an opt-in flag for TopoBench/PyG conventions that need weighted GCNConv behavior.
- Attention normalization guards small denominators and the unit tests assert finite outputs.

**Files in this PR**

- `topobench/nn/backbones/graph/sgformer.py`
- `configs/model/graph/sgformer.yaml`
- `test/nn/backbones/graph/test_sgformer.py`
- `test/pipeline/test_pipeline.py`
- `2026_tdl_challenge/results.json`

## Issue

Submission to the **TDL Challenge 2026**, Track 1 (GNNs).

No existing open Track 1 PR appears to submit SGFormer.

## Additional context

Validation performed:

- Import probe: `SGFormer` exports through `MODEL_CLASSES`.
- `pre-commit run --all-files` passes.
- `.venv-gpu/bin/python -m pytest test/nn/backbones/graph/test_sgformer.py -q` -> `11 passed, 1 warning`.
- `.venv-gpu/bin/python -m pytest test/pipeline/test_pipeline.py -q` -> `1 passed, 3 warnings`.
- Slurm GPU challenge sanity check -> all 24 configurations passed.
- Slurm GPU full challenge evaluation -> 72/72 runs completed.

The included `results.json` contains `model_config=graph/sgformer`, train seeds `[42, 43, 44]`, and both challenge tasks (`community_detection`, `triangle_counting`).

Environment used for challenge evaluation: Python 3.11.7, PyTorch 2.3.0+cu121, PyG 2.9.0.dev20260619, CUDA available.
