### PR TITLE
Track: Track2; Team name: LoopCounter; Model: PhenomNN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-29_23-40-00/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-29_23-40-00/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-06-29_23-40-00",
+    "model_config": "hypergraph/phenomnn",
+    "generated_at_utc": "2026-06-30T01:48:27.871002+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.18692684173584,
+      "test_best_rerun_accuracy": 0.31816792488098145,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3167545199394226,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3228665292263031,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3219115436077118,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3407823443412781,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33856675028800964,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3380701243877411,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3392925262451172,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3752005398273468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3754679560661316,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38543814420700073,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39349836111068726,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1878914833068848,
+      "test_best_rerun_accuracy": 0.31843534111976624,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3162197172641754,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3243945240974426,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3228665292263031,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3429597318172455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3402475416660309,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3398273289203644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34020933508872986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3755825459957123,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37703415751457214,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3868897557258606,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39319276809692383,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.179628849029541,
+      "test_best_rerun_accuracy": 0.321682333946228,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3202689290046692,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3280617296695709,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3266865313053131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3455573320388794,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3423103392124176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3419283330440521,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3424249291419983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3776835501194,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.378447562456131,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3875773549079895,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39418596029281616,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1919827461242676,
+      "test_best_rerun_accuracy": 0.31667813658714294,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32225534319877625,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.321644127368927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3397127389907837,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3364275395870209,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3351287245750427,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3354725241661072,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3684391379356384,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3689739406108856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3780655562877655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38413935899734497,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1982126235961914,
+      "test_best_rerun_accuracy": 0.31515011191368103,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31679272651672363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32225534319877625,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3212239146232605,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3393307328224182,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33570173382759094,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33558714389801025,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33638933300971985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3692413568496704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3708839416503906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37921154499053955,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3855527639389038,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1905715465545654,
+      "test_best_rerun_accuracy": 0.3168691396713257,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31942853331565857,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32500573992729187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.323554128408432,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34017112851142883,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3382229208946228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33829933404922485,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33978912234306335,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3701581358909607,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3722209632396698,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3806631565093994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38658416271209717,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.150718927383423,
+      "test_best_rerun_accuracy": 0.3300863206386566,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32007792592048645,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31751853227615356,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3285965323448181,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35010313987731934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3468179404735565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3508671522140503,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3496447503566742,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39552295207977295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3957139551639557,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.410802960395813,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4224921762943268,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1497902870178223,
+      "test_best_rerun_accuracy": 0.33012452721595764,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3210711181163788,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3173275291919708,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3280235230922699,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3517839312553406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34796392917633057,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3524715304374695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34972113370895386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3938421607017517,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39540836215019226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4100007712841034,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4173733592033386,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1539158821105957,
+      "test_best_rerun_accuracy": 0.32874932885169983,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31969591975212097,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3173275291919708,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32554054260253906,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35079073905944824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3465123474597931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34960654377937317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34972113370895386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3932691514492035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3949499726295471,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40965697169303894,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4193597733974457,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1661152839660645,
+      "test_best_rerun_accuracy": 0.32523491978645325,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31652534008026123,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3258843421936035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34849873185157776,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.345328152179718,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34605392813682556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3458629250526428,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3912063539028168,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39174115657806396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4078615605831146,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4174497723579407,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1626460552215576,
+      "test_best_rerun_accuracy": 0.32580792903900146,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3193139135837555,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31641072034835815,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32771793007850647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.349148154258728,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34605392813682556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34792575240135193,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3485751450061798,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39009854197502136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3913591504096985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4042707681655884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41412636637687683,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1624903678894043,
+      "test_best_rerun_accuracy": 0.3258843421936035,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31996333599090576,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3162197172641754,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32661011815071106,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3487279415130615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3455573320388794,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34739094972610474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3475819528102875,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3889525532722473,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3926197588443756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40778517723083496,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4173733592033386,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0491509437561035,
+      "test_best_rerun_accuracy": 0.36481013894081116,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3179387152194977,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3148445188999176,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33016273379325867,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32771793007850647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3583161532878876,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36412253975868225,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3636641502380371,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42677056789398193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.429864764213562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4552677869796753,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46959277987480164,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0804505348205566,
+      "test_best_rerun_accuracy": 0.35476353764533997,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3163343369960785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3123997151851654,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32676294445991516,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3246237337589264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3480403423309326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35503095388412476,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35514554381370544,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4063717722892761,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4094659686088562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4303995668888092,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4414011836051941,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.032519817352295,
+      "test_best_rerun_accuracy": 0.36725494265556335,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3177095353603363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3133929371833801,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3315379321575165,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3276415169239044,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36194515228271484,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3675605356693268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3677515387535095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.43632057309150696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4400641620159149,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4676445722579956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4862479865550995,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.06315279006958,
+      "test_best_rerun_accuracy": 0.3575139343738556,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31912294030189514,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31679272651672363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33043012022972107,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32703033089637756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36209794878959656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3606845438480377,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3606463372707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4232943654060364,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4264267683029175,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44854459166526794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4636717736721039,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.088837146759033,
+      "test_best_rerun_accuracy": 0.3488425314426422,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3171747326850891,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3138895332813263,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32699212431907654,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32550233602523804,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3519367277622223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35281533002853394,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35445794463157654,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40396517515182495,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40801435708999634,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4253953695297241,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4376193881034851,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.065969228744507,
+      "test_best_rerun_accuracy": 0.35839253664016724,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.317862331867218,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3154939115047455,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3296279311180115,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3268393278121948,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3610665500164032,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3611047565937042,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3614867329597473,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42256855964660645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4275345802307129,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44934678077697754,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4673389792442322,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0480434894561768,
+      "test_best_rerun_accuracy": 0.3653067350387573,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3106043338775635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3058675229549408,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3257315158843994,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.321605920791626,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35720834136009216,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35121095180511475,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3582015335559845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41943615674972534,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4182901680469513,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44823896884918213,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46008098125457764,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.038599729537964,
+      "test_best_rerun_accuracy": 0.36916494369506836,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3167163133621216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3095729351043701,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33096492290496826,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32603713870048523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3597295582294464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3515547513961792,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3609519302845001,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41439375281333923,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4157307744026184,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44392237067222595,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4544273912906647,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0038509368896484,
+      "test_best_rerun_accuracy": 0.377607136964798,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3149973154067993,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30678433179855347,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33161434531211853,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32592251896858215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36905035376548767,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3591565489768982,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3730613589286804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4423179626464844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4423561692237854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47914278507232666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4954923987388611,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9848365783691406,
+      "test_best_rerun_accuracy": 0.3836427628993988,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3122469186782837,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3081595301628113,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32852011919021606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32603713870048523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.371915340423584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.366261750459671,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3787149488925934,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45698678493499756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45969897508621216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.49896860122680664,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5241805911064148,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.022226333618164,
+      "test_best_rerun_accuracy": 0.3692413568496704,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31366032361984253,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30838871002197266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32878753542900085,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.325425922870636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.364351749420166,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35762855410575867,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36767515540122986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.43425777554512024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43750476837158203,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.46703338623046875,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.48659178614616394,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9783462285995483,
+      "test_best_rerun_accuracy": 0.3836427628993988,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3107571303844452,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30242952704429626,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32920771837234497,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.323515921831131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37294673919677734,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36572694778442383,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3800901472568512,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4558025896549225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.461914598941803,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5028650164604187,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5314385890960693,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5877125263214111,
+      "test_best_rerun_accuracy": 0.5321261882781982,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28741690516471863,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2793567180633545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29643210768699646,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38834136724472046,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3791733384132385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3857055604457855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.395637571811676,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5407212376594543,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6030636429786682,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6414546370506287,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5844411849975586,
+      "test_best_rerun_accuracy": 0.5333486199378967,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2895561158657074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27928030490875244,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30731913447380066,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29753991961479187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38910534977912903,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3792879581451416,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.386087566614151,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39674535393714905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5384292006492615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.601459264755249,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6396974325180054,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5971429347991943,
+      "test_best_rerun_accuracy": 0.5293375849723816,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.288486510515213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27687370777130127,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30567651987075806,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29727253317832947,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3868897557258606,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3791733384132385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3887997567653656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39972496032714844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5384292006492615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6008480191230774,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6439758539199829,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5371137857437134,
+      "test_best_rerun_accuracy": 0.5474826097488403,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28416991233825684,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2754220962524414,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2985331118106842,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29318511486053467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38776835799217224,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37867674231529236,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3855145573616028,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.395599365234375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5391932129859924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.612002432346344,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6521506905555725,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5310941934585571,
+      "test_best_rerun_accuracy": 0.5489724278450012,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28665292263031006,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27809610962867737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.304530531167984,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2962411046028137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.391779363155365,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3824203610420227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3882649540901184,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.399381160736084,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5402246117591858,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6133394241333008,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6529528498649597,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5239003896713257,
+      "test_best_rerun_accuracy": 0.5528306365013123,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2870731055736542,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2738177180290222,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30456870794296265,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29356712102890015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39074796438217163,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3821147382259369,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39105355739593506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40056535601615906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5421346426010132,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.616624653339386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6582626700401306,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.321030855178833,
+      "test_best_rerun_accuracy": 0.6342730522155762,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27496370673179626,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26312169432640076,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2965849041938782,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29074031114578247,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39242875576019287,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37989914417266846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40132936835289,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41263657808303833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5529834032058716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5606234073638916,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6787760853767395,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3182096481323242,
+      "test_best_rerun_accuracy": 0.6376346349716187,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28107571601867676,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2653754949569702,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30048131942749023,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2886393070220947,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3944915533065796,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38177093863487244,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4040415585041046,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41401177644729614,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.554931640625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.558675229549408,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6845060586929321,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.340204119682312,
+      "test_best_rerun_accuracy": 0.6306058764457703,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2759568989276886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2636183202266693,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2991825342178345,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28879210352897644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3904423415660858,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37936434149742126,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40132936835289,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4143555760383606,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.547329843044281,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5544732213020325,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6754526495933533,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1481279134750366,
+      "test_best_rerun_accuracy": 0.6962334513664246,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2672854959964752,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25525251030921936,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29414013028144836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.282794713973999,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39430055022239685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38043394684791565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4034685492515564,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4208495616912842,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5604324340820312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5675376057624817,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6502024531364441,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.157596230506897,
+      "test_best_rerun_accuracy": 0.6938268542289734,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2721368968486786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2570478916168213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2933761179447174,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2842845022678375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3926961421966553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37921154499053955,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4027045667171478,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41683855652809143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5596684217453003,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5636793971061707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6451218724250793,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1498998403549194,
+      "test_best_rerun_accuracy": 0.6984872817993164,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26938650012016296,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2569715082645416,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.291160523891449,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2829093039035797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3939567506313324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3798227608203888,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40725037455558777,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4257773756980896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5608526468276978,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5648636221885681,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6489036679267883,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 127.40982818603516,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 124.80390930175781,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.08991636116841341,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104.87609100341797,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5519794263337788
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10522.1591796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7980401349781949
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134.56874084472656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.045355153638263083
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7245.1865234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9679607913744155
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.8185272216797,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13628542937968885
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169933.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.946072996005945
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13800.2841796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9676261519904291
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45309.46484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.322490381042083
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3414.02490234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6069377604166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 750576.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.490392011583317
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257414.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.283607543723894
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 126.39274597167969,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 125.98463439941406,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09076702766528391,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.09168243408203,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.45311411807411595
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11157.138671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8461993683636708
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.7897186279297,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05621493718501169
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7354.61328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9825802646960587
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.65110778808594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13786796872891705
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172021.96875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9945655013468326
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14400.91015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0097398791368672
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45527.51171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3336671135757854
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3475.715087890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6179049045138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753149.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.519498772666086
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259309.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.315131078078978
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 132.7816162109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 125.72525024414062,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09058015147272379,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.55795288085938,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3924102783203125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11307.4365234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8575985228242321
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171.02407836914062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05764208910318187
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7414.5439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9905870334418838
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160.57298278808594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13866406112960789
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172418.46875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.003772727800483
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14540.83203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.01955069634343
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45629.6015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3389000749654008
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3520.061767578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6257887586805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753832.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.527224047826431
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259957.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.325920604313314
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.2801403999328613,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.220306634902954,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.016948982288962917,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 198.3452911376953,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14290006566116378
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12940.955078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9814907150644672
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 377.3301696777344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1271756554357042
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8142.01904296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.087778095253006
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172.7839813232422,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14920896487326613
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177956.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.132370570546164
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16029.693359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1239442826654746
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47707.62109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.445416017927623
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3964.044189453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7047189670138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764662.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.649734030519326
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266484.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.434540524686736
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.7728404998779297,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.6972720623016357,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.014196168748955977,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205.13284301757812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14779023272159808
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13051.462890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9898720432783467
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 401.0680236816406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13517628031063048
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8179.86669921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0928345623538744
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.13233947753906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1538275815868213
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178315.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.140711354031209
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16147.896484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1322322594569485
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47792.5625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4497699779588906
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3988.879150390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7091340711805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765209.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.655918775380925
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266869.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.440944140748506
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.194457530975342,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.1481051445007324,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.016568974444740696,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195.4131622314453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14078758085839
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12894.1806640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9779431675436102
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 369.7420959472656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12461816513220951
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8132.68017578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0865304176060455
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174.8235626220703,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15097026133166694
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177827.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.12937829451514
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16014.9697265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1229119146376736
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47673.87109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4436860471449076
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3964.019287109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7047145399305556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764466.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.647519032159542
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266387.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.432923239811625
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5109.3349609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4911.7548828125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.372525967600493,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4955.177734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.5700127769272334
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5898.3720703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 31.044063527960525
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5842.86181640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.9692827153374621
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6487.30810546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8667078297219439
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5006.82080078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.323679447997625
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134470.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1225690251718374
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8948.65234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.627447226458421
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33943.671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7398980919062996
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4658.97021484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8282613715277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 672121.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.602930613214483
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211190.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5143865550064066
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5101.67138671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4917.2626953125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3729437008200607,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4672.95263671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.3666805740048633
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5573.078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 29.331990131578948
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6205.6591796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.091560222341591
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6469.76708984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8643643406604876
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4851.18603515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.18927982310557
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134130.515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1146785162780977
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9274.4248046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6502892164273945
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34345.35546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.760487747642114
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4665.78759765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8294733506944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 672122.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.602942632037374
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211658.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5221755237714873
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5054.07861328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4772.9375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.36199753507773985,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4675.31103515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.3683797083258287
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5625.197265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 29.606301398026314
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5435.119140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.8318568050640378
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6189.671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.826943470273881
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4927.52392578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.255202008446675
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133800.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1070046181265094
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8741.71875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.612937789230122
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33138.96875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.698650302424522
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4554.66943359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8097190104166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 670497.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.584553126025135
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210857.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.508844884179522
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 133.31124877929688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 131.20887756347656,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04422274269075718,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194.40895080566406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14006408559485883
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281.004150390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.478969212582237
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10293.990234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7807349438282138
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6760.84423828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9032524032439879
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257.462646484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.22233389160999567
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168107.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9036764321707227
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13437.8076171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9422106028037793
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43504.8125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.229986800963658
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3124.4765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5554625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743685.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.412444289220954
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253944.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.2258543528364365
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 139.19430541992188,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 137.00743103027344,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.046177091685296066,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202.4411163330078,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14585094836672033
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 283.13323974609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.4901749460320723
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10269.3115234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7788632175530906
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6795.25146484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9078492271000334
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 270.7131652832031,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.23377648124628939
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168195.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.905712645713357
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13466.466796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9442200811159024
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43589.3984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.234322540237839
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3156.9150390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5612293402777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744019.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.416225269504428
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254011.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.2269659111710185
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 140.9046173095703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 138.358642578125,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04663250508194304,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.301513671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15007313665120678
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 301.8733825683594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5888072766755756
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10177.7109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7719158845278726
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6739.234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9003653139612559
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.1663513183594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.24625764362552624
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167731.390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8949329050947425
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13404.5830078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9398810130285024
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43363.28125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2227321364498436
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3147.021728515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5594705295138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742903.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.40360550546927
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253643.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.2208433698600505
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5259.12890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5414.75732421875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7234144721735137,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1343.873779296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9682087747095641
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1881.90185546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.904746607730264
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6671.58642578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5059982120425673
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1073.4932861328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.36181101655976156
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1506.637451171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.3010686106838298
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151100.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5087511465493217
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9928.3896484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.696142872559073
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37383.84375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9162357757957866
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2779.94677734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4942127604166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 708144.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.010416784498263
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232997.515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.877282139766695
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5356.07958984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5511.11376953125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7362877447603541,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1176.3377685546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8475055969414175
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1659.1163330078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.732191226356909
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6701.734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5082847459233978
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1037.935791015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.34982669060182847
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1344.3299560546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.1609066978019753
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151879.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5268390505991083
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10113.314453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7091091328793296
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37971.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9463679023143166
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2788.40625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4957166666666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710837.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.040869653744782
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234274.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.898536435192119
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5158.6826171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5339.32177734375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7133362427980962,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1520.7362060546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.095631272373694
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2019.6087646484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 10.629519813939146
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5845.8642578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4433723365803944
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1906.96044921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6427234409230704
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1621.8253173828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.4005399977399071
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146522.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.402428652702954
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9211.7353515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6458936580817908
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37008.08203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8969748337305858
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2762.590087890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4911271267361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702601.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.94771105052996
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 228789.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.80726306516566
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 137.5102081298828,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 144.1934051513672,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12451934814453125,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146.90093994140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10583641206153188
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.429832458496094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18647280241313732
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11943.9345703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9058729291097839
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231.0826873779297,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0778842896454094
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7675.63330078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0254687108592184
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174323.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.048018283833365
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14979.837890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0503322038020615
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46453.578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.381135789891845
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3651.574462890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6491687934027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757778.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.571858421094307
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262136.421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3621789871532455
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 144.11155700683594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 151.7782440185547,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13106929535281062,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.36566162109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11409629799790616
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.881887435913086,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1414836180837531
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12293.095703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9323546229142965
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 290.9588928222656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09806501274764598
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7773.0048828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.038477606254175
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175612.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.077941769807728
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15377.34375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0782038809423644
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46677.91796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3926350898944078
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3714.163818359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6602957899305556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759752.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.594190808004253
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263453.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.38408799693808
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 147.4540557861328,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 154.39671325683594,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13333049504044553,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.09805297851562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10886026871650982
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30.837940216064453,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1623049485056024
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12107.1572265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9182523493790292
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257.0034484863281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08662064323772434
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7710.62646484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.03014381627839
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174872.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.060764211406279
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15222.0751953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.067317009908323
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46453.15234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3811139650289608
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3693.535888671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6566286024305555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758386.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.578738843704398
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262851.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.374074351421963
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112660.0234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78974.2421875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8338807864457551,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64010.140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 46.11681601224784
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67557.0703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 355.5635279605263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38768.4609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9403459186575653
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69005.84375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.257783535557802
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47923.875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.402655310621243
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64145.98828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 55.393772263601036
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42814.07421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.0019684629610155
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40501.48046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.076040825708647
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52776.1796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.382431944444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 481375.40625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.445238354467609
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124850.6796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.077624343725559
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112433.4140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78714.1484375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8278410839099943,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67129.8671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 48.36445762788185
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70894.4609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 373.1287417763158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40708.97265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.0875216273227153
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71445.359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 24.07999978934951
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50783.046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.784642201068804
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67595.40625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 58.372544257340245
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44887.578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.1473550781797783
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42271.80859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.166785001473679
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55865.66015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.931672916666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 476626.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.391516690610048
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123632.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0573551099961724
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112698.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78769.078125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8291166200306521,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65250.578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 47.010502971902014
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68911.640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 362.6928453947368
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39269.95703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9783812689609404
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69591.890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.45530523255814
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49199.0859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.573024173346694
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65743.5078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 56.773322808721936
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43450.69140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.0466057640057493
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41184.23828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1110378943692654
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54231.69140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.641189583333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 478959.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.417904723255998
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124179.7578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.066459617800742
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8413.830078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8077.69189453125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5663786211282604,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5080.91552734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.660601964945065
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6182.24072265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 32.538109066611845
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5003.3564453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3794733746918847
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4533.939453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5281224985254467
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6138.34033203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8200855487015698
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5334.00341796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.606220568194084
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133782.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.106592440901913
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31957.65625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.638098121379876
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4577.01171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8136909722222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 666271.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.53674790448288
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208874.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4758496725908175
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8681.609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8225.35546875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5767322583613799,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5024.62890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.6200496442723344
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6170.1611328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 32.47453227796053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4755.24853515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3606559374407471
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4456.416015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5019939385321874
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6021.7607421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8045104531980628
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5400.21484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.6633979652417965
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133622.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1028737750789523
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31649.560546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6223056305743504
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4608.775390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8193378472222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 666242.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.536421275296087
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209139.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.48025664386867
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8342.001953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7930.72900390625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.556074113301518,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4822.5146484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.474434184753242
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5921.10693359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 31.163720703125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5137.0615234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.38961407079541144
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4264.12109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.437182707701382
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6082.45458984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8126191836798597
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5169.5712890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.464223911107513
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134330.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1193274835129112
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32141.90625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6475424803936645
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4482.20556640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7968365451388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668149.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.557991527436852
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209205.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4813697622851247
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27161.05859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27611.2109375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4153063169562765,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12761.181640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.193934899585734
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14314.16015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 75.33768503289474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6390.12255859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.48465093353005306
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14729.0703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.964297375294911
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9582.3466796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.280206637232799
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12860.212890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.105537902094127
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111866.4140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.5976782013398663
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10168.9541015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7130103843473917
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9602.0166015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.707025173611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 614057.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.946114668054252
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181300.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0169955319255153
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27289.28125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27720.2890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4208974864165258,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13388.0908203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.645598573712176
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15081.4169921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 79.37587890625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6503.48583984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4932488312357793
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14760.7265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.974966822548028
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10167.052734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.3583236786072144
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13681.5595703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.814818281789723
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111864.0546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.5976234136982166
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10416.4521484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7303640547214626
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10290.8115234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8294776041666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612188.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.924973558589641
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180705.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0070942123042617
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27319.45703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27727.7890625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4212819243682402,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12186.9609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.780231222982708
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13779.9287109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 72.52594058388158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6019.333984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4565289332100872
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13680.45703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.610871935035389
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9378.328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2529496492985972
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12438.1923828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 10.741098776176598
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113359.2109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.632342813893275
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9909.072265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.694788407349951
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9327.22265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.6581729166666668
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 617119.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.980755036593781
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183004.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0453588604329953
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2672.75341796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2829.7470703125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5030661458333333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 447.3961486816406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.322331519223084
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 686.3916625976562,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.612587697882401
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8853.232421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6714624514125901
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282.3326721191406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09515762457672418
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6170.35107421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8243622009644288
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 532.459716796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4598097727088731
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161921.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.760009810979008
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11907.455078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8349078024207685
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41287.2421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1163177091342456
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 731022.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.26920961392713
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 246044.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.094402894263891
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2680.539794921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2840.750732421875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5050223524305556,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 473.04376220703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3408096269503107
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742.1088256835938,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.9058359246504932
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8672.7001953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6577702082148275
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 300.3287353515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1012230318003244
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6112.10302734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8165802307740481
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 600.37646484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5184598142001295
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161637.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.75342586034739
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11939.9052734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8371830930751297
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41021.42578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.102692387167461
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 730391.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.262069726140515
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245672.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.088212489391443
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2614.11962890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2767.4892578125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4919980902777778,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 568.1101684570312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.40930127410448935
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 866.6616821289062,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.561377274362664
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8054.7568359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6109030592292378
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 459.87823486328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.15499771987303043
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5946.9482421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7945154632181028
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 691.775634765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5973882856352547
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158609.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6831057408740477
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11251.03125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7888817311737484
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40314.125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.066437285355477
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 725095.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.20215801499949
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 242404.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.033818674804054
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 487410.15625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 319653.0625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.615862159655215,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434247.59375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 312.85849693804033
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 441927.53125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2325.934375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 372246.03125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 28.23253934395146
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 472122.625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 159.12457869902258
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 378414.71875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 50.5564086506346
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 431711.40625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 372.80777741796203
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 213626.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.960685331715586
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376676.59375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 26.411204161407937
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 296069.09375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 15.176026128966118
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 396687.4375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 70.5222111111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 190930.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.177244281779908
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 493347.15625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 321208.375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6334555953983463,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 402340.4375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 289.87063220461096
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 409997.75,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2157.882894736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 342971.25,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 26.01222980659841
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 437930.28125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 147.60036442534548
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349547.84375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 46.6997787241149
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 400201.03125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 345.59674546632124
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196937.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.573141501602266
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 346967.9375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 24.328140337961017
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 272066.375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.945685324721923
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 366498.40625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 65.15527222222222
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177852.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9596261211788395
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 489441.75,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 319590.625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6151558770629957,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 417461.53125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 300.7647919668588
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 424842.40625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2236.0126644736843
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 355858.125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 26.9896188850967
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 452891.03125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 152.64274730367376
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 363710.9375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 48.59197561790247
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415681.3125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 358.9648639896373
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204223.65625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.742329004504923
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 360271.875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 25.26096445098864
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 284049.78125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 14.559935478497104
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 381814.34375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 67.87810555555555
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183486.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0533691008104107
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 109838.5234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 106810.7109375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.777423509185762,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130196.34375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 93.8014003962536
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134969.078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 710.3635690789474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93287.71875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.0752915244596135
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140831.96875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 47.466116868891135
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104113.1875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 13.909577488309953
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129512.203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 111.84128076424871
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82594.4140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.917945710163942
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96060.4140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.73540976458421
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77711.6875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.9833762622379414
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111872.9453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 19.88852361111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 408759.78125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.62382250885151
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111341.0,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107097.8828125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7822022999767029,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121424.3203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 87.4814987842219
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126273.0234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 664.5948601973685
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84575.4296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.414518747629883
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129700.359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 43.71431054095046
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96594.5078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 12.905077864061456
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121313.546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 104.76126673143351
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80883.78125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8782226743916033
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87680.1328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.147814669225915
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72334.6328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.707757076861961
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104289.1640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 18.54029583333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 417277.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.720173877017748
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "phenomnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 110451.4765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 106808.0234375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7773787868387334,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126962.34375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 91.47142921469741
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132052.9375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 695.0154605263158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88763.53125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.732160125142207
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135152.40625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 45.551872682844625
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101877.84375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 13.610934368737475
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127548.4140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 110.14543528713298
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80959.7421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8799865824702768
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92379.2734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.477301461050343
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76268.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.909391178430468
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110337.84375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 19.615616666666668
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 409920.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.636952012375145
+        }
+      },
+      "output_dir": "/home/sud/temp_/topo/TopoBench/logs/train/runs/notebook_gu_grid_2026-06-29_23-40-00__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/hypergraph/phenomnn.yaml
+++ b/configs/model/hypergraph/phenomnn.yaml
@@ -1,0 +1,41 @@
+_target_: topobench.model.TBModel
+
+model_name: phenomnn
+model_domain: hypergraph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.hypergraph.phenomnn.PhenomNN
+  num_features: ${model.feature_encoder.out_channels}
+  num_layers: 1 # number of stacked unfolded energy-descent blocks
+  prop_step: 16 # number of unfolded iterations within each block
+  lam0: 10.0 # clique-expansion energy weight
+  lam1: 10.0 # star-expansion energy weight
+  alpha: null # step size; null -> 1 / (1 + lam0 + lam1) as in the reference
+  dropout: 0.5
+  compatibility: true # learnable compatibility matrices (full PhenomNN)
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.HypergraphWrapper
+  _partial_: true
+  wrapper_name: HypergraphWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: 1
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: 1
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/hypergraph/test_phenomnn.py
+++ b/test/nn/backbones/hypergraph/test_phenomnn.py
@@ -1,0 +1,156 @@
+"""Unit tests for the PhenomNN backbone."""
+
+import pytest
+import torch
+
+from ...._utils.nn_module_auto_test import NNModuleAutoTest
+from topobench.nn.backbones.hypergraph import PhenomNN
+from topobench.nn.backbones.hypergraph.phenomnn import (
+    PhenomNNConv,
+    build_expansion_operators,
+)
+
+
+def _toy_incidence(sparse=True):
+    """Build a small node-hyperedge incidence matrix.
+
+    Hyperedges: {0, 1, 2} and {2, 3} over 4 nodes.
+
+    Parameters
+    ----------
+    sparse : bool, optional
+        Whether to return a sparse COO tensor (default: True).
+
+    Returns
+    -------
+    torch.Tensor
+        Incidence matrix of shape ``(4, 2)``.
+    """
+    dense = torch.tensor(
+        [[1.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
+    )
+    return dense.to_sparse_coo() if sparse else dense
+
+
+def test_PhenomNN():
+    """Test the PhenomNN backbone end to end with the auto-test harness."""
+    torch.manual_seed(0)
+    x = torch.randn(4, 6)
+    incidence = _toy_incidence(sparse=True)
+    auto_test = NNModuleAutoTest(
+        [
+            {
+                "module": PhenomNN,
+                "init": (x.shape[1],),
+                "forward": (x, incidence),
+                "assert_shape": x.shape,
+            },
+        ]
+    )
+    auto_test.run()
+
+
+def test_build_expansion_operators_properties():
+    """Test shape, symmetry and finiteness of the expansion operators."""
+    incidence = _toy_incidence(sparse=False)
+    n = incidence.shape[0]
+    a_beta, a_gamma, d_beta, d_gamma = build_expansion_operators(incidence)
+
+    for adj in (a_beta, a_gamma):
+        assert adj.shape == (n, n)
+        assert torch.allclose(adj, adj.t(), atol=1e-6)  # symmetric
+        assert torch.isfinite(adj).all()
+    assert d_beta.shape == (n,)
+    assert d_gamma.shape == (n,)
+    # Node 3 only shares hyperedge {2,3}; node 0 shares {0,1,2}. The clique
+    # adjacency must therefore connect 0 with 1 and 2 but not with 3.
+    assert a_beta[0, 1] > 0
+    assert a_beta[0, 2] > 0
+    assert torch.isclose(a_beta[0, 3], torch.tensor(0.0))
+
+
+def test_sparse_and_dense_incidence_match():
+    """Test that sparse and dense incidence inputs give identical operators."""
+    a_sparse = build_expansion_operators(_toy_incidence(sparse=True))
+    a_dense = build_expansion_operators(_toy_incidence(sparse=False))
+    for s, d in zip(a_sparse, a_dense):
+        assert torch.allclose(s, d, atol=1e-6)
+
+
+def test_full_variant_has_parameters():
+    """Test that the full variant exposes learnable compatibility matrices."""
+    model = PhenomNN(num_features=6, compatibility=True)
+    names = [n for n, _ in model.named_parameters()]
+    assert any("H_beta" in n for n in names)
+    assert any("H_gamma" in n for n in names)
+
+
+def test_simple_variant_is_parameter_free():
+    """Test that the simple variant has no learnable backbone parameters."""
+    model = PhenomNN(num_features=6, compatibility=False)
+    assert sum(p.numel() for p in model.parameters()) == 0
+    out, hyper = model(torch.randn(4, 6), _toy_incidence())
+    assert out.shape == (4, 6)
+    assert hyper is None
+
+
+def test_forward_shapes_full():
+    """Test forward output shapes for the full variant."""
+    model = PhenomNN(num_features=6, compatibility=True, prop_step=4)
+    out, hyper = model(torch.randn(4, 6), _toy_incidence())
+    assert out.shape == (4, 6)
+    assert hyper is None
+    assert torch.isfinite(out).all()
+
+
+def test_multiple_layers():
+    """Test that num_layers controls the number of stacked blocks."""
+    model = PhenomNN(num_features=6, num_layers=3)
+    assert len(model.convs) == 3
+    out, _ = model(torch.randn(4, 6), _toy_incidence())
+    assert out.shape == (4, 6)
+
+
+def test_alpha_default_resolution():
+    """Test that alpha defaults to 1 / (1 + lam0 + lam1)."""
+    model = PhenomNN(num_features=6, lam0=10.0, lam1=10.0, alpha=None)
+    assert pytest.approx(model.convs[0].alpha) == 1.0 / 21.0
+    # Explicit alpha is respected.
+    model2 = PhenomNN(num_features=6, alpha=0.25)
+    assert model2.convs[0].alpha == 0.25
+
+
+def test_invalid_num_layers():
+    """Test that a non-positive num_layers raises an assertion error."""
+    with pytest.raises(AssertionError):
+        PhenomNN(num_features=6, num_layers=0)
+
+
+def test_invalid_prop_step():
+    """Test that a non-positive prop_step raises an assertion error."""
+    with pytest.raises(AssertionError):
+        PhenomNN(num_features=6, prop_step=0)
+
+
+def test_reset_parameters_reinitializes_identity():
+    """Test that reset_parameters re-centers compatibility matrices on identity."""
+    model = PhenomNN(num_features=6, compatibility=True)
+    with torch.no_grad():
+        model.convs[0].H_beta.add_(5.0)
+    model.reset_parameters()
+    # After reset, H_beta should be close to the identity (plus small noise).
+    diff = model.convs[0].H_beta - torch.eye(6)
+    assert diff.abs().mean() < 0.5
+
+
+def test_conv_repr():
+    """Test the PhenomNNConv repr string."""
+    conv = PhenomNNConv(
+        channels=6,
+        prop_step=4,
+        lam0=10.0,
+        lam1=10.0,
+        alpha=0.05,
+        compatibility=False,
+    )
+    assert "PhenomNNConv" in repr(conv)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "hypergraph/phenomnn"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/hypergraph/phenomnn.py
+++ b/topobench/nn/backbones/hypergraph/phenomnn.py
@@ -1,0 +1,331 @@
+"""PhenomNN: from hypergraph energy functions to hypergraph neural networks.
+
+This module implements PhenomNN, introduced in
+
+    Yuxin Wang, Quan Gan, Xipeng Qiu, Xuanjing Huang, David Wipf.
+    "From Hypergraph Energy Functions to Hypergraph Neural Networks."
+    ICML 2023. https://arxiv.org/abs/2306.09623
+
+Reference implementation: https://github.com/yxzwang/PhenomNN
+(``models/phenomnn.py``, ``models/phenomnn_s.py`` and the operator construction
+``B2A`` in ``train_faster.py``).
+
+Notes
+-----
+PhenomNN defines a hypergraph-regularized energy whose two smoothness terms
+correspond to the **clique expansion** (subscript :math:`\\beta`) and the
+**star expansion** (subscript :math:`\\gamma`) of the hypergraph, plus a fidelity
+term to the encoded input features :math:`Y^{(0)}`. A single PhenomNN layer is an
+unfolded proximal-gradient step that minimizes this energy, iterated for
+``prop_step`` steps (Eq. (6) of the paper):
+
+.. math::
+
+    \\hat Y = \\lambda_0\\big(A_\\beta Y (H_\\beta+H_\\beta^\\top) - D_\\beta Y H_\\beta H_\\beta^\\top\\big)
+            + Y^{(0)}
+            + \\lambda_1\\big(L_\\gamma Y + A_\\gamma Y (H_\\gamma+H_\\gamma^\\top)
+                              - D_\\gamma Y H_\\gamma H_\\gamma^\\top\\big),
+
+    Y \\leftarrow (1-\\alpha) Y + \\alpha\\, \\tilde Q^{-1} \\hat Y,
+    \\qquad \\tilde Q = \\lambda_0 D_\\beta + \\lambda_1 D_\\gamma + I,
+
+with :math:`L_\\gamma = D_\\gamma - A_\\gamma` and learnable compatibility matrices
+:math:`H_\\beta, H_\\gamma`. Setting ``compatibility=False`` (i.e. :math:`H = I`)
+recovers the parameter-free *PhenomNN_simple* update
+:math:`\\hat Y = \\lambda_0 A_\\beta Y + Y^{(0)} + \\lambda_1 A_\\gamma Y`.
+
+Both expansion operators are reconstructed from the node-hyperedge incidence
+matrix :math:`B` (TopoBench's ``incidence_hyperedges``):
+
+* clique (node-normalized):
+  :math:`A_\\beta = \\hat D^{-1/2}(BB^\\top + I)\\hat D^{-1/2}`,
+* star (edge-size normalized):
+  :math:`A_\\gamma = \\hat D^{-1/2}(B D_E^{-1} B^\\top + I)\\hat D^{-1/2}`,
+  with :math:`D_E = \\mathrm{diag}(\\mathbf{1}^\\top B)` the hyperedge sizes,
+
+and :math:`D_\\beta, D_\\gamma` are the row-sum degrees of the renormalized
+adjacencies. The input/output linear maps of the original architecture are
+provided by TopoBench's feature encoder and readout, so the backbone operates on
+pre-encoded, equal-dimensional node features (as EDGNN does).
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+def _renormalize(adj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Symmetrically normalize a dense adjacency and return its degree vector.
+
+    Computes :math:`\\hat A = \\hat D^{-1/2} A \\hat D^{-1/2}` with
+    :math:`\\hat D = \\mathrm{diag}(A\\mathbf{1})`, then returns the renormalized
+    adjacency together with its (recomputed) row-sum degree vector.
+
+    Parameters
+    ----------
+    adj : torch.Tensor
+        Dense ``(n, n)`` adjacency matrix (already including self-loops).
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        The renormalized adjacency ``(n, n)`` and its degree vector ``(n,)``.
+    """
+    deg = adj.sum(dim=1)
+    deg_inv_sqrt = deg.pow(-0.5)
+    deg_inv_sqrt.masked_fill_(torch.isinf(deg_inv_sqrt), 0.0)
+    adj = deg_inv_sqrt.unsqueeze(1) * adj * deg_inv_sqrt.unsqueeze(0)
+    deg = adj.sum(dim=1)
+    return adj, deg
+
+
+def build_expansion_operators(
+    incidence: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build the clique- and star-expansion operators from a hypergraph incidence.
+
+    Parameters
+    ----------
+    incidence : torch.Tensor
+        Node-hyperedge incidence matrix :math:`B` of shape
+        ``(n_nodes, n_hyperedges)`` (sparse or dense; values are treated as
+        unsigned membership).
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        ``(A_beta, A_gamma, D_beta, D_gamma)`` where the adjacencies are dense
+        ``(n, n)`` tensors and the degree vectors are ``(n,)``.
+    """
+    if incidence.is_sparse:
+        incidence = incidence.to_dense()
+    b = incidence.abs()
+    n = b.shape[0]
+    identity = torch.eye(n, device=b.device, dtype=b.dtype)
+
+    # Clique expansion (node-normalized): A_beta = D^-1/2 (B B^T + I) D^-1/2.
+    a_beta = b @ b.t() + identity
+    a_beta, d_beta = _renormalize(a_beta)
+
+    # Star expansion (edge-size normalized): A_gamma = D^-1/2 (B D_E^-1 B^T + I) D^-1/2.
+    edge_size_inv = b.sum(dim=0).pow(-1)
+    edge_size_inv.masked_fill_(torch.isinf(edge_size_inv), 0.0)
+    a_gamma = (b * edge_size_inv.unsqueeze(0)) @ b.t() + identity
+    a_gamma, d_gamma = _renormalize(a_gamma)
+
+    return a_beta, a_gamma, d_beta, d_gamma
+
+
+class PhenomNNConv(nn.Module):
+    """A single unfolded PhenomNN energy-descent layer.
+
+    Parameters
+    ----------
+    channels : int
+        Node feature dimension.
+    prop_step : int
+        Number of unfolded iterations (``T`` in the paper).
+    lam0 : float
+        Weight :math:`\\lambda_0` of the clique-expansion energy term.
+    lam1 : float
+        Weight :math:`\\lambda_1` of the star-expansion energy term.
+    alpha : float
+        Step size of the unfolded update.
+    compatibility : bool
+        If ``True``, use learnable compatibility matrices :math:`H_\\beta,
+        H_\\gamma`; if ``False``, reduce to the parameter-free simple update.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        prop_step: int,
+        lam0: float,
+        lam1: float,
+        alpha: float,
+        compatibility: bool,
+    ):
+        super().__init__()
+        self.channels = channels
+        self.prop_step = prop_step
+        self.lam0 = lam0
+        self.lam1 = lam1
+        self.alpha = alpha
+        self.compatibility = compatibility
+
+        if compatibility:
+            self.H_beta = nn.Parameter(torch.empty(channels, channels))
+            self.H_gamma = nn.Parameter(torch.empty(channels, channels))
+        else:
+            self.register_parameter("H_beta", None)
+            self.register_parameter("H_gamma", None)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Initialize each compatibility matrix as identity plus small noise."""
+        if self.compatibility:
+            bound = 1.0 / self.channels
+            for h in (self.H_beta, self.H_gamma):
+                nn.init.normal_(h, mean=0.0, std=bound)
+                with torch.no_grad():
+                    h.add_(torch.eye(self.channels, device=h.device))
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        operators: tuple[
+            torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+        ],
+    ) -> torch.Tensor:
+        """Run the unfolded energy descent.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Encoded node features ``(n, channels)`` used as both the initial
+            iterate and the fidelity anchor :math:`Y^{(0)}`.
+        operators : tuple of torch.Tensor
+            ``(A_beta, A_gamma, D_beta, D_gamma)`` from
+            :func:`build_expansion_operators`.
+
+        Returns
+        -------
+        torch.Tensor
+            Smoothed node features ``(n, channels)``.
+        """
+        a_beta, a_gamma, d_beta, d_gamma = operators
+        q_inv = (self.lam0 * d_beta + self.lam1 * d_gamma + 1.0).pow(-1)
+        q_inv = q_inv.unsqueeze(1)
+
+        y = y0 = x
+        if self.compatibility:
+            h_beta = self.H_beta + self.H_beta.t()
+            hh_beta = self.H_beta @ self.H_beta.t()
+            h_gamma = self.H_gamma + self.H_gamma.t()
+            hh_gamma = self.H_gamma @ self.H_gamma.t()
+            d_beta_col = d_beta.unsqueeze(1)
+            d_gamma_col = d_gamma.unsqueeze(1)
+
+        for _ in range(self.prop_step):
+            if self.compatibility:
+                beta_term = self.lam0 * (
+                    a_beta @ y @ h_beta - d_beta_col * (y @ hh_beta)
+                )
+                # L_gamma @ Y = D_gamma Y - A_gamma Y
+                l_gamma_y = d_gamma_col * y - a_gamma @ y
+                gamma_term = self.lam1 * (
+                    l_gamma_y
+                    + a_gamma @ y @ h_gamma
+                    - d_gamma_col * (y @ hh_gamma)
+                )
+                y_hat = beta_term + y0 + gamma_term
+            else:
+                y_hat = (
+                    self.lam0 * (a_beta @ y) + y0 + self.lam1 * (a_gamma @ y)
+                )
+            y = (1 - self.alpha) * y + self.alpha * (q_inv * y_hat)
+        return y
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(channels={self.channels}, "
+            f"prop_step={self.prop_step}, lam0={self.lam0}, lam1={self.lam1}, "
+            f"alpha={self.alpha:.4g}, compatibility={self.compatibility})"
+        )
+
+
+class PhenomNN(nn.Module):
+    """PhenomNN hypergraph backbone.
+
+    Stacks ``num_layers`` unfolded energy-descent blocks (each a
+    :class:`PhenomNNConv`), with dropout and a ReLU nonlinearity between blocks.
+    The expansion operators are built once per forward pass from the hypergraph
+    incidence matrix and shared across blocks.
+
+    Parameters
+    ----------
+    num_features : int
+        Dimension of the (encoded) input node features and of every block.
+    num_layers : int, optional
+        Number of stacked PhenomNN blocks (default: 1).
+    prop_step : int, optional
+        Number of unfolded iterations within each block (default: 16).
+    lam0 : float, optional
+        Clique-expansion energy weight :math:`\\lambda_0` (default: 10.0).
+    lam1 : float, optional
+        Star-expansion energy weight :math:`\\lambda_1` (default: 10.0).
+    alpha : float or None, optional
+        Step size; if ``None`` it defaults to ``1 / (1 + lam0 + lam1)`` as in the
+        reference implementation (default: None).
+    dropout : float, optional
+        Dropout applied before each block (default: 0.5).
+    compatibility : bool, optional
+        Use learnable compatibility matrices (full PhenomNN) when ``True``;
+        otherwise the parameter-free PhenomNN_simple update (default: True).
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        num_layers: int = 1,
+        prop_step: int = 16,
+        lam0: float = 10.0,
+        lam1: float = 10.0,
+        alpha: float | None = None,
+        dropout: float = 0.5,
+        compatibility: bool = True,
+    ):
+        super().__init__()
+        assert num_layers >= 1, "num_layers must be a positive integer."
+        assert prop_step >= 1, "prop_step must be a positive integer."
+
+        resolved_alpha = (
+            alpha if alpha is not None else 1.0 / (1.0 + lam0 + lam1)
+        )
+        self.dropout = dropout
+        self.convs = nn.ModuleList(
+            [
+                PhenomNNConv(
+                    channels=num_features,
+                    prop_step=prop_step,
+                    lam0=lam0,
+                    lam1=lam1,
+                    alpha=resolved_alpha,
+                    compatibility=compatibility,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def reset_parameters(self) -> None:
+        """Reset all learnable parameters of the backbone."""
+        for conv in self.convs:
+            conv.reset_parameters()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        incidence: torch.Tensor,
+    ) -> tuple[torch.Tensor, None]:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Encoded node features ``(n_nodes, num_features)``.
+        incidence : torch.Tensor
+            Node-hyperedge incidence matrix ``(n_nodes, n_hyperedges)``.
+
+        Returns
+        -------
+        tuple
+            ``(x_0, None)`` where ``x_0`` is the updated node embedding; the
+            second element follows the hypergraph wrapper's ``(nodes, hyperedges)``
+            return contract (PhenomNN produces no hyperedge embedding).
+        """
+        operators = build_expansion_operators(incidence)
+        h = x
+        for conv in self.convs:
+            h = F.dropout(h, p=self.dropout, training=self.training)
+            h = F.relu(conv(h, operators))
+        return h, None


### PR DESCRIPTION
Add PhenomNN (Wang et al., ICML 2023 (arXiv:2306.09623)) as a Track-2 TNN backbone for the 2026 TDL Challenge, with config, unit tests (100% backbone coverage), a pipeline-test entry, and the GraphUniverse evaluation results.json.

<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [ ] I linked to issues and PRs that are relevant to this PR.

## Description

Track-2 (TNN) submission for the 2026 TDL Challenge — **team LoopCounter**.

Adds **PhenomNN — From Hypergraph Energy Functions to Hypergraph Neural Networks** (Wang, Gan, Qiu, Huang, Wipf — ICML 2023, [arXiv:2306.09623](https://arxiv.org/abs/2306.09623); reference code [yxzwang/PhenomNN](https://github.com/yxzwang/PhenomNN)) as a **hypergraph** backbone.

Included:
- `topobench/nn/backbones/hypergraph/phenomnn.py` — the unfolded hypergraph-energy descent (Eq. 6) with learnable compatibility matrices H_β/H_γ over the clique and star expansions; a `compatibility=False` switch recovers the parameter-free PhenomNN_simple update. Both expansion operators are reconstructed from `incidence_hyperedges` per the reference `B2A` (node-normalized clique `BBᵀ`, edge-size-normalized star `B D_E⁻¹ Bᵀ`).
- Reuses the existing `HypergraphWrapper` (no new wrapper needed).
- `configs/model/hypergraph/phenomnn.yaml`
- `test/nn/backbones/hypergraph/test_phenomnn.py` — **100% backbone coverage**; covers both variants, operator symmetry/normalization, and sparse == dense incidence equivalence.
- `hypergraph/phenomnn` added to `test/pipeline/test_pipeline.py`.
- `2026_tdl_challenge/outputs/.../results.json` — full 12×3×2 GraphUniverse grid (community detection + triangle counting, in-distribution + OOD).

## Issue

N/A — this is a model contribution for the 2026 TDL Challenge (Track 2 / `track-2-tnn`), not a bug fix.

## Additional context

`results.json` was generated via the evaluation notebook's own functions (`run_challenge_grid` + `save_challenge_artifacts`), because the published `2026_tdl_challenge/run_evaluation.ipynb` currently fails its own SHA-256 integrity check on `main` (embedded `expected_hash` `f87b2c…` ≠ the actual hash `3c1d78…` of the locked cells) — happy to open a separate issue for that.
