### PR TITLE
Track: Track2; Team name: LoopCounter; Model: EHNN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-30_01-01-51/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-30_01-01-51/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-30_01-01-51",
+    "model_config": "hypergraph/ehnn",
+    "generated_at_utc": "2026-06-30T02:11:04.372395+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2195804119110107,
+      "test_best_rerun_accuracy": 0.3133547306060791,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3103751242160797,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29360532760620117,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2986477315425873,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32985714077949524,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3193139135837555,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3237069249153137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3120177388191223,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34307435154914856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33310413360595703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3537321388721466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32672473788261414,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.226524829864502,
+      "test_best_rerun_accuracy": 0.3079303205013275,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30525633692741394,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2902437150478363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3009397089481354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3163343369960785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31113913655281067,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3059057295322418,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30365192890167236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3220643401145935,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31110092997550964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31950491666793823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29299411177635193,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2151293754577637,
+      "test_best_rerun_accuracy": 0.3147299289703369,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31167393922805786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28623270988464355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.288448303937912,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3240507245063782,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3161051273345947,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3077775239944458,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29276493191719055,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32752692699432373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.317824125289917,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3208037316799164,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28459012508392334,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.218604326248169,
+      "test_best_rerun_accuracy": 0.31152111291885376,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3089999258518219,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3103751242160797,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31274351477622986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33623653650283813,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3402857482433319,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3341355323791504,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3530063331127167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3697379529476166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.380357563495636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38413935899734497,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4211551547050476,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2223076820373535,
+      "test_best_rerun_accuracy": 0.3095729351043701,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30433952808380127,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3016655147075653,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31247612833976746,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31530293822288513,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3212621212005615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30281153321266174,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3217969238758087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32752692699432373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3329513370990753,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3201161324977875,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3334861397743225,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2110304832458496,
+      "test_best_rerun_accuracy": 0.313240110874176,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3125525116920471,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3115975260734558,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3133929371833801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3441821336746216,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3435709476470947,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33776453137397766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35789594054222107,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3786003589630127,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3866223692893982,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39731836318969727,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42871877551078796,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1751582622528076,
+      "test_best_rerun_accuracy": 0.33069753646850586,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29643210768699646,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29058751463890076,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.319772332906723,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32745054364204407,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3109099268913269,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3674841523170471,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3593093454837799,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3638933598995209,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3522423505783081,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42134615778923035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.418404757976532,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.261259078979492,
+      "test_best_rerun_accuracy": 0.30254411697387695,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29119873046875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2879517078399658,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30414852499961853,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2967377305030823,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2924211025238037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3139277398586273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30311712622642517,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30036672949790955,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29612651467323303,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3117121160030365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29249751567840576,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1513288021087646,
+      "test_best_rerun_accuracy": 0.3337535262107849,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3018947243690491,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2909313142299652,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31599053740501404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3477347493171692,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3271831274032593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3919321596622467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38028115034103394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40652456879615784,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38589656352996826,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4808617830276489,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.48089998960494995,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1692445278167725,
+      "test_best_rerun_accuracy": 0.3252731263637543,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.303728312253952,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2989533245563507,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32661011815071106,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33314234018325806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32821452617645264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3591947555541992,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3815799653530121,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3753533363342285,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3766903579235077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4288715720176697,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46405377984046936,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2031068801879883,
+      "test_best_rerun_accuracy": 0.3152265250682831,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2962411046028137,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30147451162338257,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2869585156440735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2991061210632324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3035373091697693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29123690724372864,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31507372856140137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30242952704429626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3033081293106079,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3005577325820923,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30185651779174805,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.163881540298462,
+      "test_best_rerun_accuracy": 0.3284437358379364,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30582931637763977,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3009779155254364,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32725954055786133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3413553237915039,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33394452929496765,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36889755725860596,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38899075984954834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3935747444629669,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3893345594406128,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.451600581407547,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4854840040206909,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9625751972198486,
+      "test_best_rerun_accuracy": 0.41103217005729675,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27427610754966736,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25441211462020874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2818015217781067,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2622049152851105,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3808923661708832,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4233325719833374,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42298877239227295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.554053008556366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5437772274017334,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6358774304389954,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6459622383117676,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.968425989151001,
+      "test_best_rerun_accuracy": 0.40874016284942627,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27752310037612915,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25127971172332764,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27740851044654846,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25360989570617676,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3777599632740021,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4136679768562317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40339216589927673,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5496600270271301,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5364428162574768,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6278172731399536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6251814365386963,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9715770483016968,
+      "test_best_rerun_accuracy": 0.41248375177383423,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2784399092197418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25723889470100403,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27588051557540894,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2551378905773163,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.377607136964798,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41523417830467224,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4093131721019745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5537092089653015,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.541867196559906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6311406493186951,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6457330584526062,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.010399341583252,
+      "test_best_rerun_accuracy": 0.3899839520454407,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2814195156097412,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2645733058452606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28054091334342957,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2623959183692932,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40747955441474915,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4212697744369507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43234777450561523,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5514172315597534,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5496982336044312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6316372752189636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6647566556930542,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0125513076782227,
+      "test_best_rerun_accuracy": 0.3894873559474945,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2850867211818695,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27102911472320557,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2906639277935028,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27725571393966675,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40583696961402893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4289097785949707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4457559883594513,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5477499961853027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5417908430099487,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.634807825088501,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6712506413459778,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0100131034851074,
+      "test_best_rerun_accuracy": 0.3933073580265045,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28474292159080505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2676292955875397,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27851632237434387,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2744289040565491,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41294217109680176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42314156889915466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43849796056747437,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5516082048416138,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5496982336044312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6335090398788452,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6665138602256775,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8214435577392578,
+      "test_best_rerun_accuracy": 0.4586293697357178,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2657575011253357,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24589349329471588,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31045153737068176,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2933379113674164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38559094071388245,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3474673330783844,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46718618273735046,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5195966362953186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4977079927921295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.635686457157135,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6690732836723328,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8453094959259033,
+      "test_best_rerun_accuracy": 0.45561158657073975,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25403010845184326,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2317976951599121,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29857131838798523,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27546030282974243,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3763083517551422,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33107954263687134,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45232638716697693,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5050805807113647,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.482886403799057,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6309114694595337,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6534876823425293,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8233048915863037,
+      "test_best_rerun_accuracy": 0.45996639132499695,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.261822909116745,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24295209348201752,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3067079186439514,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.289288729429245,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3947589695453644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.350981742143631,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46745359897613525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5277332067489624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5090534090995789,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.647070050239563,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6755290627479553,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7696592807769775,
+      "test_best_rerun_accuracy": 0.4751317799091339,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27347391843795776,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2563984990119934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3009779155254364,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2887157201766968,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3847505450248718,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35407593846321106,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45236459374427795,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5105432271957397,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5014516115188599,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6287722587585449,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6788142919540405,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7644522190093994,
+      "test_best_rerun_accuracy": 0.4755519926548004,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2792420983314514,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2588050961494446,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30483612418174744,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2895561158657074,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38910534977912903,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36003515124320984,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.455382376909256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.516808032989502,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5050423741340637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6301474571228027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.682939887046814,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.752015471458435,
+      "test_best_rerun_accuracy": 0.4757812023162842,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2764917016029358,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25891971588134766,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3030407130718231,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28932690620422363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3916647434234619,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36263275146484375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45710137486457825,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5195202231407166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5164260268211365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6376728415489197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6845442652702332,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4998270273208618,
+      "test_best_rerun_accuracy": 0.5638322234153748,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23714569211006165,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21307969093322754,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24807089567184448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23072808980941772,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3915501534938812,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35843074321746826,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40583696961402893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4115287661552429,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5522958040237427,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6460386514663696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6680800914764404,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.482330322265625,
+      "test_best_rerun_accuracy": 0.5644816160202026,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23848269879817963,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21273589134216309,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2468867003917694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22297349572181702,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39445334672927856,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3601115345954895,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41385897994041443,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41443195939064026,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5512261986732483,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.650126039981842,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6760256886482239,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.506928563117981,
+      "test_best_rerun_accuracy": 0.560929000377655,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23431889712810516,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20925968885421753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2472686916589737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2226678878068924,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.389907568693161,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35625335574150085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40656277537345886,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4064481556415558,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5492016077041626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6416074633598328,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6675834655761719,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.496061086654663,
+      "test_best_rerun_accuracy": 0.5619986057281494,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23664909601211548,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2180456817150116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2470013052225113,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23783329129219055,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3888379633426666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37076935172080994,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.412751168012619,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43185117840766907,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5658186078071594,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6519978642463684,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6937505006790161,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5102100372314453,
+      "test_best_rerun_accuracy": 0.5533654093742371,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23920848965644836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21571548283100128,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24344870448112488,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2233554869890213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38413935899734497,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3635113537311554,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40025976300239563,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4163801670074463,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.560929000377655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6429062485694885,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6806478500366211,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5167510509490967,
+      "test_best_rerun_accuracy": 0.5547788143157959,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23210328817367554,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20819008350372314,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22939109802246094,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2123538851737976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3831843435764313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35976773500442505,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39647796750068665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40572234988212585,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5598976016044617,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.640308678150177,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6809916496276855,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1987751722335815,
+      "test_best_rerun_accuracy": 0.6553212404251099,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2274428904056549,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2014668732881546,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25334250926971436,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23168309032917023,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38463595509529114,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34257772564888,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42505156993865967,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.434486985206604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5522575974464417,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5334632396697998,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6895866990089417,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2037556171417236,
+      "test_best_rerun_accuracy": 0.6535640358924866,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21407288312911987,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1908472776412964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23859728872776031,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2188860923051834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36954694986343384,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3259607255458832,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41741156578063965,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42994117736816406,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5476354360580444,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5230346322059631,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6919932961463928,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1991322040557861,
+      "test_best_rerun_accuracy": 0.6566964387893677,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22094888985157013,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19783787429332733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25781190395355225,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23794789612293243,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37894415855407715,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.335778146982193,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43505996465682983,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44923219084739685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5506532192230225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5320116281509399,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6968064904212952,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0196311473846436,
+      "test_best_rerun_accuracy": 0.7018870711326599,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2298876941204071,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21067307889461517,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2467339038848877,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2298876941204071,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38452136516571045,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3530063331127167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42256855964660645,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44583237171173096,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5555810332298279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5498892068862915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.653946042060852,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0277193784713745,
+      "test_best_rerun_accuracy": 0.6974940896034241,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22664068639278412,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2058216780424118,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23962870240211487,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21770188212394714,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37420734763145447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3446023464202881,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42165178060531616,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43807777762413025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.546451210975647,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5326610207557678,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6466880440711975,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0144526958465576,
+      "test_best_rerun_accuracy": 0.6999006867408752,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23248529434204102,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21353808045387268,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24872030317783356,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22855068743228912,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37798914313316345,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3508671522140503,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42936816811561584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4518679678440094,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5476354360580444,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.535029411315918,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6495530605316162,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 42.33945846557617,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 42.47359848022461,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.030600575273937038,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.47296142578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10775242855674343
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4931.36083984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.37401295713642396
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 297.1102600097656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10013827435448791
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5751.767578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7684392221943888
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144.53631591796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12481547143175194
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138214.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.209508304500279
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9373.6220703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6572445709095849
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40019.75,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0513480957506793
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3006.114990234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5344204427083333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 681533.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.709398295306721
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 217140.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6134091117101828
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 41.95964813232422,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 41.89948654174805,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.030186949958031735,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.39784812927246,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09156762173301296
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5447.57763671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4131647809418847
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202.57131958007812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06827479594879614
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5991.1884765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8004259821726787
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.5338134765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12826754186231648
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143291.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3274011500325096
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10063.671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7056283743514233
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40973.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1002241753805935
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3114.677001953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5537203559027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 694110.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.851662273904732
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224332.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.733081692127203
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 44.09916305541992,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 44.501319885253906,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.03206146965796391,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.552949905395508,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10291026265997635
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5668.9775390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4299565824089875
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135.45050048828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04565234259800514
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6017.8125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8039829659318637
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.37232971191406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13762722773049574
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143309.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.327835460013004
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10340.6728515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7250506837443906
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41024.16796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1028329472935567
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3167.649169921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5631376302083333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 692846.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.837367651550287
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224715.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7394559266470306
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.500572681427002,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.3395113945007324,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012313217865793329,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203.07394409179688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14630687614682772
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12661.79296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.960318010523322
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 297.60986328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1003066610317661
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8119.36669921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.084751730022545
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173.88186645507812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15015705220645778
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177017.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.110565814833736
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15577.3447265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0922272280579512
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47542.3046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4369421645138143
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3917.83837890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6965046006944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 762549.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.62583212673778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 264199.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.396505208593347
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.783440113067627,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.7341983318328857,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.014390517535962556,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200.81982421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14468287047460374
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12915.5712890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9795655130119454
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 382.9841613769531,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1290812812190607
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8117.533203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.084506773964596
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175.53468322753906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15158435511877294
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177642.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.125085991199145
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15978.29296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1203402726651241
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47558.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.437762699267005
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3953.218017578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7027943142361112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 763366.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.635076722509417
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 265595.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.419745748256869
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.289235830307007,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.2091572284698486,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.011627143307736046,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176.5327606201172,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1271849860375484
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11854.4482421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8990859493505878
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206.13031005859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06947432088257288
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7904.865234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0560942196893788
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.1334686279297,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14001163093949023
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173933.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.038963446846554
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14751.443359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0343180030412986
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46850.62890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4014879751012352
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3798.033447265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6752059461805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755828.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.549806002058753
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259454.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.317543744695722
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1855.3890380859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1854.1512451171875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.1406258054696388,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 941.4755249023438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6782964876818038
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2255.179443359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 11.869365491365132
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2154.8701171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7262791092644085
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6257.46826171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8360011037700401
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2588.537353515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.235351773329555
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106337.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.469290982607282
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13859.990234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9718125251980788
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40813.00390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0920090166717924
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6265.35498046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.1138408854166666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 631246.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.140549528862143
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215056.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5787284916712427
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2000.306640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1973.1514892578125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.14965123164640215,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1116.0457763671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8040675622241985
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2884.0341796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 15.179127261513157
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2770.30126953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.9337045060772666
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6443.31396484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8608301890238811
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3205.392822265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.7680421608511443
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106189.4296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4658515160574956
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14494.7197265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.016317467856016
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41432.76171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1237768065380083
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6897.66015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2262506944444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 634137.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.1732569878850265
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216406.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6011928906028987
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1838.2955322265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1833.0264892578125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.13902362451708855,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1085.041259765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7817300142403638
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2731.187255859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.37466976768092
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2484.968017578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8375355637270391
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6641.29443359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8872804854500668
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3045.2548828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.629753784812176
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107971.6484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.507236866930615
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14359.8916015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0068638060273805
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41759.7421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.140537300092265
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6787.9638671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2067491319444446
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 634145.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.1733439476035885
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216203.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.597819993593264
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 103.68867492675781,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 100.30265808105469,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.03380608630975891,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.731361389160156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0293453612313834
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.484228134155273,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.06044330596923828
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5707.54541015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.43288171483930604
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6214.2607421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8302285560704743
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.431884765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13767865696513384
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145798.421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3856219086708155
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11402.8251953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7995249751305917
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41651.453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.134986576708186
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3301.292724609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.586896484375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 701544.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.935759391649604
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232710.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8724994487710713
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 105.38099670410156,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 101.36060333251953,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.03416265700455663,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.62246322631836,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03286920981723225
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.046409606933594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.21077057687859785
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5585.58837890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.42363203480517636
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6426.96875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8586464595858383
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204.16769409179688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.17631061665958278
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146424.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.400150430173695
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11565.0107421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8108968407087015
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42445.08203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.175666719526885
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3453.68017578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6139875868055555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 705572.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.981319214280059
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234671.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9051342814470904
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 99.0638656616211,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 95.54582214355469,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.032202838605849236,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.28114318847656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04919390719630876
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94.640869140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.49810983758223687
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5036.86279296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.38201462214400833
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6514.46240234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8703356582957582
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276.32574462890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.23862326824603303
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143945.46875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.342594017044399
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11583.2451171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8121753693161898
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42603.41015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.18378236487006
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3597.442138671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6395452690972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702850.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.950522748096784
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233858.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8916151319621255
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1413.9173583984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1347.7305908203125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1800575271637024,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 399.8102722167969,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.28804774655388826
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.8836612701416,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.13096663826390317
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27867.3984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.1135683304891923
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10125.404296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.4126741816228514
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.00489807128906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08463289988885066
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48510.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1264778149962846
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23415.51171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.6418112269492358
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15692.66015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8043805503229279
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 615.9083251953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10949481336805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 417168.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.718945836114159
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92529.5546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5397725972659044
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 803.3796997070312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 809.0317993164062,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.10808708073699483,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 314.81927490234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2268150395550027
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.136004447937012,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07966318130493164
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14228.28125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0791263746681836
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4600.9169921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5506966606631278
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71.56339263916016,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06179913008563053
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38998.8515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9056021633498978
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16519.076171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1582580403782778
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11100.923828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5690155224832129
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 424.88214111328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.07553460286458333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348238.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.9392155102202415
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75888.3203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2628479242590651
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1390.6016845703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1416.4036865234375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.18923228944868906,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207.51307678222656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14950509854627275
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.323232650756836,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.14906964553029914
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15471.68359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.1734306859120212
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5110.32568359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7223881643389787
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80.55229949951172,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06956157124310165
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50240.0234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1666362492453093
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13914.7373046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9756511923073552
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16916.482421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8671117136642063
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 659.1923217773438,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11718974609375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 438454.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.959724570998722
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93831.1484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.561432253964688
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 93.8189468383789,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 89.72311401367188,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07748110018451802,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194.45291137695312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14009575747619102
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.40443229675293,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10212859103554174
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3684.5654296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2794513029721274
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1468.519287109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.4949508888134058
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4676.17529296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6247395180986974
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124339.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.887315064497028
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6882.11181640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4825488582531377
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35622.28515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8259411121149214
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2297.13134765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.40837890625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 645658.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.303575670508919
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 192170.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1978909253157606
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 90.50847625732422,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 86.95283508300781,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07508880404404819,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 187.6091766357422,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13516511284995836
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.771432876586914,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08827069935045745
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3700.6650390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2806723579114524
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1655.0574951171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5578218723010406
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4726.87109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6315125041750167
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125964.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9250436124140813
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7045.21240234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.49398488306995864
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36138.8359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8524186753549643
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2335.888427734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.41526905381944446
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 652065.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.376051293508139
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195452.734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2525041914199657
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 89.80485534667969,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 86.7081527709961,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07487750671070474,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222.91490173339844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16060151421714586
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.239004135131836,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09599475860595703
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3510.395751953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.26624161941244784
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1701.306884765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5734098027521486
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4522.44140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6042005886773547
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121996.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.832912931915289
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6698.87939453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4697012617116288
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35116.359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.800008169306474
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2240.01318359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3982245659722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 641027.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.251194105403663
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189648.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1559148424109296
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 6919.73291015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6362.015625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.14773396862808844,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4561.43017578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.2863329796694885
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 432.8190002441406,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.277994738127056
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13960.96484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0588520928138037
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1001.2432250976562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3374597994936489
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2529.360107421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3379238620470107
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 642.689453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5549995277417962
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4970.708984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3485281856945029
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5903.31103515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.30259424035861654
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1928.4691162109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.34283895399305553
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153921.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.741137885592118
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48757.26171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8113634153520377
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 12134.908203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9756.2880859375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.22655322510536643,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2532.42431640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.8245131962581052
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.880247116088867,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.15726445850573087
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11937.017578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9053483184015927
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 321.0369567871094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10820254694543625
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1759.931884765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.23512784031604878
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257.0179443359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.22194986557507557
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7938.6640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5566304909900435
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8085.8798828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.41446921332782305
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1929.9239501953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3430975911458333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206449.328125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.335320386468785
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67631.1484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1254413731632635
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 19783.193359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15016.681640625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.34870614993091675,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7128.67236328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.135931097464877
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1802.8504638671875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.488686651932566
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20106.392578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.5249444503697382
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1177.9625244140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.39702141031818755
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4041.4150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5399352089595858
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1821.30810546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.5728049270023747
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5319.59130859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.372990555924397
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8596.1328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4406239588138808
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2430.631591796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4321122829861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252665.140625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.858105953700666
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68487.5234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.139692201046711
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3480.36279296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2726.00244140625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.19113745908051114,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1021.825439453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7361854751103206
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.07621002197266,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.35303268432617185
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5843.330078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.44318013485968905
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 767.1104736328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2585475138634353
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1539.81689453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.20572035999081495
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.7605438232422,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12328198948466511
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44164.9140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0255646029746424
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15552.6064453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7972016220878825
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1029.3211669921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1829904296875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 408346.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.619148954221011
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98594.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6407032641073003
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3594.27978515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2818.0029296875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.19758820149260273,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1644.9228515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1851029189931557
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186.15797424316406,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9797788118061267
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7472.2509765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5667236235542283
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1204.0408935546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.40581088424492334
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1657.3739013671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22142603892681195
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245.17530822753906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.21172306409977468
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43167.5390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0024043066714656
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14936.0146484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7655961170965965
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1035.2823486328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1840501953125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 404659.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.5774404573374206
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97903.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.629207540811742
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3846.521484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3020.5458984375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.21178978393195205,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1642.8597412109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.183616528249955
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92.81565856933594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.48850346615439966
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10354.0615234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.785290976369928
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1297.3956298828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.4372752375742543
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1589.6273193359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2123750593635187
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.47007751464844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1575734693563458
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41969.9453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9745946803014118
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15259.837890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7821947762891486
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1122.4212646484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19954155815972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 407684.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.611658399601824
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100252.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6682865516782321
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2883.60498046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2633.488037109375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.1349883662468284,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1067.6656494140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7692115629784312
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175.46591186523438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9235047992907073
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36894.24609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.798198414391354
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34993.73828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 11.794316913127739
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 732.8380126953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.09790755012629425
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 430.0614318847656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.37138292908874404
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23256.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5400377925877763
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54310.84765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.8080807499824707
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1196.380859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.21268993055555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156484.59375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.7701276398990984
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85840.6484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4284633557569102
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 4689.0859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4231.37939453125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.2168937103147906,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1029.1904296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7414916640399856
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.61720275878906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.271669488204153
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23396.923828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.7745107188566553
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11403.171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.8433339652847995
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 569.4530639648438,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.07607923366263777
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.27955627441406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15740894324215376
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20955.654296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.48661653113679637
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24890.892578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.7452596114237133
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1125.8756103515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2001556640625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185972.15625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.1036860315826384
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113632.9765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8909519671592365
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 4580.34033203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4242.84326171875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.21748132973082937,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 746.25732421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5376493690336815
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 392.9409484863281,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.0681102551912005
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31238.833984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.369270685200986
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7098.18310546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.392377184182255
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610.3366088867188,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.08154129711245407
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 424.6646728515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3667225154158571
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21791.939453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5060361195691296
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22304.28125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.563895754452391
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1060.6763916015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.18856469184027777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180671.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.0437258916552605
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91109.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5161351467725026
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 546.7799682617188,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 577.3193969726562,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.10263455946180555,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212.3577117919922,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15299546959077248
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55.13813018798828,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2902006851999383
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6126.04345703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.46462218104142966
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15695.056640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.289874162664307
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2755.4013671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3681230951486306
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.16577911376953,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07354557781845383
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71461.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.659435302689021
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16790.330078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1772773859293928
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19978.748046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0240785302616742
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 458898.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.190980509711209
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93946.2578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5633477744912052
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 366.9873046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 383.5204162597656,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.06818140733506944,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214.79542541503906,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15475174741717512
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.826820373535156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.23593063354492189
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6470.55859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4907515050246492
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18367.267578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.190518226533536
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2716.395263671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.362911858873998
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.43997192382812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07378235917429027
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68368.5234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5876027177572916
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17723.42578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.242702691154817
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17729.15625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9087680685837306
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 420086.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.751943160865581
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82715.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3764633567969646
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 721.0418701171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 758.7537841796875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.13488956163194443,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 271.4668273925781,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.19558128774681421
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.57645034790039,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2451392123573705
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6311.68896484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.47870223472459233
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12796.3046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.312876537748568
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3278.706298828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4380369136710922
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.06607055664062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06655101084338569
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89247.4140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.072436700318131
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16326.4345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.144750706093991
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22472.80859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1519200673407146
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 498070.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.634091179032386
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104422.9609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.7376892639325712
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 87285.515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 47330.92578125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.5353995427898375,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8988.1572265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.475617598387968
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 498.1808776855469,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.622004619397615
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33735.39453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.558619228763747
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10136.955078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.416567265967307
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5161.31982421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.689555086735972
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2763.03662109375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.386041987127591
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20127.79296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4673925545409158
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14299.3515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0026189568433599
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5058.80810546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.25930637682447844
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3838.626708984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6824225260416666
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46134.0859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7677114794984441
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 89182.71875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 45840.33203125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.518538194758662,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15255.2978515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.990848596226584
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5551.51953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 29.21852384868421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50577.1484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.835961201175578
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25736.8671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.674373841422312
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11864.91015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.58515833750835
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7334.38330078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.3336643357351035
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24367.232421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5658376468018531
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34629.63671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.428105224985977
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7112.22509765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3645612331568122
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8408.5087890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.4948460069444445
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50640.9921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8427103354384038
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 57427.5,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28162.830078125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.31857323934849496,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4550.62939453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.2785514369821684
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1855.5465087890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.76603425678454
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18748.18359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.4219327716154722
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17517.556640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.904130987740142
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3206.287109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.42836167125918506
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1547.5465087890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.3363959488679296
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11095.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.2576397919375813
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23466.046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.6453545698359275
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3053.464599609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.1565156901742465
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2883.009521484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5125350260416667
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39299.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6539811209292263
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 20025.103515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 17720.220703125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.29487994779966054,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8531.99609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.1469712490994235
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1773.3302001953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.333316843133224
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14227.2783203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0790503087078118
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10750.2890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.6232858316481296
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7319.7490234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9779223812207749
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2224.1396484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.9206732715349741
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59243.69140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.375712692881525
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15695.70703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1005263659549853
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9877.099609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5062842590278845
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4452.88037109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7916231770833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141574.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.6014692657489
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 32286.474609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 31534.55078125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.5247624645341388,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77268.28125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 55.6687905259366
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51472.05859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 270.9055715460526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40827.6640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.096523630072052
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4287.93212890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.445207997609117
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59420.3125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.938585504342018
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46350.26953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 40.02613949158031
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44475.17578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0327692685595857
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9834.4541015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6895564508177324
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38883.33203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9930971362576246
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39670.66015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 7.0525618055555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178370.296875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.017695065495515
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ehnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 17135.53515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15789.0966796875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.2627443575738855,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5733.78515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.130969132744957
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 943.3428955078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.964962607935855
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11894.3974609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9021158483835798
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8034.17333984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.7078440646591675
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5595.0888671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7475068626837007
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1233.957763671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.0655939237235534
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66180.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.536804233234256
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12470.103515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8743586815050484
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11229.5078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5756065309600698
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3268.301025390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5810312934027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146887.78125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.6615700966030564
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-30_01-01-51__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/hypergraph/ehnn.yaml
+++ b/configs/model/hypergraph/ehnn.yaml
@@ -1,0 +1,40 @@
+_target_: topobench.model.TBModel
+
+model_name: ehnn
+model_domain: hypergraph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.hypergraph.ehnn.EHNN
+  num_features: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  max_edge_order: 200 # upper bound on hyperedge size for the order hypernetworks
+  dropout: 0.5
+  hyper_layers: 3 # layers in each order-conditioned hypernetwork
+  hyper_dropout: 0.0
+  input_dropout: 0.0
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.HypergraphWrapper
+  _partial_: true
+  wrapper_name: HypergraphWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: 1
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: 1
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/hypergraph/test_ehnn.py
+++ b/test/nn/backbones/hypergraph/test_ehnn.py
@@ -1,0 +1,157 @@
+"""Unit tests for the EHNN backbone."""
+
+import pytest
+import torch
+
+from ...._utils.nn_module_auto_test import NNModuleAutoTest
+from topobench.nn.backbones.hypergraph import EHNN
+from topobench.nn.backbones.hypergraph.ehnn import (
+    BiasV,
+    InnerMLP,
+    PositionalEncoding,
+)
+
+
+def _toy_incidence(sparse=True):
+    """Build a small node-hyperedge incidence matrix.
+
+    Hyperedges {0,1,2}, {2,3}, {3,4} over 5 nodes.
+
+    Parameters
+    ----------
+    sparse : bool, optional
+        Whether to return a sparse COO tensor (default: True).
+
+    Returns
+    -------
+    torch.Tensor
+        Incidence matrix of shape ``(5, 3)``.
+    """
+    dense = torch.tensor(
+        [
+            [1.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    return dense.to_sparse_coo() if sparse else dense
+
+
+def test_EHNN():
+    """Test the EHNN backbone end to end with the auto-test harness."""
+    torch.manual_seed(0)
+    x = torch.randn(5, 6)
+    incidence = _toy_incidence(sparse=True)
+    NNModuleAutoTest(
+        [
+            {
+                "module": EHNN,
+                "init": {
+                    "num_features": 6,
+                    "hidden_channels": 8,
+                    "max_edge_order": 10,
+                },
+                "forward": (x, incidence),
+                "assert_shape": (5, 8),
+            }
+        ]
+    ).run()
+
+
+def test_build_cache():
+    """Test that the operator cache has correct orders and normalizers."""
+    model = EHNN(num_features=6, hidden_channels=8, max_edge_order=10)
+    cache = model._build_cache(_toy_incidence(sparse=False))
+    assert torch.equal(
+        cache["edge_orders"], torch.tensor([3, 2, 2])
+    )  # hyperedge sizes
+    assert torch.allclose(
+        cache["prefix_normalizer"], torch.tensor([3.0, 2.0, 2.0])
+    )
+    # node degrees: nodes 2 and 3 are in two hyperedges.
+    assert torch.allclose(
+        cache["suffix_normalizer"], torch.tensor([1.0, 1.0, 2.0, 2.0, 1.0])
+    )
+    assert cache["incidence"].is_sparse
+
+
+def test_edge_order_clamping():
+    """Test that hyperedge orders are clamped to max_edge_order."""
+    model = EHNN(num_features=6, hidden_channels=8, max_edge_order=2)
+    cache = model._build_cache(_toy_incidence(sparse=False))
+    # The size-3 hyperedge must be clamped down to 2.
+    assert cache["edge_orders"].max().item() == 2
+
+
+def test_forward_shapes():
+    """Test forward output shapes and that the hyperedge slot is None."""
+    model = EHNN(num_features=6, hidden_channels=8, max_edge_order=10)
+    out, hyper = model(torch.randn(5, 6), _toy_incidence())
+    assert out.shape == (5, 8)
+    assert hyper is None
+    assert torch.isfinite(out).all()
+
+
+def test_sparse_and_dense_incidence_run():
+    """Test that both sparse and dense incidence inputs are accepted."""
+    model = EHNN(num_features=6, hidden_channels=8, max_edge_order=10)
+    model.eval()
+    x = torch.randn(5, 6)
+    out_sparse, _ = model(x, _toy_incidence(sparse=True))
+    out_dense, _ = model(x, _toy_incidence(sparse=False))
+    assert out_sparse.shape == out_dense.shape == (5, 8)
+
+
+def test_invalid_max_edge_order():
+    """Test that a non-positive max_edge_order raises an assertion error."""
+    with pytest.raises(AssertionError):
+        EHNN(num_features=6, hidden_channels=8, max_edge_order=0)
+
+
+def test_reset_parameters():
+    """Test that reset_parameters runs and keeps parameters finite."""
+    model = EHNN(num_features=6, hidden_channels=8, max_edge_order=10)
+    model.reset_parameters()
+    for p in model.parameters():
+        assert torch.isfinite(p).all()
+
+
+def test_custom_hyper_dims():
+    """Test EHNN with explicit pe_dim / hyper_dim and multiple hyper layers."""
+    model = EHNN(
+        num_features=6,
+        hidden_channels=8,
+        max_edge_order=10,
+        pe_dim=4,
+        hyper_dim=16,
+        hyper_layers=2,
+    )
+    out, _ = model(torch.randn(5, 6), _toy_incidence())
+    assert out.shape == (5, 8)
+
+
+def test_inner_mlp_single_and_multi_layer():
+    """Test the InnerMLP for both single- and multi-layer configurations."""
+    x = torch.randn(4, 6)
+    single = InnerMLP(6, 3, 5, n_layers=1, dropout=0.0)
+    assert single(x).shape == (4, 3)
+    multi = InnerMLP(6, 3, 5, n_layers=3, dropout=0.0)
+    assert multi(x).shape == (4, 3)
+
+
+def test_positional_encoding_shape():
+    """Test that the positional encoding looks up the right shape."""
+    pe = PositionalEncoding(dim=8, max_pos=5)
+    idx = torch.tensor([0, 2, 4])
+    assert pe(idx).shape == (3, 8)
+
+
+def test_bias_v():
+    """Test the learnable node bias module."""
+    bias = BiasV(dim_out=8)
+    x = torch.randn(5, 8)
+    out = bias(x)
+    assert out.shape == x.shape
+    assert not torch.allclose(out, x)  # a nonzero bias is added

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "hypergraph/ehnn"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/hypergraph/ehnn.py
+++ b/topobench/nn/backbones/hypergraph/ehnn.py
@@ -1,0 +1,666 @@
+"""EHNN: Equivariant Hypergraph Neural Networks (linear / MLP variant).
+
+This module implements the EHNN-MLP (``linear``) model introduced in
+
+    Jinwoo Kim, Saeyoon Oh, Sungjun Cho, Seunghoon Hong.
+    "Equivariant Hypergraph Neural Networks." ECCV 2022.
+    https://arxiv.org/abs/2208.10428
+
+Reference implementation: https://github.com/jw9730/ehnn
+(``models.py``, ``linear.py``, ``hypernetwork.py``, ``mlp.py``).
+
+Notes
+-----
+EHNN derives the *maximally expressive* linear equivariant layer for hypergraphs
+of arbitrary, mixed order. A layer is built from order-equivariant aggregation
+blocks whose parameters are produced by small hypernetworks conditioned on the
+**order** (size) of each hyperedge, so that hyperedges of different cardinalities
+are treated by a shared but order-aware basis. The ``linear`` variant alternates
+two such blocks:
+
+* :class:`LinearV2E` maps node signals to a (node, hyperedge) pair using the
+  normalized incidence aggregation :math:`x_e = H^\\top x / |e|` together with a
+  global term, each refined by positional MLPs keyed on the hyperedge order;
+* :class:`LinearE2V` maps the (node, hyperedge) pair back to nodes via
+  :math:`x = (x_v + H x_e) / (1 + \\deg)` plus a global term.
+
+Everything is computed from the binary node-hyperedge incidence matrix
+:math:`H` (TopoBench's ``incidence_hyperedges``) and the derived hyperedge sizes
+and node degrees; no coordinates or precomputed positional features are needed.
+
+In TopoBench the original input linear and MLP classifier head are provided by
+the feature encoder and readout, so this backbone consumes pre-encoded node
+features and returns node embeddings at the hidden width.
+"""
+
+import math
+
+import torch
+from torch import nn
+
+
+class InnerMLP(nn.Module):
+    """Plain feed-forward MLP used inside every EHNN block.
+
+    Mirrors ``mlp.py``'s ``MLP``: a stack of linear layers with ReLU and dropout
+    between them (no internal normalization in the forward pass).
+
+    Parameters
+    ----------
+    dim_in : int
+        Input dimension.
+    dim_out : int
+        Output dimension.
+    dim_hidden : int
+        Hidden dimension for intermediate layers.
+    n_layers : int
+        Number of linear layers (``>= 1``).
+    dropout : float
+        Dropout probability between layers.
+    """
+
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        dim_hidden: int,
+        n_layers: int,
+        dropout: float,
+    ):
+        super().__init__()
+        assert n_layers > 0, "InnerMLP requires at least one layer."
+        self.n_layers = n_layers
+        self.act = nn.ReLU(inplace=True)
+        self.dropout = nn.Dropout(dropout)
+        self.layers = nn.ModuleList()
+        if n_layers == 1:
+            self.layers.append(nn.Linear(dim_in, dim_out))
+        else:
+            for i in range(n_layers):
+                self.layers.append(
+                    nn.Linear(
+                        dim_hidden if i > 0 else dim_in,
+                        dim_hidden if i < n_layers - 1 else dim_out,
+                    )
+                )
+
+    def reset_parameters(self) -> None:
+        """Reset the linear layers."""
+        for layer in self.layers:
+            layer.reset_parameters()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the MLP.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input features.
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed features.
+        """
+        for i in range(self.n_layers - 1):
+            x = self.dropout(self.act(self.layers[i](x)))
+        return self.layers[-1](x)
+
+
+class PositionalEncoding(nn.Module):
+    """Fixed sinusoidal positional encoding indexed by an integer position.
+
+    Parameters
+    ----------
+    dim : int
+        Encoding dimension.
+    max_pos : int
+        Number of distinct positions (e.g. ``max_order + 1``).
+    """
+
+    def __init__(self, dim: int, max_pos: int):
+        super().__init__()
+        self.max_pos = max_pos
+        position = torch.arange(max_pos).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, dim, 2) * (-math.log(10000.0) / dim)
+        )
+        pe = torch.zeros(max_pos, dim)
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        self.register_buffer("pe", pe)
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        """Look up the encoding for a batch of integer positions.
+
+        Parameters
+        ----------
+        idx : torch.Tensor
+            Long tensor of positions.
+
+        Returns
+        -------
+        torch.Tensor
+            Positional encodings.
+        """
+        return self.pe[idx]
+
+
+class PositionalMLP(nn.Module):
+    """Hypernetwork that maps an integer position to a feature vector.
+
+    Used to produce order-conditioned hyperedge biases.
+
+    Parameters
+    ----------
+    dim_out : int
+        Output dimension.
+    max_pos : int
+        Number of distinct positions.
+    dim_pe : int
+        Positional-encoding dimension.
+    dim_hidden : int
+        Hidden dimension of the hypernetwork MLP.
+    n_layers : int
+        Number of layers in the hypernetwork MLP.
+    dropout : float
+        Dropout probability inside the hypernetwork MLP.
+    """
+
+    def __init__(
+        self,
+        dim_out: int,
+        max_pos: int,
+        dim_pe: int,
+        dim_hidden: int,
+        n_layers: int,
+        dropout: float,
+    ):
+        super().__init__()
+        self.max_pos = max_pos
+        self.pe = PositionalEncoding(dim_pe, max_pos)
+        self.input = nn.Linear(dim_pe, dim_hidden)
+        self.mlp = InnerMLP(dim_hidden, dim_out, dim_hidden, n_layers, dropout)
+
+    def reset_parameters(self) -> None:
+        """Reset the hypernetwork parameters."""
+        self.input.reset_parameters()
+        self.mlp.reset_parameters()
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        """Map positions to feature vectors.
+
+        Parameters
+        ----------
+        idx : torch.Tensor
+            Long tensor of positions.
+
+        Returns
+        -------
+        torch.Tensor
+            Feature vectors.
+        """
+        return self.mlp(self.input(self.pe(idx)))
+
+
+class BiasE(nn.Module):
+    """Order-conditioned hyperedge bias (and a fixed node bias).
+
+    Parameters
+    ----------
+    dim_out : int
+        Output dimension.
+    max_l : int
+        Maximum hyperedge order.
+    pe_dim : int
+        Positional-encoding dimension of the bias hypernetwork.
+    hyper_dim : int
+        Hidden width of the bias hypernetwork.
+    hyper_layers : int
+        Number of layers in the bias hypernetwork MLP.
+    hyper_dropout : float
+        Dropout inside the bias hypernetwork.
+    """
+
+    def __init__(
+        self,
+        dim_out: int,
+        max_l: int,
+        pe_dim: int,
+        hyper_dim: int,
+        hyper_layers: int,
+        hyper_dropout: float,
+    ):
+        super().__init__()
+        self.dim_out = dim_out
+        self.b = PositionalMLP(
+            dim_out, max_l + 1, pe_dim, hyper_dim, hyper_layers, hyper_dropout
+        )
+
+    def reset_parameters(self) -> None:
+        """Reset the bias hypernetwork."""
+        self.b.reset_parameters()
+
+    def forward(
+        self,
+        x: tuple[torch.Tensor, torch.Tensor],
+        edge_orders: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Add order-conditioned bias to hyperedges, fixed bias to nodes.
+
+        Parameters
+        ----------
+        x : tuple of torch.Tensor
+            ``(x_v, x_e)`` node and hyperedge features.
+        edge_orders : torch.Tensor
+            Long tensor of hyperedge orders ``[|E|]``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Biased ``(x_v, x_e)``.
+        """
+        x_v, x_e = x
+        b_e = self.b(edge_orders)
+        b_1 = self.b(torch.ones(1, dtype=torch.long, device=x_v.device)).view(
+            1, self.dim_out
+        )
+        return x_v + b_1, x_e + b_e
+
+
+class BiasV(nn.Module):
+    """Learnable node bias.
+
+    Parameters
+    ----------
+    dim_out : int
+        Output dimension.
+    """
+
+    def __init__(self, dim_out: int):
+        super().__init__()
+        self.dim_out = dim_out
+        self.b = nn.Parameter(torch.empty(1, dim_out))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset the node bias."""
+        stdv = 1.0 / math.sqrt(self.dim_out)
+        self.b.data.uniform_(-stdv, stdv)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Add the node bias.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features.
+
+        Returns
+        -------
+        torch.Tensor
+            Biased node features.
+        """
+        return x + self.b
+
+
+class LinearV2E(nn.Module):
+    """Equivariant node-to-(node, hyperedge) block.
+
+    Parameters
+    ----------
+    dim : int
+        Shared input/inner/output dimension.
+    max_l : int
+        Maximum hyperedge order.
+    pe_dim : int
+        Positional-encoding dimension of the bias hypernetwork.
+    hyper_dim : int
+        Hidden width of the hypernetworks.
+    hyper_layers : int
+        Number of layers in each hypernetwork MLP.
+    hyper_dropout : float
+        Dropout inside the hypernetworks.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        max_l: int,
+        pe_dim: int,
+        hyper_dim: int,
+        hyper_layers: int,
+        hyper_dropout: float,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.max_l = max_l
+        self.mlp1 = InnerMLP(dim, dim, hyper_dim, hyper_layers, hyper_dropout)
+        self.mlp2 = InnerMLP(
+            dim * 2, dim, hyper_dim, hyper_layers, hyper_dropout
+        )
+        self.mlp3 = InnerMLP(
+            dim * 2, dim, hyper_dim, hyper_layers, hyper_dropout
+        )
+        self.norm1 = nn.LayerNorm(dim)
+        self.norm2 = nn.LayerNorm(dim)
+        self.norm3 = nn.LayerNorm(dim)
+        self.pe2 = PositionalEncoding(dim, 2)
+        self.pe3 = PositionalEncoding(dim, max_l + 1)
+        self.b = BiasE(
+            dim, max_l, pe_dim, hyper_dim, hyper_layers, hyper_dropout
+        )
+
+    def reset_parameters(self) -> None:
+        """Reset all submodules."""
+        for m in (
+            self.mlp1,
+            self.mlp2,
+            self.mlp3,
+            self.norm1,
+            self.norm2,
+            self.norm3,
+            self.b,
+        ):
+            m.reset_parameters()
+
+    def forward(
+        self, x: torch.Tensor, cache: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Aggregate node features into node and hyperedge representations.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features ``[N, dim]``.
+        cache : dict
+            Operators ``incidence`` (sparse ``[N, |E|]``), ``edge_orders``
+            ``[|E|]`` and ``prefix_normalizer`` ``[|E|]``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            ``(x_v, x_e)`` node and hyperedge features.
+        """
+        incidence = cache["incidence"]
+        edge_orders = cache["edge_orders"]
+        prefix_normalizer = cache["prefix_normalizer"]
+
+        x = x + self.mlp1(self.norm1(x))
+        x0 = x.mean(dim=0, keepdim=True)
+        x1_v = x
+        x1_e = torch.sparse.mm(incidence.t(), x) / prefix_normalizer[:, None]
+
+        pe2_s0 = self.pe2(
+            torch.zeros(1, dtype=torch.long, device=x.device)
+        ).view(1, self.dim)
+        pe2_s1 = self.pe2(
+            torch.ones(1, dtype=torch.long, device=x.device)
+        ).view(1, self.dim)
+        x0 = x0 + self.mlp2(torch.cat((self.norm2(x0), pe2_s0), dim=-1))
+        x1_v = x1_v + self.mlp2(
+            torch.cat((self.norm2(x1_v), pe2_s1.expand(x1_v.shape)), dim=-1)
+        )
+        x1_e = x1_e + self.mlp2(
+            torch.cat((self.norm2(x1_e), pe2_s1.expand(x1_e.shape)), dim=-1)
+        )
+        x_v = x0 + x1_v
+        x_e = x0 + x1_e
+
+        pe3_l1 = self.pe3(
+            torch.ones(1, dtype=torch.long, device=x.device)
+        ).view(1, self.dim)
+        pe3_l = self.pe3(edge_orders)
+        x_v = x_v + self.mlp3(
+            torch.cat((self.norm3(x_v), pe3_l1.expand(x_v.shape)), dim=-1)
+        )
+        x_e = x_e + self.mlp3(torch.cat((self.norm3(x_e), pe3_l), dim=-1))
+        return self.b((x_v, x_e), edge_orders)
+
+
+class LinearE2V(nn.Module):
+    """Equivariant (node, hyperedge)-to-node block.
+
+    Parameters
+    ----------
+    dim : int
+        Shared input/inner/output dimension.
+    max_k : int
+        Maximum hyperedge order.
+    hyper_dim : int
+        Hidden width of the hypernetworks.
+    hyper_layers : int
+        Number of layers in each hypernetwork MLP.
+    hyper_dropout : float
+        Dropout inside the hypernetworks.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        max_k: int,
+        hyper_dim: int,
+        hyper_layers: int,
+        hyper_dropout: float,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.max_k = max_k
+        self.mlp1 = InnerMLP(
+            dim * 2, dim, hyper_dim, hyper_layers, hyper_dropout
+        )
+        self.mlp2 = InnerMLP(
+            dim * 2, dim, hyper_dim, hyper_layers, hyper_dropout
+        )
+        self.mlp3 = InnerMLP(dim, dim, hyper_dim, hyper_layers, hyper_dropout)
+        self.norm1 = nn.LayerNorm(dim)
+        self.norm2 = nn.LayerNorm(dim)
+        self.norm3 = nn.LayerNorm(dim)
+        self.pe1 = PositionalEncoding(dim, max_k + 1)
+        self.pe2 = PositionalEncoding(dim, 2)
+        self.b = BiasV(dim)
+
+    def reset_parameters(self) -> None:
+        """Reset all submodules."""
+        for m in (
+            self.mlp1,
+            self.mlp2,
+            self.mlp3,
+            self.norm1,
+            self.norm2,
+            self.norm3,
+            self.b,
+        ):
+            m.reset_parameters()
+
+    def forward(
+        self,
+        x: tuple[torch.Tensor, torch.Tensor],
+        cache: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        """Aggregate node and hyperedge features back into node features.
+
+        Parameters
+        ----------
+        x : tuple of torch.Tensor
+            ``(x_v, x_e)`` node and hyperedge features.
+        cache : dict
+            Operators ``incidence`` (sparse ``[N, |E|]``), ``edge_orders``
+            ``[|E|]`` and ``suffix_normalizer`` (node degrees) ``[N]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Node features ``[N, dim]``.
+        """
+        incidence = cache["incidence"]
+        edge_orders = cache["edge_orders"]
+        suffix_normalizer = cache["suffix_normalizer"]
+        x_v, x_e = x
+
+        pe1_k1 = self.pe1(
+            torch.ones(1, dtype=torch.long, device=x_v.device)
+        ).view(1, self.dim)
+        pe1_k = self.pe1(edge_orders)
+        x_v = x_v + self.mlp1(
+            torch.cat((self.norm1(x_v), pe1_k1.expand(x_v.shape)), dim=-1)
+        )
+        x_e = x_e + self.mlp1(torch.cat((self.norm1(x_e), pe1_k), dim=-1))
+
+        x0 = torch.cat((x_v, x_e)).mean(dim=0, keepdim=True)
+        x1 = (x_v + torch.sparse.mm(incidence, x_e)) / (
+            1 + suffix_normalizer[:, None]
+        )
+
+        pe2_s0 = self.pe2(
+            torch.zeros(1, dtype=torch.long, device=x_v.device)
+        ).view(1, self.dim)
+        pe2_s1 = self.pe2(
+            torch.ones(1, dtype=torch.long, device=x_v.device)
+        ).view(1, self.dim)
+        x0 = x0 + self.mlp2(torch.cat((self.norm2(x0), pe2_s0), dim=-1))
+        x1 = x1 + self.mlp2(
+            torch.cat((self.norm2(x1), pe2_s1.expand(x1.shape)), dim=-1)
+        )
+        x = x0 + x1
+        x = x + self.mlp3(self.norm3(x))
+        return self.b(x)
+
+
+class EHNN(nn.Module):
+    """Equivariant Hypergraph Neural Network backbone (linear variant).
+
+    Builds the incidence-derived operator cache, then applies the V2E and E2V
+    equivariant blocks. The returned node embeddings are mapped to task logits by
+    the TopoBench readout.
+
+    Parameters
+    ----------
+    num_features : int
+        Dimension of the (encoded) input node features.
+    hidden_channels : int, optional
+        Shared hidden width of the two blocks and of the returned embedding
+        (default: 64).
+    max_edge_order : int, optional
+        Upper bound on hyperedge order used to size the order hypernetworks;
+        larger hyperedges are clamped to this value (default: 100).
+    dropout : float, optional
+        Dropout applied to the input and between the blocks (default: 0.5).
+    pe_dim : int or None, optional
+        Positional-encoding dimension of the bias hypernetwork; defaults to
+        ``hidden_channels`` when ``None`` (default: None).
+    hyper_dim : int or None, optional
+        Hidden width of the hypernetworks; defaults to ``hidden_channels`` when
+        ``None`` (default: None).
+    hyper_layers : int, optional
+        Number of layers in each hypernetwork MLP (default: 3).
+    hyper_dropout : float, optional
+        Dropout inside the hypernetworks (default: 0.0).
+    input_dropout : float, optional
+        Dropout applied to the input features (default: 0.0).
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        hidden_channels: int = 64,
+        max_edge_order: int = 100,
+        dropout: float = 0.5,
+        pe_dim: int | None = None,
+        hyper_dim: int | None = None,
+        hyper_layers: int = 3,
+        hyper_dropout: float = 0.0,
+        input_dropout: float = 0.0,
+    ):
+        super().__init__()
+        assert max_edge_order >= 1, (
+            "max_edge_order must be a positive integer."
+        )
+        dim = hidden_channels
+        pe_dim = pe_dim if pe_dim is not None else dim
+        hyper_dim = hyper_dim if hyper_dim is not None else dim
+        self.max_edge_order = max_edge_order
+
+        self.input_dropout = nn.Dropout(input_dropout)
+        self.input = nn.Linear(num_features, dim)
+        self.layer1 = LinearV2E(
+            dim, max_edge_order, pe_dim, hyper_dim, hyper_layers, hyper_dropout
+        )
+        self.layer2 = LinearE2V(
+            dim, max_edge_order, hyper_dim, hyper_layers, hyper_dropout
+        )
+        self.act = nn.ReLU(inplace=True)
+        self.dropout = nn.Dropout(dropout)
+
+    def reset_parameters(self) -> None:
+        """Reset all learnable parameters of the backbone."""
+        self.input.reset_parameters()
+        self.layer1.reset_parameters()
+        self.layer2.reset_parameters()
+
+    def _build_cache(self, incidence: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Derive the EHNN operator cache from a hypergraph incidence matrix.
+
+        Parameters
+        ----------
+        incidence : torch.Tensor
+            Node-hyperedge incidence ``[N, |E|]`` (sparse or dense).
+
+        Returns
+        -------
+        dict
+            Cache with ``incidence`` (sparse, coalesced, unsigned),
+            ``edge_orders`` (clamped hyperedge sizes), ``prefix_normalizer``
+            (hyperedge sizes) and ``suffix_normalizer`` (node degrees).
+        """
+        if not incidence.is_sparse:
+            incidence = incidence.to_sparse_coo()
+        incidence = incidence.coalesce()
+        incidence = torch.sparse_coo_tensor(
+            incidence.indices(),
+            incidence.values().abs(),
+            size=incidence.shape,
+        ).coalesce()
+
+        edge_sizes = torch.sparse.sum(incidence, dim=0).to_dense()
+        node_degrees = torch.sparse.sum(incidence, dim=1).to_dense()
+        edge_orders = (
+            edge_sizes.round().long().clamp(min=1, max=self.max_edge_order)
+        )
+        prefix_normalizer = edge_sizes.clone()
+        prefix_normalizer[prefix_normalizer == 0] = 1e-5
+        suffix_normalizer = node_degrees.clone()
+        suffix_normalizer[suffix_normalizer == 0] = 1e-5
+        return {
+            "incidence": incidence,
+            "edge_orders": edge_orders,
+            "prefix_normalizer": prefix_normalizer,
+            "suffix_normalizer": suffix_normalizer,
+        }
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        incidence: torch.Tensor,
+    ) -> tuple[torch.Tensor, None]:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Encoded node features ``[N, num_features]``.
+        incidence : torch.Tensor
+            Node-hyperedge incidence matrix ``[N, |E|]``.
+
+        Returns
+        -------
+        tuple
+            ``(x_0, None)`` node embeddings and the (unused) hyperedge slot,
+            matching the hypergraph wrapper's ``(nodes, hyperedges)`` contract.
+        """
+        cache = self._build_cache(incidence)
+        x = self.input(self.input_dropout(x))
+        x_v, x_e = self.layer1(x, cache)
+        x_v, x_e = self.dropout(self.act(x_v)), self.dropout(self.act(x_e))
+        x = self.layer2((x_v, x_e), cache)
+        return x, None


### PR DESCRIPTION
Add EHNN (Kim et al., ECCV 2022 (arXiv:2208.10428)) as a Track-2 TNN backbone for the 2026 TDL Challenge, with config, unit tests (100% backbone coverage), a pipeline-test entry, and the GraphUniverse evaluation results.json.

<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [ ] I linked to issues and PRs that are relevant to this PR.

## Description

Track-2 (TNN) submission for the 2026 TDL Challenge — **team LoopCounter**.

Adds **EHNN — Equivariant Hypergraph Neural Networks** (Kim, Oh, Cho, Hong — ECCV 2022, [arXiv:2208.10428](https://arxiv.org/abs/2208.10428); reference code [jw9730/ehnn](https://github.com/jw9730/ehnn)) as a **hypergraph** backbone.

Included:
- `topobench/nn/backbones/hypergraph/ehnn.py` — the EHNN-Linear (MLP) variant: the V2E and E2V maximally-expressive equivariant aggregation blocks with order-conditioned positional hypernetworks, all derived from the incidence matrix and its hyperedge sizes / node degrees (`Hᵀx / |e|` and `(x_v + H x_e)/(1+deg)`, plus global and order-conditioned bias terms).
- Reuses the existing `HypergraphWrapper` (no new wrapper needed).
- `configs/model/hypergraph/ehnn.yaml`
- `test/nn/backbones/hypergraph/test_ehnn.py` — **100% backbone coverage**; covers the operator cache, hyperedge-order clamping, sparse/dense incidence, and the building-block modules.
- `hypergraph/ehnn` added to `test/pipeline/test_pipeline.py`.
- `2026_tdl_challenge/outputs/.../results.json` — full 12×3×2 GraphUniverse grid (community detection + triangle counting, in-distribution + OOD).

## Issue

N/A — this is a model contribution for the 2026 TDL Challenge (Track 2 / `track-2-tnn`), not a bug fix.

## Additional context

The original input projection and MLP classifier head are provided by TopoBench's feature encoder and readout, so this backbone consumes pre-encoded node features and returns node embeddings (consistent with the existing EDGNN backbone).

`results.json` was generated via the evaluation notebook's own functions (`run_challenge_grid` + `save_challenge_artifacts`), because the published `2026_tdl_challenge/run_evaluation.ipynb` currently fails its own SHA-256 integrity check on `main` (embedded `expected_hash` `f87b2c…` ≠ the actual hash `3c1d78…` of the locked cells) — happy to open a separate issue for that.