### PR TITLE
Track: Track1; Team name: TripleA; Model: Graph Inductive Bias Transformer (GRIT)

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-07_01-28-25/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-07_01-28-25/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-07_01-28-25",
+    "model_config": "graph/grit",
+    "generated_at_utc": "2026-07-07T05:35:15.981156+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.197070598602295,
+      "test_best_rerun_accuracy": 0.33887234330177307,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3210711181163788,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33654212951660156,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3137367367744446,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3466651439666748,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3298189342021942,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.321605920791626,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3073573112487793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4166857600212097,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4023607671260834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44621437788009644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4358239769935608,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.741937319437662,
+        "AvgTime/train_epoch_std": 0.015217178444296726,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2245097160339355,
+      "test_best_rerun_accuracy": 0.33134692907333374,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3128199279308319,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.312094122171402,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2908167243003845,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.333868145942688,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31438612937927246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2888685166835785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2750401198863983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.379517138004303,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36087554693222046,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3872717618942261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37267935276031494,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.736713922023773,
+        "AvgTime/train_epoch_std": 0.018182478548890255,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1801116466522217,
+      "test_best_rerun_accuracy": 0.3327603340148926,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3145389258861542,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.296928733587265,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3417373299598694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3252731263637543,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.304530531167984,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2726716995239258,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3818855583667755,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3698907494544983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39051875472068787,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.360493540763855,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.734034125010172,
+        "AvgTime/train_epoch_std": 0.019785009790048817,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.23787522315979,
+      "test_best_rerun_accuracy": 0.312132328748703,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3162197172641754,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3027351200580597,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29207730293273926,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31232333183288574,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3070899248123169,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2966231107711792,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28737872838974,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3288257420063019,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32603713870048523,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33218732476234436,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3201543390750885,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.727361730166844,
+        "AvgTime/train_epoch_std": 0.01948289935200969,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2816505432128906,
+      "test_best_rerun_accuracy": 0.3042631149291992,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3103369176387787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29887691140174866,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2834059000015259,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3095729351043701,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3035373091697693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28692030906677246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2777141034603119,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32431814074516296,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3224845230579376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.319734126329422,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3104897141456604,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.718649983406067,
+        "AvgTime/train_epoch_std": 0.02068065384111235,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2485129833221436,
+      "test_best_rerun_accuracy": 0.31385132670402527,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3147299289703369,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3059057295322418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2940637171268463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3114447295665741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3035373091697693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3027351200580597,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2853159010410309,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3161051273345947,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3134693205356598,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3149591386318207,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29723432660102844,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.740457639098167,
+        "AvgTime/train_epoch_std": 0.024176310583775604,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.053968906402588,
+      "test_best_rerun_accuracy": 0.37592634558677673,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32145312428474426,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2985331118106842,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3499503433704376,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35025593638420105,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32363054156303406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3763083517551422,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3518603444099426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44621437788009644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44201236963272095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5311329960823059,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5442737936973572,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.010541168126194,
+        "AvgTime/train_epoch_std": 0.09264251886290528,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.018927574157715,
+      "test_best_rerun_accuracy": 0.3776835501194,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33352434635162354,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3123997151851654,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3611811399459839,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35216593742370605,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32890212535858154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36736953258514404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35189855098724365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4270379841327667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.41061195731163025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48047980666160583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4718465805053711,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.991366055276659,
+        "AvgTime/train_epoch_std": 0.02781894763256057,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.0678646564483643,
+      "test_best_rerun_accuracy": 0.3761555552482605,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.306402325630188,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2818015217781067,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3505615293979645,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34819313883781433,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3123997151851654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36740773916244507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35063794255256653,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4555351734161377,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43891817331314087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5307891964912415,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5395370125770569,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.986410415172577,
+        "AvgTime/train_epoch_std": 0.022228699342998315,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.263169527053833,
+      "test_best_rerun_accuracy": 0.32661011815071106,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31316372752189636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2943311035633087,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3412407338619232,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3314233422279358,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31316372752189636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33650392293930054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3310031294822693,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40365955233573914,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.41049736738204956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4389945864677429,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47952479124069214,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.008847615935586,
+        "AvgTime/train_epoch_std": 0.021841360889569332,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.22247052192688,
+      "test_best_rerun_accuracy": 0.34257772564888,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3071281313896179,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2887157201766968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35323554277420044,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33379173278808594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30972573161125183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3574375510215759,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3493391275405884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4132477641105652,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3995339572429657,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4721139967441559,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.48865458369255066,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.013231992721558,
+        "AvgTime/train_epoch_std": 0.04938135458218032,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.096831798553467,
+      "test_best_rerun_accuracy": 0.3511727452278137,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3212621212005615,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37134236097335815,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34456413984298706,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3251585364341736,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3629383444786072,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3499503433704376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4125601649284363,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40025976300239563,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4650851786136627,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47028037905693054,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.998177255902972,
+        "AvgTime/train_epoch_std": 0.021541292086308745,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.8056491613388062,
+      "test_best_rerun_accuracy": 0.4495759904384613,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31381312012672424,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2906257212162018,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30158913135528564,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2585377097129822,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42096418142318726,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4737947881221771,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45194438099861145,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6094812154769897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6077622175216675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6796164512634277,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6854228973388672,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.964644619396754,
+        "AvgTime/train_epoch_std": 0.4415928958742924,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.8430553674697876,
+      "test_best_rerun_accuracy": 0.455382376909256,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3054855167865753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2831385135650635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27905112504959106,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2357322871685028,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42531895637512207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4589731693267822,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4285277724266052,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6163572669029236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6121170520782471,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6830544471740723,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6734662652015686,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.792065406667776,
+        "AvgTime/train_epoch_std": 0.056193637767912405,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.8419036865234375,
+      "test_best_rerun_accuracy": 0.44392237067222595,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30174192786216736,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.282794713973999,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29654672741889954,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26174649596214294,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40480557084083557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45480936765670776,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42829856276512146,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6072656512260437,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6027580499649048,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6858812570571899,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6912674903869629,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.783765358083388,
+        "AvgTime/train_epoch_std": 0.022041553037496282,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.8933137655258179,
+      "test_best_rerun_accuracy": 0.42081135511398315,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2971961200237274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2853159010410309,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2645350992679596,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2410420924425125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.43314996361732483,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42612117528915405,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43372297286987305,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5945068597793579,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6102070212364197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6710214614868164,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7029184699058533,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.013374837239583,
+        "AvgTime/train_epoch_std": 0.8851119452465267,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9661719799041748,
+      "test_best_rerun_accuracy": 0.42081135511398315,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2838261127471924,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2717167139053345,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2682405114173889,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23760409653186798,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.436396986246109,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4464053809642792,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43643516302108765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6063870191574097,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6163190603256226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.678432285785675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7054014801979065,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.773399753229958,
+        "AvgTime/train_epoch_std": 0.02156640676489578,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9344711303710938,
+      "test_best_rerun_accuracy": 0.41389715671539307,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2902437150478363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2821071147918701,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27236610651016235,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2548705041408539,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4322713613510132,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4444189667701721,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4593169689178467,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6007716655731201,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6145618557929993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6888608932495117,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.720184862613678,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.773057092319835,
+        "AvgTime/train_epoch_std": 0.021723141763696312,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.591068983078003,
+      "test_best_rerun_accuracy": 0.5196347832679749,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29643210768699646,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27782872319221497,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3303537368774414,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3020475208759308,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44266176223754883,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4055313766002655,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.515203595161438,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6199480295181274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6267094612121582,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7149896621704102,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7334020733833313,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.981560769834017,
+        "AvgTime/train_epoch_std": 0.020946956182442675,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.6808658838272095,
+      "test_best_rerun_accuracy": 0.5095118284225464,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2954389154911041,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27221331000328064,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3105279207229614,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27546030282974243,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44136297702789307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4057605564594269,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5089005827903748,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6119260191917419,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6176942586898804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6960806846618652,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7149515151977539,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.978724439938864,
+        "AvgTime/train_epoch_std": 0.01899036387592078,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.614193320274353,
+      "test_best_rerun_accuracy": 0.519061803817749,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29165711998939514,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26678889989852905,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3278707265853882,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29601192474365234,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44121018052101135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39537015557289124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5144777894020081,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6215142607688904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6239208579063416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7114753127098083,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7327908873558044,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.972574482793393,
+        "AvgTime/train_epoch_std": 0.021503890438368527,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.5576200485229492,
+      "test_best_rerun_accuracy": 0.5395752191543579,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28692030906677246,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2716403007507324,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3034227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2811139225959778,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41320955753326416,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3977767527103424,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4953778088092804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.585377037525177,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.608220636844635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6939414739608765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7691572904586792,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.008978283923605,
+        "AvgTime/train_epoch_std": 0.016661784240500327,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.5150387287139893,
+      "test_best_rerun_accuracy": 0.5480556488037109,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2890213131904602,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2822217047214508,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3103369176387787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29356712102890015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4237145781517029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40194055438041687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.511345386505127,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5968752503395081,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6114676594734192,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7183130979537964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7735885381698608,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.03434926813299,
+        "AvgTime/train_epoch_std": 0.1298764788794854,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.5097429752349854,
+      "test_best_rerun_accuracy": 0.5435479879379272,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2962411046028137,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28756970167160034,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31408053636550903,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28974711894989014,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4287951588630676,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.407021164894104,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5053098201751709,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5999694466590881,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6102070212364197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7109786868095398,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7644205093383789,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.000263929367065,
+        "AvgTime/train_epoch_std": 0.023346202459833335,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.163971185684204,
+      "test_best_rerun_accuracy": 0.6808388829231262,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22767208516597748,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21487508714199066,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1923752725124359,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16433647274971008,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4224921762943268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3913973569869995,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38914355635643005,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36740773916244507,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6827488541603088,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7402399182319641,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7529605031013489,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.765999408868643,
+        "AvgTime/train_epoch_std": 0.08841521237406452,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.095828890800476,
+      "test_best_rerun_accuracy": 0.6803422570228577,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2736649215221405,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25498509407043457,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26014211773872375,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23588509857654572,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4499961733818054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4198181629180908,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4637099802494049,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4582855701446533,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6834746599197388,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7427610754966736,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7550233006477356,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.788279950618744,
+        "AvgTime/train_epoch_std": 0.15735576030424706,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.1126089096069336,
+      "test_best_rerun_accuracy": 0.6804950833320618,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24222630262374878,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22515088319778442,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20494307577610016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15597066283226013,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.43674078583717346,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4019787609577179,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4051493704319,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3620215356349945,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6853464841842651,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7428756952285767,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7574298977851868,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.752990048507165,
+        "AvgTime/train_epoch_std": 0.016352750008479643,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.0360305309295654,
+      "test_best_rerun_accuracy": 0.6961953043937683,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2438689023256302,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22690808773040771,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1877530813217163,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16632287204265594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41958895325660706,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3965543508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.366261750459671,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3436855375766754,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6686912775039673,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7280158996582031,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7698448896408081,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.755281695004168,
+        "AvgTime/train_epoch_std": 0.02923645956664987,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.0331273078918457,
+      "test_best_rerun_accuracy": 0.7052486538887024,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2456642985343933,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2347772866487503,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22564749419689178,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21965008974075317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.43047598004341125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4087783694267273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41431736946105957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43101078271865845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6841240525245667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.740851104259491,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7810757160186768,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.747093960642815,
+        "AvgTime/train_epoch_std": 0.024732518408313198,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.040709376335144,
+      "test_best_rerun_accuracy": 0.6965008974075317,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24222630262374878,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2260676920413971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2146458923816681,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20570708811283112,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42478418350219727,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40896937251091003,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4066009521484375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4351363778114319,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6730842590332031,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.744785726070404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.798762321472168,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.740589872483284,
+        "AvgTime/train_epoch_std": 0.017517859146506942,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 0.7990604639053345,
+      "test_best_rerun_accuracy": 0.7634655237197876,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2467339038848877,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23852089047431946,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23508289456367493,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21223928034305573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4190923571586609,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39323094487190247,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45668119192123413,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45752158761024475,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6734662652015686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6797310709953308,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.794178307056427,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.843988406030755,
+        "AvgTime/train_epoch_std": 0.020749708463499793,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 0.7971766591072083,
+      "test_best_rerun_accuracy": 0.7670180797576904,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24352510273456573,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22706088423728943,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2516235113143921,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2217128872871399,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4291389584541321,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.387997567653656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.46596378087997437,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4441133737564087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6809534430503845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6856138706207275,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7972725033760071,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.844806299209594,
+        "AvgTime/train_epoch_std": 0.017587500314232313,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 0.8217180371284485,
+      "test_best_rerun_accuracy": 0.767591118812561,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22625869512557983,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21456947922706604,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21991749107837677,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2000916749238968,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42558637261390686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38589656352996826,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45221176743507385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4493085741996765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.670792281627655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6829016804695129,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.8042249083518982,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.844800414710209,
+        "AvgTime/train_epoch_std": 0.021583481743481646,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.6276825070381165,
+      "test_best_rerun_accuracy": 0.8104897141456604,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21835128962993622,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2013140767812729,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22304989397525787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21132248640060425,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3594239354133606,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3339827358722687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42841318249702454,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4650851786136627,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.570097029209137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6091374158859253,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7379860877990723,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.90659381213941,
+        "AvgTime/train_epoch_std": 0.0249635963476686,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.6293020844459534,
+      "test_best_rerun_accuracy": 0.8138895034790039,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23420429229736328,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22014668583869934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21823668479919434,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21109329164028168,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37584996223449707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3546871542930603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4318893849849701,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4646649956703186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6040568351745605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6361448764801025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7487202882766724,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.893579301834107,
+        "AvgTime/train_epoch_std": 0.020359840873521017,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.623955249786377,
+      "test_best_rerun_accuracy": 0.8164489269256592,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23752769827842712,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2206432819366455,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22247688472270966,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20261287689208984,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3794025480747223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3504469394683838,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4415539801120758,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46130338311195374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.57857745885849,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6147910356521606,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.7389410734176636,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.899301511900765,
+        "AvgTime/train_epoch_std": 0.02265537023211389,
+        "model/params/total": 190145,
+        "model/params/trainable": 190145,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 9.446905136108398,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9.510706901550293,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.006852094309474275,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.054598093032837,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.010813674173857037
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3064.434326171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.23241822724094616
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.313636779785156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.009542850279671437
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3769.449951171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.503600527878674
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.6667423248291,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.023028274891907688
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122434.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.84308565449099
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8575.38671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6012751871231243
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27086.962890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3884342042454765
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1297.6361083984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.23069086371527778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 599884.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.7857970034953565
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177081.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.946783267185862
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.333174617202193,
+        "AvgTime/train_epoch_std": 0.05520503054220583,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 7.806185722351074,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8.001262664794922,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.005764598461667811,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.138280987739563,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.005990952567050332
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1199.7017822265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.09098989626291715
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.34381675720215,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.005845573561578075
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2063.300048828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.27565798915539413
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.329056739807129,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.009783295975653824
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91192.5234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1176045754574586
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5557.52099609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3896733274501297
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19917.705078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.020949565745297
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 811.8192749023438,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.14432342664930556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 529826.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.993303394681176
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157047.9375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.613414832010384
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.315952784306294,
+        "AvgTime/train_epoch_std": 0.012405906469937094,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 8.146217346191406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7.633643627166748,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.005499743247238291,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.5106277465820312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.007950672350431743
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1399.8787841796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1061720731270146
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.2776107788086,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.025371624799059182
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2475.921630859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3307844530206246
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.23723316192627,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.013158232436896606
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102609.0078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.382709637109883
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6809.15673828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.47743351130845957
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21987.236328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1270304130465427
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 868.787109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.15445104166666668
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 565435.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.396114950850084
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166590.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.772217645982061
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.31762691338857,
+        "AvgTime/train_epoch_std": 0.007699610788929651,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.0149359703063965,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.9716066718101501,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.005113719325316579,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186.46165466308594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13433836791288611
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11795.37109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8946053161736822
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156.4814453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05274062868638355
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7843.90185546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0479494796885438
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136.66830444335938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11802098829305646
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173212.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.022220561257663
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14194.396484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9952598853158744
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46102.4609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3631380869086063
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3486.252197265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6197781684027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 749276.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.475695112156828
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 251563.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.186237113723728
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.291994377970695,
+        "AvgTime/train_epoch_std": 0.014285461012436735,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.9991987347602844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.027902364730835,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.005410012445951763,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137.7879180908203,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09927083435938062
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10021.419921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7600621859594235
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60.9860725402832,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.020554793576098147
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7238.8115234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9671090879676019
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.26469421386719,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08744792246447944
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166217.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.859768672789337
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12657.5546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8875020815804235
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43864.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2484476315418527
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3071.029296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5459607638888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 732410.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.284901247695213
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240001.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9938410567786597
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.297595007078987,
+        "AvgTime/train_epoch_std": 0.016170844865547908,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.682165801525116,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.693132758140564,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0036480671481082315,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.96763610839844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10948676953054642
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11056.47265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8385644790481608
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119.38554382324219,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04023779704187468
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7448.36083984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9951049886230795
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115.37804412841797,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09963561669120723
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170446.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9579695337172582
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13723.337890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9622309557302622
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44986.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.305945533151366
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3296.512451171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5860466579861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744643.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.423282439509972
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250062.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.16125266253973
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.292237199269808,
+        "AvgTime/train_epoch_std": 0.014234958104869615,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 224.9774627685547,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 236.6813507080078,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.01795080399757359,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53.83433532714844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03878554418382452
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55.93257141113281,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.29438195479543583
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54.85235595703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0184874809427136
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 977.7211303710938,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.13062406551384018
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.98883056640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10448085541140437
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49148.80859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.141296874274336
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1342.365234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.09412180860854018
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11164.97265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5722985625224255
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3178.05078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5649868055555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 307021.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.472975323235637
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50123.93359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8341060288843959
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.513711675008137,
+        "AvgTime/train_epoch_std": 0.015527579668762987,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1181.300537109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1203.593994140625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.09128509625639931,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1234.3182373046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.889278268951504
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1123.3980712890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.912621427837171
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2003.1409912109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.6751402060030123
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1830.2308349609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.24451981763005176
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1219.9595947265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.0535056949279469
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44248.52734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0275062080566133
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3576.492919921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.25077078389579827
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8850.91796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4536838366266851
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3225.31787109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.57338984375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 274135.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.1009800289582934
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46399.83984375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7721338565847936
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.500350041822953,
+        "AvgTime/train_epoch_std": 0.007851740779009683,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 201.35293579101562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 210.23056030273438,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.015944676549316222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.32938003540039,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.016807910688328813
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.083053588867188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.12675291362561678
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123.62006378173828,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04166500295980394
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1922.549560546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2568536487036573
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 352.2408447265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.30418034950480355
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35048.5703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8138716866175925
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 803.8795776367188,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.056365136561262005
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25120.2109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2876216585934697
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8524.16796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.5154076388888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 237339.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.684746275578883
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49919.28515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8307005001622485
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.462740285055977,
+        "AvgTime/train_epoch_std": 0.010184003502384185,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2197654247283936,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.186542510986328,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0007369539976361066,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59.162498474121094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04262427843956851
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.3048051595687866,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0068673955766778245
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3933.916259765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2983630079458191
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4400.81787109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5879516193846025
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.612977981567383,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.01780049912052451
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120053.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.787803835570314
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5843.56298828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.40972956024970203
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30564.142578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.566668849152955
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1468.9442138671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.26114563802083335
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 609495.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.894510791488977
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169894.21875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8271881708352056
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.474656105041504,
+        "AvgTime/train_epoch_std": 0.009564293708647484,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 3.183586835861206,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.0949885845184326,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.001043137372604797,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.18468475341797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02390827431802447
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.40093162655830383,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00211016645557002
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3266.927001953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.24777603351938757
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3998.5712890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5342112610637942
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.37257194519043,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.012411547448350976
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113729.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6409428408879805
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5199.06494140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.364539681770176
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26687.80078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3679737957481162
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1194.8514404296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.21241803385416666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 559240.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.326036022533172
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145212.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.416467496214201
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.478945817947388,
+        "AvgTime/train_epoch_std": 0.008570783133000864,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 4.313688278198242,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.28415060043335,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0014439334682957027,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.111244201660156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.025296285447881955
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.241829514503479,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.006535944813176205
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3484.43505859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2642726627678233
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3737.5849609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4993433481546426
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.95984172821045,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.013782246742841493
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114263.4921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6533413567597064
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5469.45703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.38349859986327306
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27345.630859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.401693108789533
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1278.1326904296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.22722358940972223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 583594.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.60152794588419
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162429.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.702960671376034
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.526639975034273,
+        "AvgTime/train_epoch_std": 0.009268188082438154,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 127.45100402832031,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 128.75433349609375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.017201647761669173,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.875770568847656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.033772168997728856
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72.58142852783203,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.382007518567537
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4010.681640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3041851832100872
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 654.6192016601562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.22063336759695187
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.670772552490234,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04375714382771177
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16962.369140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3938874498566088
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1110.3416748046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.07785315347109013
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3903.720458984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.20009843964244067
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1406.43505859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.25003289930555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131657.046875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.4892825681820752
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15823.6337890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.26331908523559316
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.50305215774044,
+        "AvgTime/train_epoch_std": 0.9635494408727502,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 143.64865112304688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 132.67529296875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.01772549004258517,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88.7671127319336,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06395325124779078
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.6074438095092773,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0189865463658383
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5003.203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3794617463026166
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 311.4652404785156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10497648819633153
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30.840782165527344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.026632799797519296
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17633.169921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4094642839001254
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 903.5293579101562,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.06335221973847681
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3395.200927734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.174032545375692
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 737.9278564453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13118717447916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152391.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.7238265386921259
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19347.35546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.3219568912976553
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.300160749753315,
+        "AvgTime/train_epoch_std": 0.0078852357336108,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 293.7858581542969,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 299.4715881347656,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.04000956421306154,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80.73700714111328,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05816787258005279
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.31694507598877,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.054299710926256683
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4733.291015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3589905965585893
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 474.2143249511719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.15982956688613814
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.35976028442383,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.027944525288794323
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27098.466796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6292603287403632
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1105.7098388671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.07752838584119952
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3089.83642578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.15838005155473114
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 362.6694030761719,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.064474560546875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216604.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.450193997941246
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38742.1484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6447031840230976
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.29826597213745,
+        "AvgTime/train_epoch_std": 0.009257618804147315,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 5.879385948181152,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5.882578372955322,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.00507994678148128,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.33633422851562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11335470765743201
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.8402045369148254,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.004422129141656976
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2551.707763671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.19353111594022562
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258.7095947265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08719568410062774
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 984.7431030273438,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.13156220481327238
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54392.9609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.263072657846461
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1850.136474609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1297248965509308
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8954.5693359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.45899683919921574
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194.47906494140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.03457405598958333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 396075.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.480337205750936
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102028.5859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6978447728936814
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.28568854698768,
+        "AvgTime/train_epoch_std": 0.010950336004060349,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 5.364110469818115,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5.556965351104736,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.004798761097672484,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.1408233642578,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1196979995419725
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.828108310699463,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00962162268789191
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3108.095703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2357296703166477
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 371.5286865234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12522031901699948
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1394.3758544921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.18628935931759352
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68189.1328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5834370428315996
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2754.40087890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.19312865509088836
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14814.1650390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7593503018638833
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 448.0984802246094,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.07966195203993055
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 470756.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.325118350055994
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128249.2265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1341791317208325
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.290621771131242,
+        "AvgTime/train_epoch_std": 0.01001675152420338,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 11.3062162399292,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10.088743209838867,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.008712213479999021,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.09537124633789,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.018080238650099344
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.5736489295959473,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00828236278734709
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3007.6103515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22810848324326888
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.5953369140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04907156619954921
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2944.431884765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.39337767331538076
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114054.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6484893849851385
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6217.9775390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.435982158116849
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23069.0859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1824842860987237
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 957.337158203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.17019327256944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 563563.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.374937784916802
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163276.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7170614713860184
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.620633708106148,
+        "AvgTime/train_epoch_std": 0.9007087621115318,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 4222.85791015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2374.262451171875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.05513334690627612,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 275.1305847167969,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.19822088236080468
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1057.51806640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.565884560032894
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 724.3203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.05493517728479332
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222.97393798828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07515131041061046
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 317.9654541015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.042480354589387107
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 556.5218505859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.48058881743172494
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 344.1034240722656,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.024127290988098838
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3695.560791015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.18942850945797451
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1473.716796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2619940972222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54676.984375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.6184969330791942
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20660.357421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.3438063904593713
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.524580040398765,
+        "AvgTime/train_epoch_std": 0.2730323224483155,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 5303.12353515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3468.3154296875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.08053862692010728,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3714.92333984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.6764577376395895
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3922.819091796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 20.64641627261513
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1531.8382568359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.11618037594508437
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2930.862060546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.987820040629213
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3774.631591796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5042927978352538
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4210.25,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.6357944732297063
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3464.536865234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.24292082914278326
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5899.45751953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3023967153381132
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5283.828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9393472222222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53602.25390625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.6063397611647795
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25441.349609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.423366275762152
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.501575885500227,
+        "AvgTime/train_epoch_std": 0.011710335146250283,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 4793.97021484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3706.93212890625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.08607960544552874,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 354.1632385253906,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.25516083467247164
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 264.06024169921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.3897907457853618
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 597.970458984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.045352329084897613
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1154.4654541015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.38910193936688997
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 686.3757934570312,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0917001728065506
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 355.44451904296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.30694690763641513
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2573.6787109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1804570684993339
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4067.525390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.20849481729586344
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1037.3433837890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1844166015625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51058.953125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.5775703666730767
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24310.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.40454587056728736
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.494092045603571,
+        "AvgTime/train_epoch_std": 0.011780104395426908,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 237.422119140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 227.67147827148438,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.015963502893807626,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153.56210327148438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11063552108896568
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.6783447265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5035702354029605
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376.74835205078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.02857401229054086
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.06159973144531,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01586167837258015
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 395.1230773925781,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.052788654294265616
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177.01280212402344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15286079630744684
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19484.833984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4524622418812697
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3348.744873046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.17165128264118484
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 663.7607421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11800190972222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161557.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.8275168122122551
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20209.873046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.33630993704549617
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.554691096146902,
+        "AvgTime/train_epoch_std": 0.15937449453646635,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 262.97943115234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 269.0545959472656,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.01886513784513151,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.46004867553711,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.023386202215804834
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.095420837402344,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17418642546001234
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4624.3857421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3507308109357224
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.2949333190918,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.017625525217085204
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 433.3280029296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.057892852762817304
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.49909210205078,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04015465639209912
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4513.1640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.10480132041844696
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3286.487548828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.16846007221426648
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 670.5285034179688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11920506727430556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85915.765625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.9718648193500221
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28036.6171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4665537947431481
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.526718160084316,
+        "AvgTime/train_epoch_std": 0.01607039346862239,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 255.9279327392578,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 250.39906311035156,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.017557079169145392,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.2549934387207,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0419704563679544
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.59876251220703,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09788822374845806
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1105.2635498046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.083827345453522
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282.0784606933594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09507194495900215
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165.4119415283203,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.022099123784678733
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.412601470947266,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02021813598527398
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10971.0537109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.25476160391365177
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2979.873046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.15274350540135323
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 782.0632934570312,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1390334743923611
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134952.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.5265601846091197
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15962.0595703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2656226111246318
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.519505677684661,
+        "AvgTime/train_epoch_std": 0.012024894578164939,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1990.036865234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1787.007080078125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.09159911220862807,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255.17486572265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.18384356320076098
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 500.6609802246094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.635057790655839
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28666.50390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.1741754953545698
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6823.7724609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.2998896059782608
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 386.60504150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.05165064014748247
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 392.8005065917969,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3392059642416208
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14707.693359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3415310551591817
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9254.85546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6489170851738887
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 903.8798217773438,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.16068974609375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94449.6796875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.0683990326968542
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14754.4052734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.24552618896439685
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.259096031188966,
+        "AvgTime/train_epoch_std": 0.009761580868535121,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1563.02783203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1634.4119873046875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.08377733288762558,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.66363525390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06604008303595552
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130.51731872558594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6869332564504523
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3475.20458984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.263572589294179
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1462.3756103515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.49288021919499914
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 509.4921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0680684285237141
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.31398010253906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12030568229925653
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12790.9951171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.2970229220970532
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1731.8128662109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1214284718981165
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279.4439392089844,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.04967892252604167
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105643.0390625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.1950164481126206
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12906.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.214781151714842
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.333570850306543,
+        "AvgTime/train_epoch_std": 0.36465474665383935,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1018.0672607421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1040.5814208984375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.05333853200566085,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 217.15638732910156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15645272862327203
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.10983276367188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8163675408614309
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21937.5703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.6638278583617747
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10000.5703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.370600037917088
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.03318786621094,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.02886214934752317
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127.5851058959961,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11017712080828679
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5989.65478515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.1390872836976651
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7202.14501953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5049884321645807
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.3193817138672,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.025834556749131946
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61293.87890625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.6933461410387657
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13790.310546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.22948281075790858
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.314690232276917,
+        "AvgTime/train_epoch_std": 0.4110781079911846,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 93.59300231933594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 98.29429626464844,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.017474541558159723,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130.65579223632812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09413241515585599
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.51803207397461,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.27641069512618216
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2395.105224609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.18165379026237202
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1767.55419921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5957378494164981
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1137.529052734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.15197448934326988
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.55805206298828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.044523361021578826
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49028.44921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1385019788860766
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1927.1778564453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.13512676037339172
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6718.37109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.34437290961863753
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 269584.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.049491391694852
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43103.94921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7172873582405604
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.255164022445678,
+        "AvgTime/train_epoch_std": 0.014655401104388056,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 155.41229248046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 163.5042266845703,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.029067418077256945,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61.29933547973633,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04416378636868611
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.121070861816406,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0743214255885074
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1784.38916015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.13533478651166098
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1084.5457763671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.36553615651068
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1393.707763671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1862001020269706
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.42643165588379,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.021093637008535223
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50885.33203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1816211227765652
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2425.71826171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1700826154619794
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7869.7509765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4033907927911477
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 271626.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.0725951042385438
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49405.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8221483263441666
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.256274716607455,
+        "AvgTime/train_epoch_std": 0.01191679297732294,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 187.56198120117188,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 197.26611328125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.03506953125,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167.5176239013672,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12068993076467377
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.941375732421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.04705987227590461
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1725.870361328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1308965006695582
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 824.8140869140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.27799598480420035
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1386.5062255859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.185237972690172
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.792351722717285,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.011910493715645324
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59000.38671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3700628533984303
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2618.80712890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.18362131039869933
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8717.126953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4468259240927264
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 311741.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.526362581021006
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61968.53515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.031210542929293
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.27357117912986,
+        "AvgTime/train_epoch_std": 0.13015078001444583,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 24196.40625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 14857.63671875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.16806710992556814,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19205.23046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 13.836621375180115
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21428.3125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 112.78059210526315
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6969.619140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5286021342908608
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3534.656982421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1913235532261122
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18207.1484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.4324847611890448
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19901.845703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 17.186395253130396
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15711.0537109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3648303388198379
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7736.03759765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5424230541057531
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15676.7353515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8035642704168589
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18860.484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.352975
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9814.931640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.16332903400770474
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.393125149938795,
+        "AvgTime/train_epoch_std": 0.1641210817088168,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 34243.2734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20981.32421875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.23733724216089952,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15066.86328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.855088819344381
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17582.99609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 92.54208470394737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4592.802734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.34833543681266593
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5627.22900390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.8966056636017021
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15003.662109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.004497275801603
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17031.978515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 14.708098890867875
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9629.5380859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.22360993140297
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7045.33740234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.49399364761911024
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15063.5302734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7721323631881439
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15742.28125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.798627777777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9297.392578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.15471673203409714
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.360978478477115,
+        "AvgTime/train_epoch_std": 0.01353182925461107,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 75500.6953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 43193.3125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.48859555105595964,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9692.169921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.982831355817724
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11098.58984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 58.41363075657895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5491.03515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4164607627038301
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7688.41357421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.591308922891389
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10789.6962890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.441509190255511
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11288.3720703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 9.748162409596286
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7023.958984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.16310512224537896
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8099.92333984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.567937409889479
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13513.0556640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6926575254529961
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11811.1328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.0997569444444446
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12884.6083984375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2144111360464197
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.35944849945778,
+        "AvgTime/train_epoch_std": 0.012953961748892403,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 22624.83984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 21695.60546875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.36103382205498147,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11415.712890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.224577010536743
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12351.66796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 65.00877878289474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9059.349609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6870951542946531
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17623.173828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.939728287200876
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13596.1123046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.8164478696977289
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12824.33203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.074552704015543
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23987.095703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5570103962271271
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20939.955078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.4682341241147805
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18694.162109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9582327187131581
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14237.0419921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.5310296875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84745.6796875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.9586290022680226
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.413340024650097,
+        "AvgTime/train_epoch_std": 0.012158098357128255,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 24491.333984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 22974.9609375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.38232341433278416,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2419.5400390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.7431844661833573
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2798.07958984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.726734683388157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4194.12255859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3180980325061623
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8372.37890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.821833133215369
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4458.95068359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5957181942009018
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3329.25439453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.875003794931995
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14190.7666015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3295273686039964
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11220.3955078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7867336634281658
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10332.6162109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5296333082647753
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5420.5009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9636446180555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91246.359375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.032163607287083
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.561740691011602,
+        "AvgTime/train_epoch_std": 0.665365655273888,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "grit_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1159.1561279296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1188.0784912109375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.01977066365817878,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1587.7396240234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1439046282589607
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3456.47021484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 18.19194849917763
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5653.6435546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.42879359534982936
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 605.3051147460938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.20401250918304475
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1081.5838623046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.14450018200463427
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2343.9453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.0241323942141625
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3326.0322265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0772346327921814
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713.5162353515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0500291849215792
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1371.7388916015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.07031313196994016
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1302.4796142578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2315519314236111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40223.60546875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.455002720142416
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-07_01-28-25__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.422792846156705,
+        "AvgTime/train_epoch_std": 0.16056033438402936,
+        "model/params/total": 188910,
+        "model/params/trainable": 188910,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/graph/grit.yaml
+++ b/configs/model/graph/grit.yaml
@@ -1,0 +1,46 @@
+_target_: topobench.model.TBModel
+
+model_name: grit
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.GRITBackbone
+  hidden_dim: ${model.feature_encoder.out_channels}
+  num_layers: 4
+  num_heads: 8
+  walk_length: 8 # Number of RRWP channels; kept in sync with the AddRRWP transform.
+  dropout: 0.0
+  attn_dropout: 0.2
+  clamp: 5.0
+  pad_to_full_graph: true # Global attention; set false for sparse (RRWP-support) attention.
+  deg_scaler: true
+  edge_enhance: true
+  update_pair_rep: true
+  edge_dim: null # Set to the raw edge-attribute dimension to fuse edge features.
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GRITWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  residual_connections: false # GRIT layers already contain residual connections.
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: mean
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/transforms/data_manipulations/rrwp_positional_encodings.yaml
+++ b/configs/transforms/data_manipulations/rrwp_positional_encodings.yaml
@@ -1,0 +1,3 @@
+transform_name: "AddRRWP"
+transform_type: "data manipulation"
+walk_length: 8

--- a/configs/transforms/model_defaults/grit.yaml
+++ b/configs/transforms/model_defaults/grit.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - data_manipulations@grit_rrwp: rrwp_positional_encodings
+
+# Keep the number of RRWP channels in sync with the GRIT backbone.
+grit_rrwp:
+  walk_length: ${model.backbone.walk_length}

--- a/test/nn/backbones/graph/test_grit.py
+++ b/test/nn/backbones/graph/test_grit.py
@@ -1,0 +1,409 @@
+"""Unit tests for the GRIT backbone (Graph Inductive Bias Transformer)."""
+
+import hydra
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph import BACKBONE_CLASSES
+from topobench.nn.backbones.graph.grit import (
+    GRITAttention,
+    GRITBackbone,
+    GRITTransformerLayer,
+    full_edge_index,
+)
+from topobench.transforms.data_manipulations.rrwp_positional_encodings import (
+    AddRRWP,
+)
+
+HIDDEN_DIM = 16
+WALK_LENGTH = 4
+
+
+def _make_graph(num_nodes: int, seed: int = 0) -> Data:
+    """Create a small random connected graph with RRWP encodings.
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes in the graph.
+    seed : int, optional
+        Random seed for the node features (default: 0).
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Graph with features, labels and RRWP attributes.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    src = torch.arange(num_nodes - 1)
+    dst = src + 1
+    edge_index = torch.cat(
+        [torch.stack([src, dst]), torch.stack([dst, src])], dim=1
+    )
+    data = Data(
+        x=torch.randn(num_nodes, HIDDEN_DIM, generator=generator),
+        edge_index=edge_index,
+        y=torch.zeros(1, dtype=torch.long),
+    )
+    return AddRRWP(walk_length=WALK_LENGTH)(data)
+
+
+def _forward(model: GRITBackbone, data: Data, **overrides) -> torch.Tensor:
+    """Run the backbone on a (batched) data object.
+
+    Parameters
+    ----------
+    model : GRITBackbone
+        The backbone to evaluate.
+    data : torch_geometric.data.Data
+        Graph or batch with RRWP attributes.
+    **overrides : dict
+        Keyword arguments overriding the batch attributes.
+
+    Returns
+    -------
+    torch.Tensor
+        Node representations.
+    """
+    kwargs = {
+        "batch": data.get("batch", None),
+        "edge_attr": data.get("edge_attr", None),
+        "rrwp": data.get("rrwp", None),
+        "rrwp_index": data.get("rrwp_index", None),
+        "rrwp_val": data.get("rrwp_val", None),
+        "log_deg": data.get("log_deg", None),
+    }
+    kwargs.update(overrides)
+    return model(data.x, data.edge_index, **kwargs)
+
+
+class TestFullEdgeIndex:
+    """Test the full_edge_index utility."""
+
+    def test_single_graph(self):
+        """Test all pairs of a single graph."""
+        batch = torch.zeros(3, dtype=torch.long)
+        index = full_edge_index(batch)
+        assert index.shape == (2, 9)
+
+    def test_no_cross_graph_pairs(self):
+        """Test that no pair connects two different graphs."""
+        batch = torch.tensor([0, 0, 1, 1, 1])
+        index = full_edge_index(batch)
+
+        assert index.shape == (2, 4 + 9)
+        assert torch.equal(batch[index[0]], batch[index[1]])
+
+
+class TestGRITAttention:
+    """Test the GRIT attention mechanism."""
+
+    def test_invalid_num_heads(self):
+        """Test that indivisible head counts are rejected."""
+        with pytest.raises(ValueError, match="divisible"):
+            GRITAttention(hidden_dim=10, num_heads=4)
+
+    def test_signed_sqrt(self):
+        """Test the signed square root activation."""
+        x = torch.tensor([4.0, -9.0, 0.0])
+        expected = torch.tensor([2.0, -3.0, 0.0])
+        assert torch.allclose(GRITAttention.signed_sqrt(x), expected)
+
+    def test_forward_shapes(self):
+        """Test output shapes of the attention forward pass."""
+        num_nodes, num_pairs, num_heads = 5, 12, 4
+        attention = GRITAttention(HIDDEN_DIM, num_heads)
+        x = torch.randn(num_nodes, HIDDEN_DIM)
+        pair_index = torch.randint(0, num_nodes, (2, num_pairs))
+        pair_attr = torch.randn(num_pairs, HIDDEN_DIM)
+
+        x_out, pair_out = attention(x, pair_index, pair_attr)
+
+        assert x_out.shape == (num_nodes, num_heads, HIDDEN_DIM // num_heads)
+        assert pair_out.shape == (num_pairs, HIDDEN_DIM)
+        assert torch.isfinite(x_out).all()
+        assert torch.isfinite(pair_out).all()
+
+    def test_no_clamp_and_no_edge_enhance(self):
+        """Test the forward pass without clamping and edge enhancement."""
+        attention = GRITAttention(
+            HIDDEN_DIM, num_heads=2, clamp=None, edge_enhance=False
+        )
+        assert attention.clamp is None
+        assert not hasattr(attention, "W_Ev")
+
+        x = torch.randn(4, HIDDEN_DIM)
+        pair_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 0]])
+        pair_attr = torch.randn(4, HIDDEN_DIM)
+        x_out, _ = attention(x, pair_index, pair_attr)
+        assert x_out.shape == (4, 2, HIDDEN_DIM // 2)
+
+
+class TestGRITTransformerLayer:
+    """Test the GRIT transformer layer."""
+
+    def _inputs(self, num_nodes=6, num_pairs=20):
+        """Create random layer inputs.
+
+        Parameters
+        ----------
+        num_nodes : int, optional
+            Number of nodes (default: 6).
+        num_pairs : int, optional
+            Number of attention pairs (default: 20).
+
+        Returns
+        -------
+        tuple
+            Node features, pair index, pair attributes and log-degrees.
+        """
+        x = torch.randn(num_nodes, HIDDEN_DIM)
+        pair_index = torch.randint(0, num_nodes, (2, num_pairs))
+        pair_attr = torch.randn(num_pairs, HIDDEN_DIM)
+        log_deg = torch.rand(num_nodes, 1)
+        return x, pair_index, pair_attr, log_deg
+
+    def test_forward_shapes(self):
+        """Test output shapes of the layer."""
+        layer = GRITTransformerLayer(HIDDEN_DIM, num_heads=4)
+        x, pair_index, pair_attr, log_deg = self._inputs()
+
+        x_out, pair_out = layer(x, pair_index, pair_attr, log_deg)
+
+        assert x_out.shape == x.shape
+        assert pair_out.shape == pair_attr.shape
+        assert not torch.equal(pair_out, pair_attr)
+
+    def test_no_degree_scaler(self):
+        """Test the layer without the adaptive degree scaler."""
+        layer = GRITTransformerLayer(HIDDEN_DIM, num_heads=4, deg_scaler=False)
+        assert not hasattr(layer, "deg_coef")
+
+        x, pair_index, pair_attr, log_deg = self._inputs()
+        x_out, _ = layer(x, pair_index, pair_attr, log_deg)
+        assert x_out.shape == x.shape
+
+    def test_frozen_pair_representations(self):
+        """Test that update_pair_rep=False keeps pair representations."""
+        layer = GRITTransformerLayer(
+            HIDDEN_DIM, num_heads=4, update_pair_rep=False
+        )
+        x, pair_index, pair_attr, log_deg = self._inputs()
+
+        _, pair_out = layer(x, pair_index, pair_attr, log_deg)
+        assert torch.equal(pair_out, pair_attr)
+
+
+class TestGRITBackbone:
+    """Test the GRIT backbone."""
+
+    def test_registration(self):
+        """Test that the backbone is auto-discovered by TopoBench."""
+        assert "GRITBackbone" in BACKBONE_CLASSES
+
+    def test_initialization(self):
+        """Test default and custom initialization."""
+        model = GRITBackbone(hidden_dim=HIDDEN_DIM)
+        assert len(model.layers) == 4
+        assert model.walk_length == 8
+
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=2, walk_length=WALK_LENGTH
+        )
+        assert len(model.layers) == 2
+        assert model.abs_pe_encoder.in_features == WALK_LENGTH
+
+    def test_forward_with_precomputed_rrwp(self):
+        """Test the forward pass with precomputed RRWP encodings."""
+        data = _make_graph(7)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=2, walk_length=WALK_LENGTH
+        )
+
+        out = _forward(model, data)
+
+        assert out.shape == (7, HIDDEN_DIM)
+        assert torch.isfinite(out).all()
+
+    def test_forward_without_batch_vector(self):
+        """Test that a missing batch vector defaults to a single graph."""
+        data = _make_graph(5)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=1, walk_length=WALK_LENGTH
+        )
+        out = model(
+            data.x,
+            data.edge_index,
+            rrwp=data.rrwp,
+            rrwp_index=data.rrwp_index,
+            rrwp_val=data.rrwp_val,
+            log_deg=data.log_deg,
+        )
+        assert out.shape == (5, HIDDEN_DIM)
+
+    def test_fallback_matches_precomputed(self):
+        """Test on-the-fly RRWP equals the precomputed transform output."""
+        batch = Batch.from_data_list([_make_graph(6, 0), _make_graph(4, 1)])
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=2, walk_length=WALK_LENGTH
+        ).eval()
+
+        out_precomputed = _forward(model, batch)
+        out_on_the_fly = _forward(
+            model,
+            batch,
+            rrwp=None,
+            rrwp_index=None,
+            rrwp_val=None,
+            log_deg=None,
+        )
+
+        assert torch.allclose(out_precomputed, out_on_the_fly, atol=1e-6)
+
+    def test_batching_matches_individual_graphs(self):
+        """Test that batched processing equals per-graph processing."""
+        data_0, data_1 = _make_graph(6, 0), _make_graph(4, 1)
+        batch = Batch.from_data_list([data_0, data_1])
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=2, walk_length=WALK_LENGTH
+        ).eval()
+
+        out_batched = _forward(model, batch)
+        out_individual = torch.cat(
+            [_forward(model, data_0), _forward(model, data_1)]
+        )
+
+        assert torch.allclose(out_batched, out_individual, atol=1e-5)
+
+    def test_walk_length_mismatch(self):
+        """Test that mismatched RRWP channels raise an error."""
+        data = _make_graph(5)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=1, walk_length=WALK_LENGTH + 1
+        )
+        with pytest.raises(ValueError, match="walk_length"):
+            _forward(model, data)
+
+    def test_sparse_attention(self):
+        """Test the forward pass without full-graph padding."""
+        data = _make_graph(6)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM,
+            num_layers=1,
+            walk_length=WALK_LENGTH,
+            pad_to_full_graph=False,
+        )
+        out = _forward(model, data)
+        assert out.shape == (6, HIDDEN_DIM)
+
+    def test_edge_attributes_used_when_configured(self):
+        """Test that configured edge attributes change the output."""
+        data = _make_graph(5)
+        data.edge_attr = torch.randn(data.edge_index.size(1), 3)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM,
+            num_layers=1,
+            walk_length=WALK_LENGTH,
+            edge_dim=3,
+        ).eval()
+
+        out_with_edges = _forward(model, data)
+        out_without_edges = _forward(model, data, edge_attr=None)
+
+        assert out_with_edges.shape == (5, HIDDEN_DIM)
+        assert not torch.allclose(out_with_edges, out_without_edges)
+
+    def test_edge_attributes_ignored_by_default(self):
+        """Test that edge attributes are ignored when edge_dim is None."""
+        data = _make_graph(5)
+        data.edge_attr = torch.randn(data.edge_index.size(1), 3)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=1, walk_length=WALK_LENGTH
+        ).eval()
+
+        assert model.edge_attr_encoder is None
+        out_with_edges = _forward(model, data)
+        out_without_edges = _forward(model, data, edge_attr=None)
+        assert torch.allclose(out_with_edges, out_without_edges)
+
+    def test_backward_pass(self):
+        """Test gradient flow through the backbone."""
+        data = _make_graph(6)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=2, walk_length=WALK_LENGTH
+        )
+
+        out = _forward(model, data)
+        out.sum().backward()
+
+        # The pair-representation output of the last layer does not
+        # influence the node output, so its projection has no gradient;
+        # every other parameter must receive one.
+        last_layer_pair_params = {
+            id(p)
+            for name, p in model.layers[-1].named_parameters()
+            if "W_O_pair" in name or "norm1_pair" in name
+        }
+        for name, param in model.named_parameters():
+            if id(param) in last_layer_pair_params:
+                continue
+            assert param.grad is not None, f"No gradient for {name}"
+
+    def test_deterministic_in_eval_mode(self):
+        """Test deterministic outputs in eval mode despite dropout."""
+        data = _make_graph(6)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM,
+            num_layers=2,
+            walk_length=WALK_LENGTH,
+            dropout=0.5,
+            attn_dropout=0.5,
+        ).eval()
+
+        assert torch.allclose(_forward(model, data), _forward(model, data))
+
+    def test_extra_kwargs_ignored(self):
+        """Test that unused keyword arguments are ignored gracefully."""
+        data = _make_graph(5)
+        model = GRITBackbone(
+            hidden_dim=HIDDEN_DIM, num_layers=1, walk_length=WALK_LENGTH
+        )
+        out = _forward(model, data, unused_kwarg="test")
+        assert out.shape == (5, HIDDEN_DIM)
+
+
+class TestGRITHydraConfig:
+    """Test Hydra configuration loading for the GRIT model."""
+
+    def setup_method(self):
+        """Reset the global Hydra state."""
+        hydra.core.global_hydra.GlobalHydra.instance().clear()
+
+    def test_config_composition_and_instantiation(self):
+        """Test that the grit model config composes and instantiates."""
+        with hydra.initialize(
+            config_path="../../../../configs", job_name="test_grit", version_base="1.3"
+        ):
+            cfg = hydra.compose(
+                config_name="run.yaml",
+                overrides=["model=graph/grit", "dataset=graph/MUTAG"],
+                return_hydra_config=True,
+            )
+
+            # The model-default transform is picked up and kept in sync
+            # with the backbone's walk_length.
+            assert "grit_rrwp" in cfg.transforms
+            assert cfg.transforms.grit_rrwp.transform_name == "AddRRWP"
+            assert (
+                cfg.transforms.grit_rrwp.walk_length
+                == cfg.model.backbone.walk_length
+            )
+
+            backbone = hydra.utils.instantiate(cfg.model.backbone)
+            # The exports manager loads backbones under a separate module
+            # identity, so compare by class name instead of isinstance.
+            assert type(backbone).__name__ == GRITBackbone.__name__
+            assert (
+                backbone.hidden_dim == cfg.model.feature_encoder.out_channels
+            )

--- a/test/nn/wrappers/graph/test_grit_wrapper.py
+++ b/test/nn/wrappers/graph/test_grit_wrapper.py
@@ -1,0 +1,99 @@
+"""Unit tests for the GRIT wrapper."""
+
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.grit import GRITBackbone
+from topobench.nn.wrappers import GRITWrapper
+from topobench.nn.wrappers.graph import WRAPPER_CLASSES
+from topobench.transforms.data_manipulations.rrwp_positional_encodings import (
+    AddRRWP,
+)
+
+HIDDEN_DIM = 16
+WALK_LENGTH = 4
+
+
+def _make_batch(with_rrwp: bool = True) -> Batch:
+    """Create a TopoBench-style batch of two small graphs.
+
+    Parameters
+    ----------
+    with_rrwp : bool, optional
+        Whether to attach precomputed RRWP encodings (default: True).
+
+    Returns
+    -------
+    torch_geometric.data.Batch
+        Batch with ``x_0`` and ``batch_0`` attributes.
+    """
+    transform = AddRRWP(walk_length=WALK_LENGTH)
+    data_list = []
+    for num_nodes in (5, 4):
+        src = torch.arange(num_nodes - 1)
+        dst = src + 1
+        edge_index = torch.cat(
+            [torch.stack([src, dst]), torch.stack([dst, src])], dim=1
+        )
+        data = Data(
+            x=torch.randn(num_nodes, HIDDEN_DIM),
+            edge_index=edge_index,
+            y=torch.zeros(1, dtype=torch.long),
+        )
+        if with_rrwp:
+            data = transform(data)
+        data_list.append(data)
+
+    batch = Batch.from_data_list(data_list)
+    batch.x_0 = batch.x
+    batch.batch_0 = batch.batch
+    return batch
+
+
+def _make_wrapper() -> GRITWrapper:
+    """Instantiate a GRIT wrapper around a small backbone.
+
+    Returns
+    -------
+    GRITWrapper
+        The wrapped backbone.
+    """
+    backbone = GRITBackbone(
+        hidden_dim=HIDDEN_DIM, num_layers=1, walk_length=WALK_LENGTH
+    )
+    return GRITWrapper(
+        backbone,
+        out_channels=HIDDEN_DIM,
+        num_cell_dimensions=1,
+        residual_connections=False,
+    )
+
+
+class TestGRITWrapper:
+    """Test the GRIT wrapper."""
+
+    def test_registration(self):
+        """Test that the wrapper is auto-discovered by TopoBench."""
+        assert "GRITWrapper" in WRAPPER_CLASSES
+
+    def test_forward_with_precomputed_rrwp(self):
+        """Test the wrapper forward pass on a batch with RRWP."""
+        batch = _make_batch(with_rrwp=True)
+        wrapper = _make_wrapper()
+
+        model_out = wrapper(batch)
+
+        assert set(model_out.keys()) == {"labels", "batch_0", "x_0"}
+        assert model_out["x_0"].shape == (batch.num_nodes, HIDDEN_DIM)
+        assert torch.equal(model_out["labels"], batch.y)
+        assert torch.equal(model_out["batch_0"], batch.batch_0)
+
+    def test_forward_without_rrwp(self):
+        """Test that the wrapper works when RRWP attributes are absent."""
+        batch = _make_batch(with_rrwp=False)
+        wrapper = _make_wrapper()
+
+        model_out = wrapper(batch)
+
+        assert model_out["x_0"].shape == (batch.num_nodes, HIDDEN_DIM)
+        assert torch.isfinite(model_out["x_0"]).all()

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/grit"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/test/transforms/data_manipulations/test_AddRRWP.py
+++ b/test/transforms/data_manipulations/test_AddRRWP.py
@@ -1,0 +1,255 @@
+"""Unit tests for the AddRRWP transform (RRWP positional encodings)."""
+
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.transforms.data_manipulations import DATA_MANIPULATIONS
+from topobench.transforms.data_manipulations.rrwp_positional_encodings import (
+    AddRRWP,
+    compute_rrwp,
+)
+from topobench.transforms.data_transform import DataTransform
+
+
+def _cycle_graph(num_nodes: int) -> Data:
+    """Create an undirected cycle graph.
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes in the cycle.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        The cycle graph data object.
+    """
+    src = torch.arange(num_nodes)
+    dst = (src + 1) % num_nodes
+    edge_index = torch.cat(
+        [torch.stack([src, dst]), torch.stack([dst, src])], dim=1
+    )
+    return Data(x=torch.randn(num_nodes, 3), edge_index=edge_index)
+
+
+def _path_graph(num_nodes: int) -> Data:
+    """Create an undirected path graph.
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes in the path.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        The path graph data object.
+    """
+    src = torch.arange(num_nodes - 1)
+    dst = src + 1
+    edge_index = torch.cat(
+        [torch.stack([src, dst]), torch.stack([dst, src])], dim=1
+    )
+    return Data(x=torch.randn(num_nodes, 3), edge_index=edge_index)
+
+
+class TestComputeRRWP:
+    """Test the compute_rrwp helper function."""
+
+    def test_shapes(self):
+        """Test output shapes for a small graph."""
+        data = _cycle_graph(6)
+        walk_length = 4
+        abs_pe, rel_index, rel_val, deg = compute_rrwp(
+            data.edge_index, data.num_nodes, walk_length
+        )
+
+        assert abs_pe.shape == (6, walk_length)
+        assert rel_index.shape[0] == 2
+        assert rel_val.shape == (rel_index.shape[1], walk_length)
+        assert deg.shape == (6,)
+
+    def test_identity_channel(self):
+        """Test that the first channel is the identity matrix."""
+        data = _cycle_graph(5)
+        abs_pe, rel_index, rel_val, _ = compute_rrwp(
+            data.edge_index, data.num_nodes, 3
+        )
+
+        assert torch.allclose(abs_pe[:, 0], torch.ones(5))
+        self_loops = rel_index[0] == rel_index[1]
+        assert torch.allclose(
+            rel_val[self_loops, 0], torch.ones(int(self_loops.sum()))
+        )
+        assert torch.allclose(
+            rel_val[~self_loops, 0], torch.zeros(int((~self_loops).sum()))
+        )
+
+    def test_one_step_probabilities(self):
+        """Test that the second channel matches D^{-1} A exactly."""
+        data = _cycle_graph(4)
+        _, rel_index, rel_val, deg = compute_rrwp(
+            data.edge_index, data.num_nodes, 2
+        )
+
+        # On a cycle, every node has degree 2 and hops to each neighbor
+        # with probability 1/2. Pair orientation is (source=j, target=i)
+        # with value P_{i, j}.
+        assert torch.allclose(deg, torch.full((4,), 2.0))
+        for source, target, val in zip(
+            rel_index[0], rel_index[1], rel_val, strict=True
+        ):
+            if source == target:
+                expected = torch.tensor([1.0, 0.0])
+            else:
+                expected = torch.tensor([0.0, 0.5])
+            assert torch.allclose(val, expected)
+
+    def test_matches_dense_matrix_powers(self):
+        """Test the values against explicitly computed matrix powers."""
+        data = _path_graph(5)
+        walk_length = 4
+        _, rel_index, rel_val, _ = compute_rrwp(
+            data.edge_index, data.num_nodes, walk_length
+        )
+
+        adj = torch.zeros(5, 5)
+        adj[data.edge_index[0], data.edge_index[1]] = 1.0
+        transition = adj / adj.sum(dim=1, keepdim=True).clamp(min=1.0)
+        dense = torch.stack(
+            [torch.matrix_power(transition, k) for k in range(walk_length)],
+            dim=-1,
+        )
+
+        source, target = rel_index[0], rel_index[1]
+        assert torch.allclose(rel_val, dense[target, source], atol=1e-6)
+
+        # All non-zero entries of the dense tensor must be represented.
+        mask = torch.zeros(5, 5, dtype=torch.bool)
+        mask[target, source] = True
+        assert torch.all(dense.abs().sum(-1)[~mask] == 0)
+
+    def test_sparsity_of_relative_encodings(self):
+        """Test that unreachable node pairs are not materialized."""
+        data = _path_graph(6)
+        _, rel_index, _, _ = compute_rrwp(data.edge_index, data.num_nodes, 2)
+
+        # With K=2 (identity + one hop), only self-loops and direct
+        # neighbors can appear.
+        distance = (rel_index[0] - rel_index[1]).abs()
+        assert torch.all(distance <= 1)
+
+    def test_isolated_node(self):
+        """Test a graph containing an isolated node."""
+        edge_index = torch.tensor([[0, 1], [1, 0]])
+        abs_pe, rel_index, rel_val, deg = compute_rrwp(edge_index, 3, 3)
+
+        assert deg[2] == 0
+        # The isolated node only appears in its own identity pair.
+        expected_abs = torch.tensor([1.0, 0.0, 0.0])
+        assert torch.allclose(abs_pe[2], expected_abs)
+        node_2_pairs = (rel_index == 2).any(dim=0)
+        assert int(node_2_pairs.sum()) == 1
+        assert torch.allclose(rel_val[node_2_pairs][0], expected_abs)
+
+    def test_empty_graph(self):
+        """Test a graph with no edges."""
+        edge_index = torch.empty((2, 0), dtype=torch.long)
+        abs_pe, rel_index, rel_val, deg = compute_rrwp(edge_index, 3, 4)
+
+        assert abs_pe.shape == (3, 4)
+        assert torch.all(deg == 0)
+        # Only identity pairs remain.
+        assert rel_index.shape[1] == 3
+        assert torch.equal(rel_index[0], rel_index[1])
+
+
+class TestAddRRWP:
+    """Test the AddRRWP transform."""
+
+    def test_registration(self):
+        """Test that the transform is discoverable by TopoBench."""
+        assert "AddRRWP" in DATA_MANIPULATIONS
+
+    def test_data_transform_instantiation(self):
+        """Test instantiation through TopoBench's DataTransform."""
+        transform = DataTransform(
+            transform_name="AddRRWP",
+            transform_type="data manipulation",
+            walk_length=4,
+        )
+        data = transform(_cycle_graph(5))
+        assert data.rrwp.shape == (5, 4)
+
+    def test_invalid_walk_length(self):
+        """Test that too-short walk lengths are rejected."""
+        with pytest.raises(ValueError, match="walk_length"):
+            AddRRWP(walk_length=1)
+
+    def test_repr(self):
+        """Test the string representation."""
+        assert repr(AddRRWP(walk_length=6)) == "AddRRWP(walk_length=6)"
+
+    def test_attached_attributes(self, simple_graph_0):
+        """Test the attributes attached to the data object.
+
+        Parameters
+        ----------
+        simple_graph_0 : torch_geometric.data.Data
+            Test graph fixture.
+        """
+        walk_length = 5
+        data = AddRRWP(walk_length=walk_length)(simple_graph_0)
+
+        num_nodes = simple_graph_0.num_nodes
+        assert data.rrwp.shape == (num_nodes, walk_length)
+        assert data.rrwp_index.shape[0] == 2
+        assert data.rrwp_val.shape == (
+            data.rrwp_index.shape[1],
+            walk_length,
+        )
+        assert data.log_deg.shape == (num_nodes,)
+
+    def test_log_deg(self):
+        """Test that log_deg equals log(1 + degree)."""
+        data = AddRRWP(walk_length=3)(_cycle_graph(4))
+        assert torch.allclose(data.log_deg, torch.full((4,), 3.0).log())
+
+    def test_diagonal_matches_abs_encoding(self):
+        """Test that rrwp equals the diagonal of the relative encodings."""
+        data = AddRRWP(walk_length=4)(_cycle_graph(6))
+
+        self_loops = data.rrwp_index[0] == data.rrwp_index[1]
+        diag_nodes = data.rrwp_index[0, self_loops]
+        diag_vals = data.rrwp_val[self_loops]
+        assert torch.allclose(data.rrwp[diag_nodes], diag_vals)
+
+    def test_batching_offsets_pair_index(self):
+        """Test that rrwp_index is offset like edge_index when batching."""
+        transform = AddRRWP(walk_length=3)
+        data_0 = transform(_cycle_graph(4))
+        data_1 = transform(_path_graph(3))
+        batch = Batch.from_data_list([data_0, data_1])
+
+        assert batch.rrwp.shape == (7, 3)
+        assert batch.rrwp_index.max() == 6
+        # Pairs of the second graph must be offset by 4 nodes.
+        num_pairs_0 = data_0.rrwp_index.shape[1]
+        assert torch.equal(
+            batch.rrwp_index[:, num_pairs_0:], data_1.rrwp_index + 4
+        )
+        assert torch.allclose(
+            batch.rrwp_val, torch.cat([data_0.rrwp_val, data_1.rrwp_val])
+        )
+
+    def test_deterministic(self):
+        """Test that the transform is deterministic."""
+        transform = AddRRWP(walk_length=4)
+        graph = _cycle_graph(5)
+        data_a = transform(graph.clone())
+        data_b = transform(graph.clone())
+
+        assert torch.equal(data_a.rrwp, data_b.rrwp)
+        assert torch.equal(data_a.rrwp_index, data_b.rrwp_index)
+        assert torch.equal(data_a.rrwp_val, data_b.rrwp_val)

--- a/topobench/nn/backbones/graph/grit.py
+++ b/topobench/nn/backbones/graph/grit.py
@@ -1,0 +1,663 @@
+"""Graph Inductive Bias Transformer (GRIT) backbone.
+
+This module implements GRIT [1]_, a graph transformer that incorporates
+graph inductive biases without message passing, based on three design
+choices:
+
+1. Learned relative positional encodings initialized with Relative Random
+   Walk Probabilities (RRWP, Eq. (1) in [1]_), precomputed by the
+   :class:`topobench.transforms.data_manipulations.AddRRWP` transform (or
+   computed on the fly as a fallback).
+2. A flexible attention mechanism that jointly updates node and node-pair
+   representations (Eq. (2)-(3) in [1]_).
+3. Injection of degree information through adaptive degree scalers
+   (Eq. (5) in [1]_), paired with batch normalization, since layer
+   normalization would cancel the degree information (Proposition 3.3
+   in [1]_).
+
+References
+----------
+.. [1] Ma, Lin, Lim, Romero-Soriano, Dokania, Coates, Torr, Lim.
+    "Graph Inductive Biases in Transformers without Message Passing."
+    ICML 2023. https://arxiv.org/abs/2305.17589
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch_geometric.utils import coalesce, scatter, softmax
+
+from topobench.transforms.data_manipulations.rrwp_positional_encodings import (
+    compute_rrwp,
+)
+
+
+def full_edge_index(
+    batch: torch.Tensor, device: torch.device | None = None
+) -> torch.Tensor:
+    r"""Build the edge index of the fully-connected graph for each example.
+
+    All node pairs (including self-loops) are generated independently for
+    every graph in the batch, so no attention edge crosses two different
+    graphs.
+
+    Parameters
+    ----------
+    batch : torch.Tensor
+        Batch vector of shape ``[num_nodes]`` assigning each node to an
+        example.
+    device : torch.device, optional
+        Device of the output tensor (default: the device of ``batch``).
+
+    Returns
+    -------
+    torch.Tensor
+        Edge indices of shape ``[2, num_pairs]`` covering all intra-graph
+        node pairs.
+    """
+    device = batch.device if device is None else device
+    num_nodes_per_graph = torch.bincount(batch)
+    node_offsets = torch.cat(
+        [batch.new_zeros(1), num_nodes_per_graph.cumsum(dim=0)[:-1]]
+    )
+
+    index_list = []
+    for offset, num_nodes in zip(
+        node_offsets.tolist(), num_nodes_per_graph.tolist(), strict=True
+    ):
+        nodes = torch.arange(num_nodes, device=device)
+        pairs = torch.cartesian_prod(nodes, nodes).t()
+        index_list.append(pairs + offset)
+    return torch.cat(index_list, dim=1)
+
+
+class GRITAttention(nn.Module):
+    r"""GRIT multi-head attention conditioned on node-pair representations.
+
+    Implements Eq. (2) of the GRIT paper for a sparse set of attention
+    pairs: given node representations :math:`\mathbf{x}` and node-pair
+    representations :math:`\mathbf{e}`, it computes
+
+    .. math::
+        \hat{\mathbf{e}}_{i,j} &= \sigma(\rho((\mathbf{W}_Q \mathbf{x}_i +
+        \mathbf{W}_K \mathbf{x}_j) \odot \mathbf{W}_{Ew} \mathbf{e}_{i,j})
+        + \mathbf{W}_{Eb} \mathbf{e}_{i,j}) \\
+        \alpha_{ij} &= \mathrm{Softmax}_{j}(\mathbf{W}_A
+        \hat{\mathbf{e}}_{i,j}) \\
+        \hat{\mathbf{x}}_i &= \sum_j \alpha_{ij} (\mathbf{W}_V \mathbf{x}_j
+        + \mathbf{W}_{Ev} \hat{\mathbf{e}}_{i,j}),
+
+    where :math:`\rho(x) = \mathrm{ReLU}(x)^{1/2} -
+    \mathrm{ReLU}(-x)^{1/2}` is the signed square root that stabilizes
+    training.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Dimension of node and node-pair representations.
+    num_heads : int
+        Number of attention heads; must divide ``hidden_dim``.
+    attn_dropout : float, optional
+        Dropout applied to the attention weights (default: 0).
+    clamp : float, optional
+        Symmetric clamping value for attention logits; ``None`` disables
+        clamping (default: 5.0).
+    edge_enhance : bool, optional
+        Whether to add the pair-representation term
+        :math:`\mathbf{W}_{Ev}\hat{\mathbf{e}}_{i,j}` to the aggregated
+        node update (default: True).
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        attn_dropout: float = 0.0,
+        clamp: float | None = 5.0,
+        edge_enhance: bool = True,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim ({hidden_dim}) must be divisible by "
+                f"num_heads ({num_heads})."
+            )
+
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.clamp = abs(clamp) if clamp is not None else None
+        self.edge_enhance = edge_enhance
+        self.attn_dropout = nn.Dropout(attn_dropout)
+
+        self.W_Q = nn.Linear(hidden_dim, hidden_dim, bias=True)
+        self.W_K = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.W_E = nn.Linear(hidden_dim, hidden_dim * 2, bias=True)
+        self.W_V = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        nn.init.xavier_normal_(self.W_Q.weight)
+        nn.init.xavier_normal_(self.W_K.weight)
+        nn.init.xavier_normal_(self.W_E.weight)
+        nn.init.xavier_normal_(self.W_V.weight)
+
+        # W_A in Eq. (2): maps each head's pair representation to a logit.
+        self.W_A = nn.Parameter(torch.zeros(self.head_dim, num_heads, 1))
+        nn.init.xavier_normal_(self.W_A)
+
+        if self.edge_enhance:
+            # W_Ev in Eq. (2), applied after aggregating \hat{e}_{i,j}.
+            self.W_Ev = nn.Parameter(
+                torch.zeros(self.head_dim, num_heads, self.head_dim)
+            )
+            nn.init.xavier_normal_(self.W_Ev)
+
+    @staticmethod
+    def signed_sqrt(x: torch.Tensor) -> torch.Tensor:
+        r"""Signed square root :math:`\rho` from Eq. (2) of the GRIT paper.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Elementwise signed square root of the input.
+        """
+        return torch.sqrt(torch.relu(x)) - torch.sqrt(torch.relu(-x))
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        pair_index: torch.Tensor,
+        pair_attr: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        r"""Compute the attention update for nodes and node pairs.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node representations of shape ``[num_nodes, hidden_dim]``.
+        pair_index : torch.Tensor
+            Attention pairs of shape ``[2, num_pairs]``; row 0 holds the
+            source (attended) nodes, row 1 the target (attending) nodes.
+        pair_attr : torch.Tensor
+            Node-pair representations of shape ``[num_pairs, hidden_dim]``.
+
+        Returns
+        -------
+        x_out : torch.Tensor
+            Updated node representations, ``[num_nodes, num_heads,
+            head_dim]``.
+        pair_out : torch.Tensor
+            Updated node-pair representations, ``[num_pairs, hidden_dim]``.
+        """
+        source, target = pair_index[0], pair_index[1]
+        num_nodes = x.size(0)
+
+        q = self.W_Q(x).view(-1, self.num_heads, self.head_dim)
+        k = self.W_K(x).view(-1, self.num_heads, self.head_dim)
+        v = self.W_V(x).view(-1, self.num_heads, self.head_dim)
+        e = self.W_E(pair_attr).view(-1, self.num_heads, self.head_dim * 2)
+        e_w, e_b = e[..., : self.head_dim], e[..., self.head_dim :]
+
+        # \hat{e}_{i,j} (Eq. 2), with i = target, j = source.
+        score = q[target] + k[source]
+        score = self.signed_sqrt(score * e_w) + e_b
+        pair_update = torch.relu(score)
+
+        # Attention logits and per-target softmax.
+        logits = torch.einsum("phd,dho->pho", pair_update, self.W_A)
+        if self.clamp is not None:
+            logits = torch.clamp(logits, min=-self.clamp, max=self.clamp)
+        alpha = softmax(logits, index=target, num_nodes=num_nodes)
+        alpha = self.attn_dropout(alpha)
+
+        # Aggregate messages towards target nodes.
+        x_out = scatter(
+            v[source] * alpha,
+            target,
+            dim=0,
+            dim_size=num_nodes,
+            reduce="sum",
+        )
+        if self.edge_enhance:
+            pair_agg = scatter(
+                pair_update * alpha,
+                target,
+                dim=0,
+                dim_size=num_nodes,
+                reduce="sum",
+            )
+            x_out = x_out + torch.einsum("nhd,dhc->nhc", pair_agg, self.W_Ev)
+
+        return x_out, pair_update.flatten(1)
+
+
+class GRITTransformerLayer(nn.Module):
+    r"""GRIT transformer layer.
+
+    Combines the GRIT attention mechanism with the adaptive degree scaler
+    (Eq. (5) in the GRIT paper), residual connections, batch normalization
+    and a feed-forward network. Batch normalization is used instead of
+    layer normalization because the latter cancels out degree information
+    (Proposition 3.3 in the GRIT paper).
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Dimension of node and node-pair representations.
+    num_heads : int
+        Number of attention heads.
+    dropout : float, optional
+        Dropout applied to node/pair updates and inside the FFN
+        (default: 0).
+    attn_dropout : float, optional
+        Dropout applied to the attention weights (default: 0).
+    clamp : float, optional
+        Symmetric clamping value for attention logits (default: 5.0).
+    deg_scaler : bool, optional
+        Whether to apply the adaptive degree scaler of Eq. (5)
+        (default: True).
+    edge_enhance : bool, optional
+        Whether the attention update uses the pair-representation term
+        (default: True).
+    update_pair_rep : bool, optional
+        Whether to update the node-pair representations (learned RRWP);
+        if False, the input pair representations are passed through
+        unchanged (default: True).
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        dropout: float = 0.0,
+        attn_dropout: float = 0.0,
+        clamp: float | None = 5.0,
+        deg_scaler: bool = True,
+        edge_enhance: bool = True,
+        update_pair_rep: bool = True,
+    ):
+        super().__init__()
+        self.deg_scaler = deg_scaler
+        self.update_pair_rep = update_pair_rep
+        self.dropout = dropout
+
+        self.attention = GRITAttention(
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            attn_dropout=attn_dropout,
+            clamp=clamp,
+            edge_enhance=edge_enhance,
+        )
+
+        self.W_O_node = nn.Linear(hidden_dim, hidden_dim)
+        self.W_O_pair = nn.Linear(hidden_dim, hidden_dim)
+
+        if self.deg_scaler:
+            # theta_1, theta_2 in Eq. (5), stacked on the last dimension.
+            self.deg_coef = nn.Parameter(torch.zeros(1, hidden_dim, 2))
+            nn.init.xavier_normal_(self.deg_coef)
+
+        self.norm1_node = nn.BatchNorm1d(hidden_dim)
+        self.norm1_pair = nn.BatchNorm1d(hidden_dim)
+        self.norm2_node = nn.BatchNorm1d(hidden_dim)
+
+        self.ffn = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim * 2),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim * 2, hidden_dim),
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        pair_index: torch.Tensor,
+        pair_attr: torch.Tensor,
+        log_deg: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        r"""Update node and node-pair representations.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node representations of shape ``[num_nodes, hidden_dim]``.
+        pair_index : torch.Tensor
+            Attention pairs of shape ``[2, num_pairs]``.
+        pair_attr : torch.Tensor
+            Node-pair representations of shape ``[num_pairs, hidden_dim]``.
+        log_deg : torch.Tensor
+            Log-degrees :math:`\log(1 + d_i)` of shape ``[num_nodes, 1]``.
+
+        Returns
+        -------
+        x : torch.Tensor
+            Updated node representations, ``[num_nodes, hidden_dim]``.
+        pair_attr : torch.Tensor
+            Updated node-pair representations, ``[num_pairs, hidden_dim]``.
+        """
+        x_res, pair_res = x, pair_attr
+
+        x_attn, pair_update = self.attention(x, pair_index, pair_attr)
+
+        x = F.dropout(
+            x_attn.flatten(1), p=self.dropout, training=self.training
+        )
+        if self.deg_scaler:
+            # x' = x * theta_1 + log(1 + d) * x * theta_2 (Eq. 5).
+            x = torch.stack([x, x * log_deg], dim=-1)
+            x = (x * self.deg_coef).sum(dim=-1)
+        x = self.W_O_node(x)
+        x = self.norm1_node(x + x_res)
+
+        if self.update_pair_rep:
+            pair_attr = F.dropout(
+                pair_update, p=self.dropout, training=self.training
+            )
+            pair_attr = self.W_O_pair(pair_attr)
+            pair_attr = self.norm1_pair(pair_attr + pair_res)
+        else:
+            pair_attr = pair_res
+
+        x = self.norm2_node(x + self.ffn(x))
+
+        return x, pair_attr
+
+
+class GRITBackbone(nn.Module):
+    r"""GRIT backbone: a graph transformer without message passing.
+
+    The backbone expects node features already projected to ``hidden_dim``
+    (e.g. by TopoBench's ``AllCellFeatureEncoder``) and RRWP positional
+    encodings attached to the batch by the ``AddRRWP`` transform. When the
+    RRWP attributes are missing (e.g. the transform was not configured),
+    they are computed on the fly per graph, which is functionally
+    equivalent but slower than precomputing them once.
+
+    Following the GRIT paper, node representations are initialized as
+    :math:`\mathbf{x}_i = \mathbf{x}'_i + \mathrm{FC}(\mathbf{P}_{i,i})`
+    and node-pair representations as :math:`\mathbf{e}_{i,j} =
+    \mathrm{FC}(\mathbf{P}_{i,j}) (+ \mathrm{FC}(\mathbf{e}'_{i,j}))`,
+    after which a stack of :class:`GRITTransformerLayer` updates both.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Dimension of node and node-pair representations.
+    num_layers : int, optional
+        Number of GRIT transformer layers (default: 4).
+    num_heads : int, optional
+        Number of attention heads (default: 8).
+    walk_length : int, optional
+        Number of RRWP channels :math:`K`; must match the ``walk_length``
+        used by the ``AddRRWP`` transform (default: 8).
+    dropout : float, optional
+        Dropout applied to node/pair updates and inside the FFN
+        (default: 0).
+    attn_dropout : float, optional
+        Dropout applied to the attention weights (default: 0.2).
+    clamp : float, optional
+        Symmetric clamping value for attention logits (default: 5.0).
+    pad_to_full_graph : bool, optional
+        Whether to extend the attention pairs to all intra-graph node
+        pairs (global attention). If False, attention is restricted to
+        pairs reachable by walks shorter than ``walk_length``
+        (default: True).
+    deg_scaler : bool, optional
+        Whether to apply the adaptive degree scaler (default: True).
+    edge_enhance : bool, optional
+        Whether the attention update uses the pair-representation term
+        (default: True).
+    update_pair_rep : bool, optional
+        Whether layers update the node-pair representations
+        (default: True).
+    edge_dim : int, optional
+        Dimension of the raw edge attributes. If set, edge attributes are
+        linearly projected and fused into the initial node-pair
+        representations; if None, edge attributes are ignored
+        (default: None).
+    **kwargs : dict
+        Additional arguments (ignored).
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_layers: int = 4,
+        num_heads: int = 8,
+        walk_length: int = 8,
+        dropout: float = 0.0,
+        attn_dropout: float = 0.2,
+        clamp: float | None = 5.0,
+        pad_to_full_graph: bool = True,
+        deg_scaler: bool = True,
+        edge_enhance: bool = True,
+        update_pair_rep: bool = True,
+        edge_dim: int | None = None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.walk_length = walk_length
+        self.pad_to_full_graph = pad_to_full_graph
+
+        # Linear encoders for the absolute (node) and relative (pair) RRWP.
+        self.abs_pe_encoder = nn.Linear(walk_length, hidden_dim, bias=False)
+        self.rel_pe_encoder = nn.Linear(walk_length, hidden_dim, bias=False)
+        nn.init.xavier_uniform_(self.abs_pe_encoder.weight)
+        nn.init.xavier_uniform_(self.rel_pe_encoder.weight)
+
+        self.edge_attr_encoder = (
+            nn.Linear(edge_dim, hidden_dim) if edge_dim is not None else None
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                GRITTransformerLayer(
+                    hidden_dim=hidden_dim,
+                    num_heads=num_heads,
+                    dropout=dropout,
+                    attn_dropout=attn_dropout,
+                    clamp=clamp,
+                    deg_scaler=deg_scaler,
+                    edge_enhance=edge_enhance,
+                    update_pair_rep=update_pair_rep,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_attr: torch.Tensor | None = None,
+        rrwp: torch.Tensor | None = None,
+        rrwp_index: torch.Tensor | None = None,
+        rrwp_val: torch.Tensor | None = None,
+        log_deg: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""Forward pass of the GRIT backbone.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``[num_nodes, hidden_dim]``.
+        edge_index : torch.Tensor
+            Edge indices of shape ``[2, num_edges]``.
+        batch : torch.Tensor, optional
+            Batch vector assigning each node to an example; a single graph
+            is assumed if None (default: None).
+        edge_attr : torch.Tensor, optional
+            Raw edge attributes of shape ``[num_edges, edge_dim]``; only
+            used when ``edge_dim`` was configured (default: None).
+        rrwp : torch.Tensor, optional
+            Precomputed node-level RRWP of shape ``[num_nodes,
+            walk_length]`` (default: None).
+        rrwp_index : torch.Tensor, optional
+            Precomputed relative RRWP indices, ``[2, num_pairs]``
+            (default: None).
+        rrwp_val : torch.Tensor, optional
+            Precomputed relative RRWP values, ``[num_pairs, walk_length]``
+            (default: None).
+        log_deg : torch.Tensor, optional
+            Precomputed log-degrees of shape ``[num_nodes]``
+            (default: None).
+        **kwargs : dict
+            Additional arguments (ignored).
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node representations of shape ``[num_nodes,
+            hidden_dim]``.
+        """
+        num_nodes = x.size(0)
+        if batch is None:
+            batch = x.new_zeros(num_nodes, dtype=torch.long)
+
+        if any(attr is None for attr in (rrwp, rrwp_index, rrwp_val, log_deg)):
+            rrwp, rrwp_index, rrwp_val, log_deg = self._rrwp_fallback(
+                edge_index, batch
+            )
+        if rrwp_val.size(-1) != self.walk_length:
+            raise ValueError(
+                f"RRWP encodings have {rrwp_val.size(-1)} channels but the "
+                f"backbone was configured with walk_length="
+                f"{self.walk_length}. Make sure the AddRRWP transform and "
+                f"the GRIT backbone use the same walk_length."
+            )
+
+        # Initialize node and node-pair representations from RRWP.
+        x = x + self.abs_pe_encoder(rrwp)
+        pair_index, pair_attr = self._build_pair_representations(
+            rrwp_index, rrwp_val, edge_index, edge_attr, batch, num_nodes
+        )
+
+        log_deg = log_deg.view(num_nodes, 1)
+        for layer in self.layers:
+            x, pair_attr = layer(x, pair_index, pair_attr, log_deg)
+
+        return x
+
+    def _build_pair_representations(
+        self,
+        rrwp_index: torch.Tensor,
+        rrwp_val: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_attr: torch.Tensor | None,
+        batch: torch.Tensor,
+        num_nodes: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        r"""Build the initial node-pair representations.
+
+        Combines (by sum over coinciding pairs) the projected relative
+        RRWP, optionally the projected edge attributes, and, when
+        ``pad_to_full_graph`` is set, zero paddings for all remaining
+        intra-graph node pairs.
+
+        Parameters
+        ----------
+        rrwp_index : torch.Tensor
+            Relative RRWP indices of shape ``[2, num_pairs]``.
+        rrwp_val : torch.Tensor
+            Relative RRWP values of shape ``[num_pairs, walk_length]``.
+        edge_index : torch.Tensor
+            Edge indices of shape ``[2, num_edges]``.
+        edge_attr : torch.Tensor, optional
+            Raw edge attributes of shape ``[num_edges, edge_dim]``.
+        batch : torch.Tensor
+            Batch vector of shape ``[num_nodes]``.
+        num_nodes : int
+            Total number of nodes in the batch.
+
+        Returns
+        -------
+        pair_index : torch.Tensor
+            Attention pair indices of shape ``[2, num_pairs_out]``.
+        pair_attr : torch.Tensor
+            Initial pair representations, ``[num_pairs_out, hidden_dim]``.
+        """
+        pair_index = rrwp_index
+        pair_attr = self.rel_pe_encoder(rrwp_val)
+
+        if edge_attr is not None and self.edge_attr_encoder is not None:
+            edge_attr = edge_attr.view(edge_index.size(1), -1).float()
+            pair_index = torch.cat([pair_index, edge_index], dim=1)
+            pair_attr = torch.cat(
+                [pair_attr, self.edge_attr_encoder(edge_attr)], dim=0
+            )
+
+        if self.pad_to_full_graph:
+            padding_index = full_edge_index(batch)
+            padding_attr = pair_attr.new_zeros(
+                padding_index.size(1), pair_attr.size(1)
+            )
+            pair_index = torch.cat([pair_index, padding_index], dim=1)
+            pair_attr = torch.cat([pair_attr, padding_attr], dim=0)
+
+        return coalesce(
+            pair_index, pair_attr, num_nodes=num_nodes, reduce="sum"
+        )
+
+    @torch.no_grad()
+    def _rrwp_fallback(
+        self,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        r"""Compute RRWP encodings on the fly for a (batched) graph.
+
+        Each graph in the batch is processed independently, which is
+        equivalent to applying the ``AddRRWP`` transform before batching.
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            Edge indices of shape ``[2, num_edges]``.
+        batch : torch.Tensor
+            Batch vector of shape ``[num_nodes]``.
+
+        Returns
+        -------
+        rrwp : torch.Tensor
+            Node-level RRWP, ``[num_nodes, walk_length]``.
+        rrwp_index : torch.Tensor
+            Relative RRWP indices, ``[2, num_pairs]``.
+        rrwp_val : torch.Tensor
+            Relative RRWP values, ``[num_pairs, walk_length]``.
+        log_deg : torch.Tensor
+            Log-degrees, ``[num_nodes]``.
+        """
+        num_nodes_per_graph = torch.bincount(batch, minlength=1)
+        node_offsets = torch.cat(
+            [batch.new_zeros(1), num_nodes_per_graph.cumsum(dim=0)[:-1]]
+        )
+        edge_graph = batch[edge_index[0]]
+
+        abs_list, index_list, val_list, deg_list = [], [], [], []
+        for graph_id, (offset, graph_num_nodes) in enumerate(
+            zip(
+                node_offsets.tolist(),
+                num_nodes_per_graph.tolist(),
+                strict=True,
+            )
+        ):
+            graph_edge_index = edge_index[:, edge_graph == graph_id] - offset
+            abs_pe, rel_index, rel_val, deg = compute_rrwp(
+                graph_edge_index, graph_num_nodes, self.walk_length
+            )
+            abs_list.append(abs_pe)
+            index_list.append(rel_index + offset)
+            val_list.append(rel_val)
+            deg_list.append(deg)
+
+        return (
+            torch.cat(abs_list, dim=0),
+            torch.cat(index_list, dim=1),
+            torch.cat(val_list, dim=0),
+            torch.log1p(torch.cat(deg_list, dim=0)),
+        )

--- a/topobench/nn/wrappers/graph/grit_wrapper.py
+++ b/topobench/nn/wrappers/graph/grit_wrapper.py
@@ -1,0 +1,44 @@
+"""Wrapper for the GRIT backbone."""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class GRITWrapper(AbstractWrapper):
+    r"""Wrapper for the GRIT backbone.
+
+    This wrapper defines the forward pass of the model. Besides the node
+    features and connectivity, it forwards the RRWP positional encodings
+    (``rrwp``, ``rrwp_index``, ``rrwp_val``) and the log-degrees
+    (``log_deg``) attached to the batch by the ``AddRRWP`` transform. When
+    these attributes are absent, the backbone computes them on the fly.
+    The GRIT backbone returns the embeddings of the cells of rank 0.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the GRIT wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the updated model output.
+        """
+        x_0 = self.backbone(
+            batch.x_0,
+            batch.edge_index,
+            batch=batch.batch_0,
+            edge_attr=batch.get("edge_attr", None),
+            rrwp=batch.get("rrwp", None),
+            rrwp_index=batch.get("rrwp_index", None),
+            rrwp_val=batch.get("rrwp_val", None),
+            log_deg=batch.get("log_deg", None),
+        )
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+
+        return model_out

--- a/topobench/transforms/data_manipulations/rrwp_positional_encodings.py
+++ b/topobench/transforms/data_manipulations/rrwp_positional_encodings.py
@@ -1,0 +1,156 @@
+"""Relative Random Walk Probabilities (RRWP) positional encodings.
+
+This transform implements the RRWP positional encodings introduced in
+"Graph Inductive Biases in Transformers without Message Passing"
+(GRIT) [1]_, Eq. (1):
+
+.. math::
+    \\mathbf{P}_{i,j} = [\\mathbf{I}, \\mathbf{M}, \\mathbf{M}^2, \\ldots,
+    \\mathbf{M}^{K-1}]_{i,j} \\in \\mathbb{R}^{K},
+    \\quad \\mathbf{M} = \\mathbf{D}^{-1}\\mathbf{A},
+
+where :math:`\\mathbf{M}_{i,j}` is the probability that a simple random
+walk starting at node :math:`i` reaches node :math:`j` in one step. The
+diagonal :math:`\\mathbf{P}_{i,i}` coincides with the Random Walk
+Structural Encodings (RWSE) and is used as a node-level (absolute)
+positional encoding, while the off-diagonal entries provide relative
+node-pair encodings.
+
+References
+----------
+.. [1] Ma, Lin, Lim, Romero-Soriano, Dokania, Coates, Torr, Lim.
+    "Graph Inductive Biases in Transformers without Message Passing."
+    ICML 2023. https://arxiv.org/abs/2305.17589
+"""
+
+import torch
+from torch_geometric.data import Data
+from torch_geometric.transforms import BaseTransform
+from torch_geometric.utils import degree
+
+
+def compute_rrwp(
+    edge_index: torch.Tensor,
+    num_nodes: int,
+    walk_length: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    r"""Compute RRWP encodings for a single graph.
+
+    The relative encodings are returned in sparse (COO) form, keeping only
+    node pairs :math:`(i, j)` for which at least one of the ``walk_length``
+    random walk probabilities is non-zero. Following the reference GRIT
+    implementation, the returned pair index is oriented as
+    ``(source=j, target=i)`` with value :math:`\mathbf{P}_{i,j}`, so that
+    during attention node :math:`i` attends to node :math:`j` conditioned
+    on the probabilities of walks from :math:`i` to :math:`j`.
+
+    Parameters
+    ----------
+    edge_index : torch.Tensor
+        Edge indices of shape ``[2, num_edges]``.
+    num_nodes : int
+        Number of nodes in the graph.
+    walk_length : int
+        Number of random walk channels :math:`K` (including the identity,
+        i.e. powers :math:`\mathbf{M}^0, \ldots, \mathbf{M}^{K-1}`).
+
+    Returns
+    -------
+    abs_pe : torch.Tensor
+        Node-level encodings :math:`\mathbf{P}_{i,i}` of shape
+        ``[num_nodes, walk_length]`` (equivalent to RWSE).
+    rel_pe_index : torch.Tensor
+        Indices of the non-zero node-pair encodings, shape ``[2, num_pairs]``.
+    rel_pe_val : torch.Tensor
+        Values of the non-zero node-pair encodings, shape
+        ``[num_pairs, walk_length]``.
+    deg : torch.Tensor
+        Node out-degrees of shape ``[num_nodes]``.
+    """
+    device = edge_index.device
+    deg = degree(edge_index[0], num_nodes=num_nodes, dtype=torch.float)
+
+    # Random walk transition matrix M = D^{-1} A (dense; graphs handled by
+    # this transform are small enough for an [n, n, K] tensor).
+    adj = torch.zeros(num_nodes, num_nodes, device=device)
+    adj[edge_index[0], edge_index[1]] = 1.0
+    transition = adj / deg.clamp(min=1.0).unsqueeze(-1)
+
+    pe_list = [torch.eye(num_nodes, device=device)]
+    walk_matrix = torch.eye(num_nodes, device=device)
+    for _ in range(walk_length - 1):
+        walk_matrix = walk_matrix @ transition
+        pe_list.append(walk_matrix)
+    pe = torch.stack(pe_list, dim=-1)  # [n, n, K]
+
+    abs_pe = pe.diagonal().transpose(0, 1)  # [n, K]
+
+    # Sparsify: keep node pairs with at least one non-zero probability.
+    # P_{i, j} describes walks from i to j; the attention edge is oriented
+    # (source=j, target=i) as in the reference implementation.
+    target_idx, source_idx = pe.abs().sum(dim=-1).nonzero(as_tuple=True)
+    rel_pe_index = torch.stack([source_idx, target_idx], dim=0)
+    rel_pe_val = pe[target_idx, source_idx]
+
+    return abs_pe, rel_pe_index, rel_pe_val, deg
+
+
+class AddRRWP(BaseTransform):
+    r"""Add RRWP positional encodings (GRIT) to a graph.
+
+    The transform attaches to each ``Data`` object:
+
+    - ``rrwp``: node-level encodings of shape ``[num_nodes, walk_length]``
+      (the diagonal of the RRWP tensor, equivalent to RWSE),
+    - ``rrwp_index`` / ``rrwp_val``: sparse relative encodings for node
+      pairs connected by walks of length ``< walk_length``,
+    - ``log_deg``: :math:`\log(1 + d_i)` used by GRIT's degree scaler.
+
+    Since ``rrwp_index`` contains the substring ``"index"``, PyTorch
+    Geometric automatically offsets it by the number of nodes when
+    batching, exactly like ``edge_index``.
+
+    Parameters
+    ----------
+    walk_length : int, optional
+        Number of random walk channels :math:`K`, including the identity
+        (default: 8).
+    **kwargs : dict
+        Additional arguments (not used).
+    """
+
+    def __init__(self, walk_length: int = 8, **kwargs):
+        super().__init__()
+        if walk_length < 2:
+            raise ValueError(
+                f"walk_length must be at least 2, got {walk_length}."
+            )
+        self.walk_length = walk_length
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(walk_length={self.walk_length})"
+
+    def forward(self, data: Data) -> Data:
+        r"""Compute and attach RRWP encodings to the input graph.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            Input graph data object.
+
+        Returns
+        -------
+        torch_geometric.data.Data
+            Graph data object with ``rrwp``, ``rrwp_index``, ``rrwp_val``
+            and ``log_deg`` attributes.
+        """
+        abs_pe, rel_pe_index, rel_pe_val, deg = compute_rrwp(
+            data.edge_index, data.num_nodes, self.walk_length
+        )
+
+        data.rrwp = abs_pe
+        data.rrwp_index = rel_pe_index
+        data.rrwp_val = rel_pe_val
+        data.log_deg = torch.log1p(deg)
+
+        return data


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.


## Description

This PR adds **GRIT (Graph Inductive Bias Transformer)** to TopoBench, follwing the paperÖ

> Ma, Lin, Lim, Romero-Soriano, Dokania, Coates, Torr, Lim.
> **"Graph Inductive Biases in Transformers without Message Passing."** ICML 2023.
> Paper: <https://arxiv.org/abs/2305.17589> · Official code: <https://github.com/LiamMa/GRIT>

## The model

GRIT is a graph transformer that injects graph inductive biases without any message-passing modules. It differs from both classical MPNNs and hybrid graph transformers in three ways:

1. **RRWP positional encodings (Eq. 1).** Each node pair is encoded by its Relative Random Walk Probabilities `P_{i,j} = [I, M, ..., M^(K-1)]_{i,j}` with `M = D^(-1)A`. These are *learned* (updated in every layer), and provably more expressive than shortest-path distances (Prop. 3.2). An MLP on RRWP can recover SPD and general propagation matrices (Prop. 3.1).

2. **Attention conditioned on node-pair representations (Eq. 2–3).** Every layer jointly updates node representations **and** pair representations, with a signed-square-root stabilizer and an edge-enhanced value aggregation, so the attention pattern itself can learn to emulate $k$-hop propagation.

3. **Degree scaler + BatchNorm (Eq. 5, Prop. 3.3).** attention is degree-invariant, therefore GRIT re-injects degree information with adaptive scalers and uses BatchNorm because LayerNorm would cancel the degree signal.

Attention is global (all intra-graph node pairs) by default, but convertable to the sparse RRWP support with `pad_to_full_graph: false`. The default configuration has **~190K parameters** (hidden 64, 4 layers, 8 heads, $K=8$).

## Files added

**Model**

| File | Description |
|---|---|
| `topobench/nn/backbones/graph/grit.py` | The backbone: `GRITAttention`, `GRITTransformerLayer` (attention + degree scaler + BatchNorm + FFN), `GRITBackbone` (RRWP node/pair encoders + layer stack), and the `full_edge_index` utility.
| `topobench/transforms/data_manipulations/rrwp_positional_encodings.py` | `AddRRWP` data-manipulation transform + `compute_rrwp`: precomputes node-level (`rrwp`) and sparse relative (`rrwp_index`/`rrwp_val`) encodings plus `log_deg` per graph. |
| `topobench/nn/wrappers/graph/grit_wrapper.py` | `GRITWrapper`: thin wrapper forwarding connectivity, RRWP attributes and log-degrees from the batch to the backbone. Returns rank-0 cell embeddings. |

**Configs**

| File | Description |
|---|---|
| `configs/model/graph/grit.yaml` | Full `TBModel` composition (`AllCellFeatureEncoder` → `GRITBackbone` → `GRITWrapper` → `NoReadOut`). |
| `configs/transforms/data_manipulations/rrwp_positional_encodings.yaml` | Config for the `AddRRWP` transform. |
| `configs/transforms/model_defaults/grit.yaml` | Automatically applies RRWP precomputation whenever `model=graph/grit` is selected, interpolates `walk_length` from the backbone config so transform and model can never drift apart. |

**Tests**

| File | Description |
|---|---|
| `test/nn/backbones/graph/test_grit.py` | Attention/layer/backbone tests: shapes, batching-vs-individual equivalence, precomputed-vs-on-the-fly RRWP equivalence, error handling, gradients, determinism, Hydra composition & instantiation. |
| `test/transforms/data_manipulations/test_AddRRWP.py` | RRWP correctness against explicit $\mathbf{M}^k$ matrix powers, identity channel, sparsity, isolated nodes, empty graphs, batching offsets, registration, determinism. |
| `test/nn/wrappers/graph/test_grit_wrapper.py` | Wrapper forward with and without precomputed RRWP. |

**Modified**

| File | Description |
|---|---|
| `test/pipeline/test_pipeline.py` | Set `DATASET = "graph/MUTAG"`, `MODELS = ["graph/grit"]`, full end-to-end training pipeline test. |

## Testing

- **42 new unit tests, all passing**, deterministic; **100% line coverage** on all three contributed source files.
- Pipeline test (`graph/grit` on `graph/MUTAG`) passes end-to-end through the real Hydra → PreProcessor → Lightning stack.


## Evaluation results (official notebook, `results.json` included)

`2026_tdl_challenge/run_evaluation.ipynb` was run unmodified with `MODEL_CONFIG = "graph/grit"`: 12 GraphUniverse settings × 3 seeds = **36 runs per task**.

| Task | Metric | Result | Params | Avg epoch time |
|---|---|---|---|---|
| Community detection (node, inductive) | avg test accuracy | **0.5207** | 190,145 | 8.87 s |
| Triangle counting (graph, inductive) | avg test MSE / total triangles | **0.0693** | 188,910 | 8.40 s |

<img width="3187" height="2171" alt="telegram-cloud-document-4-5940249982970895124" src="https://github.com/user-attachments/assets/655453cb-31b3-40c4-9883-2afb72862dd5" />

<img width="3161" height="2171" alt="telegram-cloud-document-4-5940249982970895125" src="https://github.com/user-attachments/assets/060f0ebb-4957-4386-b8fc-8659c19864e4" />


## Limitations

- Pair representations scale as $O(n^2)$ with `pad_to_full_graph: true` (as in the paper). Set it to `false` for sparse RRWP-support attention on larger graphs.
- Datasets with their own `dataset_defaults` transform config use the on-the-fly RRWP fallback, which is slower than the cached precomputation.
