### PR TITLE
Track: Track2;  Team name: TripleA;  Model: Cell Isomorphism Network (CIN)

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-03_07-02-04/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-03_07-02-04/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-03_07-02-04",
+    "model_config": "cell/cin",
+    "generated_at_utc": "2026-07-03T11:39:14.175492+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2109646797180176,
+      "test_best_rerun_accuracy": 0.32378333806991577,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3000229299068451,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30731913447380066,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30200931429862976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2917335033416748,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28867751359939575,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2800825238227844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.301818311214447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2856215238571167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29463672637939453,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28432270884513855,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.776449814648696,
+        "AvgTime/train_epoch_std": 0.16188174495458738,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1989693641662598,
+      "test_best_rerun_accuracy": 0.32007792592048645,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3112919330596924,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30365192890167236,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29979372024536133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29899153113365173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2905111014842987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2822217047214508,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27465811371803284,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28974711894989014,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2775613069534302,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2826037108898163,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2634654939174652,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.792720627039671,
+        "AvgTime/train_epoch_std": 0.1683498293366751,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.195542573928833,
+      "test_best_rerun_accuracy": 0.323515921831131,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3117121160030365,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3053327202796936,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31178852915763855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2997173070907593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2908931076526642,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28760790824890137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2842845022678375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2899763286113739,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28634729981422424,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28607991337776184,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27416151762008667,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.976048259174123,
+        "AvgTime/train_epoch_std": 0.20720206895740906,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.237360954284668,
+      "test_best_rerun_accuracy": 0.310222327709198,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30445411801338196,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23779509961605072,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2739323079586029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28241270780563354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28470471501350403,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23244708776474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2528840899467468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28268012404441833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2733975052833557,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2595309019088745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2430666983127594,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.949019557139913,
+        "AvgTime/train_epoch_std": 0.372967505121712,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2343850135803223,
+      "test_best_rerun_accuracy": 0.311330109834671,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30877071619033813,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2917335033416748,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2994499206542969,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2832149267196655,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2825273275375366,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2793949246406555,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.280846506357193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27821069955825806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26938650012016296,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2762243151664734,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2677057087421417,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.699864987973814,
+        "AvgTime/train_epoch_std": 0.19173080278036647,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.239635944366455,
+      "test_best_rerun_accuracy": 0.30865612626075745,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30743372440338135,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24405989050865173,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2701123058795929,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2830239236354828,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2811139225959778,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23821529746055603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2517763078212738,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26950111985206604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2659102976322174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25063028931617737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23676370084285736,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.919401967164242,
+        "AvgTime/train_epoch_std": 0.21442417245436735,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1557345390319824,
+      "test_best_rerun_accuracy": 0.3383375406265259,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046833276748657,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2957063317298889,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32550233602523804,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28619450330734253,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2735503017902374,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.317862331867218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30365192890167236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28879210352897644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27943310141563416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3203071355819702,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3110245168209076,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.265848402543502,
+        "AvgTime/train_epoch_std": 0.4790516963697369,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.17771053314209,
+      "test_best_rerun_accuracy": 0.33570173382759094,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3038047254085541,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2921537160873413,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32103294134140015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28745511174201965,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27374130487442017,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3243945240974426,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30907630920410156,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.294216513633728,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28268012404441833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33505234122276306,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31763312220573425,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.416637328133654,
+        "AvgTime/train_epoch_std": 0.2205534964450883,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1638987064361572,
+      "test_best_rerun_accuracy": 0.33451753854751587,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29654672741889954,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2850485146045685,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31992512941360474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28203070163726807,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26571929454803467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31396591663360596,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3028879165649414,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28512492775917053,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27400872111320496,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32045993208885193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3164489269256592,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.388180564431583,
+        "AvgTime/train_epoch_std": 0.16131597875541115,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.174985885620117,
+      "test_best_rerun_accuracy": 0.33287492394447327,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2982275187969208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2996409237384796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31068071722984314,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2881809175014496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28283292055130005,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29138970375061035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3161815404891968,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3054473102092743,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.300672322511673,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3261517286300659,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3512491285800934,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.049772631888296,
+        "AvgTime/train_epoch_std": 0.2392260477100156,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.181217670440674,
+      "test_best_rerun_accuracy": 0.3312705457210541,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3030407130718231,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2996027171611786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30785393714904785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2917335033416748,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28459012508392334,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2993353307247162,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3133547306060791,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3110627233982086,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30621132254600525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3323401212692261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3575139343738556,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.1972371459007265,
+        "AvgTime/train_epoch_std": 0.32789184924143655,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1635642051696777,
+      "test_best_rerun_accuracy": 0.3295133411884308,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30808311700820923,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30185651779174805,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3200397193431854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29096952080726624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2845137119293213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29708153009414673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3209947347640991,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31113913655281067,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3013981282711029,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3505615293979645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.366261750459671,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.872134378323188,
+        "AvgTime/train_epoch_std": 0.2802162601045582,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9894319772720337,
+      "test_best_rerun_accuracy": 0.40736496448516846,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2607150971889496,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24272289872169495,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24421270191669464,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22545649111270905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37623193860054016,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4022843539714813,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4002215564250946,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.550347626209259,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5254030227661133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5841546058654785,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.57093745470047,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.346616604498455,
+        "AvgTime/train_epoch_std": 0.19804590511817174,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0014808177948,
+      "test_best_rerun_accuracy": 0.4026663601398468,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25987470149993896,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23959049582481384,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2447092980146408,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23061348497867584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3693559467792511,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4001069664955139,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4006035625934601,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5409504175186157,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.518221378326416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5850332379341125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5678431987762451,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.693355657436229,
+        "AvgTime/train_epoch_std": 0.19682847639949164,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9897493124008179,
+      "test_best_rerun_accuracy": 0.4071357548236847,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2642677128314972,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24757429957389832,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2436015009880066,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2317976951599121,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37703415751457214,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40534037351608276,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40492016077041626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5507678389549255,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5288410186767578,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5964550375938416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5808694362640381,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.443068403464097,
+        "AvgTime/train_epoch_std": 0.18399428364429413,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0608322620391846,
+      "test_best_rerun_accuracy": 0.38276416063308716,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25712430477142334,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24707770347595215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2306898981332779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23798608779907227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4033539593219757,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3653831481933594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40167316794395447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5460692048072815,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5480556488037109,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5945068597793579,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6172740459442139,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.525739922243006,
+        "AvgTime/train_epoch_std": 0.27154459643682,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0531022548675537,
+      "test_best_rerun_accuracy": 0.38616394996643066,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26243409514427185,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2525402903556824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22113989293575287,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23225609958171844,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39552295207977295,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35109633207321167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3903277516365051,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5494308471679688,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5505003929138184,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5867140293121338,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6058522462844849,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.497858538347132,
+        "AvgTime/train_epoch_std": 0.17725842629589578,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.07970929145813,
+      "test_best_rerun_accuracy": 0.37733975052833557,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2513943016529083,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24665750563144684,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2218656837940216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.231912299990654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38750094175338745,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3477729260921478,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3913973569869995,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5243716239929199,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5323172211647034,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5459546446800232,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5867904424667358,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.36389835097573,
+        "AvgTime/train_epoch_std": 0.20362084205312583,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.925898551940918,
+      "test_best_rerun_accuracy": 0.4250897765159607,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22201849520206451,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20857208967208862,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2513560950756073,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2361142933368683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34483152627944946,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3022003173828125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42012375593185425,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46050119400024414,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44472458958625793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5794560313224792,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.577775239944458,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.360119915008545,
+        "AvgTime/train_epoch_std": 0.18628370974199157,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9051389694213867,
+      "test_best_rerun_accuracy": 0.4503399729728699,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24054549634456635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2211780846118927,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26174649596214294,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24703949689865112,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3764229416847229,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33696234226226807,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44380778074264526,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5126823782920837,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4997326135635376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6290014386177063,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6424096822738647,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.163128443559011,
+        "AvgTime/train_epoch_std": 0.3076832982226376,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9088058471679688,
+      "test_best_rerun_accuracy": 0.43872717022895813,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22740468382835388,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21032927930355072,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2547559142112732,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23741309344768524,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36641454696655273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31900832056999207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44109559059143066,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48536938428878784,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46989840269088745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5983268618583679,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.615058422088623,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.100682199001312,
+        "AvgTime/train_epoch_std": 0.20191866253696455,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8034236431121826,
+      "test_best_rerun_accuracy": 0.4697073996067047,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2411566972732544,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22610588371753693,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2614026963710785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2511269152164459,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37145695090293884,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3470853269100189,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4212697744369507,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5064939856529236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5102375745773315,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6149056553840637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6795400977134705,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.134383746555874,
+        "AvgTime/train_epoch_std": 0.22563956094464005,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8020540475845337,
+      "test_best_rerun_accuracy": 0.4685613811016083,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22923828661441803,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22110168635845184,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25223469734191895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23378409445285797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36832454800605774,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33245474100112915,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42803117632865906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5050805807113647,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5046985745429993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6116204261779785,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6756436824798584,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.145878799259663,
+        "AvgTime/train_epoch_std": 0.20207260617950001,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8190714120864868,
+      "test_best_rerun_accuracy": 0.47902819514274597,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24448010325431824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2361142933368683,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2608678936958313,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2470013052225113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38222935795783997,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3554893434047699,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4371991753578186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.522805392742157,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5260524153709412,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6366796493530273,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6960424780845642,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.936600318661442,
+        "AvgTime/train_epoch_std": 0.5134662413849511,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4317176342010498,
+      "test_best_rerun_accuracy": 0.6012682318687439,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22041408717632294,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2013522833585739,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20123767852783203,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18649247288703918,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38860875368118286,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36045533418655396,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3803957402706146,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4004889726638794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5909542441368103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6646420955657959,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6721674799919128,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.999222142355783,
+        "AvgTime/train_epoch_std": 0.3332129115426882,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3871519565582275,
+      "test_best_rerun_accuracy": 0.6079532504081726,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2317976951599121,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20937427878379822,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2175108939409256,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1998242735862732,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40339216589927673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37202996015548706,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4006035625934601,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41061195731163025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5966078639030457,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6744212508201599,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6840094923973083,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.1250081503832785,
+        "AvgTime/train_epoch_std": 0.26104023878098404,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3965091705322266,
+      "test_best_rerun_accuracy": 0.6108182668685913,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22832149267196655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2045992761850357,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22113989293575287,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20081748068332672,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4042707681655884,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36832454800605774,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40476736426353455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4195125699043274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6019940376281738,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6768278479576111,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6908472776412964,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.0413184031000675,
+        "AvgTime/train_epoch_std": 0.40593911222104434,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4140836000442505,
+      "test_best_rerun_accuracy": 0.6034456491470337,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22736649215221405,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21036748588085175,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.210176482796669,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1980670839548111,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3877301514148712,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36790433526039124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.371953547000885,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4038887619972229,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.593017041683197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6604782938957214,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7084192633628845,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.0599539784284735,
+        "AvgTime/train_epoch_std": 0.23102685826276584,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3993080854415894,
+      "test_best_rerun_accuracy": 0.5971044301986694,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2203758955001831,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20387348532676697,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20891588926315308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19940407574176788,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3848269581794739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3656887412071228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3644663393497467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.392887145280838,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.580793023109436,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6451982855796814,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6782030463218689,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.080683200787275,
+        "AvgTime/train_epoch_std": 0.2198147774814406,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3319791555404663,
+      "test_best_rerun_accuracy": 0.6211704611778259,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2347772866487503,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21460768580436707,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22656428813934326,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2146458923816681,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39934295415878296,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3780655562877655,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3923523426055908,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41183435916900635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6027580499649048,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6649476885795593,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.710405707359314,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.7091336025381985,
+        "AvgTime/train_epoch_std": 0.2689058753623847,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1104629039764404,
+      "test_best_rerun_accuracy": 0.6866834759712219,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2111314833164215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1884024739265442,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21896249055862427,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20559248328208923,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3875391483306885,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3393307328224182,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42665597796440125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44472458958625793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5765910148620605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5657422542572021,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7162503004074097,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.310873933271928,
+        "AvgTime/train_epoch_std": 0.20849129540725486,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.13346266746521,
+      "test_best_rerun_accuracy": 0.6872182488441467,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20536328852176666,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18836428225040436,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2097562849521637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1923752725124359,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.381465345621109,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3271831274032593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4136679768562317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4296737611293793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5741080045700073,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5594774484634399,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7068148851394653,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.347795502892856,
+        "AvgTime/train_epoch_std": 0.5107637403335964,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1154271364212036,
+      "test_best_rerun_accuracy": 0.689815878868103,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2111314833164215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18519367277622223,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21460768580436707,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19653907418251038,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3809305429458618,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3310031294822693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.423026978969574,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4359767735004425,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.582359254360199,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5660860538482666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7146840691566467,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.282740478004728,
+        "AvgTime/train_epoch_std": 0.28762712406669,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0019161701202393,
+      "test_best_rerun_accuracy": 0.7227824926376343,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21770188212394714,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20612728595733643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21716707944869995,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20547787845134735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3817327618598938,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3598823547363281,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41076475381851196,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4435403645038605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5673466324806213,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5774314403533936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6723966598510742,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.487854209946997,
+        "AvgTime/train_epoch_std": 0.34727962975037313,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9939878582954407,
+      "test_best_rerun_accuracy": 0.7145695090293884,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2093360871076584,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19673007726669312,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20498128235340118,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19333027303218842,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36698755621910095,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34154632687568665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4067537486553192,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4392619729042053,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5326228141784668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5480937957763672,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6562380790710449,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.255288246515635,
+        "AvgTime/train_epoch_std": 0.2526169490887458,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9973622560501099,
+      "test_best_rerun_accuracy": 0.712544858455658,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20158147811889648,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19027428328990936,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19894568622112274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18251967430114746,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36274734139442444,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33478492498397827,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40098556876182556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4291771650314331,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.535908043384552,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.554167628288269,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6558178663253784,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.443260889786941,
+        "AvgTime/train_epoch_std": 0.2182077925558059,
+        "model/params/total": 496243,
+        "model/params/trainable": 496243,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 56.906593322753906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 42.3307991027832,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.03049769387808588,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.534310340881348,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0659700544256913
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3764.867431640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2855417088843857
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135.42210388183594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.045642771783564524
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4684.43359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.625842831496326
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66.92904663085938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05779710417172658
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133631.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.103081315019506
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8203.5263671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.575201680492743
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37519.2578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9231768831052334
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2395.864501953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4259314670138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 685797.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.757628417587639
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216126.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5965412464846156
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.162644910812378,
+        "AvgTime/train_epoch_std": 0.13447590999992612,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 34.54967498779297,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 30.99357032775879,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.02232966161942276,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.363893032073975,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03349417385302092
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3856.504150390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.29249178235803
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.65533447265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03325087107268495
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4931.595703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6588638213927855
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81.52149200439453,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07039852504697282
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133848.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1081395568224037
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9131.6728515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6402799643501963
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38228.7578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.959544713337434
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2633.0576171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.46809913194444447
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 686478.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.765326120154294
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 219902.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6593621033231822
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.03707294030623,
+        "AvgTime/train_epoch_std": 0.18404698562413752,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 57.2517204284668,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 42.4683723449707,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.030596810046808864,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.815447807312012,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03587077793322111
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3089.007080078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2342819173362249
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90.98257446289062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03066483803939691
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4414.8671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5898286155644623
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.320098876953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05468056897837057
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129024.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9961075376184283
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8160.93896484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5722156054440997
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35405.1875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8148130350094829
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2377.388671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.422646875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668893.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.566407531418617
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211320.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.516563129233022
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.1103964412913605,
+        "AvgTime/train_epoch_std": 0.2382792461473045,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.6718015670776367,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.6924679279327393,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0089077259364881,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.5765609741211,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08687072116291145
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11221.1708984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.85105581330584
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186.91685485839844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06299860291823338
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7568.8759765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0112058752922513
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143.467041015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12389209068706822
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171945.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.992783633080996
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14459.0712890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0138179279948465
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46185.3203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3673853253626533
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3641.220458984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6473280815972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753261.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.520769939934166
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258749.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.305815829214717
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.704106998443604,
+        "AvgTime/train_epoch_std": 0.25245059700930605,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.319387674331665,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.2377616167068481,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.006514534824772885,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.73997497558594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10932274854148842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11934.4404296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9051528577692454
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201.73875427246094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06799418748650521
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7767.00341796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0376758073438543
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.81333923339844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12073690780086221
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174890.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.061178928455322
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14774.578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0359401293647454
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46606.76171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3889877348275155
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3651.574462890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6491687934027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757755.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.57160461183444
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260034.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.327197791340089
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.904275723866054,
+        "AvgTime/train_epoch_std": 0.2090342372614937,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.34957754611969,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.3515710830688477,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0071135320161518295,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96.87628173828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.069795592030462
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10433.45703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7913126303564657
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.5488052368164,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03321496637573859
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7430.58740234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9927304478749165
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.2238006591797,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12022780713227953
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170669.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9631522269180754
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13560.50390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9508136240534287
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46218.1796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3690696441386025
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3575.46826171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6356388020833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752568.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.512934374399059
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256026.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.260496230842195
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.0543634708111105,
+        "AvgTime/train_epoch_std": 0.1554453053380394,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1191.260498046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1015.602783203125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.07702713562405196,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109.7734146118164,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0790874745041905
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.3988037109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9494673879523027
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 701.7221069335938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.23650896762170331
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2880.870849609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3848858850513527
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218.14813232421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.18838353395873814
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83279.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9338466439485418
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6114.7041015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.42874099716466835
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27069.845703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3875568047119278
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1364.371826171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.24255499131944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 569106.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.437632914041378
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156875.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.610537781022748
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.923052999708387,
+        "AvgTime/train_epoch_std": 0.19289158109654692,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1510.7333984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1309.0528564453125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.09928349309406996,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 300.14404296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.21624210588526657
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97.669677734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.514050935444079
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125.01134490966797,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04213392143905223
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2455.985107421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.32812092283525385
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.658203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14132832739637305
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79355.5234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.842734614469162
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5034.69091796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3530143681088732
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25495.4609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3068563707775898
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1286.9364013671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2287886935763889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 561772.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.354671928554461
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158451.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.636775757991779
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.691353627613613,
+        "AvgTime/train_epoch_std": 0.27379785574602566,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1227.9298095703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1056.6512451171875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.08014040539379504,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.48089599609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.20567787895972173
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 543.4521484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.860274465460526
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348.43426513671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11743655717449233
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3495.150146484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.46695392738602204
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 442.96124267578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.38252266206889574
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82109.8203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.906692836533996
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5697.19140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.39946651284882906
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29513.1328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5127957769491005
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1740.775634765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3094712239583333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 579774.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.558311793717408
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167680.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.790346837402027
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.499097764492035,
+        "AvgTime/train_epoch_std": 0.0711816623936093,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 39.886192321777344,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 37.195064544677734,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.012536253638246625,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107.18062591552734,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07721947112069694
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117.2992172241211,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6173643011795847
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2826.593017578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.21437944767372963
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5051.47998046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6748804249123247
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202.31600952148438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1747115798976549
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128432.2265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.982357109476593
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8095.83837890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5676509871621266
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38839.49609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9908501765210929
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2687.1357421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.47771302083333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 681704.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.711324134927548
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211522.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5199152251510157
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.536306814713911,
+        "AvgTime/train_epoch_std": 0.2282132287313485,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 45.60859298706055,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 43.37580871582031,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.014619416486626327,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.68486785888672,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03507555321245441
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.92064666748047,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08905603509200247
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2967.9326171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22509917460656048
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4941.06201171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6601285252797261
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.22085571289062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08827362324083819
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130130.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.021798224735278
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8219.0751953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5762919082395527
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38538.390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9754159939002511
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2490.060302734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.44267738715277777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 680265.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.695048527764895
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211045.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.511979088662573
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.606167805194855,
+        "AvgTime/train_epoch_std": 0.16123064099564677,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 68.97755432128906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 64.85797119140625,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.021859781325044236,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 374.48455810546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.26980155483102936
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 442.3377685546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.3280935187088816
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3431.907470703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2602887729012609
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6913.98974609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9237127249290247
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 582.1832885742188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5027489538637467
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137172.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.185307405837823
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10481.8701171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.734950926741516
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43820.32421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.246159424816751
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3578.10009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6361066840277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702579.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.947461483207584
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 226367.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.766950549564841
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.562009167671204,
+        "AvgTime/train_epoch_std": 0.148137188090656,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 972.7385864257812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 910.2193603515625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.12160579296614062,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 398.9453430175781,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.28742459871583437
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 288.14666748046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5165614077919407
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17435.509765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.3223746504076601
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4676.12939453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.576046307560246
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 315.20904541015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.272201248195299
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37824.125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8783235417053687
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7485.25927734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.524839382789493
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17066.76171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8748147890076375
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 782.9923706054688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13919864366319445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 450995.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.101586626019479
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102895.9375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.712278260363104
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.528036276499431,
+        "AvgTime/train_epoch_std": 0.23919757759025972,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 856.4227294921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 851.2385864257812,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.11372593005020458,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210.73681640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15182767752611673
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.1802978515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7641068307976974
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19689.87109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.4933538941031475
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2514.595703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8475213020306707
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 223.85604858398438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.19331264989981378
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34550.875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8023145783020621
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4930.2451171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3456910052718763
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18905.130859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9690466379299297
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1016.7896118164062,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.18076259765625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 440642.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.984478750721129
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103370.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.720183195214085
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.357274423946034,
+        "AvgTime/train_epoch_std": 0.15088683838278236,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1528.912353515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1603.0997314453125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.21417498082101705,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173.68234252929688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12513137069834068
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.08634948730469,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3320334183542352
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8863.923828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.672273327882063
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 408.1122131347656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13755045943200728
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76.61652374267578,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06616280115947822
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58883.51953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3673490509764537
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2999.134521484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.21028849540628067
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21615.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1079996331821211
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 947.3036499023438,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.16840953776041667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 512915.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.802014991007092
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130804.4765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1767007232539566
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.164163385118757,
+        "AvgTime/train_epoch_std": 0.12167421529994013,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 63.22575759887695,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 64.75020599365234,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.05591554921731636,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 286.42181396484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.20635577374988742
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.258519649505615,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03820273499739797
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3652.41162109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.27701263717055363
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706.4642944335938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.23810727820478386
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4215.2978515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5631660456329325
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128277.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9787547313301133
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7430.767578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5210186213802412
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36096.09765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8502279797144907
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2258.517822265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4015142795138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 672121.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.602927785256156
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208224.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4650341449919293
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.984464446703593,
+        "AvgTime/train_epoch_std": 0.17002683131754506,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 93.2395248413086,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 90.62582397460938,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07826064246512036,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 284.75958251953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2051582006624865
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.687440872192383,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09835495195890728
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4053.2236328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3074117279342055
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3049.314697265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.0277434099311173
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4112.20458984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.549392730774048
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115919.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6918013741175923
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6511.53857421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.45656559908980154
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37233.328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9085205866523143
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2479.801513671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.44085360243055555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 664775.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.519828229811205
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203943.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3937917061887406
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.443388223648071,
+        "AvgTime/train_epoch_std": 0.2638239073118474,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 83.47779083251953,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 85.40047454833984,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07374825090530211,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135.28024291992188,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09746415195959789
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.324334144592285,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0753912323399594
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3213.97509765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.24375996190036026
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186.91014099121094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0629963400711867
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4689.75732421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.626554084731964
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130040.6171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0197059536387703
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8671.1435546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6079893110845254
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36843.328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8885298131631554
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2500.494140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4445322916666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 674167.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.626069675237265
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215392.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.584320605145358
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.232434144386878,
+        "AvgTime/train_epoch_std": 0.23848597186838827,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 15667.349609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 14650.6416015625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.34020624190884496,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2680.42822265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.931144252634186
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3624.21630859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 19.07482267680921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6435.67919921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4881061205323284
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20671.232421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.967048339020897
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2379.483642578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3179002862495825
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2782.593017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.4029300669931994
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15457.1201171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0837975120731664
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8854.177734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4538509269760111
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2777.195556640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4937236545138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 309383.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.4996984689433615
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73813.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2283166820594744
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.792301995413644,
+        "AvgTime/train_epoch_std": 0.11848503979591507,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 13759.9580078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11175.0712890625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.25949914752606584,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2244.916748046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.6173751787081232
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4747.4326171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 24.98648745888158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4513.90087890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3423512232769245
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13973.2099609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.709541611370914
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3257.9736328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.43526701841182364
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4783.6669921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.130973222959844
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12403.33203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.869676905851213
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14063.365234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7208655099889795
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5565.0751953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9893467013888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 325877.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.6862666566745474
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68112.5078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1334516135406787
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.825423134697808,
+        "AvgTime/train_epoch_std": 0.20110766690832785,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 17462.09765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15021.0732421875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.34880812841787806,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2268.9736328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.6347072282510806
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2403.546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 12.650246710526316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7663.4892578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.581227854214069
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25496.779296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.59345443103303
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1956.573974609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.26139932860512693
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1886.031494140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.6286973179107298
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23751.376953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.66536088578916
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10572.7197265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5419406287642883
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2338.30322265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.41569835069444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 307589.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.4794057469769126
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88757.0546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4769949026924933
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.868231217066447,
+        "AvgTime/train_epoch_std": 0.07979799752652125,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2489.362060546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2023.9095458984375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.141909237547219,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2812.9208984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.026600070920389
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1446.2607421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.611898643092105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68097.234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.16475042662116
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 313.9371337890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10580961705057718
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3123.811767578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4173429215201236
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1400.8460693359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.209711631550896
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43615.2734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0128012594626603
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13639.2939453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6991282969558922
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1303.7052001953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.23176981336805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 391845.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.432496281234799
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84377.9140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4041221783319189
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.310640096664429,
+        "AvgTime/train_epoch_std": 0.20156279485935413,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2558.747802734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2048.619140625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.14364178520719395,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2911.0146484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.0972728014679394
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 833.5995483398438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.387366043893914
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70021.0390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.310659011186955
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 441.5301513671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1488136674645054
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3742.07177734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.49994278922428187
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 665.2871704101562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5745139640847636
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41460.3828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9627620010333457
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12787.4736328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6554653561337075
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 575.0280151367188,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10222720269097223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 313928.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.551101560467405
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59605.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9918935545737441
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.479909400145213,
+        "AvgTime/train_epoch_std": 0.1570650947618238,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1766.342529296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1650.4237060546875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.11572175754134677,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2524.009521484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.818450663893642
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3127.63623046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 16.461243318256578
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22718.697265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.7230714649696626
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 745.6725463867188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2513220581013545
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2005.80517578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.26797664339094857
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2212.918701171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.910983334345315
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25429.423828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5905030612141232
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15058.990234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7718996480790917
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1551.2637939453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.27578023003472224
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361442.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.088575543250795
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79756.5234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3272182024112626
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.912537314675071,
+        "AvgTime/train_epoch_std": 0.41672350453884033,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 8809.9267578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9054.72265625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.4641305375083295,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4783.6962890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.4464670670479105
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3327.33544921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.51229183799342
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53728.09375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.074940747061055
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9426.080078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.176973400109538
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4728.92138671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6317864244113226
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4134.8173828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.5706540438795336
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48128.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1175924205833179
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27373.32421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.9193187644615062
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4814.8251953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8559689236111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250748.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.836423113469
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55600.24609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9252366514194665
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.695435305436452,
+        "AvgTime/train_epoch_std": 0.1577371170695666,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 7013.328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7097.58154296875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.3638106280674945,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3371.753662109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.4292173358136706
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4275.201171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 22.501058799342104
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23698.205078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.7973610222317027
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8435.0107421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.8429426161737443
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3159.4267578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.42210110324816297
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4252.96826171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.6726841638331176
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31414.400390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7294817107241548
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22093.779296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.5491361167350302
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3513.69287109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6246565104166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230848.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.611318337612977
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49411.70703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8222539568876575
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.705769729614258,
+        "AvgTime/train_epoch_std": 0.21221761308228135,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 8688.208984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8617.6884765625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.44172886752588547,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4494.83642578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.2383547736176155
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2875.364990234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 15.133499948601974
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19247.09765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.4597722909556314
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9796.65625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.3018726828446243
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3678.349609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4914294735303941
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2567.470947265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.217159712664616
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38764.7734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9001665762005387
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38406.73046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.6929414155623337
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4081.689208984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7256336371527777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203626.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.3033872577853693
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64227.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.068800910671792
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.34474457865176,
+        "AvgTime/train_epoch_std": 0.25138784058670827,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 626.3052978515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 656.2920532226562,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.1166741427951389,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276.3219909667969,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.19907924421238968
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215.24473571777344,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.1328670300935444
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11557.6669921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.876576942903868
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2922.95556640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.9851552296616953
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1688.48291015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2255822191257515
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221.23223876953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.19104683831565739
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49750.5234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.155269446347297
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6037.6904296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.42334107626472445
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16938.37890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.868234092277923
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 455272.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.149971932513602
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102692.8203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.708898212978217
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.207208139555795,
+        "AvgTime/train_epoch_std": 0.09728614202407704,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 787.8460693359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 823.7380981445312,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.14644232855902778,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 771.2615356445312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5556639305796335
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 815.53076171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.29226716694079
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29789.439453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.2593431515453166
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1062.77294921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3581978258236434
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1474.8974609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.19704708896960588
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 585.872314453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5059346411512305
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44726.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0386015218628089
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4395.36962890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.30818746521569557
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17713.029296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9079414268734943
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 442817.28125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.009075271766795
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104059.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.731633416121678
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.198027801513672,
+        "AvgTime/train_epoch_std": 0.1244283312342927,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1133.156005859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1167.55859375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.20756597222222223,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2229.160400390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.6060233432209114
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.80503845214844,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7989738865902549
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33659.14453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.5528361419226395
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4692.73095703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5816417111665824
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2616.589599609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3495777688188878
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183.2282257080078,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15822817418653523
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63479.74609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.474079186646619
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6876.02978515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.48212240815848056
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23808.671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2203942731559794
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 527111.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.962600958112281
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137862.515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.294152657131446
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.155696749687195,
+        "AvgTime/train_epoch_std": 0.09542691707611084,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 153181.96875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 101498.125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 1.1481298711582186,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17469.8359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 12.586337130763688
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13077.2431640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 68.82759560032895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87606.625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.644416003033751
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65389.06640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.038782071536907
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14254.0166015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.9043442353456914
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12790.9013671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.045683391353627
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173386.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.026257793632733
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41782.04296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.929606154028187
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13842.734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7095563265672253
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18796.205078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.3415475694444443
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67271.5859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1194579391526467
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.713962217171987,
+        "AvgTime/train_epoch_std": 0.27823635913770783,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 244289.375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 143276.78125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 1.6207230665248917,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95983.9765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 69.15272086635447
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137809.046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 725.3107730263158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48824.1328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.703005901592719
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101966.8359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 34.36698211577351
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95748.6875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 12.792075818303273
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120846.203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 104.35768836355786
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112216.7890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6058143475408695
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83388.796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.846921671224232
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80587.984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.130810619457686
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76201.0234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 13.54684861111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39242.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.653023750686436
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.660029232501984,
+        "AvgTime/train_epoch_std": 0.036107343942922594,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 109134.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 81880.203125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.9262152090426795,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9553.4658203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.882900446911023
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7643.09814453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 40.22683233963816
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68865.109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.22298895525218
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19098.19140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.436869365099427
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9739.1455078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.301155044463928
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7061.40478515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.09793159339918
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96104.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.231673715284228
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25546.37109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.7912194007677744
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10825.349609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5548900307229997
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12577.912109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.2360732638888887
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68348.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1373750894446941
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.629607534408569,
+        "AvgTime/train_epoch_std": 0.205295797573127,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 36014.39453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 34455.44140625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.573368635385985,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6717.01416015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.839347377634186
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2654.00390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 13.968441611842104
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136341.625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 10.340661736822147
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30142.44921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 10.159234654111897
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9241.650390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2346894309452239
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4130.388671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.5668295957469773
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267589.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 6.21376033345718
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19566.515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.3719335033655868
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7418.15673828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3802427975950202
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6835.40478515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2151830729166666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144992.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.6401338189880434
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.000830411911011,
+        "AvgTime/train_epoch_std": 0.24443317504918796,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 30053.14453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28875.333984375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.48051077470545656,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2755.272216796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.9850664386144632
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4039.146240234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 21.258664422286184
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129235.5703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.801711817406144
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7287.9931640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.456350914749747
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8090.109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0808429358717435
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3541.887939453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.0586251636037347
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225408.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 5.234262159228126
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15640.6298828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0966645549581056
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9231.7529296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.47320482493656774
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5073.80224609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9020092881944445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120468.296875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.3627172932479668
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.91532852099492,
+        "AvgTime/train_epoch_std": 0.3292896540261535,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cin_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 38362.41796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 35341.09375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.5881066638377183,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43715.4140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 31.495255088256485
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47741.0234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 251.26854440789472
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81531.5546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.183659817026925
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7775.72021484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.620734821315723
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58077.1015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.759131805277221
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42813.765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 36.97216375215889
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176636.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.101715615130968
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12322.21484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.863989261236152
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67503.3828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.4601149629658106
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37242.46484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 6.620882638888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180894.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.046250904946665
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-03_07-02-04__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.001546541849772,
+        "AvgTime/train_epoch_std": 0.284262186440755,
+        "model/params/total": 495008,
+        "model/params/trainable": 495008,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/cell/cin.yaml
+++ b/configs/model/cell/cin.yaml
@@ -1,0 +1,40 @@
+# configs/model/cell/cin.yaml
+
+_target_: topobench.model.TBModel
+
+model_name: cin
+model_domain: cell
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.cell.cin.CIN
+  in_channels_0: ${model.feature_encoder.out_channels}
+  in_channels_1: ${model.feature_encoder.out_channels}
+  in_channels_2: ${model.feature_encoder.out_channels}
+  hid_channels: ${model.feature_encoder.out_channels}
+  n_layers: 4
+  dropout: 0.5
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.cell.cin_wrapper.CINWrapper
+  _partial_: true
+  wrapper_name: CINWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+compile: false

--- a/test/nn/backbones/cell/test_cin.py
+++ b/test/nn/backbones/cell/test_cin.py
@@ -1,0 +1,535 @@
+"""Unit tests for the CIN (Cell Isomorphism Network) backbone."""
+
+import pytest
+import torch
+import torch_geometric.data
+
+from topobench.nn.backbones.cell.cin import CIN, CINLayer
+
+# ──────────────────────────────────────────────────────────────────────────── #
+# A minimal synthetic cell complex
+# ──────────────────────────────────────────────────────────────────────────── #
+
+
+@pytest.fixture()
+def cell_complex_batch():
+    """Minimal synthetic cell complex batch for testing.
+
+    Complex: 5 nodes, 6 edges, 2 rings.  All features in R^8.
+    The connectivity mirrors a simple graph with two 3-cycles sharing an edge.
+    """
+    torch.manual_seed(0)
+    N0, N1, N2, D = 5, 6, 2, 8
+
+    x_0 = torch.randn(N0, D)
+    x_1 = torch.randn(N1, D)
+    x_2 = torch.randn(N2, D)
+
+    # adjacency_0: [N0, N0] sparse — upper-adjacency for nodes (A_up,0)
+    # A_up,0[i,j] = 1 if nodes i and j share a common edge
+    adj0_rows = torch.tensor([0, 1, 1, 2, 2, 3, 3, 4, 4, 0])
+    adj0_cols = torch.tensor([1, 0, 2, 1, 3, 2, 4, 3, 0, 4])
+    adjacency_0 = torch.sparse_coo_tensor(
+        torch.stack([adj0_rows, adj0_cols]),
+        torch.ones(adj0_rows.size(0)),
+        size=(N0, N0),
+    ).float()
+
+    # adjacency_1: [N1, N1] sparse — upper-adjacency for edges (A_up,1)
+    # A_up,1[i,j] = 1 if edges i and j share a common ring
+    adj1_rows = torch.tensor([0, 1, 2, 3, 4, 5])
+    adj1_cols = torch.tensor([1, 0, 3, 2, 5, 4])
+    adjacency_1 = torch.sparse_coo_tensor(
+        torch.stack([adj1_rows, adj1_cols]),
+        torch.ones(adj1_rows.size(0)),
+        size=(N1, N1),
+    ).float()
+
+    # incidence_1: B1 [N0, N1] sparse; B1[v,e]=1 iff v ∈ boundary(edge e)
+    b1_idx = torch.tensor(
+        [
+            [0, 1, 1, 2, 2, 3, 3, 4, 4, 0, 1, 2],
+            [0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 5],
+        ]
+    )
+    incidence_1 = torch.sparse_coo_tensor(
+        b1_idx, torch.ones(b1_idx.size(1)), size=(N0, N1)
+    )
+
+    # incidence_2: B2 [N1, N2] sparse; B2[e,r]=1 iff e ∈ boundary(ring r)
+    b2_idx = torch.tensor(
+        [
+            [0, 1, 2, 3, 4, 5],
+            [0, 0, 0, 1, 1, 1],
+        ]
+    )
+    incidence_2 = torch.sparse_coo_tensor(
+        b2_idx, torch.ones(b2_idx.size(1)), size=(N1, N2)
+    )
+
+    batch = torch_geometric.data.Data(
+        x_0=x_0,
+        x_1=x_1,
+        x_2=x_2,
+        adjacency_0=adjacency_0,
+        adjacency_1=adjacency_1,
+        incidence_1=incidence_1,
+        incidence_2=incidence_2,
+        y=torch.zeros(1, dtype=torch.long),
+        batch_0=torch.zeros(N0, dtype=torch.long),
+    )
+    batch._N0, batch._N1, batch._N2, batch._D = N0, N1, N2, D
+    return batch
+
+
+# ──────────────────────────────────────────────────────────────────────────── #
+# CINLayer tests
+# ──────────────────────────────────────────────────────────────────────────── #
+
+
+class TestCINLayer:
+    """Tests for CINLayer — single message passing step."""
+
+    def _make_layer(self, d=8, out=16, has_2_cells=True):
+        return CINLayer(
+            in_channels_0=d,
+            in_channels_1=d,
+            in_channels_2=d if has_2_cells else 0,
+            out_channels=out,
+        )
+
+    def test_output_shapes(self, cell_complex_batch):
+        """All output tensors must have shape (N_k, out_channels)."""
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        out0, out1, out2 = layer(
+            b.x_0,
+            b.x_1,
+            b.x_2,
+            b.adjacency_0,
+            b.adjacency_1,
+            b.incidence_1,
+            b.incidence_2,
+        )
+        assert out0.shape == (b._N0, 16)
+        assert out1.shape == (b._N1, 16)
+        assert out2.shape == (b._N2, 16)
+
+    def test_no_2cells_returns_none(self, cell_complex_batch):
+        """Without 2-cells, x_2_new must be None."""
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16, has_2_cells=False)
+        out0, out1, out2 = layer(
+            b.x_0,
+            b.x_1,
+            None,
+            b.adjacency_0,
+            None,
+            b.incidence_1,
+            None,
+        )
+        assert out0.shape == (b._N0, 16)
+        assert out1.shape == (b._N1, 16)
+        assert out2 is None
+
+    def test_gradients_all_streams(self, cell_complex_batch):
+        """Gradients must flow to all three cell-feature inputs."""
+        b = cell_complex_batch
+        x0 = b.x_0.requires_grad_(True)
+        x1 = b.x_1.requires_grad_(True)
+        x2 = b.x_2.requires_grad_(True)
+        layer = self._make_layer(d=b._D, out=16)
+        out0, out1, out2 = layer(
+            x0,
+            x1,
+            x2,
+            b.adjacency_0,
+            b.adjacency_1,
+            b.incidence_1,
+            b.incidence_2,
+        )
+        (out0.sum() + out1.sum() + out2.sum()).backward()
+        assert x0.grad is not None, "No gradient to x_0"
+        assert x1.grad is not None, "No gradient to x_1"
+        assert x2.grad is not None, "No gradient to x_2"
+
+    def test_2cell_boundary_depends_on_edges(self, cell_complex_batch):
+        """2-cell (ring) features must depend on 1-cell (edge) features.
+
+        Paper Section 4 and Figure 6 show rings receive boundary messages from
+        their constituent edges: m_B(ring) = AGG_{e ∈ B(ring)} MLP_B(h_e).
+        Theorem 7 only drops coboundary and lower-adjacency — boundary messages
+        are always kept.
+        """
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        layer.eval()
+
+        with torch.no_grad():
+            _, _, out2_orig = layer(
+                b.x_0,
+                b.x_1,
+                b.x_2,
+                b.adjacency_0,
+                b.adjacency_1,
+                b.incidence_1,
+                b.incidence_2,
+            )
+            x1_perturbed = b.x_1 + 10.0
+            _, _, out2_perturbed = layer(
+                b.x_0,
+                x1_perturbed,
+                b.x_2,
+                b.adjacency_0,
+                b.adjacency_1,
+                b.incidence_1,
+                b.incidence_2,
+            )
+
+        assert not torch.allclose(out2_orig, out2_perturbed, atol=1e-5), (
+            "2-cell output did not change when edge features changed — "
+            "boundary message m_B(ring)←edges is missing"
+        )
+
+    def test_1cell_boundary_depends_on_nodes(self, cell_complex_batch):
+        """1-cell (edge) features must depend on 0-cell (node) features.
+
+        Paper Section 4 and Figure 6 (orange arrows) show bonds receive
+        boundary messages from their endpoint atoms:
+        m_B(edge) = AGG_{v ∈ B(edge)} MLP_B(h_v) = B1^T @ msg_boundary_1(x_0).
+        This specifically tests the fix for the missing node→edge boundary message.
+        """
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        layer.eval()
+
+        with torch.no_grad():
+            _, out1_orig, _ = layer(
+                b.x_0,
+                b.x_1,
+                b.x_2,
+                b.adjacency_0,
+                b.adjacency_1,
+                b.incidence_1,
+                b.incidence_2,
+            )
+            x0_perturbed = b.x_0 + 10.0
+            _, out1_perturbed, _ = layer(
+                x0_perturbed,
+                b.x_1,
+                b.x_2,
+                b.adjacency_0,
+                b.adjacency_1,
+                b.incidence_1,
+                b.incidence_2,
+            )
+
+        assert not torch.allclose(out1_orig, out1_perturbed, atol=1e-5), (
+            "1-cell output did not change when node features changed — "
+            "boundary message m_B(edge)←nodes (B1^T @ msg(x_0)) is missing"
+        )
+
+    def test_boundary_aggregate_non_zero(self, cell_complex_batch):
+        """Boundary aggregation (B1^T @ msg(x_0)) produces non-zero output."""
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        # B1^T: transpose=False, x_sender=x_0, incidence=B1[N0,N1]
+        # Result shape [N1, out] — boundary message from nodes to edges
+        agg = layer._incidence_aggregate(
+            x_sender=b.x_0,
+            incidence=b.incidence_1,
+            msg_fn=layer.msg_boundary_1,
+            transpose=False,
+            n_receivers=b._N1,
+        )
+        assert agg.shape == (b._N1, 16)
+        assert agg.abs().sum() > 0
+
+    def test_incidence_aggregate_dense(self, cell_complex_batch):
+        """_incidence_aggregate must also handle dense (non-sparse) matrices.
+
+        Covers the dense branch of the helper and checks it matches the
+        sparse result for the same connectivity.
+        """
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        dense_incidence = b.incidence_1.to_dense()
+        # Test the bridge-edge path (transpose=True, B1 @ msg(x_1))
+        agg_dense = layer._incidence_aggregate(
+            x_sender=b.x_1,
+            incidence=dense_incidence,
+            msg_fn=layer.msg_bridge_e,
+            transpose=True,
+            n_receivers=b._N0,
+        )
+        agg_sparse = layer._incidence_aggregate(
+            x_sender=b.x_1,
+            incidence=b.incidence_1,
+            msg_fn=layer.msg_bridge_e,
+            transpose=True,
+            n_receivers=b._N0,
+        )
+        assert agg_dense.shape == (b._N0, 16)
+        assert torch.allclose(agg_dense, agg_sparse, atol=1e-5)
+
+    def test_incidence_aggregate_dense_transpose_false(
+        self, cell_complex_batch
+    ):
+        """Dense path with transpose=False (edges→rings via B2^T)."""
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        dense_b2 = b.incidence_2.to_dense()
+        agg = layer._incidence_aggregate(
+            x_sender=b.x_1,
+            incidence=dense_b2,
+            msg_fn=layer.msg_B_2,
+            transpose=False,
+            n_receivers=b._N2,
+        )
+        assert agg.shape == (b._N2, 16)
+
+    def test_upper_aggregate_dense(self, cell_complex_batch):
+        """_upper_aggregate must also handle dense adjacency matrices."""
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        dense_adj = b.adjacency_0.to_dense()
+        agg_dense = layer._upper_aggregate(
+            x_neighbor=b.x_0,
+            adjacency=dense_adj,
+            msg_fn=layer.msg_up_0,
+            n_receivers=b._N0,
+        )
+        agg_sparse = layer._upper_aggregate(
+            x_neighbor=b.x_0,
+            adjacency=b.adjacency_0,
+            msg_fn=layer.msg_up_0,
+            n_receivers=b._N0,
+        )
+        assert agg_dense.shape == (b._N0, 16)
+        assert torch.allclose(agg_dense, agg_sparse, atol=1e-5)
+
+    def test_upper_aggregate_zero_on_empty_adj(self, cell_complex_batch):
+        """Upper aggregation must return zeros when adjacency has no edges."""
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        empty_adj = torch.sparse_coo_tensor(
+            torch.zeros(2, 0, dtype=torch.long),
+            torch.zeros(0),
+            size=(b._N0, b._N0),
+        ).float()
+        agg = layer._upper_aggregate(
+            x_neighbor=b.x_0,
+            adjacency=empty_adj,
+            msg_fn=layer.msg_up_0,
+            n_receivers=b._N0,
+        )
+        assert agg.shape == (b._N0, 16)
+        assert agg.abs().sum() == 0.0
+
+    def test_upper_aggregate_zero_on_none_adj(self, cell_complex_batch):
+        """Upper aggregation must return zeros when adjacency is None."""
+        b = cell_complex_batch
+        layer = self._make_layer(d=b._D, out=16)
+        agg = layer._upper_aggregate(
+            x_neighbor=b.x_0,
+            adjacency=None,
+            msg_fn=layer.msg_up_0,
+            n_receivers=b._N0,
+        )
+        assert agg.shape == (b._N0, 16)
+        assert agg.abs().sum() == 0.0
+
+    def test_make_update_mlp(self):
+        """Per-stream update MLP must map (N, C) -> (N, C).
+
+        Mirrors ``update_up_nn`` / ``update_boundaries_nn`` in the reference
+        implementation (cwn-main, ``mp/layers.py::SparseCINConv``): two
+        Linear layers each followed by BatchNorm and ReLU.
+        """
+        mlp = CINLayer._make_update_mlp(16)
+        out = mlp(torch.randn(4, 16))
+        assert out.shape == (4, 16)
+        linears = [m for m in mlp if isinstance(m, torch.nn.Linear)]
+        assert len(linears) == 2
+
+    def test_make_combine_mlp(self):
+        """Combine MLP must map the concatenated streams (N, 2C) -> (N, C).
+
+        Mirrors ``combine_nn`` in the reference implementation (cwn-main,
+        ``mp/layers.py::SparseCINConv``).
+        """
+        mlp = CINLayer._make_combine_mlp(16)
+        out = mlp(torch.randn(4, 32))
+        assert out.shape == (4, 16)
+
+    def test_two_step_update_separate_eps_streams(self, cell_complex_batch):
+        """Each rank must carry two GIN eps parameters (up and boundary).
+
+        The two-step update of Appendix E.3 (and
+        ``SparseCINCochainConv.forward`` in cwn-main, lines 184-199) applies
+        separate (1+eps)-weighted updates to the upper and boundary
+        multi-sets before combining them.
+        """
+        layer = self._make_layer(d=8, out=16)
+        for name in [
+            "eps_up_0",
+            "eps_B_0",
+            "eps_up_1",
+            "eps_B_1",
+            "eps_up_2",
+            "eps_B_2",
+        ]:
+            assert hasattr(layer, name), f"Missing eps parameter: {name}"
+        # Streams must be combined by a dedicated MLP per rank
+        for name in ["combine_0", "combine_1", "combine_2"]:
+            assert hasattr(layer, name), f"Missing combine MLP: {name}"
+
+
+# ──────────────────────────────────────────────────────────────────────────── #
+# CIN tests
+# ──────────────────────────────────────────────────────────────────────────── #
+
+
+class TestCIN:
+    """Tests for the full CIN backbone (stacked CINLayers)."""
+
+    def _model(self, b, n_layers=3, dropout=0.0):
+        return CIN(
+            in_channels_0=b._D,
+            in_channels_1=b._D,
+            in_channels_2=b._D,
+            hid_channels=16,
+            n_layers=n_layers,
+            dropout=dropout,
+        )
+
+    def test_output_shapes(self, cell_complex_batch):
+        """CIN must return tensors of shape (N_k, hid_channels)."""
+        b = cell_complex_batch
+        model = self._model(b)
+        out0, out1, out2 = model(
+            b.x_0,
+            b.x_1,
+            b.x_2,
+            b.adjacency_0,
+            b.adjacency_1,
+            b.incidence_1,
+            b.incidence_2,
+        )
+        assert out0.shape == (b._N0, 16)
+        assert out1.shape == (b._N1, 16)
+        assert out2.shape == (b._N2, 16)
+
+    def test_single_layer(self, cell_complex_batch):
+        """A single CIN layer must still run and produce correct shapes."""
+        b = cell_complex_batch
+        model = self._model(b, n_layers=1)
+        out0, out1, out2 = model(
+            b.x_0,
+            b.x_1,
+            b.x_2,
+            b.adjacency_0,
+            b.adjacency_1,
+            b.incidence_1,
+            b.incidence_2,
+        )
+        assert out0.shape == (b._N0, 16)
+
+    def test_all_dims_updated_across_layers(self, cell_complex_batch):
+        """After forward pass, all three cell-dim outputs must differ from input
+        projections — verifying that 0-cells and 2-cells are genuinely updated
+        (fixing the TopoModelX CWN bug where only x_1 was updated in the loop).
+        """
+        b = cell_complex_batch
+        model = self._model(b, n_layers=2)
+        model.eval()
+
+        out0, out1, out2 = model(
+            b.x_0,
+            b.x_1,
+            b.x_2,
+            b.adjacency_0,
+            b.adjacency_1,
+            b.incidence_1,
+            b.incidence_2,
+        )
+
+        proj0_only = torch.nn.functional.elu(model.proj_0(b.x_0))
+        proj2_only = torch.nn.functional.elu(model.proj_2(b.x_2))
+
+        assert not torch.allclose(out0, proj0_only, atol=1e-5), (
+            "x_0 was NOT updated by message passing (TopoModelX bug still present)"
+        )
+        assert not torch.allclose(out2, proj2_only, atol=1e-5), (
+            "x_2 was NOT updated by message passing (TopoModelX bug still present)"
+        )
+
+    def test_no_2cells(self, cell_complex_batch):
+        """CIN must handle absence of 2-cells (x_2=None) gracefully."""
+        b = cell_complex_batch
+        model = CIN(
+            in_channels_0=b._D,
+            in_channels_1=b._D,
+            in_channels_2=0,
+            hid_channels=16,
+            n_layers=2,
+        )
+        out0, out1, out2 = model(
+            b.x_0,
+            b.x_1,
+            None,
+            b.adjacency_0,
+            None,
+            b.incidence_1,
+            None,
+        )
+        assert out0.shape == (b._N0, 16)
+        assert out1.shape == (b._N1, 16)
+        assert out2 is None
+
+    def test_end_to_end_backprop(self, cell_complex_batch):
+        """Loss on all outputs must allow gradients to reach all parameters."""
+        b = cell_complex_batch
+        model = self._model(b)
+        out0, out1, out2 = model(
+            b.x_0,
+            b.x_1,
+            b.x_2,
+            b.adjacency_0,
+            b.adjacency_1,
+            b.incidence_1,
+            b.incidence_2,
+        )
+        loss = out0.mean() + out1.mean() + out2.mean()
+        loss.backward()
+        for name, p in model.named_parameters():
+            if p.requires_grad:
+                assert p.grad is not None, f"No gradient for parameter: {name}"
+
+    def test_eval_deterministic(self, cell_complex_batch):
+        """In eval mode, two identical forward passes must produce identical outputs."""
+        b = cell_complex_batch
+        model = self._model(b, dropout=0.5)
+        model.eval()
+        with torch.no_grad():
+            out_a = model(
+                b.x_0,
+                b.x_1,
+                b.x_2,
+                b.adjacency_0,
+                b.adjacency_1,
+                b.incidence_1,
+                b.incidence_2,
+            )
+            out_b = model(
+                b.x_0,
+                b.x_1,
+                b.x_2,
+                b.adjacency_0,
+                b.adjacency_1,
+                b.incidence_1,
+                b.incidence_2,
+            )
+        assert torch.allclose(out_a[0], out_b[0])
+        assert torch.allclose(out_a[1], out_b[1])
+        assert torch.allclose(out_a[2], out_b[2])

--- a/test/nn/wrappers/cell/test_cin_wrapper.py
+++ b/test/nn/wrappers/cell/test_cin_wrapper.py
@@ -1,0 +1,157 @@
+"""Unit tests for CINWrapper."""
+
+import pytest
+import torch
+import torch_geometric.data
+
+from topobench.nn.backbones.cell.cin import CIN
+from topobench.nn.wrappers.cell.cin_wrapper import CINWrapper
+
+# ──────────────────────────────────────────────────────────────────────────── #
+# A minimal synthetic cell complex
+# ──────────────────────────────────────────────────────────────────────────── #
+
+
+@pytest.fixture()
+def cin_batch():
+    """Minimal synthetic cell complex for wrapper tests.
+
+    5 nodes, 6 edges, 2 rings. All features in R^8.
+    """
+    torch.manual_seed(42)
+    N0, N1, N2, D = 5, 6, 2, 8
+
+    x_0 = torch.randn(N0, D)
+    x_1 = torch.randn(N1, D)
+    x_2 = torch.randn(N2, D)
+
+    adj0_idx = torch.tensor(
+        [[0, 1, 1, 2, 2, 3, 3, 4, 4, 0], [1, 0, 2, 1, 3, 2, 4, 3, 0, 4]]
+    )
+    adjacency_0 = torch.sparse_coo_tensor(
+        adj0_idx, torch.ones(adj0_idx.size(1)), size=(N0, N0)
+    ).float()
+
+    adj1_idx = torch.tensor([[0, 1, 2, 3, 4, 5], [1, 0, 3, 2, 5, 4]])
+    adjacency_1 = torch.sparse_coo_tensor(
+        adj1_idx, torch.ones(adj1_idx.size(1)), size=(N1, N1)
+    ).float()
+
+    b1_idx = torch.tensor(
+        [
+            [0, 1, 1, 2, 2, 3, 3, 4, 4, 0, 1, 2],
+            [0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 5],
+        ]
+    )
+    incidence_1 = torch.sparse_coo_tensor(
+        b1_idx, torch.ones(b1_idx.size(1)), size=(N0, N1)
+    )
+
+    b2_idx = torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 0, 1, 1, 1]])
+    incidence_2 = torch.sparse_coo_tensor(
+        b2_idx, torch.ones(b2_idx.size(1)), size=(N1, N2)
+    )
+
+    batch = torch_geometric.data.Data(
+        x_0=x_0,
+        x_1=x_1,
+        x_2=x_2,
+        adjacency_0=adjacency_0,
+        adjacency_1=adjacency_1,
+        incidence_1=incidence_1,
+        incidence_2=incidence_2,
+        y=torch.zeros(1, dtype=torch.long),
+        batch_0=torch.zeros(N0, dtype=torch.long),
+    )
+    batch._N0, batch._N1, batch._N2, batch._D = N0, N1, N2, D
+    return batch
+
+
+# ──────────────────────────────────────────────────────────────────────────── #
+# CINWrapper tests
+# ──────────────────────────────────────────────────────────────────────────── #
+
+
+class TestCINWrapper:
+    """Tests for CINWrapper — forward method."""
+
+    def _make_wrapper(self, b, n_layers=2):
+        model = CIN(b._D, b._D, b._D, hid_channels=b._D, n_layers=n_layers)
+        return CINWrapper(model, out_channels=b._D, num_cell_dimensions=3)
+
+    def test_output_keys(self, cin_batch):
+        """Wrapper must return all expected keys: labels, batch_0, x_0, x_1, x_2."""
+        wrapper = self._make_wrapper(cin_batch)
+        out = wrapper(cin_batch)
+        for key in ("labels", "batch_0", "x_0", "x_1", "x_2"):
+            assert key in out, f"Missing key: {key}"
+
+    def test_output_shapes(self, cin_batch):
+        """Output tensors must have correct spatial shapes."""
+        b = cin_batch
+        wrapper = self._make_wrapper(b)
+        out = wrapper(b)
+        assert out["x_0"].shape == (b._N0, b._D)
+        assert out["x_1"].shape == (b._N1, b._D)
+        assert out["x_2"].shape == (b._N2, b._D)
+
+    def test_labels_and_batch_passthrough(self, cin_batch):
+        """labels and batch_0 must be passed through unchanged."""
+        b = cin_batch
+        wrapper = self._make_wrapper(b)
+        out = wrapper(b)
+        assert torch.equal(out["labels"], b.y)
+        assert torch.equal(out["batch_0"], b.batch_0)
+
+    def test_adjacency_0_used_for_nodes_not_adjacency_1(self, cin_batch):
+        """Node upper messages must use adjacency_0, not adjacency_1.
+
+        This tests the fix to the original CWNWrapper bug where
+        batch.adjacency_1 was incorrectly passed as adjacency_0.
+
+        With n_layers=1, x_0 depends only on adjacency_0 (unchanged between
+        the two runs) and batch.x_1 (unchanged), so zeroing adjacency_1 must
+        leave x_0 identical while changing x_1 (which uses adjacency_1 for
+        edge upper messages).
+        """
+        b = cin_batch
+        b_zeroed = b.clone()
+        b_zeroed.adjacency_1 = torch.sparse_coo_tensor(
+            torch.zeros(2, 0, dtype=torch.long),
+            torch.zeros(0),
+            size=(b._N1, b._N1),
+        ).float()
+
+        model = CIN(b._D, b._D, b._D, hid_channels=b._D, n_layers=1)
+        model.eval()
+        wrapper = CINWrapper(model, out_channels=b._D, num_cell_dimensions=3)
+
+        with torch.no_grad():
+            out_orig = wrapper(b)
+            out_zeroed = wrapper(b_zeroed)
+
+        assert torch.allclose(out_orig["x_0"], out_zeroed["x_0"], atol=1e-6), (
+            "Node outputs differ when adjacency_1 was zeroed — wrapper is "
+            "incorrectly using adjacency_1 for node messages"
+        )
+        assert not torch.allclose(
+            out_orig["x_1"], out_zeroed["x_1"], atol=1e-6
+        ), (
+            "Edge outputs identical after zeroing adjacency_1 — adjacency_1 "
+            "is not being used for edge upper messages"
+        )
+
+    def test_no_2cells_graceful(self, cin_batch):
+        """Wrapper must handle a batch without x_2, adjacency_1, incidence_2."""
+        b = cin_batch.clone()
+        del b.x_2
+        del b.adjacency_1
+        del b.incidence_2
+
+        model = CIN(b._D, b._D, 0, hid_channels=b._D, n_layers=2)
+        wrapper = CINWrapper(model, out_channels=b._D, num_cell_dimensions=2)
+        out = wrapper(b)
+
+        assert "x_0" in out
+        assert "x_1" in out
+        assert out.get("x_2") is None

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "cell/cin"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/test/pipeline/test_pipeline_cin.py
+++ b/test/pipeline/test_pipeline_cin.py
@@ -1,0 +1,47 @@
+"""Pipeline integration test for CIN.
+
+Verifies that the full TopoBench training pipeline runs end-to-end
+with the corrected CIN model on a compatible cell-complex dataset
+(MUTAG lifted to a cell complex via the dataset's default transforms).
+
+Follows the canonical pattern in ``test/pipeline/test_pipeline.py``:
+compose the Hydra config which have a short training run through the
+shared ``simplified_pipeline.run`` helper (no subprocess).
+
+"""
+
+import hydra
+
+from test._utils.simplified_pipeline import run
+
+DATASET = "graph/MUTAG"
+MODELS = ["cell/cin"]
+
+
+class TestPipelineCIN:
+    """End-to-end pipeline smoke test for CIN."""
+
+    def setup_method(self):
+        """Clear any global Hydra state before composing a config."""
+        hydra.core.global_hydra.GlobalHydra.instance().clear()
+
+    def test_pipeline_cin(self):
+        """CIN on MUTAG (lifted to a cell complex) must train end-to-end."""
+        with hydra.initialize(config_path="../../configs", job_name="job"):
+            for MODEL in MODELS:
+                cfg = hydra.compose(
+                    config_name="run.yaml",
+                    overrides=[
+                        f"model={MODEL}",
+                        f"dataset={DATASET}",
+                        "trainer.max_epochs=2",
+                        "trainer.min_epochs=1",
+                        "trainer.check_val_every_n_epoch=1",
+                        "trainer.accelerator=cpu",
+                        "trainer.devices=1",
+                        "paths=test",
+                        "callbacks=model_checkpoint",
+                    ],
+                    return_hydra_config=True,
+                )
+                run(cfg)

--- a/topobench/nn/backbones/cell/cin.py
+++ b/topobench/nn/backbones/cell/cin.py
@@ -1,0 +1,576 @@
+"""Cell Isomorphism Network backbone for cell complexes.
+
+Implements the CIN model from:
+
+    Bodnar, C., Frasca, F., Otter, N., Wang, Y.G., Liò, P., Montúfar, G.,
+    & Bronstein, M. (2021).
+    *Weisfeiler and Lehman Go Cellular: CW Networks.*
+    NeurIPS 2021. https://arxiv.org/abs/2106.12575
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+
+class CINLayer(nn.Module):
+    """Single layer of the Cell Isomorphism Network (CIN).
+
+    Implements the message types from Section 4, Bodnar et al. (2021),
+    applied simultaneously to 0-cells (nodes), 1-cells (edges), and 2-cells
+    (rings). Per Theorem 7, *lower*-adjacency (N↓) messages can be dropped
+    without loss of expressive power and are therefore omitted here.
+
+    Coboundary messages are **not** dropped: this layer follows the
+    ``use_coboundaries=True`` CIN configuration from the reference
+    implementation, which is the configuration
+    used to obtain the paper's reported SOTA results. Concretely, the up-message
+    ``m_↑(σ) = AGG_{τ∈N↑(σ), δ∈C(σ,τ)} M_↑(h_σ, h_τ, h_δ)`` (Section 4) is
+    approximated as a *sum of two separately-linear* terms - one over the
+    upper-adjacent neighbours τ (via the A_up,p matrix) and one over the
+    shared coboundary cells δ (via the B_{p+1} incidence matrix) - which is
+    exactly recovered when ``M_↑`` is itself linear in its (h_τ, h_δ)
+    arguments (as ``Linear(concat(h_τ, h_δ)) = W_τ h_τ + W_δ h_δ + b``).
+    This keeps the coboundary-cell context described in Section 4 while
+    reusing TopoBench's precomputed sparse adjacency/incidence matrices
+    (which do not carry per-pair (τ, δ) indices).
+
+    Per-dimension message schedule
+    --------------------------------
+    **0-cells (nodes):**  B(node) = ∅ → no boundary message.
+    Upper-adjacency + coboundary context (Section 4 Eq. for m_↑, p=0):
+
+    ``m_↑(node_i) ≈ AGG_{j ∈ N↑(i)} msg_↑_neighbor(h_j)``
+                  ``+ AGG_{e ∈ C(i)} msg_↑_coboundary(h_e)``
+
+    Implemented as: ``A_up,0 @ msg_up_0(x_0)  +  B1 @ msg_bridge_e(x_1)``
+    where ``B1 [N0, N1]`` rows index nodes and cols index incident edges.
+
+    **1-cells (edges):**  B(edge) = {endpoint nodes} → boundary from nodes.
+    Plus upper-adjacency + coboundary context (Section 4 Eq. for m_↑, p=1):
+
+    ``m_B(edge_e)  =  B1^T @ msg_B(x_0)``         (Section 4, Figure 6)
+    ``m_↑(edge_e) ≈  A_up,1 @ msg_↑_neighbor(x_1)``
+                  ``+  B2 @ msg_↑_coboundary(x_2)``
+
+    Implemented as: ``B1^T @ msg_boundary_1(x_0)``
+                    ``+ A_up,1 @ msg_up_1(x_1)``
+                    ``+ B2 @ msg_bridge_r(x_2)``
+
+    **2-cells (rings):**  no N↑ (no 3-cells exist).
+    Boundary from edges only:
+
+    ``m_B(ring_r)  =  B2^T @ msg_B(x_1)``          (Section 4, Figure 6)
+
+    Two-step update (GIN-style, Appendix E.3)
+    ------------------------------------------
+    Following Appendix E.3, each incoming multi-set gets
+    its own injective GIN-style update, and the two results are combined by
+    a third MLP so the overall update stays injective ("the cross product
+    of countable spaces is countable"):
+
+    ``out_↑(σ) = MLP_↑,p( (1+ε₁)·h^t_σ + m_↑(σ) )``
+    ``out_B(σ) = MLP_B,p( (1+ε₂)·h^t_σ + m_B(σ) )``
+    ``h^{t+1}_p(σ) = MLP_combine,p( out_↑(σ) ⊥ out_B(σ) )``
+
+    where ``⊥`` is concatenation. Ranks with an empty neighbourhood keep
+    the corresponding stream with a zero message (as in the reference,
+    where ``propagate`` returns zeros for absent index sets): 0-cells have
+    ``m_B = 0`` (B(node) = ∅) and 2-cells have ``m_↑ = 0`` (no 3-cells).
+
+    Parameters
+    ----------
+    in_channels_0 : int
+        Input feature dimension for 0-cells (nodes).
+    in_channels_1 : int
+        Input feature dimension for 1-cells (edges).
+    in_channels_2 : int
+        Input feature dimension for 2-cells (rings). 0 = no 2-cells.
+    out_channels : int
+        Output feature dimension for all cell dimensions.
+    eps : float, optional
+        Initial value of the learnable GIN epsilon. Default: 0.0.
+    """
+
+    def __init__(
+        self,
+        in_channels_0: int,
+        in_channels_1: int,
+        in_channels_2: int,
+        out_channels: int,
+        eps: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.out_channels = out_channels
+        self.has_2_cells = in_channels_2 > 0
+
+        # ── 0-cell messages: m_↑(node) decomposed ──────────────────────── #
+        # Component 1: neighbor node features via A_up,0
+        #   m_up_0(i) = A_up,0 @ msg_up_0(x_0)
+        self.msg_up_0 = nn.Linear(in_channels_0, out_channels, bias=False)
+        # Component 2: bridge edge features via B1 (B1[v,e]=1 if v∈∂e)
+        #   m_bridge_e(i) = B1 @ msg_bridge_e(x_1)   [N0,N1]@[N1,d]=[N0,d]
+        # Equation: m_↑(node_i) ≈ sum_j msg_up(h_j) + sum_{e sharing j,i} msg_bridge(h_e)
+        self.msg_bridge_e = nn.Linear(in_channels_1, out_channels, bias=False)
+
+        # ── 1-cell messages: m_B(edge) + m_↑(edge) decomposed ─────────── #
+        # Boundary: nodes on the boundary of each edge (paper Section 4)
+        #   m_B(edge_e) = B1^T @ msg_boundary_1(x_0)  [N1,N0]@[N0,d]=[N1,d]
+        # This is the "atoms→bonds" boundary stream.
+        self.msg_boundary_1 = nn.Linear(
+            in_channels_0, out_channels, bias=False
+        )
+        # Upper-adj component 1: neighbor edge features via A_up,1
+        self.msg_up_1 = nn.Linear(in_channels_1, out_channels, bias=False)
+        if self.has_2_cells:
+            # Upper-adj component 2: bridge ring features via B2
+            #   m_bridge_r(e) = B2 @ msg_bridge_r(x_2)  [N1,N2]@[N2,d]=[N1,d]
+            # Equation: m_↑(edge_e) ≈ sum_f msg_up(h_f) + sum_{r sharing e,f} msg_bridge(h_r)
+            self.msg_bridge_r = nn.Linear(
+                in_channels_2, out_channels, bias=False
+            )
+            # ── 2-cell messages: m_B(ring) ──────────────────────────────── #
+            # Boundary: edges on boundary of each ring
+            #   m_B(ring_r) = B2^T @ msg_B_2(x_1)  [N2,N1]@[N1,d]=[N2,d]
+            self.msg_B_2 = nn.Linear(in_channels_1, out_channels, bias=False)
+
+        # ── GIN epsilon parameters (one per stream per cell dimension,
+        #    mirroring eps1/eps2 in SparseCINCochainConv) ─────────────────── #
+        self.eps_up_0 = nn.Parameter(torch.tensor(eps))
+        self.eps_B_0 = nn.Parameter(torch.tensor(eps))
+        self.eps_up_1 = nn.Parameter(torch.tensor(eps))
+        self.eps_B_1 = nn.Parameter(torch.tensor(eps))
+        if self.has_2_cells:
+            self.eps_up_2 = nn.Parameter(torch.tensor(eps))
+            self.eps_B_2 = nn.Parameter(torch.tensor(eps))
+
+        # ── Self-feature projections (maps h^t to out_channels) ─────────── #
+        self.self_lin_0 = nn.Linear(in_channels_0, out_channels, bias=False)
+        self.self_lin_1 = nn.Linear(in_channels_1, out_channels, bias=False)
+        if self.has_2_cells:
+            self.self_lin_2 = nn.Linear(
+                in_channels_2, out_channels, bias=False
+            )
+
+        # ── Two-step update: per-stream 2-layer GIN MLPs followed by a #
+        #    combine MLP on their concatenation ─────────────────────── #
+        self.update_up_0 = self._make_update_mlp(out_channels)
+        self.update_B_0 = self._make_update_mlp(out_channels)
+        self.combine_0 = self._make_combine_mlp(out_channels)
+        self.update_up_1 = self._make_update_mlp(out_channels)
+        self.update_B_1 = self._make_update_mlp(out_channels)
+        self.combine_1 = self._make_combine_mlp(out_channels)
+        if self.has_2_cells:
+            self.update_up_2 = self._make_update_mlp(out_channels)
+            self.update_B_2 = self._make_update_mlp(out_channels)
+            self.combine_2 = self._make_combine_mlp(out_channels)
+
+    @staticmethod
+    def _make_update_mlp(channels: int) -> nn.Sequential:
+        """Build a per-stream GIN update MLP.
+
+        Mirrors ``update_up_nn`` / ``update_boundaries_nn`` in the reference
+        implementation: two Linear layers, each followed by BatchNorm and ReLU.
+
+        Parameters
+        ----------
+        channels : int
+            Input and output feature dimension of the MLP.
+
+        Returns
+        -------
+        nn.Sequential
+            The 2-layer update MLP.
+        """
+        return nn.Sequential(
+            nn.Linear(channels, channels),
+            nn.BatchNorm1d(channels),
+            nn.ReLU(),
+            nn.Linear(channels, channels),
+            nn.BatchNorm1d(channels),
+            nn.ReLU(),
+        )
+
+    @staticmethod
+    def _make_combine_mlp(channels: int) -> nn.Sequential:
+        """Build the combine MLP of the two-step update.
+
+        a single Linear layer on the concatenation of the two stream outputs, followed by BatchNorm
+        and ReLU.
+
+        Parameters
+        ----------
+        channels : int
+            Feature dimension of each input stream; the MLP maps
+            ``2 * channels -> channels``.
+
+        Returns
+        -------
+        nn.Sequential
+            The combine MLP.
+        """
+        return nn.Sequential(
+            nn.Linear(2 * channels, channels),
+            nn.BatchNorm1d(channels),
+            nn.ReLU(),
+        )
+
+    def forward(
+        self,
+        x_0: Tensor,
+        x_1: Tensor,
+        x_2: Tensor | None,
+        adjacency_0: Tensor,
+        adjacency_1: Tensor | None,
+        incidence_1: Tensor,
+        incidence_2: Tensor | None,
+    ) -> tuple[Tensor, Tensor, Tensor | None]:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x_0 : Tensor, shape [N0, d0]
+            Features of 0-cells (nodes).
+        x_1 : Tensor, shape [N1, d1]
+            Features of 1-cells (edges).
+        x_2 : Tensor or None, shape [N2, d2]
+            Features of 2-cells (rings).
+        adjacency_0 : Tensor, shape [N0, N0] sparse
+            Upper-adjacency matrix for 0-cells (A_up,0). A_up,0[i,j]=1
+            iff nodes i,j share a common edge (co-boundary).
+        adjacency_1 : Tensor or None, shape [N1, N1] sparse
+            Upper-adjacency matrix for 1-cells (A_up,1). A_up,1[e,f]=1
+            iff edges e,f share a common ring (co-boundary).
+        incidence_1 : Tensor, shape [N0, N1] sparse
+            Boundary matrix B1.  B1[v, e] = 1 iff vertex v ∈ boundary(edge e).
+            Used as-is for bridge-edge aggregation to nodes (B1 @ x_1),
+            and transposed for boundary aggregation to edges (B1^T @ x_0).
+        incidence_2 : Tensor or None, shape [N1, N2] sparse
+            Boundary matrix B2.  B2[e, r] = 1 iff edge e ∈ boundary(ring r).
+            Used as-is for bridge-ring aggregation to edges (B2 @ x_2),
+            and transposed for boundary aggregation to rings (B2^T @ x_1).
+
+        Returns
+        -------
+        Tensor
+            Updated 0-cell features, shape [N0, out_channels].
+        Tensor
+            Updated 1-cell features, shape [N1, out_channels].
+        Tensor or None
+            Updated 2-cell features, shape [N2, out_channels].
+
+        Notes
+        -----
+        Equation references are to Bodnar et al. (2021), Section 4.
+        Lower-adjacency (N↓) is dropped per Theorem 7. Boundary (B) and
+        upper-adjacency (N↑) messages are used, and coboundary-cell (C)
+        context is folded into the upper-adjacency message as a linear
+        approximation of the ``use_coboundaries=True`` configuration (see
+        class docstring) — the setting used for the paper's reported
+        results, not the theoretical minimum from Theorem 7.
+        """
+        N0, N1 = x_0.size(0), x_1.size(0)
+        dev = x_0.device
+
+        # ── 0-cell update: m_↑(node) = msg_up(neighbors) + msg_bridge(edges) #
+        # B(node) = ∅ → no boundary message for 0-cells.
+        # Upper-adj neighbor: A_up,0 @ msg_up_0(x_0)
+        m_up_0 = self._upper_aggregate(
+            x_neighbor=x_0,
+            adjacency=adjacency_0,
+            msg_fn=self.msg_up_0,
+            n_receivers=N0,
+        )  # [N0, out_channels]
+        # Upper-adj bridge edge: B1 @ msg_bridge_e(x_1)  (B1 not transposed)
+        m_bridge_e = self._incidence_aggregate(
+            x_sender=x_1,
+            incidence=incidence_1,
+            msg_fn=self.msg_bridge_e,
+            transpose=True,  # use B1 as-is: [N0,N1] @ msg(x_1) → [N0,d]
+            n_receivers=N0,
+        )  # [N0, out_channels]
+        # Two-step update (App. E.3; SparseCINCochainConv.forward): each
+        # multi-set gets its own (1+eps)-weighted GIN update, then the two
+        # stream outputs are combined. B(node) = ∅, so the boundary stream
+        # receives a zero message (as in the reference's propagate).
+        h_0 = self.self_lin_0(x_0)
+        out_up_0 = self.update_up_0(
+            (1 + self.eps_up_0) * h_0 + m_up_0 + m_bridge_e
+        )
+        out_B_0 = self.update_B_0((1 + self.eps_B_0) * h_0)
+        x_0_new = self.combine_0(torch.cat([out_up_0, out_B_0], dim=-1))
+
+        # ── 1-cell update: m_B(edge) + m_↑(edge) ───────────────────────── #
+        # Boundary (atoms→bonds, Section 4): B1^T @ msg_boundary_1(x_0)
+        m_B_1 = self._incidence_aggregate(
+            x_sender=x_0,
+            incidence=incidence_1,
+            msg_fn=self.msg_boundary_1,
+            transpose=False,  # use B1^T: [N1,N0] @ msg(x_0) → [N1,d]
+            n_receivers=N1,
+        )  # [N1, out_channels]
+        # Upper-adj neighbor: A_up,1 @ msg_up_1(x_1)
+        m_up_1 = torch.zeros(N1, self.out_channels, device=dev)
+        if adjacency_1 is not None:
+            m_up_1 = self._upper_aggregate(
+                x_neighbor=x_1,
+                adjacency=adjacency_1,
+                msg_fn=self.msg_up_1,
+                n_receivers=N1,
+            )  # [N1, out_channels]
+        # Upper-adj bridge ring: B2 @ msg_bridge_r(x_2)  (B2 not transposed)
+        m_bridge_r = torch.zeros(N1, self.out_channels, device=dev)
+        if self.has_2_cells and x_2 is not None and incidence_2 is not None:
+            m_bridge_r = self._incidence_aggregate(
+                x_sender=x_2,
+                incidence=incidence_2,
+                msg_fn=self.msg_bridge_r,
+                transpose=True,  # use B2 as-is: [N1,N2] @ msg(x_2) → [N1,d]
+                n_receivers=N1,
+            )  # [N1, out_channels]
+        # Two-step update for 1-cells: separate GIN updates for the upper
+        # multi-set (neighbour edges + bridge rings) and the boundary
+        # multi-set (endpoint nodes), then combine.
+        h_1 = self.self_lin_1(x_1)
+        out_up_1 = self.update_up_1(
+            (1 + self.eps_up_1) * h_1 + m_up_1 + m_bridge_r
+        )
+        out_B_1 = self.update_B_1((1 + self.eps_B_1) * h_1 + m_B_1)
+        x_1_new = self.combine_1(torch.cat([out_up_1, out_B_1], dim=-1))
+
+        # ── 2-cell update: m_B(ring) from edges ────────────────────────── #
+        x_2_new = None
+        if self.has_2_cells and x_2 is not None:
+            N2 = x_2.size(0)
+            # Boundary (bonds→rings, Section 4): B2^T @ msg_B_2(x_1)
+            m_B_2 = torch.zeros(N2, self.out_channels, device=dev)
+            if incidence_2 is not None:
+                m_B_2 = self._incidence_aggregate(
+                    x_sender=x_1,
+                    incidence=incidence_2,
+                    msg_fn=self.msg_B_2,
+                    transpose=False,  # use B2^T: [N2,N1] @ msg(x_1) → [N2,d]
+                    n_receivers=N2,
+                )
+            # Two-step update for 2-cells: no 3-cells exist, so the upper
+            # stream receives a zero message (as in the reference's
+            # propagate); the boundary stream aggregates constituent edges.
+            h_2 = self.self_lin_2(x_2)
+            out_up_2 = self.update_up_2((1 + self.eps_up_2) * h_2)
+            out_B_2 = self.update_B_2((1 + self.eps_B_2) * h_2 + m_B_2)
+            x_2_new = self.combine_2(torch.cat([out_up_2, out_B_2], dim=-1))
+
+        return x_0_new, x_1_new, x_2_new
+
+    # ── Private helpers ─────────────────────────────────────────────────── #
+
+    def _incidence_aggregate(
+        self,
+        x_sender: Tensor,
+        incidence: Tensor,
+        msg_fn: nn.Linear,
+        transpose: bool,
+        n_receivers: int,
+    ) -> Tensor:
+        """Aggregate messages via an incidence matrix.
+
+        Parameters
+        ----------
+        x_sender : Tensor, shape [N_sender, d]
+            Features of the sending cells.
+        incidence : Tensor, sparse or dense
+            Incidence matrix in its natural storage shape.
+            When ``transpose=True`` the caller passes shape
+            [N_receivers, N_senders] and the matrix is used as-is.
+            When ``transpose=False`` the caller passes shape
+            [N_senders, N_receivers] (e.g. B1[N0,N1] for boundary→edges)
+            and the matrix is transposed before multiplication.
+        msg_fn : nn.Linear
+            Projects sender features to ``out_channels`` before aggregation.
+        transpose : bool
+            If True use incidence as-is: shape [N_receivers, N_senders].
+            If False transpose it first: caller passes [N_senders, N_receivers].
+        n_receivers : int
+            Expected number of receiving cells; used only for the output shape.
+
+        Returns
+        -------
+        Tensor
+            Aggregated messages, shape [n_receivers, out_channels].
+        """
+        msgs = msg_fn(x_sender)  # [N_sender, out_channels]
+        if incidence.is_sparse:
+            mat = incidence if transpose else incidence.t()
+            return torch.sparse.mm(mat, msgs)
+        else:
+            mat = incidence if transpose else incidence.t()
+            return mat @ msgs
+
+    def _upper_aggregate(
+        self,
+        x_neighbor: Tensor,
+        adjacency: Tensor | None,
+        msg_fn: nn.Linear,
+        n_receivers: int,
+    ) -> Tensor:
+        """Aggregate upper-adjacency messages via a sparse adjacency matrix.
+
+        Computes ``m_up = adjacency @ msg_fn(x_neighbor)``.
+
+        Parameters
+        ----------
+        x_neighbor : Tensor, shape [N, d]
+            Features of the (same-dimension) neighbor cells.
+        adjacency : Tensor or None, shape [N, N] sparse
+            Upper-adjacency matrix. Returns zeros if None or empty.
+        msg_fn : nn.Linear
+            Projects neighbor features to ``out_channels``.
+        n_receivers : int
+            Number of receiving cells (= N).
+
+        Returns
+        -------
+        Tensor
+            Aggregated messages, shape [n_receivers, out_channels].
+        """
+        dev = x_neighbor.device
+        if adjacency is None:
+            return torch.zeros(n_receivers, self.out_channels, device=dev)
+
+        msgs = msg_fn(x_neighbor)  # [N, out_channels]
+
+        if adjacency.is_sparse:
+            if adjacency._nnz() == 0:
+                return torch.zeros(n_receivers, self.out_channels, device=dev)
+            if not adjacency.is_coalesced():
+                adjacency = adjacency.coalesce()
+            return torch.sparse.mm(adjacency, msgs)
+        else:
+            return adjacency @ msgs
+
+
+class CIN(nn.Module):
+    """Cell Isomorphism Network (CIN).
+
+    Stacks ``num_layers`` of :class:`CINLayer` to perform hierarchical
+    message passing over a regular cell complex with 0-, 1-, and 2-cells.
+
+    Follows the CIN instantiation in Section 5 of
+    Bodnar et al. (2021): GIN-style injective aggregators ensure the model
+    is as powerful as the Cellular WL (CWL) test (Theorem 18).
+
+    Message streams per layer (all three ranks updated simultaneously):
+
+    * 0-cells receive: upper-adj from neighboring nodes + bridge edge features.
+    * 1-cells receive: boundary from endpoint nodes (Section 4, Figure 6)
+      + upper-adj from neighboring edges + bridge ring features.
+    * 2-cells receive: boundary from constituent edges (Section 4, Figure 6).
+
+    Parameters
+    ----------
+    in_channels_0 : int
+        Input feature size for 0-cells (nodes).
+    in_channels_1 : int
+        Input feature size for 1-cells (edges).
+    in_channels_2 : int
+        Input feature size for 2-cells (rings). 0 = no 2-cells.
+    hid_channels : int
+        Hidden feature dimension for all intermediate layers.
+    n_layers : int
+        Number of CIN layers.
+    dropout : float, optional
+        Dropout rate applied after each layer. Default: 0.0.
+    """
+
+    def __init__(
+        self,
+        in_channels_0: int,
+        in_channels_1: int,
+        in_channels_2: int,
+        hid_channels: int,
+        n_layers: int,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.dropout = dropout
+        self.has_2_cells = in_channels_2 > 0
+
+        # Initial feature projections (one per cell dimension)
+        self.proj_0 = nn.Linear(in_channels_0, hid_channels)
+        self.proj_1 = nn.Linear(in_channels_1, hid_channels)
+        if self.has_2_cells:
+            self.proj_2 = nn.Linear(in_channels_2, hid_channels)
+
+        # Stack of CIN layers
+        self.layers = nn.ModuleList(
+            [
+                CINLayer(
+                    in_channels_0=hid_channels,
+                    in_channels_1=hid_channels,
+                    in_channels_2=hid_channels if self.has_2_cells else 0,
+                    out_channels=hid_channels,
+                )
+                for _ in range(n_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        x_0: Tensor,
+        x_1: Tensor,
+        x_2: Tensor | None,
+        adjacency_0: Tensor,
+        adjacency_1: Tensor | None,
+        incidence_1: Tensor,
+        incidence_2: Tensor | None,
+    ) -> tuple[Tensor, Tensor, Tensor | None]:
+        """Forward pass of CIN.
+
+        Parameters
+        ----------
+        x_0 : Tensor, shape [N0, d0]
+            Features of 0-cells (nodes).
+        x_1 : Tensor, shape [N1, d1]
+            Features of 1-cells (edges).
+        x_2 : Tensor or None, shape [N2, d2]
+            Features of 2-cells (rings).
+        adjacency_0 : Tensor, shape [N0, N0] sparse
+            Upper-adjacency for 0-cells (A_up,0).
+        adjacency_1 : Tensor or None, shape [N1, N1] sparse
+            Upper-adjacency for 1-cells (A_up,1).
+        incidence_1 : Tensor, shape [N0, N1] sparse
+            Boundary matrix B1.
+        incidence_2 : Tensor or None, shape [N1, N2] sparse
+            Boundary matrix B2.
+
+        Returns
+        -------
+        Tensor
+            Updated 0-cell features, shape [N0, hid_channels].
+        Tensor
+            Updated 1-cell features, shape [N1, hid_channels].
+        Tensor or None
+            Updated 2-cell features, shape [N2, hid_channels].
+        """
+        x_0 = F.elu(self.proj_0(x_0))
+        x_1 = F.elu(self.proj_1(x_1))
+        if self.has_2_cells and x_2 is not None:
+            x_2 = F.elu(self.proj_2(x_2))
+
+        for layer in self.layers:
+            x_0, x_1, x_2 = layer(
+                x_0=x_0,
+                x_1=x_1,
+                x_2=x_2,
+                adjacency_0=adjacency_0,
+                adjacency_1=adjacency_1,
+                incidence_1=incidence_1,
+                incidence_2=incidence_2,
+            )
+            x_0 = F.dropout(x_0, p=self.dropout, training=self.training)
+            x_1 = F.dropout(x_1, p=self.dropout, training=self.training)
+            if x_2 is not None:
+                x_2 = F.dropout(x_2, p=self.dropout, training=self.training)
+
+        return x_0, x_1, x_2

--- a/topobench/nn/wrappers/cell/cin_wrapper.py
+++ b/topobench/nn/wrappers/cell/cin_wrapper.py
@@ -1,6 +1,6 @@
 """Wrapper for the CIN (Cell Isomorphism Network) backbone.
 
-This wrapper is a new variant of
+This wrapper is a new version of
 ``topobench.nn.wrappers.cell.cwn_wrapper.CWNWrapper`` (not a modification of
 it), because the CIN backbone has different argument semantics from
 the existing (TopoModelX-sourced) CWN backbone:

--- a/topobench/nn/wrappers/cell/cin_wrapper.py
+++ b/topobench/nn/wrappers/cell/cin_wrapper.py
@@ -1,0 +1,144 @@
+"""Wrapper for the CIN (Cell Isomorphism Network) backbone.
+
+This wrapper is a new sibling of
+``topobench.nn.wrappers.cell.cwn_wrapper.CWNWrapper`` (not a modification of
+it), needed because the CIN backbone has different argument semantics from
+the existing (TopoModelX-sourced) CWN backbone:
+
+Difference 1 — ``adjacency_0`` must be genuine node-level upper-adjacency
+    ``CWNWrapper`` passes ``batch.adjacency_1`` (edge-edge upper-adjacency)
+    into a backbone parameter that TopoModelX's ``CWN.forward`` happens to
+    *name* ``adjacency_0`` — but that backbone only ever updates 1-cells
+    (edges); ``x_0`` and ``x_2`` are projected once and never touched again
+    by its message passing (see ``topomodelx.nn.cell.cwn.CWN.forward``,
+    which loops layers but only reassigns ``x_1``). So for TopoModelX's CWN,
+    that argument is correctly edge-edge adjacency despite the misleading
+    name, and no node-level messages are computed at all.
+
+    CIN, by contrast, genuinely updates all three ranks every layer
+    (Section 4), so it needs the *real* A_up,0 (node-node upper-adjacency,
+    TopoBench's ``batch.adjacency_0``) for node messages, in addition to
+    A_up,1 (``batch.adjacency_1``) for edge messages. Both are passed here
+    under their own names.
+
+Difference 2 — transposition is handled inside the backbone
+    ``CWNWrapper`` calls ``batch.incidence_1.T`` before passing it on,
+    coupling the wrapper to a backbone-specific orientation convention.
+    ``CINWrapper`` passes ``batch.incidence_1`` unmodified; ``CIN`` applies
+    ``B1`` or ``B1^T`` internally per message type via
+    ``_incidence_aggregate(transpose=...)``.
+
+References
+----------
+Bodnar et al. (2021). Weisfeiler and Lehman Go Cellular: CW Networks.
+NeurIPS 2021. https://arxiv.org/abs/2106.12575
+"""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class CINWrapper(AbstractWrapper):
+    r"""Wrapper for the CIN (Cell Isomorphism Network) backbone.
+
+    The CIN model updates embeddings of cells of rank 0 (nodes), 1 (edges),
+    and 2 (rings) simultaneously at each layer. This wrapper unpacks the
+    required tensors from the batch and feeds them to the backbone with
+    the correct argument names, then repacks the outputs into the
+    dictionary format expected by downstream readout modules.
+
+    Notes
+    -----
+    The batch is expected to provide the following attributes:
+    ``x_0``, ``x_1`` : Tensor, shape [N0, d0] / [N1, d1]
+        Features of 0-cells (nodes) and 1-cells (edges).
+    ``x_2`` : Tensor, shape [N2, d2], optional
+        Features of 2-cells (rings); absent for complexes with no 2-cells.
+    ``adjacency_0`` : Tensor, shape [N0, N0] sparse
+        Upper-adjacency matrix for 0-cells (A_up,0).
+    ``adjacency_1`` : Tensor, shape [N1, N1] sparse, optional
+        Upper-adjacency matrix for 1-cells (A_up,1).
+    ``incidence_1`` : Tensor, shape [N0, N1] sparse
+        B1 incidence matrix.
+    ``incidence_2`` : Tensor, shape [N1, N2] sparse, optional
+        B2 incidence matrix.
+    ``y`` : Tensor
+        Labels.
+    ``batch_0`` : Tensor
+        Batch assignment for 0-cells.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the CIN wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched cell-complex data.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys: ``labels``, ``batch_0``,
+            ``x_0``, ``x_1``, ``x_2``.
+        """
+        # Optional higher-order tensors: absent for complexes with no 2-cells.
+        # 2-cells (rings) arise from a skeleton-preserving lifting map f: G → X
+        # that attaches 2-cells to induced cycles — Definition 8 and Definition 11.
+        x_2 = getattr(batch, "x_2", None)
+
+        # A_up,1 [N1, N1]: upper-adjacency matrix for 1-cells (edges).
+        # A_up,1[e,f] = 1 iff edges e and f share a common 2-cell (ring)
+        # as their co-boundary — Definition 4(4), N↑(σ) for 1-cells.
+        # Absent when no 2-cells exist.
+        adjacency_1 = getattr(batch, "adjacency_1", None)
+
+        # B2 [N1, N2]: incidence (boundary) matrix for 2-cells.
+        # B2[e, r] = 1 iff edge e ∈ B(ring r) — Definition 3 (boundary relation)
+        # and Definition 33 (unsigned boundary matrix B_k with k=2).
+        # Used for: m_B(1-cell) ← 2-cells  and  m_B(2-cell) ← 1-cells
+        # (both directions of the B2 boundary relation; see Section 4 Eq. 1).
+        incidence_2 = getattr(batch, "incidence_2", None)
+
+        # Run the full three-stream hierarchical message passing (Section 4).
+        # Each argument below feeds a specific adjacency used by Eqs. (1)–(3):
+        x_0, x_1, x_2 = self.backbone(
+            x_0=batch.x_0,
+            x_1=batch.x_1,
+            # x_2: initial 2-cell (ring) features h^0_σ for σ ∈ X^(2).
+            # Higher-dim cells are populated as described in Appendix E.3.
+            x_2=x_2,
+            # A_up,0 [N0, N0]: upper-adjacency for 0-cells (nodes).
+            # A_up,0[i, j] = 1 iff nodes i and j share a common edge as
+            # their co-boundary — Definition 4(4), N↑(σ) for 0-cells.
+            # Feeds m_↑^{t+1}(node i) = AGG_{j ∈ N↑(i)} M_↑(h_i, h_j, h_e)
+            # in Eq. (1), Section 4.
+            adjacency_0=batch.adjacency_0,
+            # A_up,1 [N1, N1]: upper-adjacency for 1-cells (edges).
+            # Feeds m_↑^{t+1}(edge e) = AGG_{f ∈ N↑(e)} M_↑(h_e, h_f, h_r)
+            # in Eq. (1), Section 4, where r is the shared ring (co-boundary).
+            # Per Theorem 7, lower-adjacency (N↓) messages can be dropped
+            # without loss of expressive power; this stream is omitted here.
+            # Boundary (B) and upper-adjacency (N↑, incl. coboundary context
+            # per the backbone's "use_coboundaries" formulation) are kept.
+            adjacency_1=adjacency_1,
+            # B1 [N0, N1]: incidence (boundary) matrix for 1-cells.
+            # B1[v, e] = 1 iff vertex v ∈ B(edge e) — Definition 3 and
+            # Definition 33 (unsigned boundary matrix B_k with k=1).
+            # Used as B1 [N0, N1] for m_↑(node) coboundary context ← edges,
+            # and as B1^T [N1, N0] for m_B(edge) ← nodes, the atoms→bonds
+            # boundary stream (Section 4, Figure 6, orange arrows).
+            # (No .T here; the backbone applies the correct orientation
+            #  internally via _incidence_aggregate(transpose=True/False).)
+            incidence_1=batch.incidence_1,
+            # B2 [N1, N2]: incidence matrix for 2-cells (see above).
+            # Used as B2 [N1, N2] for m_↑(edge) coboundary context ← rings,
+            # and as B2^T [N2, N1] for m_B(ring) ← edges, the bonds→rings
+            # boundary stream (Section 4, Figure 6).
+            incidence_2=incidence_2,
+        )
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+        model_out["x_1"] = x_1
+        model_out["x_2"] = x_2
+        return model_out

--- a/topobench/nn/wrappers/cell/cin_wrapper.py
+++ b/topobench/nn/wrappers/cell/cin_wrapper.py
@@ -1,8 +1,8 @@
 """Wrapper for the CIN (Cell Isomorphism Network) backbone.
 
-This wrapper is a new sibling of
+This wrapper is a new variant of
 ``topobench.nn.wrappers.cell.cwn_wrapper.CWNWrapper`` (not a modification of
-it), needed because the CIN backbone has different argument semantics from
+it), because the CIN backbone has different argument semantics from
 the existing (TopoModelX-sourced) CWN backbone:
 
 Difference 1 — ``adjacency_0`` must be genuine node-level upper-adjacency
@@ -27,11 +27,6 @@ Difference 2 — transposition is handled inside the backbone
     ``CINWrapper`` passes ``batch.incidence_1`` unmodified; ``CIN`` applies
     ``B1`` or ``B1^T`` internally per message type via
     ``_incidence_aggregate(transpose=...)``.
-
-References
-----------
-Bodnar et al. (2021). Weisfeiler and Lehman Go Cellular: CW Networks.
-NeurIPS 2021. https://arxiv.org/abs/2106.12575
 """
 
 from topobench.nn.wrappers.base import AbstractWrapper


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## What this PR does

This PR adds the Cell Isomorphism Network (CIN) to TopoBench, following the paper:

> Bodnar, C., Frasca, F., Otter, N., Wang, Y.G., Liò, P., Montúfar, G., & Bronstein, M. (2021).
> *Weisfeiler and Lehman Go Cellular: CW Networks.* NeurIPS 2021.
> https://arxiv.org/abs/2106.12575

The short version of why this model is interesting: standard GNNs are capped at 1-WL expressivity, so they can't count cycles or tell certain non-isomorphic graphs apart. CIN gets around this by lifting the graph to a cell complex — nodes become 0-cells, edges become 1-cells, and induced cycles (think aromatic rings in molecules) get attached as 2-cells. Message passing then runs over all three ranks at once, so the model actually sees ring-level structure instead of having to infer it. The paper proves this is strictly more powerful than WL (Corollary 15) and no less powerful than 3-WL with ring or clique liftings (Theorem 16), and it shows up in practice: 100% on CSL where plain MPGNNs are reduced to random guessing, and SOTA MAE on ZINC.

TopoBench already ships a CWN model adapted from TopoModelX, so the natural first question was whether we could just reuse it. We compared it message-function-by-message-function against Section 4 of the paper and the authors' reference implementation (twitter-research/cwn), and unfortunately it diverges in ways that matter. That audit is what shaped this PR, so we'll walk through the issues we found before describing the new code.

## What we found in the existing CWN, and what we did about it

**1. The node-level upper-adjacency never reaches the backbone.**
`CWNWrapper` passes `batch.adjacency_1` (edge–edge upper-adjacency, per TopoBench's own convention in `get_complex_connectivity`) into a backbone argument that TopoModelX happens to call `adjacency_0`. Confusing name aside, this isn't actually a bug *for that backbone*: TopoModelX's `CWN.forward` only ever updates `x_1` in its layer loop — `x_0` and `x_2` are projected once up front and never touched again — so no node-level adjacency is used at all. But CIN genuinely updates all three ranks every layer, so it needs the real node–node upper-adjacency, which TopoBench already computes as `batch.adjacency_0` and which was simply sitting unused. The new `CINWrapper` passes `batch.adjacency_0` for node messages and `batch.adjacency_1` for edge messages, each under its own name.

**2. The wrapper transposes `incidence_1` before handing it over.**
That bakes one backbone's orientation convention into the wrapper and makes the boundary matrix confusing for anyone reading the wrapper code. `CINWrapper` passes `batch.incidence_1` as-is, and the backbone applies `B1` or `B1^T` internally depending on which message needs which orientation.

**3. Only 1-cells are updated.**
As mentioned above, TopoModelX's `CWNLayer` operates on a single rank and only returns updated edge features. The paper is explicit that the update is hierarchical across all ranks at every layer (Section 4, with the per-rank equations for p = 0, 1, 2 in Appendix E.3). `CINLayer` updates nodes, edges, and rings simultaneously.

**4. Edges never hear from their own endpoint nodes.**
This one is the most subtle and, we'd argue, the most important. Section 4 defines two message streams per cell: a boundary stream m_B(σ), aggregating from the lower-dimensional cells on σ's boundary, and an upper stream m_↑(σ), aggregating from upper-adjacent cells together with the shared coboundary "bridge" cell (Figure 6 draws the boundary messages as the orange arrows). For an edge, the boundary is its two endpoint nodes, so there should be a `B1^T @ msg(x_0)` term — the atoms→bonds direction that basically every molecular GNN relies on. The existing edge update computed the upper-adjacency term and the ring-bridge term, but the boundary message from the endpoints was missing entirely.

The fix adds a dedicated `msg_boundary_1` linear map and computes `m_B(edge) = B1^T @ msg_boundary_1(x_0)` as its own stream. Following the paper's two-step update (Appendix E.3) and the reference code (`mp/layers.py::SparseCINCochainConv.forward`), each stream gets its own (1+ε)-weighted GIN-style MLP and the two results are combined by a third MLP on their concatenation, which keeps the overall update injective. For edges, the update ends up as:

```
m_↑(e)  =  A_up,1 @ msg_up(x_1)  +  B2 @ msg_bridge(x_2)      # upper-adj neighbor + bridge ring
m_B(e)  =  B1^T @ msg_B(x_0)                                   # boundary (nodes → edges)
h'_e    =  combine( MLP_↑((1+ε₁)·h_e + m_↑(e)) ⊥ MLP_B((1+ε₂)·h_e + m_B(e)) )
```

Nodes have an empty boundary, so their boundary stream just carries a zero message (same behaviour as the reference, where `propagate` returns zeros for absent index sets):

```
m_↑(v)  =  A_up,0 @ msg_up(x_0)  +  B1 @ msg_bridge(x_1)      # upper-adj neighbor + coboundary context
h'_v    =  combine( MLP_↑((1+ε₁)·h_v + m_↑(v)) ⊥ MLP_B((1+ε₂)·h_v) )
```

And rings have no upper neighbours (there are no 3-cells), so only the boundary stream from their constituent edges is active:

```
m_B(r)  =  B2^T @ msg_B(x_1)                                   # boundary (edges → rings)
h'_r    =  combine( MLP_↑((1+ε₁)·h_r) ⊥ MLP_B((1+ε₂)·h_r + m_B(r)) )
```

A note on what's dropped and what isn't. Only *lower*-adjacency messages are omitted, which Theorem 7 shows is lossless for colour refinement. Coboundary context is kept: the `B1 @ msg(x_1)` and `B2 @ msg(x_2)` terms fold the shared coboundary cell into the upper stream, mirroring the `use_coboundaries=True` configuration the authors actually run to get their reported numbers (every experiment script in the reference repo, `cwn-zinc.sh`, `cwn-molhiv.sh`, `cwn-csl.sh`, passes `--use_coboundaries True`). This folding is exact when the up-message function M_↑ is linear in its (h_τ, h_δ) arguments; the docstring in `cin.py` spells out that caveat. An earlier draft of this write-up claimed coboundary messages were dropped "consistent with Theorem 7", that was wrong (the code clearly computes both coboundary aggregations) and we've corrected it here.

## Files changed

🔗 **Full diff:** [`main...alirezamhm:topobench:tdl_challenge_2026_track2_cwn`](https://github.com/geometric-intelligence/topobench/compare/main...alirezamhm:topobench:tdl_challenge_2026_track2_cwn?expand=1)

- [topobench/nn/backbones/cell/cin.py](topobench/nn/backbones/cell/cin.py) — new `CINLayer` + `CIN` backbone (fixes issues 3 and 4)
- [topobench/nn/wrappers/cell/cin_wrapper.py](topobench/nn/wrappers/cell/cin_wrapper.py) — new `CINWrapper` (fixes issues 1 and 2)
- [configs/model/cell/cin.yaml](configs/model/cell/cin.yaml) — Hydra config wiring the model into the TopoBench pipeline
- [test/nn/backbones/cell/test_cin.py](test/nn/backbones/cell/test_cin.py) — unit tests for `CINLayer` and `CIN`
- [test/nn/wrappers/cell/test_cin_wrapper.py](test/nn/wrappers/cell/test_cin_wrapper.py) — unit tests for `CINWrapper`
- [test/pipeline/test_pipeline_cin.py](test/pipeline/test_pipeline_cin.py) — end-to-end pipeline smoke test on MUTAG
- [test/pipeline/test_pipeline.py](test/pipeline/test_pipeline.py) — added `"cell/cin"` to the shared `MODELS` list per the submission requirements
- [2026_tdl_challenge/outputs/2026-07-03_07-02-04/results.json](2026_tdl_challenge/outputs/2026-07-03_07-02-04/results.json) — GraphUniverse evaluation results and computational complexity produced by `run_evaluation.ipynb`

## Results

Evaluation was run via the official `run_evaluation.ipynb` notebook on the GraphUniverse benchmark grid (homophily × avg. degree × power-law), 3 train seeds (42, 43, 44), 72 runs total. Full per-cell in-distribution and out-of-distribution (`ood_test`) results are in [`results.json`](2026_tdl_challenge/outputs/2026-07-03_07-02-04/results.json).

| Experiment | Runs | Params | Avg. epoch time (s) | Avg. in-distribution metric |
| --- | --- | --- | --- | --- |
| `community_detection` | 36 | 496,243 | 7.00 | Accuracy ≈ 0.468 |
| `triangle_counting` | 36 | 495,008 | 6.47 | MSE ≈ 14,071 |

**No minimum training performance is required for this challenge** - these numbers are reported to demonstrate architectural correctness and end-to-end pipeline integration, not to claim state-of-the-art performance.

<img width="3214" height="2171" alt="image" src="https://github.com/user-attachments/assets/215b8f4a-927b-47a2-857b-7988a1e163c2" />


<img width="3134" height="2171" alt="image" src="https://github.com/user-attachments/assets/3dcd9a79-8707-45ee-83fb-9ddfceed65d9" />

## Reproduction check

The unit tests check each message term, and the GraphUniverse runs show the model trains. Neither shows the model is really CIN. So we reran the paper's NCI1 experiment and compared three implementations on the same data.

**Setup.** NCI1 (4,110 graphs), using the CWN authors' own 10-fold split files from their dataset archive, scored the way the paper scores it: the peak of the fold-averaged held-out curve (`exp/run_tu_exp.py:33-38`). Those files index the authors' data file, not PyG's, so we checked the two orderings match first. On NCI1 they agree on all 4,110 graphs; on MUTAG they don't, so we skipped it. The reference code ran unchanged in its own old environment (torch 1.7.1, PyG 1.6.3, graph-tool 2.44). Every TopoBench run used a fixed 500 epochs with early stopping off, so nothing is cut short.

| Model | Split | Params | Accuracy |
| --- | --- | --- | --- |
| **CIN (this PR)** | authors' 10-fold | 499,495 | **82.97 ± 1.34** |
| TopoBench CWN | authors' 10-fold | 111,375 | 78.66 ± 2.20 |
| TopoBench CWN | TopoBench 50/25/25, as published | 111,375 | 73.93 ± 1.87 |
| Reference `sparse_cin` | authors' 10-fold | 42,615 | 83.64 ± 0.36 |

The paper reports 83.6 ± 1.4 here, so the reference run reproduces it and our CIN lands inside that range. The third row is TopoBench's own published CWN figure and is listed for orientation only: it uses a different split and reports test accuracy on a held-out quarter, so it is not comparable to the rows above it. Only the first two rows are a like-for-like model comparison.

**The fixes matter.** With the backbone as the only difference (same splits, hyperparameters, lifting, encoder, readout, budget and hardware), CIN beats TopoBench's CWN by **+4.04** (paired *t* = 9.34, *p* = 6.3e-6, better on all 10 folds). The gap holds steady from epoch 200 to 499, so it isn't down to one model stopping early. It isn't model size either: giving CWN 128 channels, 427k parameters against CIN's 499k, makes it worse, and CIN's lead grows to +5.06.

**It also works at the reference's own size.** The row above uses hidden 64, which is more parameters than the reference's 42,615, so we swept the hidden width with everything else fixed:

| Hidden | Params | Accuracy | Peak epoch |
| --- | --- | --- | --- |
| 16 | 35,287 | 80.58 ± 2.03 | 499 (still rising at the limit) |
| 32 | 130,119 | 81.90 ± 1.87 | 159 |
| 64 | 499,495 | 82.97 ± 1.34 | 369 |

Two things here line up with the original. At the reference's own hidden size our model is slightly *smaller* than it, 35,287 against 42,615, and still reaches 80.58, and that is a lower bound becausethe run had not peaked when the  epoch budget ran out. And the curve is flat: 14× the parameters buys about 2.4 points, so the model isn't leaning on capacity to get its score. Even the smallest version beats TopoBench's CWN at hidden 64, 80.58 against 78.66, with 3× fewer parameters.

**What's left.** At matched width the reference is still ahead, 83.64 against our 80.58. Two framework-level differences apply to any cell model in TopoBench and are the most likely causes:

- **Readout.** TopoBench makes every model share `PropagateSignalDown` with sum-pooling over rank 0. The paper reads out each rank separately and adds them, on Jumping-Knowledge features.
- **Lifting.** TopoBench's `CellCycleLifting` uses `nx.cycle_basis`; the reference finds all induced cycles up to size *k*.

All of the above is NCI1 at one setting, so it shows the model behaves like CIN there rather than everywhere.

## Testing

All 25 unit tests pass, and `cin.py` / `cin_wrapper.py` are both at 100% coverage. Rather than only checking shapes, we tried to write tests that would actually fail if any of the bugs above were reintroduced:

- `test_1cell_boundary_depends_on_nodes` perturbs `x_0` and asserts the edge outputs change — this is the test that catches a missing `B1^T @ msg(x_0)` term (issue 4).
- `test_2cell_boundary_depends_on_edges` does the same for the bonds→rings direction.
- `test_wrapper_uses_adjacency_0_not_1` zeros out `adjacency_1` and checks that node outputs are unaffected while edge outputs change, pinning down the wrapper fix (issue 1).
- `test_all_dims_updated_across_layers` asserts that `x_0` and `x_2` end up different from their initial projections, i.e. all ranks are really being updated (issue 3).
- `test_end_to_end_backprop` confirms gradients reach every learnable parameter, including the new boundary message map.

For a quick reference, here's the full message schedule per rank as implemented, with where each piece comes from in the paper:

| Cell rank | Boundary stream (B) | Upper-adj stream (N↑ + coboundary context) | Source |
|-----------|----------------|-----------------|-----------------|
| 0-cells (nodes) | none (B(node) = ∅) | A_up,0 @ msg(x_0) + B1 @ msg_coboundary(x_1) | Sec. 4, App. E.3 |
| 1-cells (edges) | B1^T @ msg(x_0) | A_up,1 @ msg(x_1) + B2 @ msg_coboundary(x_2) | Sec. 4, Fig. 6, App. E.3 |
| 2-cells (rings) | B2^T @ msg(x_1) | none (no 3-cells) | Sec. 4, Fig. 6, App. E.3 |
