### PR TITLE
Track: Track1; Team name: TopoCoop; Model: CoGNN

### DIFF
--- a/2026_tdl_challenge/results.json
+++ b/2026_tdl_challenge/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-04_23-22-40",
+    "model_config": "graph/cognn",
+    "generated_at_utc": "2026-07-05T01:22:28.494190+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2316112518310547,
+      "test_best_rerun_accuracy": 0.3089617192745209,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30323171615600586,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33218732476234436,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32958972454071045,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3309267461299896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32385972142219543,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3466269373893738,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34697073698043823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39281076192855835,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38872334361076355,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43345558643341064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4435785710811615,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4581846513246235,
+        "AvgTime/train_epoch_std": 0.021262474952271158,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2173733711242676,
+      "test_best_rerun_accuracy": 0.31262892484664917,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3094201385974884,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32974252104759216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3299335241317749,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33436474204063416,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3274887204170227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3469325304031372,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34632134437561035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3848651647567749,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3845595419406891,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41863396763801575,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4324241876602173,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.474292849118893,
+        "AvgTime/train_epoch_std": 0.021491027649189094,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2154788970947266,
+      "test_best_rerun_accuracy": 0.31381312012672424,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30705171823501587,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3326839208602905,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3297043442726135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3365803360939026,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32958972454071045,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35052335262298584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3476201295852661,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3971273601055145,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3925051689147949,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43700817227363586,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4472457766532898,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4796463103776567,
+        "AvgTime/train_epoch_std": 0.027489492829941797,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.255795955657959,
+      "test_best_rerun_accuracy": 0.30269691348075867,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30537092685699463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3215295374393463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32317212224006653,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3274887204170227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32118573784828186,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3378409445285797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34047672152519226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.377607136964798,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3792879581451416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4139353632926941,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4339139759540558,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5018123749530676,
+        "AvgTime/train_epoch_std": 0.0414945027078386,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2301437854766846,
+      "test_best_rerun_accuracy": 0.30919092893600464,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3111773133277893,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32863473892211914,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3277943432331085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3309267461299896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3249293267726898,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33967453241348267,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33868134021759033,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3779509365558624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37894415855407715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40828177332878113,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42501336336135864,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5230188686235817,
+        "AvgTime/train_epoch_std": 0.040995454340620005,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2259342670440674,
+      "test_best_rerun_accuracy": 0.30907630920410156,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31274351477622986,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3274887204170227,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32741233706474304,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33207273483276367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3268393278121948,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3422721326351166,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34467872977256775,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3882267475128174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3870425522327423,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4215371608734131,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43819236755371094,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5375084989475754,
+        "AvgTime/train_epoch_std": 0.02367646505377202,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.121371030807495,
+      "test_best_rerun_accuracy": 0.34265413880348206,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30334633588790894,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.294216513633728,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33856675028800964,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.329284131526947,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3190465271472931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3697379529476166,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3651157319545746,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40747955441474915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4038887619972229,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4842616021633148,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5065321922302246,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.530459364758262,
+        "AvgTime/train_epoch_std": 0.024631452071836035,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.121110200881958,
+      "test_best_rerun_accuracy": 0.3431507349014282,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30296432971954346,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2981129288673401,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33585453033447266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32878753542900085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3184735178947449,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36599433422088623,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36400794982910156,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39945757389068604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39731836318969727,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.475246399641037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49736419320106506,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.527593978246053,
+        "AvgTime/train_epoch_std": 0.024155300667277297,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.113807201385498,
+      "test_best_rerun_accuracy": 0.3451753258705139,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30877071619033813,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3016655147075653,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.339559942483902,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3297807276248932,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3164489269256592,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3638169467449188,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35747575759887695,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39078617095947266,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3867751657962799,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4609977900981903,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47467339038848877,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5323243229477495,
+        "AvgTime/train_epoch_std": 0.02562253960699549,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1381287574768066,
+      "test_best_rerun_accuracy": 0.3405531346797943,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30074870586395264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29818931221961975,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3383757472038269,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33314234018325806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32363054156303406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3609137535095215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3638169467449188,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4109175503253937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.41019177436828613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4749789834022522,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.507601797580719,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.530916222504207,
+        "AvgTime/train_epoch_std": 0.022516232692268268,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.129988193511963,
+      "test_best_rerun_accuracy": 0.3399801254272461,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30678433179855347,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30510351061820984,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3390633463859558,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3272213339805603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3198487162590027,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3569791316986084,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3576667308807373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3984261453151703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3982733488082886,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.46332797408103943,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49587440490722656,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5216205298900605,
+        "AvgTime/train_epoch_std": 0.023777953269157506,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1337902545928955,
+      "test_best_rerun_accuracy": 0.3361601233482361,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3041103184223175,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29685232043266296,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33696234226226807,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32943692803382874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3188173174858093,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35640615224838257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3612193465232849,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4066391587257385,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4093131721019745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4751317799091339,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5066086053848267,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5192107316609975,
+        "AvgTime/train_epoch_std": 0.025124875209727858,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9448506832122803,
+      "test_best_rerun_accuracy": 0.40339216589927673,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27740851044654846,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2651081085205078,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27737030386924744,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2703797221183777,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38830316066741943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40052714943885803,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3983497619628906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5576820373535156,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5512261986732483,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6268240213394165,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6482542753219604,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5118963636201004,
+        "AvgTime/train_epoch_std": 0.02351917900905185,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9682567119598389,
+      "test_best_rerun_accuracy": 0.3977767527103424,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27293911576271057,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2623959183692932,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28054091334342957,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2787073254585266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38230574131011963,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41049736738204956,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40996256470680237,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5499274134635925,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.543433427810669,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6217434406280518,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6472228765487671,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4998098541708553,
+        "AvgTime/train_epoch_std": 0.023403825464739993,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9657676219940186,
+      "test_best_rerun_accuracy": 0.40083277225494385,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26908090710639954,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2582702934741974,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2766444981098175,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2740468978881836,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38276416063308716,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41236916184425354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41538697481155396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5529451966285706,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5498892068862915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6275498270988464,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6570020914077759,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5244827563302559,
+        "AvgTime/train_epoch_std": 0.02074371618627408,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.003235340118408,
+      "test_best_rerun_accuracy": 0.3888379633426666,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2769501209259033,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2708381116390228,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29605013132095337,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3010161221027374,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39728015661239624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4081289768218994,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42516615986824036,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5435479879379272,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5466040372848511,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6146764755249023,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6547864675521851,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5223323685107846,
+        "AvgTime/train_epoch_std": 0.02300746360733431,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0127594470977783,
+      "test_best_rerun_accuracy": 0.38249674439430237,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2772939205169678,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27370309829711914,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3010925352573395,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30758652091026306,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39445334672927856,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4066391587257385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4237145781517029,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5375506281852722,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5420582294464111,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6070746183395386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6446252465248108,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5154822447213783,
+        "AvgTime/train_epoch_std": 0.021230920520958416,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.011519432067871,
+      "test_best_rerun_accuracy": 0.38490334153175354,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2784017026424408,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2704178988933563,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3034227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3057529330253601,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39498814940452576,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40854915976524353,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4221101701259613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5392314195632935,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5433570146560669,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6092138290405273,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.646267831325531,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5236563628370112,
+        "AvgTime/train_epoch_std": 0.028952681867791163,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8512767553329468,
+      "test_best_rerun_accuracy": 0.4396057724952698,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2532660961151123,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24367789924144745,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.294178307056427,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2915807068347931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.378447562456131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3545725345611572,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.447780579328537,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5177630186080933,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5129116177558899,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6232714653015137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6565436720848083,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5159276723861694,
+        "AvgTime/train_epoch_std": 0.020413309709073978,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8675739765167236,
+      "test_best_rerun_accuracy": 0.4378485679626465,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25265491008758545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2450913041830063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29127511382102966,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.291160523891449,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37688136100769043,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35296812653541565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44380778074264526,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.514401376247406,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5065321922302246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.620521068572998,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.653907835483551,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4923583136664496,
+        "AvgTime/train_epoch_std": 0.020829193607990296,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8458869457244873,
+      "test_best_rerun_accuracy": 0.44312018156051636,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25330430269241333,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24677209556102753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2924211025238037,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29074031114578247,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38643136620521545,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3599969446659088,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4499961733818054,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5324318408966064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5195966362953186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6292688250541687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.663152277469635,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5014232180335305,
+        "AvgTime/train_epoch_std": 0.057253872371117176,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8203661441802979,
+      "test_best_rerun_accuracy": 0.45274657011032104,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2486439049243927,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24436549842357635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28187790513038635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28841012716293335,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38467416167259216,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36805716156959534,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4296737611293793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5432041883468628,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5402628183364868,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6277790665626526,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6770570874214172,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5160463039691632,
+        "AvgTime/train_epoch_std": 0.02340240797881036,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8168630599975586,
+      "test_best_rerun_accuracy": 0.4552677869796753,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24543510377407074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24176789820194244,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2774467170238495,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2824891209602356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38085415959358215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36599433422088623,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4291771650314331,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5374742150306702,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5364046096801758,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6260982751846313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.673771858215332,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5187863297418718,
+        "AvgTime/train_epoch_std": 0.02475241457110755,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8109266757965088,
+      "test_best_rerun_accuracy": 0.4553059935569763,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2460463047027588,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24268469214439392,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27290090918540955,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2814195156097412,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38383376598358154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37008175253868103,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4315837621688843,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.539728045463562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5394988059997559,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6327450275421143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6808770895004272,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5810767141255466,
+        "AvgTime/train_epoch_std": 0.03213124787729899,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4447462558746338,
+      "test_best_rerun_accuracy": 0.5833142399787903,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2418442964553833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2339750975370407,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24600809812545776,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24952250719070435,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39025136828422546,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3774925470352173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3828023672103882,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3970509469509125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5822446346282959,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6570402383804321,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6942088603973389,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5973637012334971,
+        "AvgTime/train_epoch_std": 0.03623476399479197,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4923620223999023,
+      "test_best_rerun_accuracy": 0.5717778205871582,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2357322871685028,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22855068743228912,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2418442964553833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2532660961151123,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3826495409011841,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3696615397930145,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37432193756103516,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3927725553512573,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5728856325149536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6413782835006714,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6835128664970398,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5282440761039997,
+        "AvgTime/train_epoch_std": 0.03959849569618631,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4383180141448975,
+      "test_best_rerun_accuracy": 0.5859500169754028,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23729848861694336,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23466269671916962,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23825348913669586,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24203529953956604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3887615501880646,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37634655833244324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37309953570365906,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39170295000076294,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.585415244102478,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6553594470024109,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6913439035415649,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.511880804191936,
+        "AvgTime/train_epoch_std": 0.020314502438040862,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4287256002426147,
+      "test_best_rerun_accuracy": 0.5847658514976501,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23332569003105164,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22958208620548248,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24696309864521027,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25590190291404724,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38291695713996887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37241193652153015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.378447562456131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4062189757823944,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5775078535079956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.654748260974884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7002062797546387,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.513651778823451,
+        "AvgTime/train_epoch_std": 0.026603618533197527,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4580657482147217,
+      "test_best_rerun_accuracy": 0.5760180354118347,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23577049374580383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23214149475097656,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25594010949134827,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2668271064758301,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38031935691833496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3725265562534332,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38150355219841003,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4067537486553192,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5728856325149536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6426770687103271,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6913439035415649,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5462882816791534,
+        "AvgTime/train_epoch_std": 0.06989110568652966,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4425702095031738,
+      "test_best_rerun_accuracy": 0.5788830518722534,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23160669207572937,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22641149163246155,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2383299022912979,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2422644942998886,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3816945552825928,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3706929385662079,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36790433526039124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3903277516365051,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5728474259376526,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6466116309165955,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6954312920570374,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5216509480225413,
+        "AvgTime/train_epoch_std": 0.027699074925166066,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1692111492156982,
+      "test_best_rerun_accuracy": 0.6635342836380005,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22694629430770874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21922989189624786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24478569626808167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.245244100689888,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3826495409011841,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3621361553668976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4104209542274475,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42436397075653076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5673848390579224,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.565589427947998,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7090686559677124,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.523116711342689,
+        "AvgTime/train_epoch_std": 0.024439337236403787,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.213088035583496,
+      "test_best_rerun_accuracy": 0.6495530605316162,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2225532829761505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21472229063510895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24295209348201752,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24608449637889862,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3678279519081116,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3480021357536316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4038887619972229,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41783177852630615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5552754402160645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5496600270271301,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6958896517753601,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5271721611852231,
+        "AvgTime/train_epoch_std": 0.0282485120502962,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2177648544311523,
+      "test_best_rerun_accuracy": 0.6502788662910461,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22060509026050568,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21380548179149628,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24554969370365143,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24887309968471527,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3697761595249176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3502941429615021,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40778517723083496,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.422262966632843,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5539765954017639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.551149845123291,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6964244842529297,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4965979634669788,
+        "AvgTime/train_epoch_std": 0.03305715368603604,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.001002311706543,
+      "test_best_rerun_accuracy": 0.7075788974761963,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22843609750270844,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21621209383010864,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23344029486179352,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2323324978351593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3771105408668518,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36305293440818787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4010237455368042,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4299793839454651,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5576820373535156,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5648636221885681,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6550920605659485,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4964931805928547,
+        "AvgTime/train_epoch_std": 0.02326011149368551,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.037467360496521,
+      "test_best_rerun_accuracy": 0.7059744596481323,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22324088215827942,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21441668272018433,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22992588579654694,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23393689095973969,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37092214822769165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35663533210754395,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39242875576019287,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42054396867752075,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.558789849281311,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5621514320373535,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6464206576347351,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4926074660650575,
+        "AvgTime/train_epoch_std": 0.026508631336850413,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0300191640853882,
+      "test_best_rerun_accuracy": 0.7010084986686707,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22434869408607483,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21720528602600098,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23225609958171844,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23034609854221344,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37420734763145447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3599969446659088,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39659255743026733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42505156993865967,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5574527978897095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5581786036491394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6471846699714661,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4910768826802572,
+        "AvgTime/train_epoch_std": 0.022366435433294172,
+        "model/params/total": 31941,
+        "model/params/trainable": 31941,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 145.71583557128906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 142.23013305664062,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.10247127741832898,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79.55883026123047,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.41873068558542353
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11793.1298828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8944353343050815
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221.57142639160156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07467860680539318
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7446.96826171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9949189394413828
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165.1235809326172,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14259376591763143
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173614.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.031547159460338
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14877.7685546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0431754701085052
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45656.18359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.340262627184889
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3517.59130859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6253495659722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754817.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.538371152562696
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260763.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.339340168572047
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9561044619633601,
+        "AvgTime/train_epoch_std": 0.013312990798478563,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 147.40249633789062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.77659606933594,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.10574682713929102,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.8180923461914,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.39904259129574426
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11834.6171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.897581887561623
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232.69395446777344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07842735236527584
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7464.8916015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9973135072227789
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165.65850830078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14305570665007017
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173930.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.03888870344139
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14956.240234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0486776212575375
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45720.18359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3435431643728535
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3542.61376953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6297980034722223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755588.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.547089748085472
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261156.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.345865731033564
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9513909816741943,
+        "AvgTime/train_epoch_std": 0.012433979131755684,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 150.12295532226562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 148.3229217529297,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.10686089463467557,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65.28742218017578,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.34361801147460935
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11935.6767578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.905246625545127
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239.1394805908203,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08059975752976754
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7517.42431640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.004331905999499
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.9627685546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.140727779408193
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174137.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.043685706158276
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15052.9697265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0554599443670243
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45879.10546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.351689244387206
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3570.443359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6347454861111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 756052.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.55233631777202
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261448.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.350736306641372
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9563077796589244,
+        "AvgTime/train_epoch_std": 0.014678672175425586,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.5169284343719482,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.5735342502593994,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.01880807500136526,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211.43946838378906,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1523339109393293
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13214.03515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0022021354759196
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 425.1053161621094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1432778281638387
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8221.8681640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.098445980502672
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181.9023895263672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15708323793295959
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178779.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.151478758359651
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16273.73046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.141055284584911
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47876.1015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4540520561023116
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4006.324951171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.712235546875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765668.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.661110906869677
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267243.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.447169387449454
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9617615910463555,
+        "AvgTime/train_epoch_std": 0.028228795239234564,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 4.725049018859863,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.760919570922852,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.025057471425909746,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 219.96702575683594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1584776842628501
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13246.8779296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0046930549630262
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 433.4317321777344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14608416992845782
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8252.755859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1025725931028725
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188.69012451171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.16294483982013708
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178899.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.154266759938696
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16320.7451171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.144351782161513
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47931.828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.456908510174791
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4037.281982421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7177390190972223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765970.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.664531322466432
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267379.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.4494335862746075
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9647450599264591,
+        "AvgTime/train_epoch_std": 0.020597119642104606,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.723485231399536,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.767277717590332,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.01982777746100175,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211.14019775390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1521182980935924
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13121.119140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9951550353147516
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 406.34930419921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13695628722589104
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8202.4345703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.095849641992318
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.78321838378906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.156116768897918
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178500.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.145014542309121
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16177.5400390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1343107585936405
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47798.0234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.450049896842483
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4003.06005859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7116551215277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765100.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.65468790651901
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266877.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.441067387216481
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9625221135323507,
+        "AvgTime/train_epoch_std": 0.01882624865892353,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5100.7724609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4785.19677734375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.36292732478905954,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6372.99853515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.591497503714877
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7743.66015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 40.75610608552632
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5127.73388671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7282554387323052
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6651.13330078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8885949633642285
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6889.4755859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.949460782329448
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130625.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.033290567527401
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8244.2177734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.578054815133747
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30742.150390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5757932436631812
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5629.81396484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.0008558159722223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 656797.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.429585251631732
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205180.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.414379586640707
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9659139156341553,
+        "AvgTime/train_epoch_std": 0.013542656125259844,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5128.9833984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4830.86767578125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3663911775336557,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6544.7919921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.715268005898775
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7860.3359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 41.37018914473684
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5236.93798828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7650616745133973
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6678.89501953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8923039438251503
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7081.04736328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.114894096097798
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130153.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.022323605563812
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8245.087890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5781158246126069
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30601.81640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5685999490619713
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5704.3037109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.0140984375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 656500.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.426227758107757
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204792.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4079226677816052
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9620700412326388,
+        "AvgTime/train_epoch_std": 0.02008156973456525,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5003.4423828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4714.0810546875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.35753364085608647,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6120.24267578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.409396740476405
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7424.06494140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 39.074026007401315
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4834.328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.6293657313784968
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6524.7451171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.871709434493988
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6633.97607421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.728822171173359
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131360.78125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.050361816134126
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8243.8193359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5780268781333263
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30923.396484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5850836272681839
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5473.5732421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9730796875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 658959.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.454043556214156
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206255.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.432276065847936
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9634060348783221,
+        "AvgTime/train_epoch_std": 0.01142419552027994,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 145.5990447998047,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 144.19656372070312,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04860012258871019,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240.43569946289062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.17322456733637653
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361.898193359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.9047273334703947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10167.4853515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7711403376232461
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6638.4228515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8868968405561122
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 324.75653076171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2804460541983754
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167342.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8859009265279583
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13308.76953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9331629176307671
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43011.78515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2047150113409195
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3084.79638671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5484082465277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741316.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.385646556112349
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252857.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.207765463531526
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.969107985496521,
+        "AvgTime/train_epoch_std": 0.021835248353914864,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 149.37576293945312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 147.9585723876953,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.049868072931478026,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229.61891174316406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16543149261034876
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 326.8538818359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7202835886101975
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10325.6259765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7831343175246492
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6723.4853515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.898261236013694
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 307.5356140136719,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.26557479621215185
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168121.578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9039935473945757
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13510.1337890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9472818531105385
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43273.58203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.218134298592957
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3141.543701171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5584966579861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743085.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.405658603214823
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253814.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.223696759605944
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9667408333884345,
+        "AvgTime/train_epoch_std": 0.018969923546441968,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 146.10812377929688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 145.21923828125,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04894480562226154,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 237.7941131591797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1713214071752015
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 341.300048828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7963160464638157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10255.1962890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7777926650786879
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6697.220703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8947522649465598
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 317.6872253417969,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2743412999497382
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167673.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8935802671605053
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13449.4345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9430258428209578
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43151.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2118863809651956
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3139.882080078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5582012586805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742021.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.393627761501307
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253459.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.21778560938878
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9622162797234275,
+        "AvgTime/train_epoch_std": 0.01735260169300437,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5331.00537109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5502.10498046875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.735084165727288,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1307.431640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9419536315742075
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1864.6424560546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.813907663445724
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7150.6416015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5423315587078119
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 825.807373046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2783307627390883
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1540.935791015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.3306872115851685
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153072.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.554530756548393
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10356.8154296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7261825430996705
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37486.8125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9215137885078681
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2860.019287109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5084478732638888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710147.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.033069437688766
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234691.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.905476719418235
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9607182343800863,
+        "AvgTime/train_epoch_std": 0.013930072831855576,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5351.59521484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5517.7880859375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.737179436998998,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1290.2491455078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9295743123255134
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1835.96875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.662993421052631
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7166.1806640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5435100996634433
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 796.2921142578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2683829168378202
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1518.108642578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.310974648167638
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153424.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.562718424902471
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10464.9404296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7337638781157972
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37516.48828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.923034921382439
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2859.817626953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5084120225694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710967.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.042346554981165
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 235215.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9141869165293794
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9479649066925049,
+        "AvgTime/train_epoch_std": 0,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5426.70458984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5591.63720703125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7470457190422511,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1175.4234619140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8468468745778548
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1679.0538330078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.837125436883223
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7410.5517578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5620441227009859
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 705.0831909179688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.23764178999594499
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1380.38330078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.1920408469613557
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154464.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5868590934423183
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10594.3935546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7428406643309143
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37944.515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9449749154236506
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2827.046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5025861111111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713087.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.066329762564619
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236272.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9317747595393806
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9683866024017334,
+        "AvgTime/train_epoch_std": 0.024905685949260365,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 148.5265655517578,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 156.54229736328125,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13518333105637415,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.82888793945312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10938680687280485
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.61089324951172,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.20321522762900904
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12276.7236328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9311129035125142
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 283.4631652832031,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09553864687671154
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7693.00439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.027789498267368
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175338.03125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.071568624605239
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15340.8701171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0756464813621862
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46392.5859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.378009428340766
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3671.501220703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.652711328125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758421.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.579133343891044
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262917.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.375173689115205
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9678064187367758,
+        "AvgTime/train_epoch_std": 0.01851938124007356,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 150.1970672607422,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 158.5614776611328,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.1369270100700629,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160.59410095214844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11570180183872365
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36.33686828613281,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1912466751901727
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12347.0078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9364435200985969
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.1402587890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10048542594845382
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7720.80517578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.031503697499165
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175690.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.079761735440275
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15428.388671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.081782966756065
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46464.83984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.381713047503716
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3696.333740234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6571259982638888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759259.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.588614781172584
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263347.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.382339145158338
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9701837698618571,
+        "AvgTime/train_epoch_std": 0.007290013064501839,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 151.7571563720703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 159.30859375,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13757218803972365,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.10968017578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11967556208629773
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34.30971145629883,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18057742871736226
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12390.369140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9397322063424346
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 297.1221923828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10014229605082996
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7764.64404296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0373605935829993
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175771.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.081642656859558
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15445.4599609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0829799439726195
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46555.32421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3863511312086727
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3708.141357421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6592251302083333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759309.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.589180372838026
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263357.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.382500353618558
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.965558926264445,
+        "AvgTime/train_epoch_std": 0.01022798496072926,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 111401.0,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78298.15625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8181812244566227,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72857.4609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 52.49096609329971
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77591.328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 408.3754111842105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39453.41015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9922950440841865
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68390.6171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.050427093865856
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56131.65234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.49921875
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74422.890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 64.26847204231433
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43620.65625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.0585230858224652
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45875.671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3515132438874367
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62043.01953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 11.029870138888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 471919.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.338275072678529
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122259.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.034510571114772
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9712462084633964,
+        "AvgTime/train_epoch_std": 0.006341844142737057,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 111499.1484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78313.609375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8185400653678245,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74778.7265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 53.87516322946686
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79475.9296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 418.29436677631577
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40631.63671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.0816561788964734
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70370.203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.717628286147622
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57804.3125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.722687040748163
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76269.2265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 65.86288995034542
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45015.15234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.1563001222654608
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47029.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4106804471654106
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63678.92578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 11.320697916666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 469367.78125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.309410102032737
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121672.6796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0247396483367446
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9708972771962484,
+        "AvgTime/train_epoch_std": 0.010561549110232162,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112047.4375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78586.5625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8248783786921792,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71308.4375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 51.37495497118156
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75928.546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 399.62393092105265
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38350.1953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9086230802047783
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66823.4765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.522236792214358
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54860.73828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.329423952070808
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72813.2265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 62.8784339917962
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42531.23828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.9821370271525733
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45127.67578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.313172165731201
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60707.0859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.792370833333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 474004.28125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.361857417169101
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122985.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.046586904880768
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9536550641059875,
+        "AvgTime/train_epoch_std": 0.00990973312320548,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8525.076171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8124.658203125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5696717292893704,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5066.26220703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.6500448177458575
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6238.78759765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 32.83572419819079
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5146.2548828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3903113297544558
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3967.761962890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.3372975945030754
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6209.90673828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8296468588218103
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5480.81005859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.73299659636766
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134878.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1320407562000745
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31959.93359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6382148543620894
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4701.82421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8358798611111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 667266.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.548005299593905
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209834.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4918293312033017
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.969516708737328,
+        "AvgTime/train_epoch_std": 0.013005930620444821,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8349.515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8003.529296875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5611786072693171,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5349.1123046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.8538273088526656
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6539.1552734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 34.41660670230263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5203.53271484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3946554960063519
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4210.22314453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.4190169007520221
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6303.6376953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8421693647712091
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5753.42822265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.968418154280009
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133898.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.10928392915196
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31596.6171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.619591839023015
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4843.05615234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8609877604166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 664628.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.518171753221044
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208196.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.464569500607392
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9753931760787964,
+        "AvgTime/train_epoch_std": 0.017933849418704427,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8514.4833984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8147.81494140625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5712953962562228,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5318.4013671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.8317012731898417
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6527.08837890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 34.35309673108553
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4939.1220703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.37460159805176335
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4166.447265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.4042626442955848
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6234.31103515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8329072859260187
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5751.189453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.9664848472582035
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133838.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1079051673091214
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31464.2109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6128049073504536
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4851.90087890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.86256015625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 664734.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.5193679795934525
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208835.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.475200678531609
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9759392738342285,
+        "AvgTime/train_epoch_std": 0.016834901989597282,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27356.20703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 26360.39453125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.3511914773309754,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18399.619140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 13.256209755493515
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19068.892578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 100.36259251644736
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38909.375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.9510333712552144
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78626.9453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 26.50048712925514
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13181.2783203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.7610258276970607
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17495.9140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 15.108734078151986
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79185.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.838787183029909
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51496.78125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.610768563315103
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19110.923828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.3974975694444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 530046.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.99580118887368
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128408.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.136836341171185
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.963176904580532,
+        "AvgTime/train_epoch_std": 0.022246290217297748,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27380.83984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27823.9609375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4262115401865805,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12844.41015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.253897807096541
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14799.9150390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 77.89428967927631
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5539.46826171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.42013411162068637
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11044.90234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.7225825223289517
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10023.57421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.339154872244489
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13539.75390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.692360886226252
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115870.3046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.690653554883429
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9096.0927734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.637785217601844
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10215.9912109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8161762152777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 618466.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.99598500616495
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184714.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.073803313197877
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.977760124206543,
+        "AvgTime/train_epoch_std": 0.02624510356664391,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27466.44921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27925.232421875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4314025537892767,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13027.0302734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.385468496712896
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14999.7783203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 78.94620168585526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5646.8935546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.42828164995733786
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11191.30078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.7719247661779574
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10202.7158203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.3630882859468938
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13727.880859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.854819394969775
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115727.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6873298317620287
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9262.4326171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6494483674931637
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10415.974609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8517288194444443
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 617721.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.98756758820402
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184594.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0718058883730217
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.14436936378479,
+        "AvgTime/train_epoch_std": 0,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2686.611328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2830.062744140625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.503122265625,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 595.886474609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4293130220528638
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 888.0501098632812,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.673947946648848
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8792.65625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6668681266590822
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376.0146789550781,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1267322814139124
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6084.27490234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8128623784026386
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710.4411010742188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6135069957463029
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160634.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.730144378134869
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11701.912109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.820495870801781
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40547.73828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.078411926867087
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728092.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.236065235342693
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244031.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.060892855657065
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9844379305839539,
+        "AvgTime/train_epoch_std": 0.01609817455613737,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2644.466064453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2803.813232421875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4984556857638889,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 598.8924560546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.43147871473680655
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 923.3316650390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.859640342310855
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8572.7021484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.650185980162116
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 317.3017883300781,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10694364284802094
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5924.9892578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7915817311706747
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 746.2710571289062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6444482358626134
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160459.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.726063243080067
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11755.2587890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8242363475713435
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40153.4609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.058201903608591
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 726545.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.218566536203522
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244037.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.060992960910588
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.963828961054484,
+        "AvgTime/train_epoch_std": 0.011766167689471162,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2669.7939453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2832.916748046875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5036296440972222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 560.9679565429688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.40415558828744147
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 855.3569946289062,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.501878919099506
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8771.513671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6652645939988624
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.6011047363281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09625921966172164
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6035.958984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8064073459418838
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 696.9280395507812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6018376852770132
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161234.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7440745895643692
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11916.6845703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8355549411241411
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40509.80859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0764677120175303
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728071.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.235818495978643
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244863.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.074740142362671
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9656716414860317,
+        "AvgTime/train_epoch_std": 0.014370889283207849,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 501300.0625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 323782.1875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.662570133366515,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 362393.875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 261.0906880403458
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 372823.0625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1962.2266447368422
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276113.25,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 20.94146757679181
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 355984.9375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 119.98144169194472
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 316307.71875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 42.25888026052104
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 366416.3125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 316.4216860967185
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162745.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.779160450143972
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282475.875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 19.806189524610854
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 246417.171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 12.630948376390384
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 333699.78125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 59.32440555555556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153614.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.55627319321718
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9652505397796631,
+        "AvgTime/train_epoch_std": 0.012854040742525719,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 496686.34375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 321750.46875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.639587669536102,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 388789.3125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 280.10757384726224
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 400159.59375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2106.103125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 299116.25,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 22.68610163064088
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 382728.375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 128.9950707785642
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 340664.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 45.512892451569805
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 392419.09375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 338.8765921848014
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176209.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.091805945801598
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 305123.71875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.394174642406394
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267190.46875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.695754203188272
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 359584.28125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 63.926094444444445
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162894.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7107098580533506
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9773964698498065,
+        "AvgTime/train_epoch_std": 0.014282387055377078,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 497709.15625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 321867.0,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.640905851611371,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 386088.65625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 278.16185608789624
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 397348.6875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2091.3088815789474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 296743.15625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 22.506117273416763
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 380234.03125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 128.1543752106505
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 338041.375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 45.1625083500334
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389951.28125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 336.7454933074266
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174669.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.056038323773918
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 303173.1875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.257410426307672
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 264913.46875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.579038841047721
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 357082.8125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 63.48138888888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162176.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.6987541706188742
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9663667380809784,
+        "AvgTime/train_epoch_std": 0.013528724267456771,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 112271.109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108723.9921875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8092621800792106,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130504.5703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 94.02346564301153
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136892.75,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 720.4881578947368
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82200.890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.2344247724687145
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124989.6171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 42.12659831058308
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105611.4296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.109743445223781
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133013.375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 114.86474525043178
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79146.6328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8378839126068178
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86895.890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.092826435633151
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79151.0546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.057155912014967
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114547.46875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.363994444444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 408917.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.625602355123695
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9642528533935547,
+        "AvgTime/train_epoch_std": 0.006131086284728812,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 110132.703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 106735.5703125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.776173103564475,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130911.90625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 94.31693533861672
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137281.75,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 722.5355263157895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82733.8203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.274844164770573
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124546.3984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 41.977215516514995
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106604.078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.242361806947228
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132771.046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 114.65548089378238
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81120.8515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8837277438812001
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86075.4921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.035303056198289
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80551.9765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.128964916833256
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115149.171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.47096388888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 412562.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.666832927049987
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9693695068359375,
+        "AvgTime/train_epoch_std": 0.01138067666848975,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "cognn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 110334.6484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 106950.0703125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7797425708901202,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129912.15625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 93.59665435878962
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136098.828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 716.3096217105264
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81515.75,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.182461130072052
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123496.9765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 41.623517547185706
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105454.421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.08876711756847
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131962.40625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 113.95717292746114
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80180.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8619017624930336
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85224.2734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.975618667613238
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79364.03125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.068072748475063
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114154.375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.29411111111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 411545.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.655334448491567
+        }
+      },
+      "output_dir": "/kaggle/working/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-04_23-22-40__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9764393397739956,
+        "AvgTime/train_epoch_std": 0.015041170281662193,
+        "model/params/total": 30706,
+        "model/params/trainable": 30706,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/graph/cognn.yaml
+++ b/configs/model/graph/cognn.yaml
@@ -1,0 +1,49 @@
+# Co-GNN(mu, mu) — "Cooperative Graph Neural Networks" (Finkelshtein et al., ICML 2024)
+# https://arxiv.org/abs/2310.01267
+# Variant with MeanGNN action and environment networks (paper notation: Co-GNN(mu, mu)).
+_target_: topobench.model.TBModel
+
+model_name: cognn
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.CoGNN
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_layers: 3
+  env_conv_type: mean_gnn   # environment network eta (paper: mu)
+  act_conv_type: mean_gnn   # action network pi (paper: mu)
+  act_num_layers: 1
+  act_hidden_channels: 16
+  dropout: 0.0
+  temp: 0.01                # Gumbel-softmax temperature tau
+  learn_temp: false
+  layer_norm: false
+  skip: false
+  act: relu
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/graph/cognn_sum.yaml
+++ b/configs/model/graph/cognn_sum.yaml
@@ -1,0 +1,49 @@
+# Co-GNN(sigma, sigma) — "Cooperative Graph Neural Networks" (Finkelshtein et al., ICML 2024)
+# https://arxiv.org/abs/2310.01267
+# Variant with SumGNN action and environment networks (paper notation: Co-GNN(sigma, sigma)).
+_target_: topobench.model.TBModel
+
+model_name: cognn_sum
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.CoGNN
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_layers: 3
+  env_conv_type: sum_gnn    # environment network eta (paper: sigma)
+  act_conv_type: sum_gnn    # action network pi (paper: sigma)
+  act_num_layers: 1
+  act_hidden_channels: 16
+  dropout: 0.0
+  temp: 0.01                # Gumbel-softmax temperature tau
+  learn_temp: false
+  layer_norm: false
+  skip: false
+  act: relu
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/graph/test_cognn.py
+++ b/test/nn/backbones/graph/test_cognn.py
@@ -210,6 +210,32 @@ def testWeightedConvs(random_graph_input):
     assert torch.allclose(out_blocked, out_manual, atol=1e-6)
 
 
+def testWeightedAggregate_mean_gating():
+    """Regression test for mean aggregation with 0/1 action gates.
+
+    Mirrors the original Co-GNN implementation (``models/layers.py``):
+    messages are scaled by the edge weight and then reduced with a
+    standard mean over the full in-degree, so gated (weight-0) edges
+    contribute zeros to the numerator but still count in the
+    denominator.
+    """
+    from topobench.nn.backbones.graph.cognn import weighted_aggregate
+
+    x = torch.tensor([[2.0, 4.0], [6.0, 8.0], [0.0, 0.0]])
+    # Two edges into node 2: one active (from node 0), one gated
+    # (from node 1).
+    edge_index = torch.tensor([[0, 1], [2, 2]])
+    edge_weight = torch.tensor([1.0, 0.0])
+    out = weighted_aggregate(
+        x, edge_index, num_nodes=3, edge_weight=edge_weight, aggr="mean"
+    )
+    # Reference semantics: (1*x_0 + 0*x_1) / in_degree(2) = x_0 / 2.
+    assert torch.allclose(out[2], x[0] / 2)
+    # Nodes without incoming edges aggregate to zero.
+    assert torch.equal(out[0], torch.zeros(2))
+    assert torch.equal(out[1], torch.zeros(2))
+
+
 def test_build_conv_layer_invalid():
     """Test that an unsupported convolution type raises a ValueError."""
     with pytest.raises(ValueError):

--- a/test/nn/backbones/graph/test_cognn.py
+++ b/test/nn/backbones/graph/test_cognn.py
@@ -1,0 +1,216 @@
+"""Unit tests for the Co-GNN backbone."""
+
+import pytest
+import torch
+import torch_geometric
+
+from topobench.nn.backbones.graph import CoGNN
+from topobench.nn.backbones.graph.cognn import (
+    CoGNNActionNet,
+    CoGNNTempSoftPlus,
+    WeightedGCNConv,
+    WeightedGINConv,
+    WeightedGNNConv,
+    build_conv_layer,
+)
+from topobench.nn.wrappers.graph import GNNWrapper
+
+
+def testCoGNN(random_graph_input):
+    """Unit test for the CoGNN backbone forward pass via GNNWrapper.
+
+    Parameters
+    ----------
+    random_graph_input : Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+        A tuple of random input tensors for testing.
+    """
+    torch.manual_seed(0)
+    x, x_1, x_2, edges_1, edges_2 = random_graph_input
+    batch = torch_geometric.data.Data(
+        x_0=x,
+        y=x,
+        x=x,
+        edge_index=edges_1,
+        batch_0=torch.zeros(x.shape[0], dtype=torch.long),
+    )
+    model = CoGNN(x.shape[1], x.shape[1])
+    wrapper = GNNWrapper(
+        model,
+        **{"out_channels": x.shape[1], "num_cell_dimensions": 1},
+    )
+
+    _ = wrapper.__repr__()
+
+    model_out = wrapper(batch)
+    assert model_out["x_0"].shape == x.shape
+
+
+@pytest.mark.parametrize(
+    "conv_type", ["sum_gnn", "mean_gnn", "gcn", "gin"]
+)
+def testCoGNN_conv_types(random_graph_input, conv_type):
+    """Unit test for all Co-GNN action/environment layer types.
+
+    Parameters
+    ----------
+    random_graph_input : Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+        A tuple of random input tensors for testing.
+    conv_type : str
+        The convolution type to test.
+    """
+    torch.manual_seed(0)
+    x, x_1, x_2, edges_1, edges_2 = random_graph_input
+    model = CoGNN(
+        x.shape[1],
+        16,
+        num_layers=2,
+        env_conv_type=conv_type,
+        act_conv_type=conv_type,
+    )
+    out = model(x, edges_1)
+    assert out.shape == (x.shape[0], 16)
+
+
+def testCoGNN_options(random_graph_input):
+    """Unit test for skip connections, layer norm and learned temperature.
+
+    Parameters
+    ----------
+    random_graph_input : Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+        A tuple of random input tensors for testing.
+    """
+    torch.manual_seed(0)
+    x, x_1, x_2, edges_1, edges_2 = random_graph_input
+    model = CoGNN(
+        x.shape[1],
+        16,
+        num_layers=2,
+        act_num_layers=2,
+        skip=True,
+        layer_norm=True,
+        learn_temp=True,
+        dropout=0.1,
+        act="gelu",
+    )
+    out = model(x, edges_1)
+    assert out.shape == (x.shape[0], 16)
+
+    # Input edge weights are combined with the action-derived gates.
+    edge_weight = torch.rand(edges_1.shape[1])
+    out = model(x, edges_1, edge_weight=edge_weight)
+    assert out.shape == (x.shape[0], 16)
+
+
+def testCoGNN_gradient_flow(random_graph_input):
+    """Test that gradients flow through the straight-through estimator.
+
+    Parameters
+    ----------
+    random_graph_input : Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+        A tuple of random input tensors for testing.
+    """
+    torch.manual_seed(0)
+    x, x_1, x_2, edges_1, edges_2 = random_graph_input
+    model = CoGNN(x.shape[1], 16, num_layers=2)
+    out = model(x, edges_1)
+    out.sum().backward()
+
+    # The action networks receive gradients only through the
+    # straight-through Gumbel-softmax estimator of the edge weights.
+    act_grads = [
+        p.grad
+        for p in model.in_act_net.parameters()
+        if p.grad is not None
+    ]
+    assert len(act_grads) > 0
+    assert model.encoder.weight.grad is not None
+
+
+def testCoGNN_create_edge_weight():
+    """Test the action-to-edge-weight combination rule (Eq. (2))."""
+    model = CoGNN(4, 4, num_layers=1)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 0]])
+    keep_in_prob = torch.tensor([1.0, 0.0, 1.0])
+    keep_out_prob = torch.tensor([1.0, 1.0, 0.0])
+    edge_weight = model.create_edge_weight(
+        edge_index, keep_in_prob, keep_out_prob
+    )
+    # Edge (u, v) is kept iff u broadcasts and v listens:
+    # (0, 1): node 1 does not listen -> 0
+    # (1, 2): node 1 broadcasts, node 2 listens -> 1
+    # (2, 0): node 2 does not broadcast -> 0
+    assert torch.equal(edge_weight, torch.tensor([0.0, 1.0, 0.0]))
+
+
+def testCoGNNActionNet(random_graph_input):
+    """Unit test for the Co-GNN action network.
+
+    Parameters
+    ----------
+    random_graph_input : Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+        A tuple of random input tensors for testing.
+    """
+    torch.manual_seed(0)
+    x, x_1, x_2, edges_1, edges_2 = random_graph_input
+    for num_layers in [1, 2]:
+        net = CoGNNActionNet(x.shape[1], 8, num_layers)
+        logits = net(x, edges_1)
+        assert logits.shape == (x.shape[0], 2)
+
+
+def testCoGNNTempSoftPlus(random_graph_input):
+    """Unit test for the learnable Gumbel-softmax temperature module.
+
+    Parameters
+    ----------
+    random_graph_input : Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+        A tuple of random input tensors for testing.
+    """
+    torch.manual_seed(0)
+    x, x_1, x_2, edges_1, edges_2 = random_graph_input
+    temp_model = CoGNNTempSoftPlus(x.shape[1], tau0=0.5)
+    temp = temp_model(x)
+    assert temp.shape == (x.shape[0], 1)
+    # Temperatures are strictly positive and bounded by 1 / tau0.
+    assert (temp > 0).all()
+    assert (temp <= 2.0).all()
+
+
+def testWeightedConvs(random_graph_input):
+    """Unit test for the weighted convolution layers.
+
+    Parameters
+    ----------
+    random_graph_input : Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+        A tuple of random input tensors for testing.
+    """
+    torch.manual_seed(0)
+    x, x_1, x_2, edges_1, edges_2 = random_graph_input
+    edge_weight = torch.rand(edges_1.shape[1])
+    for conv in [
+        WeightedGNNConv(x.shape[1], 8, aggr="sum"),
+        WeightedGNNConv(x.shape[1], 8, aggr="mean"),
+        WeightedGCNConv(x.shape[1], 8),
+        WeightedGINConv(x.shape[1], 8),
+    ]:
+        out = conv(x, edges_1)
+        assert out.shape == (x.shape[0], 8)
+        out = conv(x, edges_1, edge_weight=edge_weight)
+        assert out.shape == (x.shape[0], 8)
+
+    # Zero edge weights must block all messages: for WeightedGNNConv the
+    # aggregated neighbor part is zero, so outputs for isolated updates
+    # coincide with using a zeroed neighborhood.
+    conv = WeightedGNNConv(x.shape[1], 8, aggr="sum")
+    zero_w = torch.zeros(edges_1.shape[1])
+    out_blocked = conv(x, edges_1, edge_weight=zero_w)
+    out_manual = conv.lin(
+        torch.cat((x, torch.zeros_like(x)), dim=-1)
+    )
+    assert torch.allclose(out_blocked, out_manual, atol=1e-6)
+
+
+def test_build_conv_layer_invalid():
+    """Test that an unsupported convolution type raises a ValueError."""
+    with pytest.raises(ValueError):
+        build_conv_layer("unsupported", 4, 4)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/cognn", "graph/cognn_sum"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "graph/cognn", "graph/cognn_sum"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/cognn", "graph/cognn_sum"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/cognn.py
+++ b/topobench/nn/backbones/graph/cognn.py
@@ -48,6 +48,16 @@ def weighted_aggregate(x, edge_index, num_nodes, edge_weight=None, aggr="sum"):
     -------
     torch.Tensor
         Aggregated messages of shape [num_nodes, channels].
+
+    Notes
+    -----
+    For ``aggr="mean"`` the weighted messages are averaged over the *full*
+    in-degree of each node, i.e. edges gated to weight 0 still count in
+    the denominator. This deliberately reproduces the original Co-GNN
+    implementation (``models/layers.py``: messages are scaled by
+    ``edge_weight`` inside ``message()`` and then reduced with PyG's
+    standard ``aggr='mean'``), which is the exact MeanGNN (:math:`\mu`)
+    semantics used to produce the results reported in the paper.
     """
     messages = x[edge_index[0]]
     if edge_weight is not None:

--- a/topobench/nn/backbones/graph/cognn.py
+++ b/topobench/nn/backbones/graph/cognn.py
@@ -1,0 +1,626 @@
+"""Co-GNN backbone from "Cooperative Graph Neural Networks" (ICML 2024).
+
+Paper: Finkelshtein, Huang, Bronstein, Ceylan,
+"Cooperative Graph Neural Networks", ICML 2024.
+https://arxiv.org/abs/2310.01267
+
+Original implementation: https://github.com/benfinkelshtein/CoGNN
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch_geometric.nn.conv.gcn_conv import gcn_norm
+from torch_geometric.utils import scatter
+
+ACTIVATIONS = {
+    "relu": F.relu,
+    "gelu": F.gelu,
+}
+
+
+def weighted_aggregate(x, edge_index, num_nodes, edge_weight=None, aggr="sum"):
+    r"""Aggregate (optionally weighted) neighbor messages.
+
+    Computes :math:`\bigoplus_{u \in \mathcal{N}(v)} w_{u,v}
+    \mathbf{h}_u` for every node :math:`v`, where messages flow from
+    source ``edge_index[0]`` to target ``edge_index[1]``. This is the
+    weighted message-passing primitive shared by all Co-GNN layers
+    (`Finkelshtein et al., ICML 2024 <https://arxiv.org/abs/2310.01267>`_,
+    Eq. (2)): with the action-derived binary weights
+    :math:`w_{u,v} \in \{0, 1\}`, only edges whose source broadcasts and
+    whose target listens contribute.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Node features of shape [num_nodes, channels].
+    edge_index : torch.Tensor
+        Edge indices of shape [2, num_edges].
+    num_nodes : int
+        Number of nodes.
+    edge_weight : torch.Tensor, optional
+        Edge weights of shape [num_edges] (default: None).
+    aggr : str, optional
+        Aggregation scheme, "sum" or "mean" (default: "sum").
+
+    Returns
+    -------
+    torch.Tensor
+        Aggregated messages of shape [num_nodes, channels].
+    """
+    messages = x[edge_index[0]]
+    if edge_weight is not None:
+        messages = edge_weight.view(-1, 1) * messages
+    return scatter(
+        messages, edge_index[1], dim=0, dim_size=num_nodes, reduce=aggr
+    )
+
+
+class WeightedGNNConv(nn.Module):
+    r"""Edge-weighted SumGNN (:math:`\Sigma`) / MeanGNN (:math:`\mu`) layer.
+
+    Implements the environment/action layer used by Co-GNN
+    (`Finkelshtein et al., ICML 2024 <https://arxiv.org/abs/2310.01267>`_,
+    Section 4). The node update concatenates the node state with the
+    (weighted) aggregation of its neighbors' states, followed by a linear
+    transformation:
+
+    .. math::
+        \mathbf{h}_v' = \mathbf{W} \left[ \mathbf{h}_v \,\Vert\,
+        \bigoplus_{u \in \mathcal{N}(v)} w_{u,v} \mathbf{h}_u \right],
+
+    where :math:`\bigoplus` is a sum (SumGNN, :math:`\Sigma`) or a mean
+    (MeanGNN, :math:`\mu`) and :math:`w_{u,v}` is the edge weight computed
+    from the sampled actions (Eq. (2) of the paper reduces to this weighted
+    form with :math:`w_{u,v} \in \{0, 1\}`).
+
+    Follows ``WeightedGNNConv`` in the original implementation
+    (``models/layers.py``).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    out_channels : int
+        Number of output features per node.
+    aggr : str, optional
+        Aggregation scheme, "sum" or "mean" (default: "sum").
+    bias : bool, optional
+        Whether the linear layer uses a bias term (default: True).
+    """
+
+    def __init__(self, in_channels, out_channels, aggr="sum", bias=True):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.aggr = aggr
+        self.lin = nn.Linear(2 * in_channels, out_channels, bias=bias)
+
+    def forward(self, x, edge_index, edge_weight=None):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        edge_index : torch.Tensor
+            Edge indices of shape [2, num_edges].
+        edge_weight : torch.Tensor, optional
+            Edge weights of shape [num_edges] (default: None).
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of shape [num_nodes, out_channels].
+        """
+        out = weighted_aggregate(
+            x, edge_index, x.size(0), edge_weight, aggr=self.aggr
+        )
+        return self.lin(torch.cat((x, out), dim=-1))
+
+
+class WeightedGCNConv(nn.Module):
+    r"""Edge-weighted GCN (:math:`*`) layer used by Co-GNN.
+
+    GCN layer (Kipf & Welling, 2017) that supports differentiable edge
+    weights, used as an action/environment network component in Co-GNN
+    (`Finkelshtein et al., ICML 2024 <https://arxiv.org/abs/2310.01267>`_,
+    Section 4). The action-derived edge weights :math:`w_{u,v}` enter the
+    symmetric normalization computed by
+    :func:`torch_geometric.nn.conv.gcn_conv.gcn_norm`.
+
+    Follows ``WeightedGCNConv`` in the original implementation
+    (``models/layers.py``); self-loops are handled by ``gcn_norm``.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    out_channels : int
+        Number of output features per node.
+    bias : bool, optional
+        Whether the linear layer uses a bias term (default: True).
+    """
+
+    def __init__(self, in_channels, out_channels, bias=True):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.lin = nn.Linear(in_channels, out_channels, bias=bias)
+
+    def forward(self, x, edge_index, edge_weight=None):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        edge_index : torch.Tensor
+            Edge indices of shape [2, num_edges].
+        edge_weight : torch.Tensor, optional
+            Edge weights of shape [num_edges] (default: None).
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of shape [num_nodes, out_channels].
+        """
+        edge_index, edge_weight = gcn_norm(
+            edge_index,
+            edge_weight,
+            x.size(0),
+            improved=False,
+            add_self_loops=True,
+            dtype=x.dtype,
+        )
+        out = weighted_aggregate(
+            x, edge_index, x.size(0), edge_weight, aggr="sum"
+        )
+        return self.lin(out)
+
+
+class WeightedGINConv(nn.Module):
+    r"""Edge-weighted GIN (:math:`\epsilon`) layer used by Co-GNN.
+
+    GIN layer (Xu et al., 2019) with support for edge weights, used as an
+    action/environment network component in Co-GNN
+    (`Finkelshtein et al., ICML 2024 <https://arxiv.org/abs/2310.01267>`_,
+    Section 4):
+
+    .. math::
+        \mathbf{h}_v' = \mathrm{MLP}\left((1 + \epsilon) \mathbf{h}_v +
+        \sum_{u \in \mathcal{N}(v)} w_{u,v} \mathbf{h}_u \right).
+
+    Follows ``WeightedGINConv`` in the original implementation
+    (``models/layers.py``) with the default MLP factory of the reference
+    code (Linear -> BatchNorm -> ReLU -> Linear).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    out_channels : int
+        Number of output features per node.
+    bias : bool, optional
+        Whether the linear layers use bias terms (default: True).
+    """
+
+    def __init__(self, in_channels, out_channels, bias=True):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.mlp = nn.Sequential(
+            nn.Linear(in_channels, 2 * in_channels, bias=bias),
+            nn.BatchNorm1d(2 * in_channels),
+            nn.ReLU(),
+            nn.Linear(2 * in_channels, out_channels, bias=bias),
+        )
+        self.eps = nn.Parameter(torch.zeros(1))
+
+    def forward(self, x, edge_index, edge_weight=None):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        edge_index : torch.Tensor
+            Edge indices of shape [2, num_edges].
+        edge_weight : torch.Tensor, optional
+            Edge weights of shape [num_edges] (default: None).
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of shape [num_nodes, out_channels].
+        """
+        out = weighted_aggregate(
+            x, edge_index, x.size(0), edge_weight, aggr="sum"
+        )
+        return self.mlp((1 + self.eps) * x + out)
+
+
+def build_conv_layer(conv_type, in_channels, out_channels):
+    """Build a single Co-GNN convolution layer.
+
+    Maps the layer names of the paper (Section 4 and Table 9 of
+    `Finkelshtein et al., ICML 2024 <https://arxiv.org/abs/2310.01267>`_)
+    to their implementations: "sum_gnn" (:math:`\\Sigma`), "mean_gnn"
+    (:math:`\\mu`), "gcn" (:math:`*`) and "gin" (:math:`\\epsilon`).
+
+    Parameters
+    ----------
+    conv_type : str
+        One of "sum_gnn", "mean_gnn", "gcn", "gin".
+    in_channels : int
+        Number of input features per node.
+    out_channels : int
+        Number of output features per node.
+
+    Returns
+    -------
+    torch_geometric.nn.conv.MessagePassing
+        The convolution layer.
+
+    Raises
+    ------
+    ValueError
+        If ``conv_type`` is not supported.
+    """
+    if conv_type == "sum_gnn":
+        return WeightedGNNConv(in_channels, out_channels, aggr="sum")
+    if conv_type == "mean_gnn":
+        return WeightedGNNConv(in_channels, out_channels, aggr="mean")
+    if conv_type == "gcn":
+        return WeightedGCNConv(in_channels, out_channels)
+    if conv_type == "gin":
+        return WeightedGINConv(in_channels, out_channels)
+    raise ValueError(f"Convolution type '{conv_type}' is not supported.")
+
+
+class CoGNNActionNet(nn.Module):
+    r"""Action network :math:`\pi` of Co-GNN.
+
+    Lightweight GNN that predicts per-node action logits from the node
+    state and its neighborhood, Eq. (1) of
+    `Finkelshtein et al., ICML 2024 <https://arxiv.org/abs/2310.01267>`_:
+
+    .. math::
+        \mathbf{p}_v^{(\ell)} = \pi \left( \mathbf{h}_v^{(\ell)},
+        \{\!\!\{ \mathbf{h}_u^{(\ell)} \mid u \in \mathcal{N}_v \}\!\!\}
+        \right).
+
+    Each of the two binary decisions (listen / broadcast) is predicted by
+    its own instance of this network, so the output has two logits per
+    node (keep vs. drop). Follows ``ActionNet`` in the original
+    implementation (``models/action.py``).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node (the environment state size).
+    hidden_channels : int
+        Number of hidden features per node.
+    num_layers : int
+        Number of convolution layers.
+    conv_type : str, optional
+        Convolution type, see :func:`build_conv_layer`
+        (default: "mean_gnn").
+    dropout : float, optional
+        Dropout rate applied between layers (default: 0.0).
+    act : str, optional
+        Activation between layers, "relu" or "gelu" (default: "relu").
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels,
+        num_layers,
+        conv_type="mean_gnn",
+        dropout=0.0,
+        act="relu",
+    ):
+        super().__init__()
+        dims = [in_channels] + [hidden_channels] * (num_layers - 1) + [2]
+        self.convs = nn.ModuleList(
+            [
+                build_conv_layer(conv_type, d_in, d_out)
+                for d_in, d_out in zip(dims[:-1], dims[1:], strict=True)
+            ]
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.act = ACTIVATIONS[act]
+
+    def forward(self, x, edge_index, edge_weight=None):
+        """Compute per-node action logits.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        edge_index : torch.Tensor
+            Edge indices of shape [2, num_edges].
+        edge_weight : torch.Tensor, optional
+            Edge weights of shape [num_edges] (default: None).
+
+        Returns
+        -------
+        torch.Tensor
+            Action logits of shape [num_nodes, 2] (keep vs. drop).
+        """
+        for conv in self.convs[:-1]:
+            x = conv(x, edge_index, edge_weight=edge_weight)
+            x = self.dropout(x)
+            x = self.act(x)
+        return self.convs[-1](x, edge_index, edge_weight=edge_weight)
+
+
+class CoGNNTempSoftPlus(nn.Module):
+    r"""Learnable Gumbel-softmax temperature module of Co-GNN.
+
+    Predicts a per-node temperature :math:`\tau_v` for the Gumbel-softmax
+    estimator from the node state (Appendix E.1 of
+    `Finkelshtein et al., ICML 2024 <https://arxiv.org/abs/2310.01267>`_):
+
+    .. math::
+        \tau_v = \left( \mathrm{softplus}(\mathbf{w}^\top
+        \mathbf{h}_v) + \tau_0 \right)^{-1}.
+
+    Follows ``TempSoftPlus`` in the original implementation
+    (``models/temp.py``) with its default linear temperature model.
+
+    Parameters
+    ----------
+    hidden_channels : int
+        Number of input features per node (the environment state size).
+    tau0 : float, optional
+        Temperature offset :math:`\tau_0` (default: 0.5).
+    """
+
+    def __init__(self, hidden_channels, tau0=0.5):
+        super().__init__()
+        self.lin = nn.Linear(hidden_channels, 1, bias=False)
+        self.softplus = nn.Softplus(beta=1)
+        self.tau0 = tau0
+
+    def forward(self, x):
+        """Compute per-node Gumbel-softmax temperatures.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, hidden_channels].
+
+        Returns
+        -------
+        torch.Tensor
+            Per-node temperatures of shape [num_nodes, 1].
+        """
+        temp = self.softplus(self.lin(x)) + self.tau0
+        temp = temp.pow(-1)
+        return temp.masked_fill(temp == float("inf"), 0.0)
+
+
+class CoGNN(nn.Module):
+    r"""Co-GNN backbone from "Cooperative Graph Neural Networks".
+
+    In a Co-GNN (`Finkelshtein et al., ICML 2024
+    <https://arxiv.org/abs/2310.01267>`_, Section 4) every node chooses at
+    every layer one of four actions: Standard (S), Listen (L),
+    Broadcast (B) or Isolate (I). The actions are predicted by action
+    networks :math:`\pi` (Eq. (1)) and sampled with the straight-through
+    Gumbel-softmax estimator; the environment network :math:`\eta` then
+    performs message passing only over edges :math:`(u, v)` where
+    :math:`u` broadcasts and :math:`v` listens (Eq. (2)):
+
+    .. math::
+        \mathbf{h}_v^{(\ell+1)} = \eta^{(\ell)} \left(
+        \mathbf{h}_v^{(\ell)}, \{\!\!\{ \mathbf{h}_u^{(\ell)} \mid
+        u \in \mathcal{N}_v,\ a_u^{(\ell)} \in \{S, B\} \}\!\!\} \right)
+        \quad \text{if } a_v^{(\ell)} \in \{S, L\}.
+
+    As in the original implementation, the four-way action is factorized
+    into two binary decisions predicted by two separate action networks:
+    an *in* network (listen vs. not) and an *out* network (broadcast vs.
+    not); the four actions are recovered as S = (listen, broadcast),
+    L = (listen, -), B = (-, broadcast), I = (-, -). Eq. (2) is then
+    realized by giving each edge :math:`(u, v)` the binary weight
+
+    .. math::
+        w_{u,v} = p_v^{\mathrm{in}} \cdot p_u^{\mathrm{out}},
+
+    where the straight-through estimator makes the hard samples
+    :math:`p^{\mathrm{in}}, p^{\mathrm{out}} \in \{0, 1\}`
+    differentiable. The paper denotes by Co-GNN(:math:`\pi, \eta`) the
+    architecture with action network type :math:`\pi` and environment
+    network type :math:`\eta`, e.g. Co-GNN(:math:`\mu, \mu`) uses
+    MeanGNN layers for both.
+
+    This backbone corresponds to the hidden part of ``CoGNN`` in the
+    original implementation (``models/CoGNN.py``): the input encoder is a
+    linear layer, and the task decoder/pooling is delegated to the
+    TopoBench readout module.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    hidden_channels : int
+        Number of hidden features per node (environment state size).
+    num_layers : int, optional
+        Number of environment layers (default: 3).
+    env_conv_type : str, optional
+        Environment network layer type :math:`\eta`, one of "sum_gnn",
+        "mean_gnn", "gcn", "gin" (default: "mean_gnn").
+    act_conv_type : str, optional
+        Action network layer type :math:`\pi`, one of "sum_gnn",
+        "mean_gnn", "gcn", "gin" (default: "mean_gnn").
+    act_num_layers : int, optional
+        Number of layers of each action network (default: 1).
+    act_hidden_channels : int, optional
+        Hidden size of the action networks (default: 16).
+    dropout : float, optional
+        Dropout rate (default: 0.0).
+    temp : float, optional
+        Gumbel-softmax temperature :math:`\tau` used when ``learn_temp``
+        is False (default: 0.01).
+    learn_temp : bool, optional
+        Whether to learn the temperature with
+        :class:`CoGNNTempSoftPlus` (default: False).
+    tau0 : float, optional
+        Temperature offset of the learned temperature model
+        (default: 0.5).
+    layer_norm : bool, optional
+        Whether to apply layer normalization to the hidden states
+        (default: False).
+    skip : bool, optional
+        Whether to use residual connections between environment layers
+        (default: False).
+    act : str, optional
+        Activation function, "relu" or "gelu" (default: "relu").
+    **kwargs
+        Additional (ignored) keyword arguments.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels,
+        num_layers=3,
+        env_conv_type="mean_gnn",
+        act_conv_type="mean_gnn",
+        act_num_layers=1,
+        act_hidden_channels=16,
+        dropout=0.0,
+        temp=0.01,
+        learn_temp=False,
+        tau0=0.5,
+        layer_norm=False,
+        skip=False,
+        act="relu",
+        **kwargs,
+    ):
+        super().__init__()
+        self.out_channels = hidden_channels
+        self.num_layers = num_layers
+        self.skip = skip
+        self.temp = temp
+        self.learn_temp = learn_temp
+
+        self.encoder = nn.Linear(in_channels, hidden_channels)
+        self.env_convs = nn.ModuleList(
+            [
+                build_conv_layer(
+                    env_conv_type, hidden_channels, hidden_channels
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.in_act_net = CoGNNActionNet(
+            hidden_channels,
+            act_hidden_channels,
+            act_num_layers,
+            conv_type=act_conv_type,
+            dropout=dropout,
+            act=act,
+        )
+        self.out_act_net = CoGNNActionNet(
+            hidden_channels,
+            act_hidden_channels,
+            act_num_layers,
+            conv_type=act_conv_type,
+            dropout=dropout,
+            act=act,
+        )
+        if learn_temp:
+            self.temp_model = CoGNNTempSoftPlus(hidden_channels, tau0=tau0)
+
+        self.hidden_layer_norm = (
+            nn.LayerNorm(hidden_channels) if layer_norm else nn.Identity()
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.act = ACTIVATIONS[act]
+
+    def create_edge_weight(self, edge_index, keep_in_prob, keep_out_prob):
+        r"""Combine the sampled actions into differentiable edge weights.
+
+        Realizes Eq. (2) of `Finkelshtein et al., ICML 2024
+        <https://arxiv.org/abs/2310.01267>`_ as an edge weight
+        :math:`w_{u,v} = p_v^{\mathrm{in}} \cdot p_u^{\mathrm{out}}`:
+        an edge :math:`(u, v)` carries a message iff the target node
+        :math:`v` listens and the source node :math:`u` broadcasts.
+        Follows ``CoGNN.create_edge_weight`` in the original
+        implementation (``models/CoGNN.py``).
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            Edge indices of shape [2, num_edges].
+        keep_in_prob : torch.Tensor
+            Per-node probability of listening, shape [num_nodes].
+        keep_out_prob : torch.Tensor
+            Per-node probability of broadcasting, shape [num_nodes].
+
+        Returns
+        -------
+        torch.Tensor
+            Edge weights of shape [num_edges].
+        """
+        u, v = edge_index
+        return keep_in_prob[v] * keep_out_prob[u]
+
+    def forward(self, x, edge_index, batch=None, edge_weight=None) -> Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        edge_index : torch.Tensor
+            Edge indices of shape [2, num_edges].
+        batch : torch.Tensor, optional
+            Batch assignment vector of shape [num_nodes]; unused, kept
+            for compatibility with the TopoBench ``GNNWrapper``
+            (default: None).
+        edge_weight : torch.Tensor, optional
+            Input edge weights of shape [num_edges]; multiplied with the
+            action-derived edge weights when provided (default: None).
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape [num_nodes, hidden_channels].
+        """
+        x = self.encoder(x)
+        x = self.dropout(x)
+        x = self.act(x)
+
+        for env_conv in self.env_convs:
+            x = self.hidden_layer_norm(x)
+
+            # Eq. (1): per-node action logits for the two binary
+            # decisions (listen / broadcast).
+            in_logits = self.in_act_net(x, edge_index)
+            out_logits = self.out_act_net(x, edge_index)
+
+            # Straight-through Gumbel-softmax sampling (Section 3).
+            temp = self.temp_model(x) if self.learn_temp else self.temp
+            in_probs = F.gumbel_softmax(in_logits, tau=temp, hard=True)
+            out_probs = F.gumbel_softmax(out_logits, tau=temp, hard=True)
+
+            # Eq. (2) as differentiable edge weights.
+            gate = self.create_edge_weight(
+                edge_index, in_probs[:, 0], out_probs[:, 0]
+            )
+            if edge_weight is not None:
+                gate = gate * edge_weight
+
+            out = env_conv(x, edge_index, edge_weight=gate)
+            out = self.dropout(out)
+            out = self.act(out)
+
+            x = x + out if self.skip else out
+
+        return self.hidden_layer_norm(x)


### PR DESCRIPTION
## Model

This PR implements **Co-GNN (Cooperative Graph Neural Networks)** as a Track 1 (GNN) backbone for the TDL Challenge 2026.

> Ben Finkelshtein, Xingyue Huang, Michael Bronstein, İsmail İlkan Ceylan.
> **Cooperative Graph Neural Networks.** ICML 2024.
> Paper: https://arxiv.org/abs/2310.01267 — Reference code: https://github.com/benfinkelshtein/CoGNN

Co-GNN reframes message passing as a cooperative game: at every layer, each node chooses one of four actions — **Standard, Listen, Broadcast, Isolate** — predicted by lightweight *action networks* (Eq. (1) of the paper) and sampled with the straight-through Gumbel-softmax estimator. The *environment network* then propagates messages only along edges whose source broadcasts and whose target listens (Eq. (2)). This gives every node a learned, task-adaptive receptive field, which is the paper's central mechanism for handling **heterophily** and long-range information flow — precisely the structural axes the GraphUniverse evaluation sweeps.

## What is included

| Component | Path |
|---|---|
| Backbone (`CoGNN`, action nets, weighted convs, learnable temperature) | `topobench/nn/backbones/graph/cognn.py` |
| Config, Co-GNN(μ,μ) variant (default) | `configs/model/graph/cognn.yaml` |
| Config, Co-GNN(Σ,Σ) variant | `configs/model/graph/cognn_sum.yaml` |
| Unit tests (100% line coverage of the new module) | `test/nn/backbones/graph/test_cognn.py` |
| Pipeline test | `test/pipeline/test_pipeline.py` |
| Evaluation results (official notebook output) | `2026_tdl_challenge/results.json` |

The implementation follows the reference code (`models/CoGNN.py`, `models/action.py`, `models/layers.py`, `models/temp.py`) and the paper's equations; all docstrings reference the specific equations/sections they implement. The backbone reuses the standard `AllCellFeatureEncoder`, `GNNWrapper` and `NoReadOut` — no custom wrapper/encoder/readout is needed.

Implementation notes (deviations allowed under "Modifications to respect TopoBench computational requirements"):
- The reference model's input encoder is folded into the backbone as a linear layer; the task decoder/pooling is delegated to the TopoBench readout, matching the TBModel composition.
- The weighted convolutions are implemented with `torch_geometric.utils.scatter` rather than `MessagePassing` subclasses, because TopoBench's file-based backbone auto-discovery is incompatible with PyG's `MessagePassing` inspector (module not registered in `sys.modules`). The math is identical to the reference layers.
- The four-way action is factorized into two binary Gumbel-softmax decisions (listen / broadcast) exactly as in the reference implementation.

## Evaluation

`2026_tdl_challenge/run_evaluation.ipynb` was run on a Kaggle P100 GPU with `MODEL_CONFIG = "graph/cognn"` (72 runs: 12 grid settings × 3 seeds × 2 tasks, full OOD evaluation; 2.6 h wall time; 31,941 parameters, ≈1.5 s/epoch). The generated `results.json` is committed. Community-detection accuracy averages 0.63 under high homophily and — consistent with the paper's central claim about learned, task-adaptive information flow — remains at 0.33 under severe heterophily (h ∈ [0, 0.1], 20 classes), far above chance.

Note on the notebook integrity check: current `main` ships a stale `expected_hash` that fails on a clean clone (#330). To run the notebook we updated only the `expected_hash` cell (which is above the `# UNIQUE_HASH_MARKER`, i.e. in the same user-editable region as `MODEL_CONFIG`) to the SHA-256 of the untouched protected cells. All cells from the marker onward are byte-identical to `main`.

## Tests

- `test/nn/backbones/graph/test_cognn.py`: 12 tests covering the backbone (all four layer types, skip/layer-norm/learned-temperature options, gradient flow through the straight-through estimator, the Eq. (2) edge-gating rule, and the weighted convolutions), 100% line coverage of `cognn.py`.
- `test/pipeline/test_pipeline.py`: end-to-end training of both variants on `graph/MUTAG`.

## Result figures

In-distribution test performance across the 12 GraphUniverse grid settings (mean ± std over 3 seeds):

**Community detection (accuracy):**

![Community detection accuracy heatmap](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/heatmap_community_detection_accuracy.png)

**Triangle counting (MSE / total triangles):**

![Triangle counting MSE heatmap](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/heatmap_triangle_mse_over_triangles.png)

<details>
<summary>OOD delta plots (OOD − in-distribution), by training homophily level</summary>

![OOD low homophily, community detection](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/OOD_low_homophily__community_detection.png)
![OOD mid homophily, community detection](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/OOD_mid_homophily__community_detection.png)
![OOD high homophily, community detection](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/OOD_high_homophily__community_detection.png)
![OOD low homophily, triangle counting](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/OOD_low_homophily__triangle_counting.png)
![OOD mid homophily, triangle counting](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/OOD_mid_homophily__triangle_counting.png)
![OOD high homophily, triangle counting](https://raw.githubusercontent.com/magoflaco/topobench/pr-assets/pr_assets/OOD_high_homophily__triangle_counting.png)

</details>
