### PR TITLE
Track: Track2; Team name: LoopCounter; Model: GSAN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-30_gsan_merged/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-30_gsan_merged/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-30_gsan_merged",
+    "model_config": "simplicial/gsan",
+    "generated_at_utc": "2026-06-30T09:02:28.793359+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1623778343200684,
+      "test_best_rerun_accuracy": 0.33012452721595764,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32443273067474365,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31843534111976624,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31805333495140076,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32034534215927124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31778591871261597,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3133547306060791,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30197110772132874,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3077393174171448,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3091527223587036,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2962029278278351,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27549850940704346,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.182530164718628,
+      "test_best_rerun_accuracy": 0.3244709372520447,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31816792488098145,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32103294134140015,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3209565281867981,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.308312326669693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3089617192745209,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29876232147216797,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30758652091026306,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2940637171268463,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2767591178417206,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1580779552459717,
+      "test_best_rerun_accuracy": 0.33146151900291443,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3259607255458832,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32332491874694824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32103294134140015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.321605920791626,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3152647316455841,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3106043338775635,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2984949052333832,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3129727244377136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3072427213191986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2955535054206848,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28119030594825745,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1911332607269287,
+      "test_best_rerun_accuracy": 0.3243945240974426,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31900832056999207,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31045153737068176,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3205363154411316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29857131838798523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3138895332813263,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2852395176887512,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29341432452201843,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27618610858917236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3010925352573395,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.263771116733551,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26568111777305603,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1987552642822266,
+      "test_best_rerun_accuracy": 0.3220261335372925,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3143097162246704,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.306440532207489,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3143097162246704,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3034609258174896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3088471293449402,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2947131097316742,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2913133203983307,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29463672637939453,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29547712206840515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28107571601867676,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2728244960308075,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1870949268341064,
+      "test_best_rerun_accuracy": 0.3232485353946686,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3186263144016266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30445411801338196,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3161815404891968,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30674612522125244,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3170219361782074,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29562991857528687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2981511056423187,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30311712622642517,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31220871210098267,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2855069041252136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2731301188468933,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.12233304977417,
+      "test_best_rerun_accuracy": 0.34525173902511597,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3298189342021942,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32359233498573303,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3356635272502899,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3098021149635315,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29845672845840454,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32363054156303406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30647870898246765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30009931325912476,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2861563265323639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30323171615600586,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.122190475463867,
+      "test_best_rerun_accuracy": 0.3429979383945465,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32378333806991577,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3181297183036804,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33459392189979553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3106425106525421,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2982657253742218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3223317265510559,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3061349093914032,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30158913135528564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2868057191371918,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30594393610954285,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2843609154224396,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1202552318573,
+      "test_best_rerun_accuracy": 0.3409733474254608,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3279089331626892,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3227519392967224,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33573994040489197,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31832072138786316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30090153217315674,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32458552718162537,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3100695312023163,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3091145157814026,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2950951159000397,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30281153321266174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28539231419563293,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1661880016326904,
+      "test_best_rerun_accuracy": 0.32745054364204407,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3186263144016266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3203835189342499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32821452617645264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2889831066131592,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2842845022678375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29005271196365356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.264840692281723,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26587212085723877,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2691954970359802,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2649171054363251,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1554386615753174,
+      "test_best_rerun_accuracy": 0.33188173174858093,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3255787193775177,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3246619403362274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32932233810424805,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.291160523891449,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2896707057952881,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2976163327693939,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29177170991897583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27030330896377563,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26705631613731384,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26923370361328125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26396211981773376,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1584200859069824,
+      "test_best_rerun_accuracy": 0.329284131526947,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3239743411540985,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3231339156627655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3288639187812805,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2894033193588257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2869585156440735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29440751671791077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2945603132247925,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2699595093727112,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2668271064758301,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2727099061012268,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26732370257377625,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9851537942886353,
+      "test_best_rerun_accuracy": 0.39919015765190125,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2699977159500122,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2680495083332062,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25563451647758484,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27209872007369995,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38031935691833496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38276416063308716,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4028191566467285,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5256704092025757,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5188708305358887,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.519023597240448,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5485140085220337,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9753406047821045,
+      "test_best_rerun_accuracy": 0.4038887619972229,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2775995135307312,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27645352482795715,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26056230068206787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27102911472320557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38299334049224854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3867369592189789,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3920467495918274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5187562108039856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.510657787322998,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5135610103607178,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5274658203125,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.972102165222168,
+      "test_best_rerun_accuracy": 0.4053785502910614,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2752692997455597,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26827871799468994,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2685078978538513,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27779051661491394,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3813125491142273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40503475069999695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41645658016204834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5258995890617371,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5134463906288147,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5427840352058411,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5604706406593323,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0192689895629883,
+      "test_best_rerun_accuracy": 0.3867751657962799,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.259110689163208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26419129967689514,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23072808980941772,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2641149163246155,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3921995460987091,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3428833484649658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4109557569026947,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5064557790756226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5386202335357666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4819313883781433,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5585988163948059,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.025045156478882,
+      "test_best_rerun_accuracy": 0.3858201503753662,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2649553120136261,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26881352066993713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24012529850006104,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26296889781951904,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38666054606437683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3334861397743225,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3991519510746002,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4892275929450989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5264726281166077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44445717334747314,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5179157853126526,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0264060497283936,
+      "test_best_rerun_accuracy": 0.3862403631210327,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2630835175514221,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26300710439682007,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22801588475704193,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2573153078556061,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38016656041145325,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3201543390750885,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39048054814338684,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4903354048728943,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5324699878692627,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.447818785905838,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5255939960479736,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9223263263702393,
+      "test_best_rerun_accuracy": 0.4264267683029175,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2676292955875397,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2631599009037018,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28187790513038635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2886011302471161,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3786003589630127,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34700894355773926,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41431736946105957,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4937734007835388,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4594697952270508,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5744900107383728,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5787684321403503,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9015487432479858,
+      "test_best_rerun_accuracy": 0.4303613603115082,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27523112297058105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26667430996894836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2898617088794708,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29383450746536255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3857055604457855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3530827462673187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42436397075653076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49663838744163513,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4677591919898987,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5688746571540833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5760180354118347,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.915655493736267,
+      "test_best_rerun_accuracy": 0.4293299615383148,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26980671286582947,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2662159204483032,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28607991337776184,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29368171095848083,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38230574131011963,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3504469394683838,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42314156889915466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49300938844680786,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4601573944091797,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5711284279823303,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5748720169067383,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8231133222579956,
+      "test_best_rerun_accuracy": 0.46202918887138367,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2506684958934784,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25059211254119873,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24982810020446777,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2625487148761749,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38585835695266724,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36668193340301514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4041561484336853,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5103139877319336,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5141339898109436,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.562609851360321,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6352662444114685,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8285950422286987,
+      "test_best_rerun_accuracy": 0.4626021981239319,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2538391053676605,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2518908977508545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2487584948539734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2701123058795929,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38666054606437683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36912673711776733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3942623436450958,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5038964152336121,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5157002210617065,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5366337895393372,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6289250254631042,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8156421184539795,
+      "test_best_rerun_accuracy": 0.45736879110336304,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24291390180587769,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2382916957139969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2484910935163498,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2659102976322174,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3784857392311096,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3477347493171692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3979295492172241,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4968675971031189,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49805179238319397,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5593628287315369,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6364122629165649,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.510421872138977,
+      "test_best_rerun_accuracy": 0.5637558102607727,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.222935289144516,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2226678878068924,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20158147811889648,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2321796864271164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38627853989601135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37149515748023987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37325236201286316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41553977131843567,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5556192398071289,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6083352565765381,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6398502588272095,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5121580362319946,
+      "test_best_rerun_accuracy": 0.5680724382400513,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23007869720458984,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22698448598384857,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21063488721847534,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23172129690647125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38902896642684937,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37500953674316406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37034913897514343,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4075559675693512,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5594392418861389,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6100542545318604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.639544665813446,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5144072771072388,
+      "test_best_rerun_accuracy": 0.5641760230064392,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23011688888072968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23195049166679382,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2003972828388214,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22209489345550537,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3857055604457855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37092214822769165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3633967339992523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39552295207977295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5537856221199036,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6167392730712891,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.639430046081543,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.459245204925537,
+      "test_best_rerun_accuracy": 0.5796088576316833,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22599129378795624,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2201084941625595,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2126212865114212,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22369928658008575,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3784857392311096,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3739781379699707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3465123474597931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4042707681655884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5547024011611938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5746810436248779,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6528764367103577,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4571034908294678,
+      "test_best_rerun_accuracy": 0.5773550271987915,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22304989397525787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21621209383010864,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20692948997020721,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21090228855609894,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37649935483932495,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3748949468135834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3429979383945465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39567574858665466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5445794463157654,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.535067617893219,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6337764263153076,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4549964666366577,
+      "test_best_rerun_accuracy": 0.5755214095115662,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23053708672523499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.219688281416893,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21838948130607605,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22560928761959076,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38517075777053833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37348154187202454,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35705554485321045,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40327757596969604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5643288493156433,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5764000415802002,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6613186597824097,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2987103462219238,
+      "test_best_rerun_accuracy": 0.6273206472396851,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20043547451496124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19512568414211273,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20700588822364807,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22564749419689178,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35690274834632874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3187791407108307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3952173590660095,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4220719635486603,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5370157957077026,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5028268098831177,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6633814573287964,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.309572458267212,
+      "test_best_rerun_accuracy": 0.6443578600883484,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2277102917432785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.221063494682312,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21835128962993622,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2387118935585022,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3773779571056366,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34590113162994385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39770036935806274,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.432576984167099,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5560393929481506,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5278860330581665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.679196298122406,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2631678581237793,
+      "test_best_rerun_accuracy": 0.6333562731742859,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2056688815355301,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19814348220825195,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21796928346157074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23359309136867523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36672013998031616,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32798531651496887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39892277121543884,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4249751567840576,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5457636117935181,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.51528000831604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6660172939300537,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.092950463294983,
+      "test_best_rerun_accuracy": 0.6896630525588989,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21380548179149628,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2059362828731537,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21476048231124878,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22522729635238647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37581175565719604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3572847545146942,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3862403631210327,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43628236651420593,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5505003929138184,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5535564422607422,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.632630467414856,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1115751266479492,
+      "test_best_rerun_accuracy": 0.6872564554214478,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21445488929748535,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2047138810157776,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20612728595733643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22625869512557983,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3742455542087555,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35105815529823303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3840247392654419,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43498358130455017,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5490870475769043,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5410650372505188,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6308350563049316,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0926244258880615,
+      "test_best_rerun_accuracy": 0.6828634738922119,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20574527978897095,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19856368005275726,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21227748692035675,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22774849832057953,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3687829375267029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3432271480560303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39223775267601013,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43987318873405457,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5432423949241638,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5338451862335205,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.620482861995697,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_06-17-05__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 4.514621734619141,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.461188316345215,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0032141126198452557,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.1217037439346313,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.005903703915445428
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2873.37451171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.21792753217434585
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.548961639404297,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01063328670016997
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4088.935302734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5462839415810788
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.95100021362305,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03363644232609935
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126938.4140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9476689128390303
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7488.8740234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5250928357479666
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31848.203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.632487730022041
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1834.4708251953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3261281467013889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 651924.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.374457738990758
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195412.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2518346562827616
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 4.784846305847168,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.76832914352417,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.003435395636544791,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.1596815586090088,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00610358715057373
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2153.798095703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1633521498447573
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.761756896972656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007334599560826645
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3580.056640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.47829748037742154
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.29939270019531,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.028755952245419096
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116364.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7021264861601337
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6683.6748046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4686351707115061
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28777.06640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4750661954098108
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1626.2515869140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2891113932291667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 622215.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.038398018166804
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180776.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0082816946233337
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 4.269009113311768,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.135320663452148,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0029793376537839687,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.6129644513130188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0032261286911211516
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1776.407470703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.13472942515761283
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.489188194274902,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0052204881005308065
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3554.27294921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4748527654266867
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.237335205078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.022657456999203907
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116041.8671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.694637450945105
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6397.4873046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.44856873542893705
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29235.703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4985751768414577
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1579.738037109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.28084231770833334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 623997.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.058554291143966
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179752.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9912437804735994
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.0487947054207325,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.049442339688539505,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0002602228404659974,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.252376556396484,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03404349895993983
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7218.59814453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5474856385689231
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.96822738647461,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.015493167302485544
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6306.68896484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8425770160111891
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79.32435607910156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06850117105276474
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156740.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6397153800157906
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10958.9404296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7684013763628874
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41570.7734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.130851065533856
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2722.315673828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.48396723090277777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 720975.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.155556089725462
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233164.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8800533652006055
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.06775221228599548,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.06833189725875854,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.00035964156451978184,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43.35740661621094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0312373246514488
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6682.43896484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5068213094306978
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34.67176818847656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.011685799861299818
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6118.978515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8174987996826988
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.3138427734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06503786077153498
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153701.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5691420037618427
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10593.6953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7427917061071379
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40698.73046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0861515438387412
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2635.2978515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.46849739583333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713073.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.06616927592955
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229413.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.817644109962891
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.05054621398448944,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.051158204674720764,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0002692537088143198,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.30824279785156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03192236512813513
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7260.98486328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5507004067714258
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.01805114746094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.014835878377978071
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6292.439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8406732736305945
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.56822204589844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06784820556640625
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157338.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.653602414429686
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10932.59375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7665540422100687
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41626.38671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.13370171299144
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2716.30224609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4828981770833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 722431.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.172019756116875
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234501.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.902304812956584
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 505.2306823730469,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 490.4625549316406,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.037198525212866186,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.0097427368164,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08646235067493978
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167.7310791015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8827951531661185
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.221981048583984,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007152673086816308
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1961.4471435546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2620503865804526
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.50230407714844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11355984808043906
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65071.33984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5110379863400984
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3886.893798828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.27253497397476684
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18398.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9430659407196679
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1092.9793701171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19430744357638888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 471889.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.337931829236564
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125833.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.093971271612334
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 534.0167846679688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 527.6214599609375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.040016796356536787,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 241.0952911376953,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.17369977747672574
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 522.1809692382812,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.748320890727796
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.152570724487305,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0037588711575622866
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2540.893310546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3394647041478791
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 331.1245422363281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2859452005495062
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87454.8984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.030812243114899
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4642.91845703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.32554469618785936
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22169.75,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1363857706699472
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1373.1876220703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.24412224392361112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 546128.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.177713850208703
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147279.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.450852220724544
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 551.7660522460938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 545.7954711914062,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.041395181736170364,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 292.4543762207031,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.210702000159008
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 598.1832275390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.1483327765213818
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39.82256317138672,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.013421827829924744
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2445.630126953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3267374919109051
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 364.8916931152344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.31510508904597095
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76380.65625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.773654473574215
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4194.6298828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.294112318245162
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18964.380859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.972083697748475
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1260.4185791015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2240744140625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 483575.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.470130043663676
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133518.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2218561230093354
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 1.8873108625411987,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.907565712928772,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0006429274394771729,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34.333396911621094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.024735876737479175
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59.21954345703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.31168180766858555
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3090.4482421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2343912204920364
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5125.80712890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6848105716641617
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.3407211303711,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07369665037165034
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134060.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.113053391463868
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7946.0439453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5571479417551886
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36461.921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8689795414936696
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2182.69873046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3880353298611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 670709.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.586953355655351
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202086.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.36289142454196
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 1.7108664512634277,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.7286155223846436,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0005826139273288316,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.060194969177246,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.005807056894219918
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.6187334060668945,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03483543897929944
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2172.441162109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16476611013343762
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4511.84765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6027852580160321
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36.691951751708984,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03168562327436009
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125474.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.913684428989411
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7090.98095703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.49719400904720584
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33958.515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7406589586857348
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1895.170166015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.336919140625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 651161.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.365833173082361
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191176.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.181337676601268
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1848976612091064,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.2117760181427,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0007454587186190429,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.270525932312012,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.008119975455556204
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.335686683654785,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0754509825455515
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2715.32421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.20594040339400835
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4820.79052734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6440601906938878
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.238319396972656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04079302193175532
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130511.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0306346368196175
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7550.306640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5294002692907727
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35409.11328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8150142642498335
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2034.5714111328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.36170158420138887
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 663058.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.5004079329887
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197690.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.289745425839948
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1418.8553466796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1436.5545654296875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1919244576392368,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.773372650146484,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.029375628710480176
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.422662734985352,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.06538243544729132
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1569.9853515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.11907359511281759
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.082862854003906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.015194763348164443
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.574989318847656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02122192514580972
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48323.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1221419718326213
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2829.05078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.19836283699691487
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19447.9609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9968712357117228
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 685.7456665039062,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.12191034071180555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 455217.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.149339530332681
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118559.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9729281592697985
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1403.1748046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1411.17431640625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.18853364280644622,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.043806076049805,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.022365854521649714
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.729490280151367,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.06699731726395457
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1668.877197265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.12657392470729048
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.036787033081055,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.009112499842629273
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.072425842285156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.030287068948432777
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50026.01953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.161666810590052
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4224.60546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.2962140982155378
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17528.541015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8984848539456148
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 865.9205322265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.15394142795138888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 440369.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.981381075868466
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123243.8828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0508858404889088
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1064.3990478515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1067.399169921875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1426050995219606,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53.68449783325195,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.038677592098884696
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.055238723754883,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.11081704591449938
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2952.3232421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22391530088642397
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55.56712341308594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.018728386725003685
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.938541412353516,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02930789413847454
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40084.3515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.930808832493498
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2541.62646484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.17820968060887324
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14171.3486328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7264005655242453
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 383.7454528808594,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0682214138454861
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389221.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.4028122631584905
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92320.0234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5362858142795335
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 20.034072875976562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20.251129150390625,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.017488021718817467,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.35556983947754,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.011783551757548659
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.295067310333252,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.012079301633332906
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 886.112060546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.06720607209305081
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.526352882385254,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.004895973334137261
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2914.495361328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3893781377859886
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97113.7578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.25510305156279
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4793.3427734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.33609190670575656
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23868.841796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2234784866920396
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1319.3466796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.23455052083333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 572568.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.47679872289402
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156996.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.6125562669528897
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 19.082876205444336,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 19.316246032714844,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.01668069605588501,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.043806076049805,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.020924932331447987
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.6553387641906738,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.008712309285214073
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 822.7232055664062,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.062398422871930696
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.817771911621094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.015105416889659957
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2533.139892578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.33842884336381096
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88311.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.050696347297046
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5056.04052734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.35451132571474897
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23068.357421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1824469435581013
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1095.40625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19473888888888888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 553196.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.257668009004219
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148604.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.472904238014411
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 16.25510025024414,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 16.330699920654297,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.014102504249269687,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.02508544921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0353206667501576
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4444292783737183,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.007602259359861675
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 727.4789428710938,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.055174739694432595
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.490062713623047,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.006568945976954179
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2787.015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.37234677688710754
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93170.9296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1635456457249673
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4442.00439453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3114573267796417
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24070.7890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2338299791122047
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1122.5712890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19956822916666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 564155.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.381630855287717
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150072.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.497335900188042
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 27526.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27759.828125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.6446179668632732,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610.1493530273438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4395888710571641
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 882.375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.644078947368421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12835.583984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9734989749241563
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 839.3964233398438,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2829108268755793
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1188.13427734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.15873537439462257
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702.3428955078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6065137266906844
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1882.2403564453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1319759049533945
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23311.478515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1949089402647497
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1064.938720703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1893224392361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218133.078125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.4674850188907618
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57074.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9497723840547152
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 9563.9482421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9626.642578125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.22354269408612762,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 625.638916015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.450748498570335
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 895.5859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.713610197368421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3672.988037109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.27857322996658135
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1948.9678955078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6568816634674124
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 735.3867797851562,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.09824806677156396
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 543.2072143554688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.46909085868347905
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1919.6854248046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1346014180903581
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5844.4404296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.2995766276942693
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 785.6854248046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13967740885416666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163271.921875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.8469047642613938
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42639.9609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.709566188033548
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 23522.7890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 23671.751953125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.5496877195133987,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7985.8798828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.753515765715058
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13450.3466796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 70.79129831414474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4492.8310546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3407532085466439
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 906.4659423828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.30551599001779994
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7235.03759765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9666048894664329
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10705.1083984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 9.244480482243091
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4570.6103515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.32047471263234467
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20069.70703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0287409416807627
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9028.2744140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.6050265625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 192611.28125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.178786706899087
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58473.05859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9730427602840597
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 325.91455078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 330.0823059082031,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.023144180753625235,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 310.2611389160156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.22353107991067409
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.57563400268555,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.26092438948781865
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19456.77734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.475675187239287
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.550418853759766,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.010970818622770396
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4134.60986328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5523860872787241
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.37297821044922,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03486440259969708
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47615.00390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1056800089692087
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17243.1015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.883853686119227
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.3307342529297,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0283254638671875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260231.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.943694642715745
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49499.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8237169886675653
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 884.1203002929688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 891.4220581054688,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.0625032995446269,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.5672607421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1048755480851495
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185.84500122070312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9781315853721217
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13728.44921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0412172331247629
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.1605224609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04049899644790613
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5311.3349609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7095971891700067
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118.40713500976562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10225141192553162
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36709.13671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.852432117749164
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16636.890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8527802873032959
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 296.9819641113281,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.052796793619791664
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 290821.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.289720795674355
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61527.38671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0238694476686137
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1085.7928466796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1099.6490478515625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.07710342503516775,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184.82061767578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13315606460791157
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.187328338623047,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.15361751757170025
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12402.5595703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9406567743885097
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137.44093322753906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.046323199604832846
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5435.927734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7262428502839011
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71.44680786132812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0616984523845666
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44017.515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0221418266997957
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23004.046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1791504882361987
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 485.6729736328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08634186197916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 315616.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.570201237514564
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63834.0859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.062254937139101
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 5785.26220703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5857.4912109375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.3002455897758727,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.1420593261719,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.20543376032144947
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147.44155883789062,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7760082044099507
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4789.77490234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.36327454701128176
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184.86843872070312,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06230820314145707
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 655.488525390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.08757361728665665
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149.55801391601562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12915199820035891
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14406.3134765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3345326369255643
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2531.71142578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.17751447383124738
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 450.1009521484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08001794704861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208873.140625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.36273814944063
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50289.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8368588583528863
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 5408.13671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5471.5888671875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.2804648555634579,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 274.72247314453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.19792685385052683
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137.19677734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7220883018092106
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6002.44189453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.45524777357081914
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114.62234497070312,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03863240477610486
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 557.2123413085938,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.07444386657429443
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176.115478515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1520859054539076
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13087.087890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.30389856703104684
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2603.128662109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.18252199285579687
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 576.2650756835938,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10244712456597223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200632.203125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.26951803813219
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55039.35546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9159029415863744
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 4268.15283203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4296.99658203125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.2202571419360936,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 362.04937744140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2608424909520218
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89.578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.47146381578947366
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1704.6864013671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1292898294552285
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 735.3939819335938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2478577627009079
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 526.7552490234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.07037478276866233
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.16354370117188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1719892432652607
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8094.04150390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.18795377818842304
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1505.7545166015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.10557807576788407
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 699.2232055664062,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.12430634765625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183510.59375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.075841246903386
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41394.7109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6888441405404956
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 573.3754272460938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 580.8834228515625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.1032681640625,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.85053253173828,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0712179629191198
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95.61247253417969,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5032235396535774
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2311.249755859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1752938760606276
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.388948440551758,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0075459886890973235
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1712.4493408203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22878414707018202
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.12551879882812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06487523212334034
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54626.7890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2685024396827977
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2460.10302734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.17249355120906956
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15716.26171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8055903285022298
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 412352.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.6644630979717885
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98556.0234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6400583002595976
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 586.307861328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 589.2870483398438,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.10476214192708333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.09503936767578,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.087244264674118
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.67296028137207,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.11933136990195826
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4095.28173828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3106015728692643
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.669297218322754,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.004270069841025532
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1816.8902587890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.24273750952425685
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.5587100982666,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.017753635663442662
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52229.1015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2128251338124652
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1995.6614990234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1399285863850398
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16279.4345703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8344576641710236
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 420182.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.753029803852811
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95190.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5840488908857937
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 234.74598693847656,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 237.83770751953125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.04228225911458333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140.56072998046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10126853744990544
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.456242084503174,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.033980221497385124
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4600.205078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3488968584091771
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.93748092651367,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.011438315108363219
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1453.912109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.19424343478623915
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.131912231445312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.014794397436481272
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38353.6171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8906190132709456
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1916.51025390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.13437878655912563
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12993.8154296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6660421051662053
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 373362.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.223419666187799
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89568.0703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4904909109630073
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 137514.328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 137256.46875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 1.55262229505786,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8576.7568359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.179219622433357
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12525.447265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 65.92340666118422
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9200.564453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.697805419273796
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1967.4599609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6631142436594203
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10160.0810546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.357392258475284
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9488.05859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 8.193487559369602
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84379.8203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9594050787780977
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5129.85888671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.35968720282700534
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11317.8359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5801340887539085
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6355.40380859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.1298495659722223
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51289.5078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8535022017955503
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 71441.1015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 72369.390625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.8186304834111965,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20518.82421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 14.783014566822766
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27527.515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 144.88166118421051
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43148.35546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.272533596416382
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18867.013671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.358953040739805
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17879.57421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.388720670507682
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24091.470703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 20.804378845531087
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66814.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5515207017462382
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16899.654296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1849428058389426
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10705.064453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.548724406844277
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20292.609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.607575
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38903.8359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6473938052268983
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 221439.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 224012.421875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 2.53399117535604,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7046.80517578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.076948973905799
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1752.251220703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.222374845805922
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22403.9375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.699198900265453
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27735.17578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 9.347885332406472
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9684.515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2938564629258518
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2693.43212890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.3259344809207687
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39720.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9223626462938882
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14360.9833984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0069403588863763
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9003.9404296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.46152752215323695
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3590.7919921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6383630208333333
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75138.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2503701294243923
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 20501.984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20775.2421875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.34571817328973425,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9252.3662109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.665969892606268
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9834.2470703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 51.759195106907896
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37742.328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.8625201459992415
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8026.61767578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.7052974977355073
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14361.61328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.918719209251837
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9097.525390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.856239542854059
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103546.9609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4044900830740294
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3905.041259765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.27380740848167334
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51417.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.635602278115229
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7534.34423828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.3394389756944445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254979.203125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.8842822429668677
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 15166.6640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15320.9814453125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.2549545112627511,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15807.7666015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 11.38888083686059
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16113.68359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 84.80886101973684
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68233.3125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.175071103526735
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19489.9375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.568903774856758
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18820.013671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.514363884018036
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15011.1796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 12.963022182642487
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174820.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.059546546999814
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8436.7412109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5915538641801641
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42211.50390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1636938800681738
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10466.9072265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8607835069444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247952.109375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.804792929821386
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "gsan_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 24551.71875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24759.5234375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.4120200928144709,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6213.4560546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.476553353521253
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1216.8709716796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.40458406147204
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41234.5,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.127379598028062
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6914.75927734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.3305558737255647
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12651.6396484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.6902658180945225
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1847.66796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.5955681940846287
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62660.23828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4550491891429036
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5155.9052734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3615134815199481
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22494.47265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.15303053238249
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2521.833740234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4483259982638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175174.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.9815429764826986
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_04-59-36__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/simplicial/gsan.yaml
+++ b/configs/model/simplicial/gsan.yaml
@@ -1,0 +1,57 @@
+_target_: topobench.model.TBModel
+
+# NOTE: GSAN uses masked dense simplicial attention (as in the reference
+# implementation), whose memory scales with (batch x cells)^2. On the densest
+# high-degree GraphUniverse settings this exceeds 24 GB at the default
+# batch size, so the challenge grid for GSAN is run with
+# `dataset.dataloader_params.batch_size=4` (override on the command line / grid
+# runner). All other settings fit comfortably at the default batch size.
+
+model_name: gsan
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 32
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
+
+backbone:
+  _target_: topobench.nn.backbones.simplicial.gsan.GSAN
+  in_channels_all:
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+  hidden_channels_all:
+    - ${model.backbone.in_channels_all[0]}
+    - ${model.backbone.in_channels_all[1]}
+    - ${model.backbone.in_channels_all[2]}
+  K: 2 # number of polynomial filter taps (kappa)
+  n_layers: 2
+  dropout: 0.2
+  alpha_leaky_relu: 0.2
+  update_func: sigmoid # per-layer nonlinearity (reference joint model)
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GSANWrapper
+  _partial_: true
+  wrapper_name: GSANWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/simplicial/test_gsan.py
+++ b/test/nn/backbones/simplicial/test_gsan.py
@@ -1,0 +1,222 @@
+"""Unit tests for the GSAN backbone."""
+
+import pytest
+import torch
+
+from ...._utils.nn_module_auto_test import NNModuleAutoTest
+from topobench.nn.backbones.simplicial import GSAN
+from topobench.nn.backbones.simplicial.gsan import GSANLayer, _to_dense
+from topobench.transforms.liftings.graph2simplicial import (
+    SimplicialCliqueLifting,
+)
+
+
+def _operators(data):
+    """Assemble the (laplacian_all, incidence_all) tuples from lifted data.
+
+    Parameters
+    ----------
+    data : torch_geometric.data.Data
+        Clique-lifted simplicial complex.
+
+    Returns
+    -------
+    tuple
+        ``(laplacian_all, incidence_all)`` as expected by the backbone.
+    """
+    laplacian_all = (
+        data.hodge_laplacian_0,
+        data.down_laplacian_1,
+        data.up_laplacian_1,
+        data.down_laplacian_2,
+        data.up_laplacian_2,
+    )
+    incidence_all = (data.incidence_1, data.incidence_2)
+    return laplacian_all, incidence_all
+
+
+def test_GSAN(simple_graph_1):
+    """Test the GSAN backbone end to end on a lifted graph with triangles.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph data.
+    """
+    data = SimplicialCliqueLifting(complex_dim=2, signed=True)(simple_graph_1)
+    out_dim = 4
+    laplacian_all, incidence_all = _operators(data)
+    x_all = (data.x_0, data.x_1, data.x_2)
+    in_dims = (data.x_0.shape[1], data.x_1.shape[1], data.x_2.shape[1])
+    expected = [
+        (data.x_0.shape[0], out_dim),
+        (data.x_1.shape[0], out_dim),
+        (data.x_2.shape[0], out_dim),
+    ]
+    NNModuleAutoTest(
+        [
+            {
+                "module": GSAN,
+                "init": (in_dims, (out_dim, out_dim, out_dim), 2),
+                "forward": (x_all, laplacian_all, incidence_all),
+                "assert_shape": expected,
+            }
+        ]
+    ).run()
+
+
+def test_forward_shapes_with_triangles(simple_graph_1):
+    """Test GSAN output shapes on a complex that contains triangles.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph data.
+    """
+    data = SimplicialCliqueLifting(complex_dim=2, signed=True)(simple_graph_1)
+    laplacian_all, incidence_all = _operators(data)
+    model = GSAN(
+        in_channels_all=(
+            data.x_0.shape[1],
+            data.x_1.shape[1],
+            data.x_2.shape[1],
+        ),
+        hidden_channels_all=(8, 8, 8),
+        K=2,
+        n_layers=2,
+    )
+    x0, x1, x2 = model(
+        (data.x_0, data.x_1, data.x_2), laplacian_all, incidence_all
+    )
+    assert x0.shape == (data.x_0.shape[0], 8)
+    assert x1.shape == (data.x_1.shape[0], 8)
+    assert x2.shape == (data.x_2.shape[0], 8)
+    assert data.x_2.shape[0] > 0  # the tetrahedron yields triangles
+    for out in (x0, x1, x2):
+        assert torch.isfinite(out).all()
+
+
+def test_no_triangle_graph_runs(simple_graph_0):
+    """Test GSAN on a graph whose clique complex has no triangles.
+
+    Parameters
+    ----------
+    simple_graph_0 : torch_geometric.data.Data
+        A simple graph fixture without 3-cliques.
+    """
+    data = SimplicialCliqueLifting(complex_dim=2, signed=True)(simple_graph_0)
+    laplacian_all, incidence_all = _operators(data)
+    model = GSAN(
+        in_channels_all=(
+            data.x_0.shape[1],
+            data.x_1.shape[1],
+            data.x_2.shape[1],
+        ),
+        hidden_channels_all=(8, 8, 8),
+        K=2,
+    )
+    x0, x1, x2 = model(
+        (data.x_0, data.x_1, data.x_2), laplacian_all, incidence_all
+    )
+    assert x0.shape == (data.x_0.shape[0], 8)
+    # No triangles -> empty rank-2 signal, and finite node/edge embeddings.
+    assert x2.shape[0] == 0
+    assert torch.isfinite(x0).all()
+    assert torch.isfinite(x1).all()
+
+
+def test_single_tap(simple_graph_1):
+    """Test GSAN with a single polynomial tap (K=1).
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph data.
+    """
+    data = SimplicialCliqueLifting(complex_dim=2, signed=True)(simple_graph_1)
+    laplacian_all, incidence_all = _operators(data)
+    model = GSAN(
+        in_channels_all=(
+            data.x_0.shape[1],
+            data.x_1.shape[1],
+            data.x_2.shape[1],
+        ),
+        hidden_channels_all=(8, 8, 8),
+        K=1,
+    )
+    x0, _, _ = model(
+        (data.x_0, data.x_1, data.x_2), laplacian_all, incidence_all
+    )
+    assert x0.shape == (data.x_0.shape[0], 8)
+
+
+@pytest.mark.parametrize("update_func", ["sigmoid", "relu", None])
+def test_update_functions(simple_graph_1, update_func):
+    """Test the supported per-layer nonlinearities.
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        Sample graph data.
+    update_func : str or None
+        Nonlinearity variant to test.
+    """
+    data = SimplicialCliqueLifting(complex_dim=2, signed=True)(simple_graph_1)
+    laplacian_all, incidence_all = _operators(data)
+    model = GSAN(
+        in_channels_all=(
+            data.x_0.shape[1],
+            data.x_1.shape[1],
+            data.x_2.shape[1],
+        ),
+        hidden_channels_all=(8, 8, 8),
+        update_func=update_func,
+    )
+    x0, _, _ = model(
+        (data.x_0, data.x_1, data.x_2), laplacian_all, incidence_all
+    )
+    assert torch.isfinite(x0).all()
+
+
+def test_invalid_K():
+    """Test that a non-positive number of taps raises an assertion error."""
+    with pytest.raises(AssertionError):
+        GSAN((3, 3, 3), (8, 8, 8), K=0)
+
+
+def test_invalid_n_layers():
+    """Test that a non-positive number of layers raises an assertion error."""
+    with pytest.raises(AssertionError):
+        GSAN((3, 3, 3), (8, 8, 8), n_layers=0)
+
+
+def test_mismatched_hidden_widths():
+    """Test that unequal per-rank hidden widths raise an assertion error."""
+    with pytest.raises(AssertionError):
+        GSAN((3, 3, 3), (8, 16, 8))
+
+
+def test_reset_parameters():
+    """Test that reset_parameters runs and keeps parameters finite."""
+    model = GSAN((3, 3, 3), (8, 8, 8))
+    model.reset_parameters()
+    for p in model.parameters():
+        assert torch.isfinite(p).all()
+
+
+def test_branch_empty_guard():
+    """Test that a layer branch returns zeros for an all-zero operator."""
+    layer = GSANLayer(
+        channels=8, K=2, dropout=0.0, alpha_leaky_relu=0.2, update_func=None
+    )
+    x = torch.randn(5, 8)
+    zero_lap = torch.zeros(5, 5)
+    out = layer._branch(x, x, layer.W, layer.att["a00"], zero_lap)
+    assert torch.equal(out, torch.zeros_like(x))
+
+
+def test_to_dense_helper():
+    """Test that _to_dense converts sparse tensors and passes dense through."""
+    dense = torch.eye(3)
+    assert torch.equal(_to_dense(dense), dense)
+    assert torch.equal(_to_dense(dense.to_sparse_coo()), dense)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "simplicial/gsan"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/simplicial/gsan.py
+++ b/topobench/nn/backbones/simplicial/gsan.py
@@ -1,0 +1,390 @@
+"""Generalized Simplicial Attention Neural Network (GSAN) backbone.
+
+This module implements GSAN, introduced in
+
+    Claudio Battiloro, Lucia Testa, Lorenzo Giusti, Stefania Sardellitti,
+    Paolo Di Lorenzo, Sergio Barbarossa.
+    "Generalized Simplicial Attention Neural Networks."
+    IEEE Transactions on Signal and Information Processing over Networks, 2024.
+    https://arxiv.org/abs/2309.02138
+
+Reference implementation: https://github.com/luciatesta97/Generalized-Simplicial-Attention-Neural-Networks
+(the single-order ``SALayer`` in ``GSAN_SAN/layers/simplicial_attention_layer.py``
+and the all-orders coupled ``SAN`` in ``GSAN_Joint/NCI1/net.py``).
+
+Notes
+-----
+GSAN generalizes the (edge-only) Simplicial Attention Network to signals living
+on simplices of *every* order and couples the orders through the incidence maps.
+For a signal :math:`x_k` on order-k simplices, a masked multi-head attention is
+run separately over the **lower** (irrotational) neighborhood — masked by the
+sparsity of :math:`L_\\downarrow^{(k)} = B_k^\\top B_k` — and the **upper**
+(solenoidal) neighborhood — masked by :math:`L_\\uparrow^{(k)} = B_{k+1} B_{k+1}^\\top`.
+Each branch applies a ``K``-tap polynomial (higher-hop) diffusion of the learned,
+topologically masked attention matrix :math:`\\alpha`:
+
+.. math::
+
+    z = \\sum_{j=0}^{K-1} \\big(\\alpha \\cdot L^{\\,j}\\big)\\, x\\, W_j ,
+    \\qquad L^0 = I,
+
+following the *correct* ``SALayer`` indexing (the public ``GSAN_Joint`` loop
+double-counts the ``j=0`` tap and raises the attention matrix rather than the
+static Laplacian — we use the paper form).
+
+The orders are coupled (``GSAN_Joint``): node features receive a lower projection
+of the edge signal (via :math:`B_1`), edge features receive both a lower
+projection of nodes (:math:`B_1^\\top`) and an upper projection of triangles
+(:math:`B_2`), and triangle features receive a lower projection of edges
+(:math:`B_2^\\top`). The harmonic component is disabled, exactly as in the
+reference joint model.
+
+Within TopoBench the operators are taken directly from the simplicial batch:
+``hodge_laplacian_0`` (= :math:`L_\\uparrow^{(0)}`), ``down_laplacian_1``,
+``up_laplacian_1``, ``down_laplacian_2`` and the incidences ``incidence_1``,
+``incidence_2``; the full edge Laplacian is recovered as
+``down_laplacian_1 + up_laplacian_1``.
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+_NEG_INF = -9e15
+
+
+def _to_dense(matrix: torch.Tensor) -> torch.Tensor:
+    """Return a dense view of a (possibly sparse) operator.
+
+    Parameters
+    ----------
+    matrix : torch.Tensor
+        Sparse or dense 2D tensor.
+
+    Returns
+    -------
+    torch.Tensor
+        Dense 2D tensor.
+    """
+    return matrix.to_dense() if matrix.is_sparse else matrix
+
+
+class GSANLayer(nn.Module):
+    """A single all-orders Generalized Simplicial Attention layer.
+
+    Each call updates node, edge and triangle signals with masked attention over
+    their lower/upper neighborhoods plus the cross-order incidence projections.
+
+    Parameters
+    ----------
+    channels : int
+        Common feature dimension of all orders.
+    K : int
+        Number of polynomial filter taps (``kappa`` in the paper).
+    dropout : float
+        Dropout applied to the attention coefficients.
+    alpha_leaky_relu : float
+        Negative slope of the LeakyReLU used in attention scoring.
+    update_func : str or None
+        Nonlinearity applied to each updated signal: ``"sigmoid"`` (reference
+        joint model), ``"relu"`` or ``None``.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        K: int,
+        dropout: float,
+        alpha_leaky_relu: float,
+        update_func: str | None,
+    ):
+        super().__init__()
+        self.channels = channels
+        self.K = K
+        self.dropout = dropout
+        self.update_func = update_func
+        self.leaky_relu = nn.LeakyReLU(alpha_leaky_relu)
+
+        # Self (W) and cross-order (A) tap weights, shared across orders.
+        self.W = nn.Parameter(torch.empty(K, channels, channels))
+        self.A = nn.Parameter(torch.empty(K, channels, channels))
+        # One GAT-style attention vector per (masked) attention term:
+        # nodes: self (00), edge->node (01);
+        # edges: self (10), node->edge (11), triangle->edge (12);
+        # triangles: self (20), edge->triangle (21).
+        self.att = nn.ParameterDict(
+            {
+                name: nn.Parameter(torch.empty(2 * channels * K, 1))
+                for name in ("a00", "a01", "a10", "a11", "a12", "a20", "a21")
+            }
+        )
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reinitialize all learnable parameters with Xavier uniform."""
+        gain = nn.init.calculate_gain("relu")
+        nn.init.xavier_uniform_(self.W, gain=gain)
+        nn.init.xavier_uniform_(self.A, gain=gain)
+        for p in self.att.values():
+            nn.init.xavier_uniform_(p, gain=gain)
+
+    def _attention(
+        self,
+        x_att: torch.Tensor,
+        taps: torch.Tensor,
+        att_vec: torch.Tensor,
+        laplacian: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute a topologically masked attention matrix.
+
+        Parameters
+        ----------
+        x_att : torch.Tensor
+            Features used to score attention, shape ``(M, channels)``.
+        taps : torch.Tensor
+            Tap weight tensor ``(K, channels, channels)``.
+        att_vec : torch.Tensor
+            GAT attention vector ``(2 * channels * K, 1)``.
+        laplacian : torch.Tensor
+            Dense neighborhood operator ``(M, M)`` whose nonzero pattern is the
+            attention mask.
+
+        Returns
+        -------
+        torch.Tensor
+            Row-stochastic attention matrix ``(M, M)``.
+        """
+        split = self.channels * self.K
+        x_f = torch.cat([x_att @ taps[k] for k in range(self.K)], dim=1)
+        scores = self.leaky_relu(
+            (x_f @ att_vec[:split]) + (x_f @ att_vec[split:]).T
+        )
+        scores = torch.where(
+            laplacian != 0, scores, torch.full_like(scores, _NEG_INF)
+        )
+        alpha = F.softmax(scores, dim=1)
+        return F.dropout(alpha, self.dropout, training=self.training)
+
+    def _branch(
+        self,
+        x_att: torch.Tensor,
+        x_val: torch.Tensor,
+        taps: torch.Tensor,
+        att_vec: torch.Tensor,
+        laplacian: torch.Tensor,
+    ) -> torch.Tensor:
+        """Masked-attention + K-tap polynomial diffusion for one branch.
+
+        Returns the zero tensor (correct shape) when the branch is empty or its
+        neighborhood operator has no nonzero entries (e.g. graphs without
+        triangles).
+
+        Parameters
+        ----------
+        x_att : torch.Tensor
+            Features that drive the attention scores, shape ``(M, channels)``.
+        x_val : torch.Tensor
+            Features that are diffused (the message), shape ``(M, channels)``.
+        taps : torch.Tensor
+            Tap weights ``(K, channels, channels)``.
+        att_vec : torch.Tensor
+            GAT attention vector.
+        laplacian : torch.Tensor
+            Dense neighborhood operator ``(M, M)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Branch contribution of shape ``(M, channels)``.
+        """
+        if x_val.shape[0] == 0 or laplacian.numel() == 0:
+            return torch.zeros_like(x_val)
+        if not torch.any(laplacian != 0):
+            return torch.zeros_like(x_val)
+
+        alpha = self._attention(x_att, taps, att_vec, laplacian)
+        accum = alpha
+        out = accum @ (x_val @ taps[0])
+        for j in range(1, self.K):
+            accum = accum @ laplacian
+            out = out + accum @ (x_val @ taps[j])
+        return out
+
+    def _activate(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the configured update nonlinearity.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Pre-activation features.
+
+        Returns
+        -------
+        torch.Tensor
+            Activated features.
+        """
+        if self.update_func == "sigmoid":
+            return torch.sigmoid(x)
+        if self.update_func == "relu":
+            return torch.relu(x)
+        return x
+
+    def forward(
+        self,
+        x_0: torch.Tensor,
+        x_1: torch.Tensor,
+        x_2: torch.Tensor,
+        operators: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Update node, edge and triangle signals.
+
+        Parameters
+        ----------
+        x_0, x_1, x_2 : torch.Tensor
+            Node, edge and triangle features, each ``(N_k, channels)``.
+        operators : dict of torch.Tensor
+            Dense operators with keys ``l0, ld1, lu1, l1, ld2, b1, b2``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Updated ``(x_0, x_1, x_2)``.
+        """
+        l0 = operators["l0"]
+        ld1, lu1, l1 = operators["ld1"], operators["lu1"], operators["l1"]
+        ld2 = operators["ld2"]
+        b1, b2 = operators["b1"], operators["b2"]
+
+        # Nodes: self-attention over L0 + lower projection of edges (B1 @ x_1).
+        z0 = self._branch(x_0, x_0, self.W, self.att["a00"], l0)
+        z0 = z0 + self._branch(x_0, b1 @ x_1, self.A, self.att["a01"], l0)
+
+        # Edges: self over L1 + node lower projection + triangle upper projection.
+        z1 = self._branch(x_1, x_1, self.W, self.att["a10"], l1)
+        z1 = z1 + self._branch(
+            b1.T @ x_0, b1.T @ x_0, self.A, self.att["a11"], ld1
+        )
+        z1 = z1 + self._branch(
+            b2 @ x_2, b2 @ x_2, self.A, self.att["a12"], lu1
+        )
+
+        # Triangles: self over L_down2 + edge lower projection.
+        z2 = self._branch(x_2, x_2, self.W, self.att["a20"], ld2)
+        z2 = z2 + self._branch(
+            b2.T @ x_1, b2.T @ x_1, self.A, self.att["a21"], ld2
+        )
+
+        return self._activate(z0), self._activate(z1), self._activate(z2)
+
+
+class GSAN(nn.Module):
+    """Generalized Simplicial Attention Network backbone.
+
+    Projects the per-order input features to a common hidden width and applies a
+    stack of :class:`GSANLayer` blocks coupling nodes, edges and triangles.
+
+    Parameters
+    ----------
+    in_channels_all : tuple of int
+        Input feature dimensions ``(nodes, edges, triangles)``.
+    hidden_channels_all : tuple of int
+        Hidden feature dimensions ``(nodes, edges, triangles)``; all three must
+        be equal (the coupled attention requires a shared width).
+    K : int, optional
+        Number of polynomial filter taps (default: 2).
+    n_layers : int, optional
+        Number of stacked GSAN layers (default: 2).
+    dropout : float, optional
+        Attention dropout (default: 0.2).
+    alpha_leaky_relu : float, optional
+        LeakyReLU negative slope in attention scoring (default: 0.2).
+    update_func : str or None, optional
+        Per-layer nonlinearity: ``"sigmoid"``, ``"relu"`` or ``None``
+        (default: ``"sigmoid"``).
+    """
+
+    def __init__(
+        self,
+        in_channels_all: tuple[int, int, int],
+        hidden_channels_all: tuple[int, int, int],
+        K: int = 2,
+        n_layers: int = 2,
+        dropout: float = 0.2,
+        alpha_leaky_relu: float = 0.2,
+        update_func: str | None = "sigmoid",
+    ):
+        super().__init__()
+        assert K >= 1, "K (filter taps) must be a positive integer."
+        assert n_layers >= 1, "n_layers must be a positive integer."
+        channels = hidden_channels_all[0]
+        assert all(h == channels for h in hidden_channels_all), (
+            "GSAN couples orders and requires a single shared hidden width "
+            "across all ranks."
+        )
+
+        self.in_linear_0 = nn.Linear(in_channels_all[0], channels)
+        self.in_linear_1 = nn.Linear(in_channels_all[1], channels)
+        self.in_linear_2 = nn.Linear(in_channels_all[2], channels)
+        self.layers = nn.ModuleList(
+            [
+                GSANLayer(
+                    channels=channels,
+                    K=K,
+                    dropout=dropout,
+                    alpha_leaky_relu=alpha_leaky_relu,
+                    update_func=update_func,
+                )
+                for _ in range(n_layers)
+            ]
+        )
+
+    def reset_parameters(self) -> None:
+        """Reset all learnable parameters of the backbone."""
+        for lin in (self.in_linear_0, self.in_linear_1, self.in_linear_2):
+            lin.reset_parameters()
+        for layer in self.layers:
+            layer.reset_parameters()
+
+    def forward(
+        self,
+        x_all: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        laplacian_all: tuple[torch.Tensor, ...],
+        incidence_all: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x_all : tuple of torch.Tensor
+            Per-rank features ``(x_0, x_1, x_2)``.
+        laplacian_all : tuple of torch.Tensor
+            ``(hodge_laplacian_0, down_laplacian_1, up_laplacian_1,
+            down_laplacian_2, up_laplacian_2)`` as in the SCCNN wrapper.
+        incidence_all : tuple of torch.Tensor
+            ``(incidence_1, incidence_2)``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Updated ``(x_0, x_1, x_2)`` at the hidden width.
+        """
+        x_0, x_1, x_2 = x_all
+        x_0 = self.in_linear_0(x_0)
+        x_1 = self.in_linear_1(x_1)
+        x_2 = self.in_linear_2(x_2)
+
+        l0, ld1, lu1, ld2, _lu2 = (_to_dense(m) for m in laplacian_all)
+        b1, b2 = (_to_dense(m) for m in incidence_all)
+        operators = {
+            "l0": l0,
+            "ld1": ld1,
+            "lu1": lu1,
+            "l1": ld1 + lu1,
+            "ld2": ld2,
+            "b1": b1,
+            "b2": b2,
+        }
+
+        for layer in self.layers:
+            x_0, x_1, x_2 = layer(x_0, x_1, x_2, operators)
+        return x_0, x_1, x_2

--- a/topobench/nn/wrappers/simplicial/gsan_wrapper.py
+++ b/topobench/nn/wrappers/simplicial/gsan_wrapper.py
@@ -1,0 +1,44 @@
+"""Wrapper for the GSAN model."""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class GSANWrapper(AbstractWrapper):
+    r"""Wrapper for the GSAN model.
+
+    GSAN jointly updates node, edge and triangle signals using masked attention
+    over the lower/upper simplicial neighborhoods. This wrapper passes the same
+    Hodge-Laplacian and incidence operators as the SCCNN wrapper and returns the
+    updated embeddings of ranks 0, 1 and 2.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the GSAN wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the updated model output.
+        """
+        x_all = (batch.x_0, batch.x_1, batch.x_2)
+        laplacian_all = (
+            batch.hodge_laplacian_0,
+            batch.down_laplacian_1,
+            batch.up_laplacian_1,
+            batch.down_laplacian_2,
+            batch.up_laplacian_2,
+        )
+        incidence_all = (batch.incidence_1, batch.incidence_2)
+        x_0, x_1, x_2 = self.backbone(x_all, laplacian_all, incidence_all)
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+        model_out["x_1"] = x_1
+        model_out["x_2"] = x_2
+
+        return model_out


### PR DESCRIPTION
Add GSAN (Battiloro et al., IEEE T-SIPN 2024 (arXiv:2309.02138)) as a Track-2 TNN backbone for the 2026 TDL Challenge, with config, unit tests (100% backbone coverage), a pipeline-test entry, and the GraphUniverse evaluation results.json.

<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [ ] I linked to issues and PRs that are relevant to this PR.

## Description

Track-2 (TNN) submission for the 2026 TDL Challenge — **team LoopCounter**.

Adds **GSAN — Generalized Simplicial Attention Neural Networks** (Battiloro, Testa, Giusti, Sardellitti, Di Lorenzo, Barbarossa — IEEE T-SIPN 2024, [arXiv:2309.02138](https://arxiv.org/abs/2309.02138); reference code [luciatesta97/Generalized-Simplicial-Attention-Neural-Networks](https://github.com/luciatesta97/Generalized-Simplicial-Attention-Neural-Networks)) as a **simplicial** backbone.

Included:
- `topobench/nn/backbones/simplicial/gsan.py` — joint all-orders masked simplicial attention coupling nodes ↔ edges ↔ triangles through the incidence maps (B₁, B₂), with the per-order K-tap polynomial filter over the lower/upper Hodge Laplacians. Uses the paper-correct `SALayer` indexing (`α·Lʲ`, `L⁰ = I`) rather than the off-by-one tap in the public `GSAN_Joint` loop, and guards triangle-free graphs (empty rank-2 signal / zero up-Laplacian).
- `topobench/nn/wrappers/simplicial/gsan_wrapper.py`
- `configs/model/simplicial/gsan.yaml`
- `test/nn/backbones/simplicial/test_gsan.py` — **100% backbone coverage**; covers the no-triangle path, the empty-operator branch guard, and all update nonlinearities.
- `simplicial/gsan` added to `test/pipeline/test_pipeline.py`.
- `2026_tdl_challenge/outputs/.../results.json` — full 12×3×2 GraphUniverse grid (community detection + triangle counting, in-distribution + OOD).

## Issue

N/A — this is a model contribution for the 2026 TDL Challenge (Track 2 / `track-2-tnn`), not a bug fix.

## Additional context

N/A