### PR TITLE
Track: Track2; Team name: LoopCounter; Model: HiGCN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-29_23-30-10/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-29_23-30-10/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-29_23-30-10",
+    "model_config": "simplicial/higcn",
+    "generated_at_utc": "2026-06-30T02:58:53.528643+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.145028591156006,
+      "test_best_rerun_accuracy": 0.3327603340148926,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3300863206386566,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34739094972610474,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33776453137397766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3765757381916046,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3610283434391022,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36863014101982117,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35449615120887756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45572617650032043,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4466727674007416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48403239250183105,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4755137860774994,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.154233932495117,
+      "test_best_rerun_accuracy": 0.3293987214565277,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.325464129447937,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34376195073127747,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33382993936538696,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37283214926719666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.356749951839447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36820995807647705,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3523951470851898,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45385438203811646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4465963840484619,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48456719517707825,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4766215980052948,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1390700340270996,
+      "test_best_rerun_accuracy": 0.33207273483276367,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3280617296695709,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3458247482776642,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33650392293930054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3747803568840027,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3580869436264038,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36954694986343384,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3537321388721466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45140957832336426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44109559059143066,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4765833914279938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4637099802494049,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.151171922683716,
+      "test_best_rerun_accuracy": 0.3303155303001404,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33329513669013977,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34303614497184753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3399801254272461,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3607991337776184,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35285353660583496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3493773341178894,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34143173694610596,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4255099594593048,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42638856172561646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.442088782787323,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4433493912220001,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.148880958557129,
+      "test_best_rerun_accuracy": 0.33111771941185,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.331958144903183,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3420047461986542,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33898693323135376,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3613721430301666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3537321388721466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3486515283584595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3397127389907837,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42283597588539124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4258155822753906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4396439790725708,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44178318977355957,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.163689374923706,
+      "test_best_rerun_accuracy": 0.3261517286300659,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3288257420063019,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33967453241348267,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3363129198551178,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35908013582229614,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3504469394683838,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34846052527427673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3394835293292999,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42623576521873474,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42665597796440125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44338756799697876,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4460233747959137,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.0836544036865234,
+      "test_best_rerun_accuracy": 0.35067614912986755,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32118573784828186,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31301093101501465,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34429672360420227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39739474654197693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.378447562456131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4088165760040283,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4056459665298462,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5274658203125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5314767956733704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5925968289375305,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6175414323806763,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.074068069458008,
+      "test_best_rerun_accuracy": 0.35419052839279175,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.325464129447937,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3186263144016266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34700894355773926,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39487355947494507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37840935587882996,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40694475173950195,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4014439582824707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5169990062713623,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5207425951957703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5780044198036194,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6018030643463135,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.103163957595825,
+      "test_best_rerun_accuracy": 0.3455955386161804,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3128963112831116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.306440532207489,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3397509455680847,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3918939530849457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3745511472225189,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4023989737033844,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40110015869140625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5209718346595764,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5249828100204468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5861028432846069,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6148674488067627,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.100362539291382,
+      "test_best_rerun_accuracy": 0.3484223484992981,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3184735178947449,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3104897141456604,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3463595509529114,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38983115553855896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3776835501194,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3901749551296234,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3884177505970001,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.522079586982727,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5330430269241333,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5819008350372314,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6148674488067627,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.0858540534973145,
+      "test_best_rerun_accuracy": 0.34968292713165283,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32607534527778625,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31996333599090576,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3517839312553406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38788294792175293,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37936434149742126,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39170295000076294,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3896401524543762,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5143632292747498,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5252119898796082,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5710138082504272,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6018794178962708,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.0894389152526855,
+      "test_best_rerun_accuracy": 0.34918633103370667,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32347771525382996,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31981053948402405,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3504469394683838,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38818854093551636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3791733384132385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39021316170692444,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38681334257125854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5108488202095032,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5224233865737915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5644816160202026,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5974100232124329,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.862805724143982,
+      "test_best_rerun_accuracy": 0.4282603859901428,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3057529330253601,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3002903163433075,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31832072138786316,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3091527223587036,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39101535081863403,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.434448778629303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41210177540779114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5720834136009216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5471388101577759,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6244938373565674,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5898846387863159,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.8653955459594727,
+      "test_best_rerun_accuracy": 0.4258919656276703,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3028879165649414,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2979601323604584,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32210251688957214,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3061349093914032,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38983115553855896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44174498319625854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.416494756937027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.577011227607727,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5500420331954956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6286576390266418,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5981358289718628,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.8750531673431396,
+      "test_best_rerun_accuracy": 0.42570096254348755,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29967913031578064,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2944457232952118,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3183589279651642,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3049507141113281,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3901749551296234,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43807777762413025,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41305676102638245,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5742990374565125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5492780208587646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6263656616210938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5950034260749817,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9486429691314697,
+      "test_best_rerun_accuracy": 0.39674535393714905,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3094201385974884,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3032699227333069,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3293987214565277,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32225534319877625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4221101701259613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4238673746585846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4299793839454651,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5681488513946533,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5635648369789124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.639506459236145,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6600580811500549,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.955946922302246,
+      "test_best_rerun_accuracy": 0.3950645625591278,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30934372544288635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.302620530128479,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32798531651496887,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3208419382572174,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41974177956581116,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42161357402801514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4295591711997986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5713576078414917,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5634884238243103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6391244530677795,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6607456803321838,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9689363241195679,
+      "test_best_rerun_accuracy": 0.39674535393714905,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30472153425216675,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29902970790863037,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3258843421936035,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3166399300098419,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4198181629180908,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4229123592376709,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42940637469291687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.573191225528717,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5662388205528259,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6422950625419617,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6652532815933228,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.7408840656280518,
+      "test_best_rerun_accuracy": 0.4750936031341553,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.271334707736969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26300710439682007,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3196195363998413,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30265870690345764,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41702955961227417,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3772633373737335,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46252578496932983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5791122317314148,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.557987630367279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.667698085308075,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.678317666053772,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.7298030853271484,
+      "test_best_rerun_accuracy": 0.47734740376472473,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2745817005634308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.265642911195755,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32130032777786255,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4172205626964569,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3781801462173462,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46241119503974915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5812896490097046,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5585606098175049,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6673924922943115,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6816028952598572,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.738891839981079,
+      "test_best_rerun_accuracy": 0.47368019819259644,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27439069747924805,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26392391324043274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3194667398929596,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30074870586395264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4162273705005646,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3776835501194,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4577125906944275,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.581595242023468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5583314299583435,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.666934072971344,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6828252673149109,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7088592052459717,
+      "test_best_rerun_accuracy": 0.4842616021633148,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27492550015449524,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26449689269065857,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3190465271472931,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31343111395835876,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4223775565624237,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3959813714027405,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4645121991634369,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5944686532020569,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5958438515663147,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6801894903182983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7208343148231506,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7058875560760498,
+      "test_best_rerun_accuracy": 0.4831155836582184,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27794331312179565,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2688899040222168,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3231339156627655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3153793215751648,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4202383756637573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39758574962615967,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4655817747116089,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5951562523841858,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5931698083877563,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6773244738578796,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7168232798576355,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7083158493041992,
+      "test_best_rerun_accuracy": 0.4850637912750244,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2767973244190216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26854610443115234,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32118573784828186,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3145771324634552,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4193979799747467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3957521617412567,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.46443578600883484,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.592940628528595,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5939338207244873,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6796546578407288,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7187333106994629,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.2937531471252441,
+      "test_best_rerun_accuracy": 0.6248376369476318,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2799296975135803,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27232789993286133,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2964703142642975,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29112231731414795,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4292917847633362,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39552295207977295,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42260676622390747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4225303828716278,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6083352565765381,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6911528706550598,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6943234801292419,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3020124435424805,
+      "test_best_rerun_accuracy": 0.6247612237930298,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2786691188812256,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2688899040222168,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29585912823677063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2882191240787506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4274199604988098,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3942241668701172,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4219573736190796,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42405837774276733,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6102070212364197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6903125047683716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6940943002700806,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.2881126403808594,
+      "test_best_rerun_accuracy": 0.6254488229751587,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2792039215564728,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2737795114517212,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2994881272315979,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29096952080726624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42749637365341187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39239054918289185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42554816603660583,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4276491701602936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6065016388893127,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6926808953285217,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7010848522186279,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.274221658706665,
+      "test_best_rerun_accuracy": 0.6340820789337158,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27465811371803284,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26705631613731384,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29753991961479187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29818931221961975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4215753674507141,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4006417691707611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40587517619132996,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42272135615348816,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6301474571228027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6999770998954773,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7327526807785034,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.2683966159820557,
+      "test_best_rerun_accuracy": 0.6344258785247803,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27901291847229004,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26858431100845337,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2981129288673401,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3009397089481354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4246695637702942,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40258994698524475,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40747955441474915,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4283367693424225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6287722587585449,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.701199471950531,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7318359017372131,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.263916254043579,
+      "test_best_rerun_accuracy": 0.6341202259063721,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2775613069534302,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2690427005290985,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29562991857528687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29601192474365234,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4242875576019287,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4003743529319763,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4044617712497711,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42054396867752075,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6315608620643616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7017343044281006,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7296202778816223,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.0243909358978271,
+      "test_best_rerun_accuracy": 0.7028802633285522,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26300710439682007,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2527312934398651,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29643210768699646,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28883031010627747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4229123592376709,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.383337140083313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4476277828216553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.461150586605072,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6201008558273315,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6022614240646362,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7285506725311279,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.033549427986145,
+      "test_best_rerun_accuracy": 0.702765703201294,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2615554928779602,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25227290391921997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2935289144515991,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28802812099456787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41890135407447815,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3782183527946472,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4473985731601715,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4603483974933624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6169302463531494,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5987088680267334,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7288181185722351,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.033774495124817,
+      "test_best_rerun_accuracy": 0.7009702920913696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26151731610298157,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25105050206184387,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29440751671791077,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2883719205856323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4154633581638336,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38031935691833496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4454885721206665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45618459582328796,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6139124631881714,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.596722424030304,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7288944721221924,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.8939577341079712,
+      "test_best_rerun_accuracy": 0.7395905256271362,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2665978968143463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2622049152851105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29318511486053467,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29585912823677063,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4210023581981659,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3950263559818268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4368935823440552,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4650469720363617,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6236152648925781,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6187256574630737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7026510834693909,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9051088094711304,
+      "test_best_rerun_accuracy": 0.7395141124725342,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26690351963043213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25861409306526184,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2926885187625885,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2967759072780609,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4178699553012848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3946061432361603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4359385669231415,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46638399362564087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6191840767860413,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6184200644493103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7009320855140686,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.8976346254348755,
+      "test_best_rerun_accuracy": 0.7397050857543945,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2688899040222168,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26025670766830444,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2927267253398895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29589730501174927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42069676518440247,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3951791524887085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4343341588973999,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4650469720363617,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6223928332328796,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6180380582809448,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7037206888198853,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 24.5224666595459,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24.43018913269043,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.01760100081605939,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.16036319732666,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07979138524908769
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3701.475341796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.28073381431906524
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 378.7960510253906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12766971723134163
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5330.001953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7120911093019372
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72.0737075805664,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.062239816563528845
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138421.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.214313652354635
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7832.28662109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5491716884794383
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36990.01171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8960485785406735
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2097.878173828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.37295611979166665
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 675852.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.645127286404308
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202124.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3635229976869185
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 24.782751083374023,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 25.267093658447266,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.018203957967181026,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.11727237701416,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05851195987902189
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3918.60205078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.29720152072667805
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349.9031677246094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11793163725130076
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5381.849609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7190179838844355
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.65888214111328,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06706293794569368
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139814.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2466721043098645
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8061.4267578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5652381684064297
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37211.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.907392101081552
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2159.998291015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.38399969618055557
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 678661.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.676903640147959
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204596.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.40466053658496
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 23.985469818115234,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24.510366439819336,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.017658765446555716,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.971940040588379,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07353652652941252
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3682.294189453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.279279043568686
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 404.0506896972656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13618156039678653
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5265.236328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7034383871910488
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.14080810546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06488843532423899
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138313.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2118068456251163
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7806.0283203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.547330551136762
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36748.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8836594648623712
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2088.1748046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3712310763888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 674936.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.6347691820413335
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201828.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.358602239445526
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.49113258719444275,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.5192976593971252,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0027331455757743433,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110.9050521850586,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07990277534946584
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9590.744140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7273981145714827
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55.50274658203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.018706689107526542
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7171.052734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9580564775384102
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105.05193328857422,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09071842252899329
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166015.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.855093944477986
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12390.22265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8687577237589399
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43856.5390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.248015739530473
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3060.161376953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5440286892361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 733505.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.297291240116285
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241602.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.020473214434293
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.7138962149620056,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.7197710275650024,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0037882685661315917,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112.27552032470703,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0808901443261578
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9678.2587890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7340355547260144
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.14208984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.018922173860380857
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7190.29736328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.960627570244656
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106.34988403320312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09183927809430321
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166261.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.86080310700353
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12440.216796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.872263132581335
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43899.828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2502346673330256
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3071.093017578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5459720920138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 733851.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.30120584143072
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241929.4375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.025917120130464
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.851161777973175,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.8788658380508423,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.004625609673951802,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110.6098403930664,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07969008673852046
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9659.6689453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7326256310437997
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53.1923713684082,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.017927998438964678
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7179.916015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9592406166499666
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103.52639770507812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08940103428763223
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166192.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8591885043191527
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12361.6923828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8667572838881293
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43845.734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2474619086062844
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3050.49072265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5423094618055555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 733393.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.296020072848206
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241365.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.016525947281713
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 356.4270935058594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 364.63427734375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.027655235293420552,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 883.6817626953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6366583304721272
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1538.37255859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.09669767680921
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.8769989013672,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07040006703787233
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4576.95556640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6114837096067134
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1108.334716796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9571111544014465
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98383.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.2845938603009475
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6116.5830078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4288727392941032
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38001.28515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9478848303987903
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2890.74853515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5139108506944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 667219.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.547479299345045
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202341.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.367131727073037
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 241.21682739257812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 252.40492248535156,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.019143338830895074,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368.4170837402344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2654301756053562
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 637.4456787109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.3549772563733553
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.53992462158203,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.026471157607543656
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3802.32666015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5079928737683701
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 472.1009521484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4076864871748165
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92125.7421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.139275083306242
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5918.8251953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.41500667475196323
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36194.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8552957529217284
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2545.6181640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4525543402777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 665444.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.527402209201045
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205488.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.419511215948613
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 329.9283752441406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 341.10272216796875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.025870513626694635,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 513.2794799804688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3697978962395308
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 927.5271606445312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.881721898129112
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116.1042709350586,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.039131874261900436
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4151.65869140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5546638198271543
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 671.344970703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5797452251322323
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95416.9296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.2157005779189114
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5970.8974609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4186577942040036
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36955.19140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8942637452585986
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2642.526123046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.469782421875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 666454.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.538822211915885
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203875.4375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.392665327076365
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 15.826082229614258,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15.768211364746094,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.005314530288084292,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125.58698272705078,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09048053510594437
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.4742317199707,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3077591143156353
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7220.61669921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5476387333499242
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6806.7666015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9093876555193721
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126.12203216552734,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10891367199095625
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157255.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6516583602312838
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10430.9228515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7313786882318398
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42075.33203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1567139285073558
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2740.42822265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4871872395833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713127.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.066774459011572
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225704.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7559223308039207
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 16.401290893554688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 16.980209350585938,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.00572302303693493,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112.16541290283203,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08081081621241501
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.63090133666992,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.24542579650878907
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7047.18017578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5344846549701365
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6747.771484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9015058763360053
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.82891845703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10434276205270401
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156717.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.639175123072636
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10372.83203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7273055694327584
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41932.578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.149396592598288
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2735.984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4863972222222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 712185.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.056128609888805
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225409.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7510143132311584
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 17.424091339111328,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17.562664031982422,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.005919334018194278,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97.23755645751953,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07005587641031666
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.67127227783203,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17721722251490543
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7137.91015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5413659580015169
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6661.5166015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8899821778974616
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.77560424804688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08788912283941872
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156755.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6400687784460337
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10286.4345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7212476910890829
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41689.765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.136950413911528
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2654.83740234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.47197109375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 711967.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.053654853342081
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224853.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.74175054706871
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3347.921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3462.551025390625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.46259866738685707,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 360.6765441894531,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.25985341800392875
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 482.7551574707031,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.5408166182668586
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4585.58642578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3477881248222412
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4639.2666015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5636220429937648
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 417.76605224609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.36076515738004644
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96197.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.233829300575887
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10504.720703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.736553127410251
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26880.236328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3778377327451432
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2750.9755859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4890623263888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 566207.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.404842737237424
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140741.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.3420575711813356
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3476.32568359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3597.65380859375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.48064847142201067,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 363.2181396484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.261684538651612
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 385.0364990234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.0265078895970396
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4397.6884765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.33353723750948044
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4669.7421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5738935583080553
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 388.8061828613281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3357566345952747
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98357.5859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.2839862980099386
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10377.03125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7276000035058197
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27363.3203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4025998417397099
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2836.148193359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5042041232638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 570261.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.450705151408889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142598.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.372955772718952
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3456.259765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3580.998779296875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.47842335060746494,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 360.1493835449219,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2594736192686757
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 456.4166259765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.4021927682976973
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4072.50048828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.30887375716960563
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4439.16796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.4961806433265925
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 418.0108947753906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3609765930702855
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98493.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.2871311449238343
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10113.67578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.709134467904221
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27288.7734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3987786886821467
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2746.357177734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.48824127604166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 570747.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.456194925511578
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142639.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.373642728770406
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 76.08370971679688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 80.388427734375,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.06942005849255181,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64.70629119873047,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04661836541695279
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.4453706741333,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05497563512701737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7184.455078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5448960999715586
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81.50235748291016,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.027469618295554485
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6413.9775390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8569108268620574
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155700.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6155667291705367
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9873.998046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6923291296364465
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40729.77734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0877429567763595
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2471.7822265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4394279513888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706215.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.988593430087215
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 220671.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6721734956650525
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 86.89955139160156,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 92.47711944580078,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07985934321744455,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.23162841796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.053481000301130226
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.232561111450195,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.043329269007632606
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7702.8984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5842167946530148
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.856258392333984,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01747767387675564
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6565.830078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.877198407231129
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158060.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.670372149591306
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10518.73046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7375354416456318
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41447.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1245560943026294
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2637.858154296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4689525607638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713434.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.070249312806126
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 226744.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7732327392541563
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 78.94156646728516,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 82.76947021484375,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.0714762264376889,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76.47723388671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05509887167631034
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.037323951721191,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.06861749448274311
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7280.11181640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5521510668491657
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79.27020263671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.026717291080794996
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6426.60546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8585979250167001
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156121.421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6253348939949843
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9888.599609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6933529385342168
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40705.265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0864865254497924
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2478.491943359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.44062078993055553
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706713.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.994227430064591
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 220994.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.677547197676934
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 92468.421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 63672.61328125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.478557804227429,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14092.681640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.153228847712535
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28179.712890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 148.31427837171051
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18226.828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.3823912116040955
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14125.1865234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.760763910831648
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11270.3095703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.505719381471276
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16769.1796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 14.481156897668393
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16431.90234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1521457259676062
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34759.81640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.781732349492542
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16979.4375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.0185666666666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 474868.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.37162872017918
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114016.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8973336120679614
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 98256.0625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 66988.203125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.555549951815902,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17050.341796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 12.284107922820604
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33076.8203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 174.0885279605263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19243.380859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.459490395098597
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15642.986328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.272324343823728
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11324.28125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.512930026720107
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17574.34765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 15.17646602439551
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16450.240234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1534315127173609
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35392.1484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.814144673612179
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15556.1767578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.765542534722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 474302.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.365227283010758
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114763.5234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9097652544805552
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 105235.9375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 70497.3046875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.6370356838078208,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15575.748046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 11.221720494866714
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28580.75390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 150.42502055921054
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16319.759765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.237751973122867
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10531.3740234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.549502535705258
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9016.2041015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.204569686247495
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17008.443359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 14.687774921740068
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16662.822265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1683369980104474
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30170.7734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5465053789276744
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10453.53125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8584055555555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 483764.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.472257728810108
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118051.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9644849961725992
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 6760.5576171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6333.21240234375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.44406201110249266,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3587.5166015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.5846661394542507
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6496.89794921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 34.19419973273026
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1698.712158203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.12883672037945582
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1159.030029296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3906403873599174
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7604.49853515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0159650681571477
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4408.4775390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.8069754223337653
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116785.0703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.711895558064741
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39934.3203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0469691072069303
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3854.531982421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6852501302083334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 639162.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.230098243272288
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171505.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8540054582064465
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 6829.52197265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6395.7255859375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.4484452100643318,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3005.793701171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.16555742159357
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5337.86474609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 28.09402497944079
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1703.5029296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.12920007051099736
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 965.987060546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.32557703422543816
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7221.2666015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9647650770290581
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3604.714111328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.1128791980381045
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118760.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7577602521827975
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39151.19140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0068271775206314
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3420.341064453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6080606336805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 642546.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.268380315147676
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172600.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8722261744296342
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 6507.3564453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6131.23291015625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.4298999376073657,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4656.005859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.3544710802413547
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8140.03857421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 42.842308285361845
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1679.4620361328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1273767187055603
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1600.07177734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5392894429874452
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8102.484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.08249624248497
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5653.966796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.882527458441278
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113895.1328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6447875908531486
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40252.00390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.063253057883541
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4304.04443359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7651634548611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 635495.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.188621285476737
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167911.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.794186198891718
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 24610.982421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24570.546875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.2594467617509868,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4115.828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.965294038184438
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2766.60302734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.561068564967105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57676.5546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.374406878081153
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13534.1640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.561565238456353
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6668.69482421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8909411922803941
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2668.361083984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.3042841830607728
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83643.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9423009938695894
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31678.19921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.2211610726931705
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7145.9443359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2703901041666668
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 483390.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.468035233532799
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120632.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.007421829497612
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 22487.921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 22179.078125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.1368639153723923,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1226.218017578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8834423757767471
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 932.5455322265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.908134380139803
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18786.0234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.4248026877133106
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15595.2470703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.256234267041624
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4044.935791015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5404055833020207
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1261.7674560546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.0896092021197648
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84478.3828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9616938234372097
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29723.13671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.0840791416877016
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7517.029296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.3363607638888888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 490203.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.545104874834564
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117698.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9586053076065433
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 21821.58984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 21585.16796875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.1064210348428931,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1513.080078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0901153300612392
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 624.9697875976562,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.2893146715666117
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20650.376953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.5662022717576791
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15862.9130859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.346448630245197
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4458.55078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5956647670340681
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1481.8193359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2796367322430915
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81626.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8954724363737692
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30204.697265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.117844430348128
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8534.015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.5171583333333334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 487647.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.516189354433673
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119419.9609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.987252441008104
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1883.5384521484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1987.8973388671875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.3534039713541667,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.4414291381836,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06155722560387867
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.846435546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8149812397203947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3993.981201171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3029185590574042
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 782.6755981445312,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2637935955997746
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5435.97607421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7262493085128591
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.52566528320312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12307915827565037
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138705.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.220923726894854
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7389.16162109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.518101361737046
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36129.34375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8519321210723256
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 659902.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.464703545128559
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186841.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.109205731116769
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1988.80859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2112.830810546875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.37561436631944445,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.8749084472656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.21028451617238159
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 490.713134765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.582700709292763
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4323.95703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3279451673302996
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 546.1842651367188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.18408637180206228
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6146.58203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8211866441215765
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 307.4284973144531,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2654822947447782
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141716.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2908414656093257
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7597.52978515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5327113858614675
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37812.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9382144138602697
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 664711.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.519110635385677
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 187817.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1254537238114257
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1926.756591796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2045.931884765625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.36372122395833334,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241.03323364257812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1736550674658344
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 365.2621765136719,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.9224325079666942
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4446.83203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3372644695676906
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 550.5960693359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.18557332973910937
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5942.74072265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7939533363602205
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255.6414337158203,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.22076116901193463
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141781.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2923439531859557
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7505.8291015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5262816646727317
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37356.828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9148509982572146
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 666288.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.53694444758662
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189357.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.151074688399647
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 509146.59375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 326177.53125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.689665862583849,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 338195.375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 243.65661023054756
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 352939.1875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1857.5746710526316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 269808.625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 20.463301099734547
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 357486.71875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 120.48760321873947
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 299134.875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 39.96457915831663
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348975.8125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 301.3608052677029
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163196.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7896198100501577
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 294742.375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 20.666272261954845
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241321.8125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 12.369768440207084
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 328291.65625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 58.36296111111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168403.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8023776687800575
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 506505.3125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 325313.1875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6798885501623246,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 338090.28125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 243.5808942723343
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349945.65625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1841.8192434210525
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281745.09375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.36860779294653
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 364966.75,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 123.00867880013482
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 302374.21875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 40.39735721442886
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348435.1875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 300.8939443005181
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171200.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9754925082435446
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 308561.1875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.63519755293788
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247152.453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 12.668637712081603
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 334093.875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 59.394466666666666
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179676.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9899798541427454
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 509888.25,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 325803.8125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6854384183794666,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 318135.5,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 229.2042507204611
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 327732.34375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1724.907072368421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 269696.6875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 20.454811338642397
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 346085.71875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 116.64500126390293
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 284862.3125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 38.05775718102873
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 327153.78125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 282.51621869602764
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164567.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8214739254365595
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 294530.65625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 20.651427306829337
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232804.984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 11.933209512276385
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 315970.0625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 56.17245555555556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174202.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8988838134225285
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 117412.25,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 113163.8671875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8831455774799062,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49904.19140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 35.954028390670025
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42109.33984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 221.62810444078949
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70018.4765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.310464661547213
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68836.6171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.200747282608695
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46073.6015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.1554577905811625
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46537.4140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 40.18774962219344
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82060.3203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9055433845555452
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69143.296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.848078591712242
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44807.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2967702807037775
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53706.44140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.547811805555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 428601.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.848271551870412
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111757.265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 106783.0,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7769623749854393,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41053.60546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 29.577525553854468
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33977.1484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 178.82709703947367
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65181.3515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.943598905005688
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60680.78125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 20.45189796090327
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39344.3671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 5.256428481963928
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39640.53125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 34.231892271157164
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82869.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9243288332481887
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64115.875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.495573902678446
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40234.46875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0623542339433083
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48035.77734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 8.53969375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434409.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.913970679728063
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "higcn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 114881.1484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 110326.5078125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.835929439576989,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28152.755859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 20.282965316552595
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18930.755859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 99.63555715460527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64479.8671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.89039569112628
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51938.1953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 17.505289960397707
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29637.94921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 3.959645854208417
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25329.34765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 21.873357216105354
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83070.4609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9290001146549323
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63229.421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.43341900680129
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36441.1875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8679167307396587
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37728.19921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 6.707235416666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 433476.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.903409315860322
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-30-10__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/simplicial/higcn.yaml
+++ b/configs/model/simplicial/higcn.yaml
@@ -1,0 +1,45 @@
+_target_: topobench.model.TBModel
+
+model_name: higcn
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 32
+  proj_dropout: 0.0
+  # HiGCN is node-centric: it only encodes rank-0 (node) features and uses the
+  # higher-order simplicial structure through the Flower-Petals Laplacians, which
+  # the backbone rebuilds from the incidence matrices attached by the lifting.
+  selected_dimensions:
+    - 0
+
+backbone:
+  _target_: topobench.nn.backbones.simplicial.higcn.HiGCN
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  K: 10 # number of propagation hops in each Flower-Petals polynomial filter
+  alpha: 0.1 # PPR teleport probability used to initialize the filter weights
+  order: 2 # highest petal order: 2 fuses pairwise (edges) and triangle structure
+  dropout: 0.5
+  dprate: 0.0
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.HiGCNWrapper
+  _partial_: true
+  wrapper_name: HiGCNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut # HiGCN already produces the final node embeddings
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/simplicial/test_higcn.py
+++ b/test/nn/backbones/simplicial/test_higcn.py
@@ -1,0 +1,276 @@
+"""Unit tests for the HiGCN backbone."""
+
+import pytest
+import torch
+from torch_sparse import SparseTensor
+
+from ...._utils.nn_module_auto_test import NNModuleAutoTest
+from topobench.nn.backbones.simplicial import HiGCN
+from topobench.nn.backbones.simplicial.higcn import (
+    HiGCNProp,
+    build_flower_petals_laplacians,
+    _binarize,
+    _to_sparse_tensor,
+)
+from topobench.transforms.liftings.graph2simplicial import (
+    SimplicialCliqueLifting,
+)
+
+
+def _lift(graph):
+    """Lift a graph to a simplicial complex with triangles.
+
+    Parameters
+    ----------
+    graph : torch_geometric.data.Data
+        Input graph.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Lifted simplicial complex (clique complex up to dimension 2).
+    """
+    lifting = SimplicialCliqueLifting(complex_dim=2, signed=False)
+    return lifting(graph)
+
+
+def test_HiGCN(simple_graph_1):
+    """Test the HiGCN backbone end to end on a lifted graph.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph data.
+    """
+    data = _lift(simple_graph_1)
+    out_dim = 4
+    incidences = (data.incidence_1, data.incidence_2)
+    expected_shapes = [(data.x_0.shape[0], out_dim)]
+
+    auto_test = NNModuleAutoTest(
+        [
+            {
+                "module": HiGCN,
+                "init": (data.x_0.shape[1], out_dim),
+                "forward": (data.x_0, incidences),
+                "assert_shape": expected_shapes,
+            },
+        ]
+    )
+    auto_test.run()
+
+
+@pytest.fixture
+def create_sample_data():
+    """Create sample node features and incidence matrices.
+
+    Returns
+    -------
+    dict
+        Sample data for testing.
+    """
+    num_nodes, num_edges, num_tri = 6, 9, 4
+    x = torch.randn(num_nodes, 5)
+
+    # Node-edge incidence: each edge connects two nodes.
+    edges = torch.tensor(
+        [[0, 0, 1, 1, 2, 2, 3, 4, 0], [1, 2, 2, 3, 3, 4, 4, 5, 5]]
+    )
+    rows = torch.cat([edges[0], edges[1]])
+    cols = torch.cat([torch.arange(num_edges), torch.arange(num_edges)])
+    incidence_1 = torch.sparse_coo_tensor(
+        torch.stack([rows, cols]),
+        torch.ones(2 * num_edges),
+        size=(num_nodes, num_edges),
+    ).coalesce()
+
+    # Edge-triangle incidence: each triangle has three edges.
+    e_rows = torch.tensor([0, 1, 2, 0, 3, 4, 2, 4, 6, 4, 7, 8])
+    t_cols = torch.tensor([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3])
+    incidence_2 = torch.sparse_coo_tensor(
+        torch.stack([e_rows, t_cols]),
+        torch.ones(12),
+        size=(num_edges, num_tri),
+    ).coalesce()
+
+    return {
+        "x": x,
+        "incidences": (incidence_1, incidence_2),
+        "num_nodes": num_nodes,
+    }
+
+
+def test_basic_initialization():
+    """Test basic initialization and module structure of HiGCN."""
+    model = HiGCN(in_channels=5, hidden_channels=8, order=2)
+    assert model is not None
+    assert len(model.lin_in) == 2
+    assert len(model.prop) == 2
+    assert model.lin_out.in_features == 8 * 2
+    assert model.lin_out.out_features == 8
+
+
+def test_different_orders(create_sample_data):
+    """Test HiGCN with order 1 and order 2.
+
+    Parameters
+    ----------
+    create_sample_data : dict
+        Sample data for testing.
+    """
+    data = create_sample_data
+    for order in (1, 2):
+        model = HiGCN(in_channels=5, hidden_channels=8, order=order)
+        assert len(model.lin_in) == order
+        out = model(data["x"], data["incidences"])
+        assert out.shape == (data["num_nodes"], 8)
+        assert torch.isfinite(out).all()
+
+
+def test_invalid_order():
+    """Test that a non-positive order raises an assertion error."""
+    with pytest.raises(AssertionError):
+        HiGCN(in_channels=5, hidden_channels=8, order=0)
+
+
+def test_invalid_K():
+    """Test that a non-positive number of hops raises an assertion error."""
+    with pytest.raises(AssertionError):
+        HiGCN(in_channels=5, hidden_channels=8, K=0)
+
+
+def test_order_exceeds_incidences(create_sample_data):
+    """Test that requesting more orders than incidences raises an error.
+
+    Parameters
+    ----------
+    create_sample_data : dict
+        Sample data for testing.
+    """
+    data = create_sample_data
+    model = HiGCN(in_channels=5, hidden_channels=8, order=3)
+    with pytest.raises(AssertionError):
+        model(data["x"], data["incidences"])
+
+
+def test_dprate_branch(create_sample_data):
+    """Test the dprate dropout branch is exercised.
+
+    Parameters
+    ----------
+    create_sample_data : dict
+        Sample data for testing.
+    """
+    data = create_sample_data
+    model = HiGCN(in_channels=5, hidden_channels=8, order=2, dprate=0.3)
+    out = model(data["x"], data["incidences"])
+    assert out.shape == (data["num_nodes"], 8)
+
+
+def test_reset_parameters(create_sample_data):
+    """Test that reset_parameters reinitializes the filter weights.
+
+    Parameters
+    ----------
+    create_sample_data : dict
+        Sample data for testing.
+    """
+    model = HiGCN(in_channels=5, hidden_channels=8, order=2, K=10, alpha=0.1)
+    # Perturb a filter weight then reset; it should return to the PPR profile.
+    with torch.no_grad():
+        model.prop[0].filter_weights[0] += 1.0
+    model.reset_parameters()
+    expected_w0 = 0.1  # alpha * (1 - alpha) ** 0
+    assert torch.isclose(
+        model.prop[0].filter_weights[0], torch.tensor(expected_w0)
+    )
+
+
+def test_higcn_prop_ppr_initialization():
+    """Test that HiGCNProp initializes filter weights with the PPR profile."""
+    K, alpha = 5, 0.2
+    prop = HiGCNProp(K=K, alpha=alpha)
+    assert "HiGCNProp" in repr(prop)
+    assert prop.filter_weights.shape == (K + 1,)
+    for k in range(K):
+        assert torch.isclose(
+            prop.filter_weights[k], torch.tensor(alpha * (1 - alpha) ** k)
+        )
+    assert torch.isclose(
+        prop.filter_weights[-1], torch.tensor((1 - alpha) ** K)
+    )
+
+
+def test_to_sparse_tensor_takes_absolute_value():
+    """Test that _to_sparse_tensor returns unsigned membership entries."""
+    signed = torch.sparse_coo_tensor(
+        torch.tensor([[0, 1], [0, 1]]),
+        torch.tensor([-1.0, 1.0]),
+        size=(2, 2),
+    )
+    st = _to_sparse_tensor(signed)
+    assert isinstance(st, SparseTensor)
+    assert (st.coo()[2] >= 0).all()
+
+
+def test_binarize():
+    """Test that _binarize maps all stored values to one."""
+    st = SparseTensor(
+        row=torch.tensor([0, 1]),
+        col=torch.tensor([0, 1]),
+        value=torch.tensor([2.0, 3.0]),
+        sparse_sizes=(2, 2),
+    )
+    binarized = _binarize(st)
+    assert torch.equal(
+        binarized.coo()[2], torch.ones_like(binarized.coo()[2])
+    )
+
+
+def test_build_flower_petals_laplacians(simple_graph_1):
+    """Test FP Laplacian construction and the triangle-membership property.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph data.
+    """
+    data = _lift(simple_graph_1)
+    incidences = (data.incidence_1, data.incidence_2)
+    laplacians = build_flower_petals_laplacians(incidences, order=2)
+
+    assert len(laplacians) == 2
+    n_nodes = data.x_0.shape[0]
+    for lap in laplacians:
+        assert lap.sparse_sizes() == (n_nodes, n_nodes)
+
+    # Order-2 (triangle) operator: nodes that are in no triangle must have an
+    # all-zero row in the Flower-Petals Laplacian.
+    l2 = laplacians[1].to_dense()
+    h2_counts = torch.sparse.mm(
+        torch.abs(data.incidence_1).coalesce(),
+        torch.abs(data.incidence_2).coalesce().to_dense(),
+    )
+    node_in_triangle = h2_counts.sum(dim=1) > 0
+    for node in range(n_nodes):
+        if not node_in_triangle[node]:
+            assert torch.allclose(l2[node], torch.zeros(n_nodes))
+
+
+def test_no_triangles_runs():
+    """Test that the order-2 branch is well defined when there are no triangles."""
+    num_nodes, num_edges = 4, 3
+    # A path graph 0-1-2-3 has no triangles.
+    rows = torch.tensor([0, 1, 1, 2, 2, 3])
+    cols = torch.tensor([0, 0, 1, 1, 2, 2])
+    incidence_1 = torch.sparse_coo_tensor(
+        torch.stack([rows, cols]), torch.ones(6), size=(num_nodes, num_edges)
+    ).coalesce()
+    incidence_2 = torch.sparse_coo_tensor(
+        size=(num_edges, 0)
+    ).coalesce()
+
+    model = HiGCN(in_channels=5, hidden_channels=8, order=2)
+    out = model(torch.randn(num_nodes, 5), (incidence_1, incidence_2))
+    assert out.shape == (num_nodes, 8)
+    assert torch.isfinite(out).all()

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "simplicial/higcn"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/simplicial/higcn.py
+++ b/topobench/nn/backbones/simplicial/higcn.py
@@ -1,0 +1,324 @@
+"""Higher-order Graph Convolutional Network (HiGCN) backbone.
+
+This module implements HiGCN, the Higher-order Graph Convolutional Network with
+Flower-Petals (FP) Laplacians introduced in
+
+    Yiming Huang, Yujie Zeng, Qiang Wu, Linyuan Lu.
+    "Higher-order Graph Convolutional Network with Flower-Petals Laplacians on
+    Simplicial Complexes." AAAI 2024. https://arxiv.org/abs/2309.12971
+
+Reference implementation (node classification): ``node_classify/models/HiGCN_model.py``
+and ``node_classify/utils/gen_HoHLaplacian.py`` at https://github.com/Yiminghh/HiGCN
+
+Notes
+-----
+For a simplicial complex, HiGCN defines, for every *petal order* ``k`` (k=1 are
+edges, k=2 are triangles/filled 2-simplices, ...), a **Flower-Petals Laplacian**
+that lives on the nodes ("hubs"):
+
+.. math::
+
+    \\mathcal{L}_k = \\frac{1}{k+1}\\, \\mathbf{D}_k^{-1/2}\\, \\mathbf{H}_k\\,
+                    \\mathbf{H}_k^{\\top}\\, \\mathbf{D}_k^{-1/2},
+
+where :math:`\\mathbf{H}_k \\in \\{0,1\\}^{N \\times n_k}` is the node-to-k-simplex
+incidence ("hub-petal" incidence) and :math:`\\mathbf{D}_k` is the diagonal matrix
+of node degrees with respect to k-simplices (Eq. 4 of the paper).
+
+Node features are then filtered, independently per order, by a learnable
+polynomial (GPR/APPNP-style) of the corresponding FP Laplacian:
+
+.. math::
+
+    \\mathbf{Z}_k = \\sum_{j=0}^{K} w_j^{(k)}\\, \\mathcal{L}_k^{\\,j}\\,
+                    \\mathbf{X} \\mathbf{W}_{\\text{in}}^{(k)},
+
+and the per-order representations are concatenated and projected, yielding a
+multi-scale node embedding that fuses pairwise (k=1) and higher-order (k>=2)
+topology.
+
+Within TopoBench the FP Laplacians are reconstructed on the fly from the
+boundary/incidence matrices produced by the (clique) graph-to-simplicial
+lifting, so the backbone needs no precomputed operators beyond the standard
+``incidence_k`` tensors carried on the batch.
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch_sparse import SparseTensor, matmul, mul
+
+
+def _to_sparse_tensor(coo: torch.Tensor) -> SparseTensor:
+    """Convert a (possibly signed) sparse COO incidence matrix to a SparseTensor.
+
+    The absolute value of the entries is taken so that the result encodes
+    unsigned membership (a node/edge belongs to a simplex), as required by the
+    Flower-Petals incidence :math:`\\mathbf{H}_k`.
+
+    Parameters
+    ----------
+    coo : torch.Tensor
+        Sparse COO tensor of shape ``(n_rows, n_cols)``.
+
+    Returns
+    -------
+    SparseTensor
+        Unsigned sparse tensor with the same shape.
+    """
+    coo = coo.coalesce()
+    idx = coo.indices()
+    val = coo.values().abs()
+    return SparseTensor(
+        row=idx[0],
+        col=idx[1],
+        value=val,
+        sparse_sizes=tuple(coo.shape),
+    )
+
+
+def _binarize(adj: SparseTensor) -> SparseTensor:
+    """Set every stored entry of a SparseTensor to one (membership indicator).
+
+    Parameters
+    ----------
+    adj : SparseTensor
+        Sparse tensor whose nonzero pattern encodes membership.
+
+    Returns
+    -------
+    SparseTensor
+        Sparse tensor with identical sparsity pattern and unit values.
+    """
+    row, col, val = adj.coo()
+    return SparseTensor(
+        row=row,
+        col=col,
+        value=torch.ones_like(val),
+        sparse_sizes=adj.sparse_sizes(),
+    )
+
+
+def build_flower_petals_laplacians(
+    incidences: tuple[torch.Tensor, ...],
+    order: int,
+) -> list[SparseTensor]:
+    """Build the Flower-Petals Laplacians for orders ``1..order``.
+
+    The node-to-k-simplex incidence :math:`\\mathbf{H}_k` is obtained by chaining
+    the boundary matrices: :math:`\\mathbf{H}_1 = |\\mathbf{B}_1|` (node-edge) and
+    :math:`\\mathbf{H}_k = \\mathbb{1}[\\mathbf{H}_{k-1} |\\mathbf{B}_k| > 0]`
+    (node-to-k-simplex membership). Each FP Laplacian is then the symmetrically
+    normalized hub-petal operator :math:`\\tfrac{1}{k+1}
+    \\mathbf{D}_k^{-1/2}\\mathbf{H}_k\\mathbf{H}_k^{\\top}\\mathbf{D}_k^{-1/2}`.
+
+    Parameters
+    ----------
+    incidences : tuple of torch.Tensor
+        Sparse incidence/boundary matrices ``(B_1, B_2, ...)`` where ``B_k`` maps
+        (k-1)-simplices to k-simplices. ``B_1`` has shape ``(n_nodes, n_edges)``.
+    order : int
+        Highest petal order to build. Must satisfy ``1 <= order <= len(incidences)``.
+
+    Returns
+    -------
+    list of SparseTensor
+        ``[L_1, ..., L_order]``, each an ``(n_nodes, n_nodes)`` node operator.
+    """
+    assert order >= 1, "order must be a positive integer."
+    assert order <= len(incidences), (
+        f"order={order} requires {order} incidence matrices, "
+        f"but only {len(incidences)} were provided."
+    )
+
+    # H_1 is the unsigned node-edge incidence.
+    hub_petal = _to_sparse_tensor(incidences[0])
+    laplacians: list[SparseTensor] = [_normalize_fp(hub_petal, order=1)]
+
+    for k in range(2, order + 1):
+        boundary_k = _to_sparse_tensor(incidences[k - 1])
+        # node -> k-simplex membership counts, then binarized to {0, 1}.
+        hub_petal = _binarize(matmul(hub_petal, boundary_k))
+        laplacians.append(_normalize_fp(hub_petal, order=k))
+
+    return laplacians
+
+
+def _normalize_fp(hub_petal: SparseTensor, order: int) -> SparseTensor:
+    """Symmetrically normalize a hub-petal incidence into an FP Laplacian.
+
+    Parameters
+    ----------
+    hub_petal : SparseTensor
+        Node-to-k-simplex incidence :math:`\\mathbf{H}_k`.
+    order : int
+        Petal order ``k`` (used for the ``1 / (k + 1)`` scaling).
+
+    Returns
+    -------
+    SparseTensor
+        The ``(n_nodes, n_nodes)`` Flower-Petals Laplacian for this order.
+    """
+    deg = hub_petal.sum(dim=1)
+    lap = matmul(hub_petal, hub_petal.t())
+    deg_inv_sqrt = deg.pow(-0.5)
+    deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float("inf"), 0.0)
+    lap = mul(lap, deg_inv_sqrt.view(1, -1))
+    lap = mul(lap, deg_inv_sqrt.view(-1, 1) / (order + 1))
+    return lap
+
+
+class HiGCNProp(nn.Module):
+    """Flower-Petals polynomial propagation for a single petal order.
+
+    Implements the GPR/APPNP-style learnable polynomial filter
+    :math:`\\sum_{j=0}^{K} w_j \\mathcal{L}^{\\,j} \\mathbf{x}` over a fixed FP
+    Laplacian, with the coefficients ``w_j`` initialized to the Personalized
+    PageRank weights :math:`\\alpha (1-\\alpha)^j` (Eq. 6 of the paper).
+
+    Parameters
+    ----------
+    K : int
+        Number of propagation hops (polynomial degree).
+    alpha : float
+        Teleport probability used to initialize the filter coefficients.
+    """
+
+    def __init__(self, K: int, alpha: float):
+        super().__init__()
+        self.K = K
+        self.alpha = alpha
+        self.filter_weights = nn.Parameter(torch.empty(K + 1))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Initialize the filter weights with the PPR profile."""
+        with torch.no_grad():
+            for k in range(self.K + 1):
+                self.filter_weights[k] = self.alpha * (1 - self.alpha) ** k
+            self.filter_weights[-1] = (1 - self.alpha) ** self.K
+
+    def forward(
+        self, x: torch.Tensor, laplacian: SparseTensor
+    ) -> torch.Tensor:
+        """Apply the polynomial FP filter to node features.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node feature tensor of shape ``(n_nodes, channels)``.
+        laplacian : SparseTensor
+            Flower-Petals Laplacian for this order, shape ``(n_nodes, n_nodes)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Filtered node features of shape ``(n_nodes, channels)``.
+        """
+        hidden = x * self.filter_weights[0]
+        for k in range(self.K):
+            x = matmul(laplacian, x)
+            hidden = hidden + self.filter_weights[k + 1] * x
+        return hidden
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(K={self.K}, alpha={self.alpha})"
+
+
+class HiGCN(nn.Module):
+    """Higher-order Graph Convolutional Network (HiGCN) backbone.
+
+    For each petal order ``1..order`` the encoded node features are linearly
+    projected, filtered by an order-specific Flower-Petals polynomial
+    (:class:`HiGCNProp`), and the resulting multi-scale node representations are
+    concatenated and projected back to ``hidden_channels``. The output is a node
+    embedding that the TopoBench readout maps to task logits.
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the (encoded) input node features.
+    hidden_channels : int
+        Width of every per-order branch and of the returned node embedding.
+    K : int, optional
+        Number of propagation hops in each polynomial filter (default: 10).
+    alpha : float, optional
+        Teleport probability for PPR filter initialization (default: 0.1).
+    order : int, optional
+        Highest petal order to use; ``order=2`` fuses edges and triangles
+        (default: 2).
+    dropout : float, optional
+        Dropout applied to the input features and the fused embedding
+        (default: 0.5).
+    dprate : float, optional
+        Dropout applied between projection and propagation in each branch
+        (default: 0.0).
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        K: int = 10,
+        alpha: float = 0.1,
+        order: int = 2,
+        dropout: float = 0.5,
+        dprate: float = 0.0,
+    ):
+        super().__init__()
+        assert order >= 1, "order must be a positive integer."
+        assert K >= 1, "K (propagation hops) must be a positive integer."
+
+        self.order = order
+        self.dropout = dropout
+        self.dprate = dprate
+
+        self.lin_in = nn.ModuleList(
+            [nn.Linear(in_channels, hidden_channels) for _ in range(order)]
+        )
+        self.prop = nn.ModuleList([HiGCNProp(K, alpha) for _ in range(order)])
+        self.lin_out = nn.Linear(hidden_channels * order, hidden_channels)
+
+    def reset_parameters(self) -> None:
+        """Reset all learnable parameters of the backbone."""
+        for layer in self.lin_in:
+            layer.reset_parameters()
+        for prop in self.prop:
+            prop.reset_parameters()
+        self.lin_out.reset_parameters()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        incidences: tuple[torch.Tensor, ...],
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Encoded node features of shape ``(n_nodes, in_channels)``.
+        incidences : tuple of torch.Tensor
+            Sparse incidence matrices ``(incidence_1, incidence_2, ...)`` with at
+            least ``order`` entries, used to build the FP Laplacians.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embedding of shape ``(n_nodes, hidden_channels)``.
+        """
+        laplacians = build_flower_petals_laplacians(incidences, self.order)
+
+        branches = []
+        for i in range(self.order):
+            h = F.dropout(x, p=self.dropout, training=self.training)
+            h = self.lin_in[i](h)
+            if self.dprate > 0.0:
+                h = F.dropout(h, p=self.dprate, training=self.training)
+            h = self.prop[i](h, laplacians[i])
+            branches.append(h)
+
+        h = torch.cat(branches, dim=1)
+        h = F.dropout(h, p=self.dropout, training=self.training)
+        h = self.lin_out(h)
+        return h

--- a/topobench/nn/wrappers/simplicial/higcn_wrapper.py
+++ b/topobench/nn/wrappers/simplicial/higcn_wrapper.py
@@ -1,0 +1,36 @@
+"""Wrapper for the HiGCN model."""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class HiGCNWrapper(AbstractWrapper):
+    r"""Wrapper for the HiGCN model.
+
+    HiGCN is a node-centric higher-order model: it carries features on the
+    nodes (rank 0) and uses the higher-order simplicial structure only through
+    the Flower-Petals Laplacians, which the backbone reconstructs from the
+    incidence matrices. This wrapper therefore feeds the node features together
+    with the simplicial incidence matrices to the backbone and returns the
+    updated node embeddings.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the HiGCN wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the updated model output.
+        """
+        incidences = (batch.incidence_1, batch.incidence_2)
+        x_0 = self.backbone(batch.x_0, incidences)
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+
+        return model_out


### PR DESCRIPTION
Add HiGCN (Huang et al., AAAI 2024 (arXiv:2309.12971)) as a Track-2 TNN backbone for the 2026 TDL Challenge, with config, unit tests (100% backbone coverage), a pipeline-test entry, and the GraphUniverse evaluation results.json.

<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [ ] I linked to issues and PRs that are relevant to this PR.

## Description

Track-2 (TNN) submission for the 2026 TDL Challenge — **team LoopCounter**.

Adds **HiGCN — Higher-order Graph Convolutional Network with Flower-Petals Laplacians** (Huang, Zeng, Wu, Lu — AAAI 2024, [arXiv:2309.12971](https://arxiv.org/abs/2309.12971); reference code [Yiminghh/HiGCN](https://github.com/Yiminghh/HiGCN)) as a **simplicial** backbone.

Included:
- `topobench/nn/backbones/simplicial/higcn.py` — Flower-Petals Laplacians `L_k = D_k^{-1/2} H_k H_kᵀ D_k^{-1/2} / (k+1)` reconstructed on the fly from the clique-lift incidence matrices, with the GPR/APPNP-style PPR-initialized polynomial filter (Eqs. 4/6), one branch per petal order, concatenated and projected.
- `topobench/nn/wrappers/simplicial/higcn_wrapper.py`
- `configs/model/simplicial/higcn.yaml`
- `test/nn/backbones/simplicial/test_higcn.py` — **100% backbone coverage**; checks the order-1 (normalized adjacency) and order-2 (triangle co-membership) operators and the no-triangle edge case.
- `simplicial/higcn` added to `test/pipeline/test_pipeline.py`.
- `2026_tdl_challenge/outputs/.../results.json` — full 12×3×2 GraphUniverse grid (community detection + triangle counting, in-distribution + OOD).

## Issue

N/A — this is a model contribution for the 2026 TDL Challenge (Track 2 / `track-2-tnn`), not a bug fix.

## Additional context

N/A