### PR TITLE
Track: Track2; Team name: TripleA; Model: TopoU-Net

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-08_03-26-07/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-08_03-26-07/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-08_03-26-07",
+    "model_config": "combinatorial/topounet",
+    "generated_at_utc": "2026-07-08T04:21:59.284948+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2168548107147217,
+      "test_best_rerun_accuracy": 0.31140652298927307,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30705171823501587,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3106425106525421,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30174192786216736,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31801512837409973,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.310260534286499,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31751853227615356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30472153425216675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3149591386318207,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3084651231765747,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30445411801338196,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2934907078742981,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8350064739396301,
+        "AvgTime/train_epoch_std": 0.0404186969808266,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.226728916168213,
+      "test_best_rerun_accuracy": 0.3065933287143707,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3031553328037262,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3066697120666504,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2978073060512543,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31438612937927246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30716630816459656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.317824125289917,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3028879165649414,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31385132670402527,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30945831537246704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3065551221370697,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2940255105495453,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8356031642472448,
+        "AvgTime/train_epoch_std": 0.06441391647036253,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2186925411224365,
+      "test_best_rerun_accuracy": 0.30999311804771423,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30716630816459656,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31121551990509033,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.317862331867218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31113913655281067,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3200397193431854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3088471293449402,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3179387152194977,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3117503225803375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30987852811813354,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3009397089481354,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8628479105302658,
+        "AvgTime/train_epoch_std": 0.05098221415198664,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2265820503234863,
+      "test_best_rerun_accuracy": 0.3099549114704132,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3072427213191986,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3065169155597687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30785393714904785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3125143349170685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31110092997550964,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30919092893600464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3115593194961548,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31236153841018677,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3114447295665741,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31041333079338074,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30731913447380066,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8381120494649381,
+        "AvgTime/train_epoch_std": 0.04546404378689635,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.237839460372925,
+      "test_best_rerun_accuracy": 0.3036901354789734,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30579110980033875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3035755157470703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3086179196834564,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.306402325630188,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3073573112487793,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30796852707862854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30999311804771423,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30892351269721985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3084269165992737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3086179196834564,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.843964291029963,
+        "AvgTime/train_epoch_std": 0.047357846499141695,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.242255687713623,
+      "test_best_rerun_accuracy": 0.3009397089481354,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3015127182006836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3016655147075653,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30158913135528564,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046833276748657,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.303728312253952,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30376651883125305,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.303728312253952,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3049125075340271,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3052945137023926,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3034227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30036672949790955,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8373107838630676,
+        "AvgTime/train_epoch_std": 0.04639824537258766,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2078700065612793,
+      "test_best_rerun_accuracy": 0.3156467378139496,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30365192890167236,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30051952600479126,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.308350533246994,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3120177388191223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3039575219154358,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32156771421432495,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3117121160030365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31167393922805786,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3059057295322418,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31354573369026184,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3034227192401886,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9761194199323655,
+        "AvgTime/train_epoch_std": 0.04765173145627622,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2189831733703613,
+      "test_best_rerun_accuracy": 0.30972573161125183,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2989533245563507,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3016273081302643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3086179196834564,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30120712518692017,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31572312116622925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30758652091026306,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30678433179855347,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3023531138896942,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30758652091026306,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30006110668182373,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.963698957975094,
+        "AvgTime/train_epoch_std": 0.0489413004002843,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2223198413848877,
+      "test_best_rerun_accuracy": 0.3088471293449402,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3019329309463501,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29738712310791016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3005959093570709,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30701351165771484,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30048131942749023,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31572312116622925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30388110876083374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30579110980033875,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3027733266353607,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3066697120666504,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29914432764053345,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9721390658085889,
+        "AvgTime/train_epoch_std": 0.04482561837802395,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2309205532073975,
+      "test_best_rerun_accuracy": 0.3047597110271454,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30414852499961853,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30120712518692017,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3096493184566498,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31083351373672485,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30663153529167175,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31515011191368103,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3098021149635315,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3117121160030365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30854153633117676,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31285813450813293,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30632591247558594,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9533804905030034,
+        "AvgTime/train_epoch_std": 0.049634510943401565,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2174408435821533,
+      "test_best_rerun_accuracy": 0.3072427213191986,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30621132254600525,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3050271272659302,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.310260534286499,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3110245168209076,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3076629340648651,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3155321180820465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3118649125099182,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31178852915763855,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3109099268913269,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3141951262950897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3087325096130371,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9422994175472774,
+        "AvgTime/train_epoch_std": 0.06379198297903255,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2197797298431396,
+      "test_best_rerun_accuracy": 0.308312326669693,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30838871002197266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30445411801338196,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3127053380012512,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3127817213535309,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30838871002197266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31900832056999207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31041333079338074,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3147299289703369,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31003132462501526,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3148063123226166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.310260534286499,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9523604132912376,
+        "AvgTime/train_epoch_std": 0.12765443803015028,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0881829261779785,
+      "test_best_rerun_accuracy": 0.3583161532878876,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28420811891555786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2835969030857086,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2816869020462036,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2822217047214508,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34116435050964355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35812515020370483,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3556039333343506,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3952173590660095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38520896434783936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38574376702308655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37978455424308777,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8913377535225142,
+        "AvgTime/train_epoch_std": 0.06401218639931905,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0809292793273926,
+      "test_best_rerun_accuracy": 0.35976773500442505,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2858507037162781,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2837115228176117,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2815723121166229,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2823745012283325,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3405531346797943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3603789508342743,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35801053047180176,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3970509469509125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38734814524650574,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38574376702308655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3867369592189789,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8945532817840576,
+        "AvgTime/train_epoch_std": 0.03831484880638879,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.084831714630127,
+      "test_best_rerun_accuracy": 0.3613721430301666,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28634729981422424,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2843609154224396,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2838643193244934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2845137119293213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34143173694610596,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35885095596313477,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3573611378669739,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39525556564331055,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3863549530506134,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38589656352996826,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3803957402706146,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8982988144587545,
+        "AvgTime/train_epoch_std": 0.042690664584522434,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1190826892852783,
+      "test_best_rerun_accuracy": 0.3458247482776642,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2889067232608795,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2894415259361267,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2877989113330841,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.292306512594223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3573611378669739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3576667308807373,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36889755725860596,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3964397609233856,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39430055022239685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39907556772232056,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41565436124801636,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8858650905985228,
+        "AvgTime/train_epoch_std": 0.0498639926432186,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1430540084838867,
+      "test_best_rerun_accuracy": 0.33814653754234314,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28134310245513916,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2812667191028595,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2805791199207306,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28802812099456787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.347199946641922,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3482695519924164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3627091348171234,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3856673538684845,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3884177505970001,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39185574650764465,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4081289768218994,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8789267941807093,
+        "AvgTime/train_epoch_std": 0.04818521760272314,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.134003162384033,
+      "test_best_rerun_accuracy": 0.3421957492828369,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28363510966300964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28355872631073,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28107571601867676,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28737872838974,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3546871542930603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35392314195632935,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36763694882392883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39174115657806396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3906715512275696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39728015661239624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41676217317581177,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8794531161242192,
+        "AvgTime/train_epoch_std": 0.046844340442506426,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.058004140853882,
+      "test_best_rerun_accuracy": 0.3658415377140045,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2801971137523651,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27519291639328003,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28867751359939575,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2859271168708801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34819313883781433,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33027732372283936,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36152493953704834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3866223692893982,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37852394580841064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39483535289764404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4053785502910614,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9898046700850778,
+        "AvgTime/train_epoch_std": 0.05133753779762809,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0561928749084473,
+      "test_best_rerun_accuracy": 0.3674459457397461,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28497210144996643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2793567180633545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2927267253398895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2899381220340729,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35063794255256653,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3344029486179352,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3601115345954895,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3847505450248718,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3769577443599701,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3893727660179138,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3988463580608368,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.969773899899782,
+        "AvgTime/train_epoch_std": 0.04965553177900177,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0710482597351074,
+      "test_best_rerun_accuracy": 0.3625181317329407,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2763389050960541,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2725571095943451,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2872259020805359,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2840934991836548,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34402933716773987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32607534527778625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3560623526573181,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3817327618598938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3745129406452179,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3847505450248718,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3939949572086334,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9377222848388385,
+        "AvgTime/train_epoch_std": 0.049231106365596126,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.047569990158081,
+      "test_best_rerun_accuracy": 0.3731377422809601,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27519291639328003,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2736267149448395,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27832531929016113,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28172510862350464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35296812653541565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33990374207496643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35911834239959717,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39609596133232117,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3949117660522461,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4054931700229645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.432576984167099,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9413940563201904,
+        "AvgTime/train_epoch_std": 0.046873292034407175,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.0325098037719727,
+      "test_best_rerun_accuracy": 0.37745434045791626,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27916571497917175,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27794331312179565,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2799296975135803,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2857361137866974,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3549545407295227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34318894147872925,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36301475763320923,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4014439582824707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4010619521141052,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41309496760368347,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43700817227363586,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.904380012249601,
+        "AvgTime/train_epoch_std": 0.05798847312877369,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.0427632331848145,
+      "test_best_rerun_accuracy": 0.3735579550266266,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.280846506357193,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.278974711894989,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27836352586746216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2838261127471924,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35518375039100647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33963632583618164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35938575863838196,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3987317681312561,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39632517099380493,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4095805585384369,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43696996569633484,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9418076014687828,
+        "AvgTime/train_epoch_std": 0.08024272563176958,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.9188804626464844,
+      "test_best_rerun_accuracy": 0.4148903787136078,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26487889885902405,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2640385031700134,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2649553120136261,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26950111985206604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36198335886001587,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3440675437450409,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3656887412071228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3726411461830139,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4091985523700714,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4177935719490051,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42818397283554077,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8882900217305059,
+        "AvgTime/train_epoch_std": 0.06061488483719829,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.9292672872543335,
+      "test_best_rerun_accuracy": 0.4132859706878662,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26354190707206726,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26323631405830383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2640002965927124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26961570978164673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35908013582229614,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34467872977256775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3632439374923706,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36905035376548767,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4051493704319,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41252195835113525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4207731783390045,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8969383899654662,
+        "AvgTime/train_epoch_std": 0.1954252219871933,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.9314988851547241,
+      "test_best_rerun_accuracy": 0.4140499532222748,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2643059194087982,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2642677128314972,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26392391324043274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2717549204826355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3555275499820709,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34181374311447144,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3661089539527893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37214455008506775,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4040033519268036,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4147375524044037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42501336336135864,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8807984842703893,
+        "AvgTime/train_epoch_std": 0.0731685231418245,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.93148934841156,
+      "test_best_rerun_accuracy": 0.4109175503253937,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2604477107524872,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26178470253944397,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26663610339164734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2733975052833557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.356749951839447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34574833512306213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3577813506126404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37707236409187317,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4102681577205658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42298877239227295,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44651997089385986,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8819489141305288,
+        "AvgTime/train_epoch_std": 0.053275074600578155,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.9249321222305298,
+      "test_best_rerun_accuracy": 0.4130185544490814,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26079151034355164,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2640002965927124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2650699019432068,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27347391843795776,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35545113682746887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3462067246437073,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.360493540763855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37787455320358276,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41126134991645813,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4227595627307892,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44816258549690247,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8709196435273998,
+        "AvgTime/train_epoch_std": 0.06077210954702345,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.9282255172729492,
+      "test_best_rerun_accuracy": 0.40858736634254456,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2633126974105835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.263694703578949,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2665978968143463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.273282915353775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3564443290233612,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34372374415397644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36209794878959656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3767285645008087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41538697481155396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42272135615348816,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4517151713371277,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.869840249209337,
+        "AvgTime/train_epoch_std": 0.04557305571010332,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.8616797924041748,
+      "test_best_rerun_accuracy": 0.4371609687805176,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24902589619159698,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2520436942577362,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2546412944793701,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2625487148761749,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3447169363498688,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33818474411964417,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35434335470199585,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37157154083251953,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4059515595436096,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4044235646724701,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4601573944091797,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9500534555368256,
+        "AvgTime/train_epoch_std": 0.04718223024694354,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.8633441925048828,
+      "test_best_rerun_accuracy": 0.43563297390937805,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2500191032886505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2529987096786499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.255328893661499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2625487148761749,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3455573320388794,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33845213055610657,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3554893434047699,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36836275458335876,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40774697065353394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4057605564594269,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4571395814418793,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9459603258541651,
+        "AvgTime/train_epoch_std": 0.05093345476839684,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.8506336212158203,
+      "test_best_rerun_accuracy": 0.44094276428222656,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25196731090545654,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25318971276283264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25838491320610046,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2652226984500885,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3485369384288788,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3408205509185791,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3598823547363281,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3741309642791748,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41103217005729675,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4083963632583618,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46332797408103943,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9590364241784857,
+        "AvgTime/train_epoch_std": 0.053567452025557245,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.7764265537261963,
+      "test_best_rerun_accuracy": 0.461914598941803,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24474750459194183,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24719229340553284,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24612270295619965,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.257200688123703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3392161428928375,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3331805467605591,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.347199946641922,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36820995807647705,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4022843539714813,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4047291576862335,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42776376008987427,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9957671913446164,
+        "AvgTime/train_epoch_std": 0.04575497273808239,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.7787859439849854,
+      "test_best_rerun_accuracy": 0.46225839853286743,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24883489310741425,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2525402903556824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2486439049243927,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25861409306526184,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.343418151140213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33627474308013916,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34998854994773865,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3706165552139282,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40343037247657776,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40602797269821167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4288715720176697,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9794565576367673,
+        "AvgTime/train_epoch_std": 0.04475707423723232,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.772709608078003,
+      "test_best_rerun_accuracy": 0.4631369709968567,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25043928623199463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25181451439857483,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24814729392528534,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2589578926563263,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34276872873306274,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3372679352760315,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35052335262298584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3724883496761322,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4030865728855133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40301015973091125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4253953695297241,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.996352449921537,
+        "AvgTime/train_epoch_std": 0.04725485174647439,
+        "model/params/total": 48257,
+        "model/params/trainable": 48257,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 93.97913360595703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 91.96137237548828,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.06625459104862268,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.806513786315918,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.04635007255955746
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8020.44580078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.60830078125
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104.01728820800781,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.035058068152345065
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7039.5634765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9404894424265197
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95.890380859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08280689193382988
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164587.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8219180318827792
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11698.8623046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8202820294970902
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44413.51953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2765656636039777
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2949.482177734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5243523871527778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 745288.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.43057362306709
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 242809.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.040568629041652
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.394690990447998,
+        "AvgTime/train_epoch_std": 0.09710010033173423,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 90.45487213134766,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 88.48877716064453,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.06375272129729433,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.357983589172363,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05451570310090718
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7457.1767578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5655803380972696
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128.43646240234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0432883257170016
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6906.359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9226933032732131
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99.22042083740234,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08568257412556333
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162586.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.775469722389931
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11176.1318359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7836300544059389
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43973.80859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2540267873161106
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2861.09619140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5086393229166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742469.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.398688392927841
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239365.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9832585014061537
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3704784257071358,
+        "AvgTime/train_epoch_std": 0.032171614935052065,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 89.65919494628906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 87.4788818359375,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.06302513100571866,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.178507804870605,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.053571093709845294
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7558.240234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5732453723454684
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116.47464752197266,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.039256706276364225
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6933.70654296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9263468995282231
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93.7807388305664,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08098509398149085
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163012.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7853481881618056
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11305.419921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7926952686772543
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44047.35546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.257796681980112
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2887.75634765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.51337890625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743028.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.405013121726638
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240055.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9947277033098696
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3713566362857819,
+        "AvgTime/train_epoch_std": 0.05429545505905464,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.8341498374938965,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.8399879932403564,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.004420989438107139,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.93080139160156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11234207593054868
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11043.626953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8375902125995449
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224.25332641601562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07558251648669216
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7791.291015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0409206433700735
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136.48800659179688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11786529066649126
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173618.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.031634601987739
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14422.2431640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0112356727010587
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46677.22265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3925994492926344
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3550.527099609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6312048177083334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758708.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.582389030915241
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258160.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.296013054765114
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3521124521891277,
+        "AvgTime/train_epoch_std": 0.02468166311989213,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.8051355481147766,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.8014853000640869,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.004218343684547826,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.6825408935547,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11360413609045726
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11089.96875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8411049488054607
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229.34317016601562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07729800140411716
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7804.03759765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0426235935412491
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137.95401000976562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.119131269438485
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173765.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.035044497724317
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14474.4013671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0148928177806409
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46722.55859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.394923296619509
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3564.642822265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6337142795138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758968.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.585321623700553
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258428.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.300481389263308
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3494086265563965,
+        "AvgTime/train_epoch_std": 0.047400554306705804,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.8562943339347839,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.8468824625015259,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.004457276118429084,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.11500549316406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11751801548498851
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11296.814453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8567929050530906
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 246.40576171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0830487906028817
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7849.4208984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0486868267785572
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.56507873535156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12224963621360238
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174272.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.046827106167565
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14650.330078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.027228304454144
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46840.91796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.400990208045005
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3607.831787109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6413923177083334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759634.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.592861667590466
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259269.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.314472983542176
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.33670973777771,
+        "AvgTime/train_epoch_std": 0.04418595284684167,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5394.2197265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4998.52001953125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.37910656196672354,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 965.1414794921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.69534688724221
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 921.177734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.848303865131579
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1595.304443359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5376826570136081
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5628.849609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7520173158817636
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1043.30126953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9009510099579016
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144153.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3474294799600592
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8121.08984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5694215288003085
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37624.68359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9285808392921215
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3015.61767578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5361098090277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702885.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.950924318179247
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210400.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5012545658396155
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4799779951572418,
+        "AvgTime/train_epoch_std": 0.05155085070641191,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5336.01171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4942.447265625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.37485379337315133,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 959.0897827148438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6909868751547865
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 909.4393920898438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.786523116262336
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1604.959716796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5409368779227756
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5608.595703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7493113831830327
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1033.6937255859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8926543398842293
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143917.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3419362025125396
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8108.39404296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5685313450405799
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37598.5078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9272391107950178
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3018.316162109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5365895399305556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 702642.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.948171300747712
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210112.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.496461994325462
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4604140080903705,
+        "AvgTime/train_epoch_std": 0.04313041469606323,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5414.35986328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5001.88623046875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3793618680674061,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 853.1990356445312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6146967115594606
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 807.328857421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.249099249588816
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1434.6982421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.48355181738709135
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5629.1640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7520593269873079
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 923.0250244140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.7970855133109348
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144923.578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.365306941412781
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8199.181640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.574897043936685
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37864.234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9408598275155056
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2940.046630859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5226749565972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 704878.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.97346314604708
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211666.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5223161911537115
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4706296920776367,
+        "AvgTime/train_epoch_std": 0.04900660246631349,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 68.82135009765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 63.02901077270508,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.021243347075397736,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143.44985961914062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10335004295327134
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133.71302795410156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7037527787057977
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9152.791015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.694182102057262
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6831.3935546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9126778296175685
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.52552795410156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13689596541804971
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166542.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8673199337033255
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12385.4716796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8684246024181391
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43775.9296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2438838324619406
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2934.207763671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5216369357638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744353.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.419997765912921
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247925.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.125698136638211
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.422817885875702,
+        "AvgTime/train_epoch_std": 0.03739603045288075,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 68.77066040039062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 62.89052200317383,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.02119667071222576,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.4567108154297,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10191405678345078
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.8101043701172,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6937373914216695
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9136.2138671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6929248287590064
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6835.44482421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9132190813919505
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.26539611816406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13580776866853547
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166554.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8676018542169794
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12386.1875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.86847479315664
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43794.49609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.244835516620534
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2939.639892578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5226026475694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744314.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.419560846351368
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247915.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.125537968232573
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4324338138103485,
+        "AvgTime/train_epoch_std": 0.044955708340784,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 69.36992645263672,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 63.26411437988281,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.021322586578996567,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.54066467285156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10485638665191034
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.2725067138672,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.73301319323088
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9263.98046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7026151284603717
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6848.525390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9149666520541082
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160.3794708251953,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13849695235336382
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166871.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8749724247631434
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12485.6796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.875450826496985
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43826.01171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.246450956930135
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2952.485107421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5248862413194444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 744602.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.422820775313054
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 248517.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.135543293312033
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.43685781955719,
+        "AvgTime/train_epoch_std": 0.008208479903274763,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5763.2060546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5790.73974609375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7736459246618237,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 449.6159362792969,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.32393078982658274
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 386.79248046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.035749897203947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5198.95849609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3943085700488244
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 940.6861572265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.31704959798670795
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 504.3416748046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4355282165843588
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148720.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4534733187813487
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8572.546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6010760675220866
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39390.6171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0190997584448205
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2699.609130859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.47993051215277777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 714501.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.082321159915388
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 217238.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.615043557485897
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4262311458587646,
+        "AvgTime/train_epoch_std": 0.04860954954869165,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5756.47021484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5772.4443359375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7712016480878423,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 441.2454833984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3179002041775486
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 350.8871765136719,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.846774613229852
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5098.0654296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3866564603479333
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1063.9840087890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.35860600228819095
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 495.4734802246094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4278700174651204
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147636.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4282982160273083
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8471.0,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5939559669050624
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39285.01953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0136869922215386
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2734.71875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.48617222222222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 713226.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.067898572446637
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215180.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.580794040071223
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3475426327098499,
+        "AvgTime/train_epoch_std": 0.04628848531569786,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5756.18017578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5763.205078125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7699672783066133,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 444.03582763671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.31991053864316915
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 325.9733581542969,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7156492534436678
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5125.720703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3887539403204399
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1146.9605712890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3865724877954373
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 491.2800598144531,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4242487563164535
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146842.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.409869975501579
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8429.2568359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5910290867997126
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39177.875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.008194935670716
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2763.48193359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4912856770833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 712425.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.058837086976686
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 213653.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.555375106085567
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3590718599466176,
+        "AvgTime/train_epoch_std": 0.06347786486497814,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 97.03758239746094,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 102.07686614990234,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.08814927992219546,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104.23179626464844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07509495408115882
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.863421440124512,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03086011284276059
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8932.650390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6774858089211225
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105.4307861328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03553447459818419
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7238.9150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9671229177104208
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167561.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.89099762852963
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12570.498046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8813979839345814
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45131.375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.31336178174176
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3101.0986328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5513064236111112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 749964.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.48347836046288
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 248244.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.131011255470687
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3545983731746674,
+        "AvgTime/train_epoch_std": 0.051630137956912334,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 98.41551971435547,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 102.93231964111328,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.08888801350700629,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104.55870819091797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07533048140556049
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.934122562408447,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.031232224012676037
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8892.150390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6744141365661737
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105.74066925048828,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03563891784647397
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7220.3466796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9646421749749499
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167414.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.887577210663199
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12505.26171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.876823847900014
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45086.3828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3110555544876723
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3083.033203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5480947916666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 749777.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.481352442790403
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247930.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.125782381059358
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.343600344657898,
+        "AvgTime/train_epoch_std": 0.06489828712353246,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 96.30252075195312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 101.3569564819336,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.08752759627109982,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.11608123779297,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07212974152578744
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.8421101570129395,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.036011106089541785
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8788.0556640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6665192009148654
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.1084213256836,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.034077661383782806
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7195.7451171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9613553930778224
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167066.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.879482790149545
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12442.95703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8724552679322676
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45008.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3070698139320314
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3070.28515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5458284722222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 749311.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.476086077395564
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247519.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.1189344016774
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.305572509765625,
+        "AvgTime/train_epoch_std": 0.04220177697951777,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 135482.078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 96042.34375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 2.2302234755248005,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95831.546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 69.04290120677233
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108972.4609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 573.5392680921053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31975.67578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.4251555389647326
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66751.65625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.49803041793057
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70466.6015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 9.414375626252506
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96512.9609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 83.34452585276338
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27928.265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.9582292543121582
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58617.60546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.004644290776052
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65528.1484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 11.649448611111112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 511759.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.788938511702091
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132819.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.210235073136638
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4798797369003296,
+        "AvgTime/train_epoch_std": 0.045898072774934746,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 138161.84375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 97317.9296875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 2.2598441781418352,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74526.765625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 53.69363517651297
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83005.96875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 436.8735197368421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29562.107421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.242101435106181
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58967.83984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 19.87456684993259
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55359.11328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.396007118403474
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75247.2578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 64.98036080526771
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28314.890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.9853380048380311
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49439.02734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.534165120905736
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53331.36328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.48113125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 526754.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.958562633621031
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133783.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.226276614996755
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4527176448277064,
+        "AvgTime/train_epoch_std": 0.06188747676948805,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 137373.21875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 96990.28125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 2.252235771177782,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91806.8125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 66.14323667146974
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104475.4296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 549.8706825657895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29639.666015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.247983770620023
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62340.93359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 21.011437004971352
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67047.203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 8.95754216766867
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92210.2421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 79.62887926381693
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25794.095703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.8085889568871827
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56688.765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.9057750589471527
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62504.5,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 11.11191111111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 516225.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.839455038290556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135208.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.2499836191403326
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.481408687738272,
+        "AvgTime/train_epoch_std": 0.054265755813873356,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8270.638671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7708.31396484375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5404791729661864,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2878.09375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.073554574927954
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3182.826416015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 16.751717979029607
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5381.24853515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.40813413235921503
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2665.05126953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8982309637786484
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5996.35986328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8011168822019038
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2978.263427734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.571902787335384
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141132.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.277278803060561
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35246.32421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8066699584166281
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3651.25,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6491111111111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 690255.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.808050914561723
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209270.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.482449338941308
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4707559141619453,
+        "AvgTime/train_epoch_std": 0.03607846890288834,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8365.0595703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7805.05419921875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5472622492791158,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2574.0390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.8544950018011528
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2722.696533203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.329981753700658
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6166.19287109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.46766726364002653
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2532.370849609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8535122513007668
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6115.46826171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8170298278849365
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2646.98046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.285820784758204
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142759.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.315047081088612
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35848.6953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8375465330104055
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3616.976318359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6430180121527778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 694189.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.852553787767383
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209792.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.491137954919874
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.479497698045546,
+        "AvgTime/train_epoch_std": 0.05681999559499922,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8374.025390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7816.328125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5480527362922452,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2673.941650390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.9264709296762428
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2740.560302734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.424001593338815
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6279.52978515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.47626316155906334
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2602.191650390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.8770447085913802
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6104.40771484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8155521329116566
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2763.782958984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.3866864930780443
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141355.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2824578679407392
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35665.75390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.828169250410067
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3671.784912109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6527617621527778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 693492.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.8446659050032235
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209008.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4780795496147636
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4721023715459383,
+        "AvgTime/train_epoch_std": 0.05138627069636706,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 32228.552734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 32021.080078125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.6413491249231125,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8812.1220703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.348791116939841
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10183.1552734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 53.595554070723686
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5956.94482421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4517971046051384
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6893.236328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.323301762091338
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8596.341796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1484758579659318
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9071.8466796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.834064490231002
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131252.46875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.047846664267137
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7526.8759765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.527757395636131
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6876.60302734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2225072048611112
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 657424.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.436675650147619
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196747.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.2740523022648227
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.407633384068807,
+        "AvgTime/train_epoch_std": 0.04537338668605613,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 31907.43359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 31801.130859375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.6300748813047825,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10682.3330078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 7.696205337040706
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12818.52734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 67.4659333881579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6565.2060546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4979299245117558
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7250.4267578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.4436895038127737
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9347.056640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2487717622745491
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10948.123046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 9.4543376916019
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133022.671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0889529972831133
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7554.25732421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5296772769750911
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7211.2275390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2819960069444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 656179.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.422588882730224
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202200.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.364800704740985
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3760701179504395,
+        "AvgTime/train_epoch_std": 0.02526522491346415,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 32122.119140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 31912.65625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.6357914936695883,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9212.919921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.637550375990634
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10615.1728515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 55.869330797697366
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6016.53271484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4563164743908798
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7180.5576171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.4201407540234245
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8788.330078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1741255949398797
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9445.27734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 8.156543474740932
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130740.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0359588345253576
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7533.107421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5281943221059459
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7100.02734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2622270833333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 655781.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.418088187052476
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195979.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.261265611219277
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3844007764543806,
+        "AvgTime/train_epoch_std": 0.04361156829576065,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2469.936767578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2628.130615234375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4672232204861111,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.94744873046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11451545297584204
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.76722717285156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6356169851202714
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6548.33154296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.49665009806361393
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263.282470703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08873692979545837
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6328.2451171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8454569294839679
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186.62051391601562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.16115761132643835
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157611.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6599331082806983
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10045.34375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7043432723320713
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41983.796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.152021983443539
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 731841.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.278464107552912
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231812.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8575640049589803
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.359649807214737,
+        "AvgTime/train_epoch_std": 0.038765813213009134,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2483.778076171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2641.910888671875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.469673046875,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.75228881835938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10212700923512923
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.84324645996094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4570697182103207
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6668.2490234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5057450908940083
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262.3943786621094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08843760655952457
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6395.5576171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8544499154559119
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169.57699584960938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14643954736581122
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158077.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6707553002507893
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10109.6875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.708854824007853
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42252.125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.165776052078528
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 733715.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.299668846079884
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232326.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8661226141147886
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3575283970151628,
+        "AvgTime/train_epoch_std": 0.033876333980249064,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2476.94873046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2634.789306640625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.46840698784722223,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.31715393066406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10253397257252454
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.53583526611328,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4133465014005962
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6694.47265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5077339898558969
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 280.759765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09462749094202899
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6384.11865234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8529216636397795
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.29879760742188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14360863351245412
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157726.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.662612623072636
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10062.9521484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7055779097207615
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42212.453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1637425354964375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 733527.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.297537979480335
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231641.65625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.854719455677034
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4162495136260986,
+        "AvgTime/train_epoch_std": 0.0730942802491716,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 620131.875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 415692.8125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 4.702247802676379,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 705902.9375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 508.57560338616713
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 829229.6875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4364.366776315789
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203143.515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 15.40716842055366
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 458985.0,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 154.69666329625883
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 499136.59375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 66.68491566466265
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 683763.9375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 590.4697215025907
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129566.5703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.00869799165196
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155371.015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 10.894055225424204
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 356290.75,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 18.26289148598083
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 391890.21875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 69.66937222222222
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161471.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.6870236550014144
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4632030187868605,
+        "AvgTime/train_epoch_std": 0.05385128421672417,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 643814.875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 427557.75,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 4.836461997895999,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 621870.125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 448.03323126801155
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 723941.4375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3810.218092105263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172230.546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 13.062612580583997
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 409126.8125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 137.89242079541626
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 418763.78125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 55.947064963259855
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 570122.5625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 492.33381908462866
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121470.9453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8207074427015604
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135945.796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 9.532028949305849
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 299125.46875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 15.33269100158901
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 332428.6875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 59.09843333333333
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162660.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.706817193766329
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.459258717875327,
+        "AvgTime/train_epoch_std": 0.05368869047967857,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 610466.5625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 413492.28125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 4.677355759985521,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 636010.0625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 458.22050612391934
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 749143.875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3942.8625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182748.15625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 13.860307641259006
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 417001.46875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 140.54650109538255
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 452202.71875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 60.41452488309953
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 621839.4375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 536.9943329015545
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131384.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.050923117336987
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150271.1875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 10.536473671294349
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 324291.96875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 16.62268536316572
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 370852.875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 65.9294
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144230.9375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.4001287587572597
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4585970242818196,
+        "AvgTime/train_epoch_std": 0.04848597913350668,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 110235.0625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 103012.703125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7142213423360457,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189075.34375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 136.2214292146974
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205517.59375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1081.6715460526316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90424.3359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.858121800341297
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153189.3125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 51.63104566902595
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150339.203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 20.085397879091516
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189742.6875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 163.85378886010363
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103457.890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4024217588937398
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85405.578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.988331098373299
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114767.171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 5.882780863960224
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145213.4375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 25.815722222222224
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 452450.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.1180442829994455
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4980262843045322,
+        "AvgTime/train_epoch_std": 0.051933985874011726,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 108919.875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 102554.71875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7066000823723229,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214462.984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 154.5122365814121
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236595.390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1245.2388980263158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90234.5078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.843724521236253
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162610.3125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 54.806306875631954
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167452.53125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 22.371747661990646
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214679.25,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 185.38795336787564
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101794.1796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.363788307809307
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83872.109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.880809800518861
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126971.3203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 6.508345907658004
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157369.765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 27.976847222222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 441011.78125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.988651756727712
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.491832368514117,
+        "AvgTime/train_epoch_std": 0.04752427841432997,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "topounet_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 108711.4765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 102564.921875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.706769871282845,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222694.953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 160.4430498018732
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245403.515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1291.5974506578948
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94353.21875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.156103052711415
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169324.6875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 57.06932507583418
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174188.78125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 23.27171426185705
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222731.0,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 192.34110535405873
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104041.78125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4159804302898014
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88009.6171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.170916925220866
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132866.84375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 6.810540968271054
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164100.78125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 29.173472222222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 440624.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.984266300351798
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-08_03-26-07__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.500195394862782,
+        "AvgTime/train_epoch_std": 0.05322013893894144,
+        "model/params/total": 47022,
+        "model/params/trainable": 47022,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/combinatorial/topounet.yaml
+++ b/configs/model/combinatorial/topounet.yaml
@@ -1,0 +1,46 @@
+_target_: topobench.model.TBModel
+
+# TopoU-Net (arXiv:2605.10091) with the triangle-bottleneck rank path
+# 0 -> 1 -> 2 -> 1 -> 0 (Section 4 of the paper).
+
+model_name: topounet
+model_domain: combinatorial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+  # TopoU-Net consumes a single input cochain at the input rank s_0
+  # (Definition 3.3); higher-rank states are computed by the encoder.
+  selected_dimensions:
+    - 0
+
+backbone:
+  _target_: topobench.nn.backbones.combinatorial.topounet.TopoUNet
+  in_channels: ${model.feature_encoder.out_channels}
+  encoder_rank_path: [0, 1, 2]
+  use_skip: true
+  aggr_norm: true
+  dropout: 0.3
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.combinatorial.TopoUNetWrapper
+  _partial_: true
+  wrapper_name: TopoUNetWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: 1
+  residual_connections: false
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut # The decoder already returns the signal to rank 0
+  num_cell_dimensions: 1
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: mean # Global mean pooling for graph-level tasks (Section 4.2)
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/combinatorial/topounet_edge.yaml
+++ b/configs/model/combinatorial/topounet_edge.yaml
@@ -1,0 +1,46 @@
+_target_: topobench.model.TBModel
+
+# TopoU-Net (arXiv:2605.10091) with the minimal node-edge rank path
+# 0 -> 1 -> 0 used for homophilic graphs (Section 4 of the paper).
+
+model_name: topounet_edge
+model_domain: combinatorial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+  # TopoU-Net consumes a single input cochain at the input rank s_0
+  # (Definition 3.3); higher-rank states are computed by the encoder.
+  selected_dimensions:
+    - 0
+
+backbone:
+  _target_: topobench.nn.backbones.combinatorial.topounet.TopoUNet
+  in_channels: ${model.feature_encoder.out_channels}
+  encoder_rank_path: [0, 1]
+  use_skip: true
+  aggr_norm: true
+  dropout: 0.3
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.combinatorial.TopoUNetWrapper
+  _partial_: true
+  wrapper_name: TopoUNetWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: 1
+  residual_connections: false
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut # The decoder already returns the signal to rank 0
+  num_cell_dimensions: 1
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: mean # Global mean pooling for graph-level tasks (Section 4.2)
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/combinatorial/topounet_global.yaml
+++ b/configs/model/combinatorial/topounet_global.yaml
@@ -1,0 +1,48 @@
+_target_: topobench.model.TBModel
+
+# TopoU-Net (arXiv:2605.10091) with the global-bottleneck rank path
+# 0 -> 1 -> 2 -> 3 -> 2 -> 1 -> 0 used for heterophilic graphs
+# (Section 4 and Appendix B.4 of the paper). Rank 3 is a single global
+# cell incident to all rank-2 triangle cells.
+
+model_name: topounet_global
+model_domain: combinatorial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+  # TopoU-Net consumes a single input cochain at the input rank s_0
+  # (Definition 3.3); higher-rank states are computed by the encoder.
+  selected_dimensions:
+    - 0
+
+backbone:
+  _target_: topobench.nn.backbones.combinatorial.topounet.TopoUNet
+  in_channels: ${model.feature_encoder.out_channels}
+  encoder_rank_path: [0, 1, 2, 3]
+  use_skip: true
+  aggr_norm: true
+  dropout: 0.3
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.combinatorial.TopoUNetWrapper
+  _partial_: true
+  wrapper_name: TopoUNetWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: 1
+  residual_connections: false
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut # The decoder already returns the signal to rank 0
+  num_cell_dimensions: 1
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: mean # Global mean pooling for graph-level tasks (Section 4.2)
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/transforms/liftings/graph2combinatorial/topounet_cc.yaml
+++ b/configs/transforms/liftings/graph2combinatorial/topounet_cc.yaml
@@ -1,0 +1,10 @@
+# Graph -> combinatorial complex lifting for TopoU-Net (arXiv:2605.10091):
+# nodes (rank 0), edges (rank 1), triangles as maximal 3-cliques (rank 2).
+transform_type: 'lifting'
+transform_name: "GraphTriangleGlobalCC"
+
+complex_dim: 2
+add_global_cell: False
+preserve_edge_attr: False
+feature_lifting: ProjectionSum
+neighborhoods: ${oc.select:model.backbone.neighborhoods,${oc.select:model.preprocessing_params.neighborhoods,null}}

--- a/configs/transforms/liftings/graph2combinatorial/topounet_cc_edge.yaml
+++ b/configs/transforms/liftings/graph2combinatorial/topounet_cc_edge.yaml
@@ -1,0 +1,10 @@
+# Graph -> combinatorial complex lifting for TopoU-Net (arXiv:2605.10091),
+# minimal node-edge variant: nodes (rank 0) and edges (rank 1) only.
+transform_type: 'lifting'
+transform_name: "GraphTriangleGlobalCC"
+
+complex_dim: 1
+add_global_cell: False
+preserve_edge_attr: False
+feature_lifting: ProjectionSum
+neighborhoods: ${oc.select:model.backbone.neighborhoods,${oc.select:model.preprocessing_params.neighborhoods,null}}

--- a/configs/transforms/liftings/graph2combinatorial/topounet_cc_global.yaml
+++ b/configs/transforms/liftings/graph2combinatorial/topounet_cc_global.yaml
@@ -1,0 +1,12 @@
+# Graph -> combinatorial complex lifting for TopoU-Net (arXiv:2605.10091),
+# global-bottleneck variant: nodes (rank 0), edges (rank 1), triangles as
+# maximal 3-cliques (rank 2) and a single global rank-3 cell incident to
+# all triangles (Appendix B.4 of the paper).
+transform_type: 'lifting'
+transform_name: "GraphTriangleGlobalCC"
+
+complex_dim: 3
+add_global_cell: True
+preserve_edge_attr: False
+feature_lifting: ProjectionSum
+neighborhoods: ${oc.select:model.backbone.neighborhoods,${oc.select:model.preprocessing_params.neighborhoods,null}}

--- a/configs/transforms/model_defaults/topounet.yaml
+++ b/configs/transforms/model_defaults/topounet.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - /transforms/liftings/graph2combinatorial@graph2combinatorial_lifting: topounet_cc

--- a/configs/transforms/model_defaults/topounet_edge.yaml
+++ b/configs/transforms/model_defaults/topounet_edge.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - /transforms/liftings/graph2combinatorial@graph2combinatorial_lifting: topounet_cc_edge

--- a/configs/transforms/model_defaults/topounet_global.yaml
+++ b/configs/transforms/model_defaults/topounet_global.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - /transforms/liftings/graph2combinatorial@graph2combinatorial_lifting: topounet_cc_global

--- a/test/nn/backbones/combinatorial/test_topounet.py
+++ b/test/nn/backbones/combinatorial/test_topounet.py
@@ -1,0 +1,172 @@
+"""Unit tests for the TopoU-Net backbone (arXiv:2605.10091)."""
+
+import pytest
+import torch
+
+from topobench.nn.backbones.combinatorial.topounet import TopoUNet
+
+
+def _toy_complex(d_feat=8):
+    """Build a small combinatorial complex with ranks 0-3.
+
+    Four nodes, four edges (01, 12, 02, 23), one triangle {0, 1, 2} and one
+    global rank-3 cell containing the triangle.
+
+    Parameters
+    ----------
+    d_feat : int
+        Feature dimension of the rank-0 cochain.
+
+    Returns
+    -------
+    tuple(dict, dict)
+        Input cochains ``{0: x_0}`` and sparse consecutive incidence
+        matrices ``{1: B_01, 2: B_12, 3: B_23}``.
+    """
+    x_0 = torch.randn(4, d_feat)
+    incidence_1 = torch.tensor(
+        [
+            [1.0, 0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    ).to_sparse()
+    incidence_2 = torch.tensor([[1.0], [1.0], [1.0], [0.0]]).to_sparse()
+    incidence_3 = torch.tensor([[1.0]]).to_sparse()
+    return {0: x_0}, {1: incidence_1, 2: incidence_2, 3: incidence_3}
+
+
+def test_invalid_rank_path():
+    """Invalid encoder rank paths must be rejected at construction."""
+    with pytest.raises(ValueError):
+        TopoUNet(8, [0])
+    with pytest.raises(ValueError):
+        TopoUNet(8, [0, 1, 1])
+    with pytest.raises(ValueError):
+        TopoUNet(8, [0, 2, 1])
+
+
+@pytest.mark.parametrize(
+    "encoder_rank_path", [[0, 1], [0, 1, 2], [0, 1, 2, 3]]
+)
+def test_forward_shapes(encoder_rank_path):
+    """Decoder states must live in the cochain space of each path rank.
+
+    Checks the structural compatibility of Proposition 3.4 of the paper.
+
+    Parameters
+    ----------
+    encoder_rank_path : list[int]
+        Encoder rank path to test.
+    """
+    d_feat = 8
+    x_all, incidence_all = _toy_complex(d_feat)
+    n_cells = {0: 4, 1: 4, 2: 1, 3: 1}
+    model = TopoUNet(d_feat, encoder_rank_path)
+    out = model(x_all, incidence_all)
+    assert set(out.keys()) == set(encoder_rank_path)
+    for rank in encoder_rank_path:
+        assert out[rank].shape == (n_cells[rank], d_feat)
+
+
+def test_skipped_rank_step():
+    """A path step with a rank gap must use the direct incidence B_{0,2}.
+
+    Section 3.5 of the paper: for s_{i+1} - s_i > 1 the transport uses the
+    direct incidence matrix, realized as the binarized product of the
+    consecutive incidence matrices.
+    """
+    d_feat = 8
+    x_all, incidence_all = _toy_complex(d_feat)
+    model = TopoUNet(d_feat, [0, 2])
+    incidence_02 = model._step_incidence(incidence_all, 0, 2)
+    dense = incidence_02.to_dense()
+    # Nodes 0, 1, 2 belong to the triangle; values are binarized.
+    assert dense.shape == (4, 1)
+    assert torch.equal(dense, torch.tensor([[1.0], [1.0], [1.0], [0.0]]))
+    out = model(x_all, incidence_all)
+    assert out[0].shape == (4, d_feat)
+    assert out[2].shape == (1, d_feat)
+
+
+def test_no_skip_ablation():
+    """Removing skip connections must change the decoder output.
+
+    Reproduces the no-skip ablation of Section 4.6.3 of the paper, where the
+    merge D_{s_i} = sigma((E_{s_i} + D~_{s_i}) W^m_i) is replaced by
+    D_{s_i} = D~_{s_i}.
+    """
+    d_feat = 8
+    x_all, incidence_all = _toy_complex(d_feat)
+    model = TopoUNet(d_feat, [0, 1, 2]).eval()
+    out_skip = model(x_all, incidence_all)
+    model.use_skip = False
+    out_no_skip = model(x_all, incidence_all)
+    assert not torch.allclose(out_skip[0], out_no_skip[0])
+
+
+def test_aggr_norm():
+    """Degree normalization must average instead of sum over incident cells."""
+    d_feat = 8
+    x_all, incidence_all = _toy_complex(d_feat)
+    torch.manual_seed(0)
+    model_norm = TopoUNet(d_feat, [0, 1, 2], aggr_norm=True).eval()
+    torch.manual_seed(0)
+    model_raw = TopoUNet(d_feat, [0, 1, 2], aggr_norm=False).eval()
+    out_norm = model_norm(x_all, incidence_all)
+    out_raw = model_raw(x_all, incidence_all)
+    assert not torch.allclose(out_norm[0], out_raw[0])
+
+
+def test_permutation_equivariance():
+    """The model must be equivariant to joint reindexing of cells.
+
+    Checks Proposition 3.5 of the paper: permuting the cells of every rank
+    (and reindexing the incidence matrices consistently) must permute the
+    output cochains accordingly.
+    """
+    d_feat = 8
+    x_all, incidence_all = _toy_complex(d_feat)
+    model = TopoUNet(d_feat, [0, 1, 2]).eval()
+    out = model(x_all, incidence_all)
+
+    perm_0 = torch.randperm(4)
+    perm_1 = torch.randperm(4)
+    incidence_1 = incidence_all[1].to_dense()[perm_0][:, perm_1].to_sparse()
+    incidence_2 = incidence_all[2].to_dense()[perm_1].to_sparse()
+    out_perm = model(
+        {0: x_all[0][perm_0]},
+        {1: incidence_1, 2: incidence_2},
+    )
+    assert torch.allclose(out[0][perm_0], out_perm[0], atol=1e-5)
+    assert torch.allclose(out[1][perm_1], out_perm[1], atol=1e-5)
+
+
+def test_empty_rank():
+    """Ranks without cells (e.g. triangle-free graphs) must be handled."""
+    d_feat = 8
+    x_0 = torch.randn(4, d_feat)
+    incidence_1 = torch.tensor(
+        [
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+            [0.0, 0.0],
+        ]
+    ).to_sparse()
+    incidence_2 = torch.sparse_coo_tensor(size=(2, 0)).coalesce()
+    model = TopoUNet(d_feat, [0, 1, 2]).eval()
+    out = model({0: x_0}, {1: incidence_1, 2: incidence_2})
+    assert out[2].shape == (0, d_feat)
+    assert out[0].shape == (4, d_feat)
+    assert torch.isfinite(out[0]).all()
+
+
+def test_repr():
+    """The repr must expose the configuration of the model."""
+    model = TopoUNet(8, [0, 1, 2], use_skip=False)
+    representation = repr(model)
+    assert "TopoUNet" in representation
+    assert "[0, 1, 2]" in representation
+    assert "use_skip=False" in representation

--- a/test/nn/wrappers/combinatorial/test_topounet_wrapper.py
+++ b/test/nn/wrappers/combinatorial/test_topounet_wrapper.py
@@ -1,0 +1,74 @@
+"""Unit tests for the TopoU-Net wrapper."""
+
+import torch
+import torch_geometric
+
+from topobench.nn.backbones.combinatorial.topounet import TopoUNet
+from topobench.nn.wrappers.combinatorial import TopoUNetWrapper
+
+
+def _toy_batch(d_feat=8):
+    """Build a single-complex batch with ranks 0-2.
+
+    Parameters
+    ----------
+    d_feat : int
+        Feature dimension of the rank-0 cochain.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Batch with rank-0 features, incidence matrices and labels.
+    """
+    incidence_1 = torch.tensor(
+        [
+            [1.0, 0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    ).to_sparse()
+    incidence_2 = torch.tensor([[1.0], [1.0], [1.0], [0.0]]).to_sparse()
+    return torch_geometric.data.Data(
+        x_0=torch.randn(4, d_feat),
+        incidence_1=incidence_1,
+        incidence_2=incidence_2,
+        y=torch.zeros(4, dtype=torch.long),
+        batch_0=torch.zeros(4, dtype=torch.long),
+    )
+
+
+def test_topounet_wrapper():
+    """The wrapper must expose decoder states of all path ranks."""
+    d_feat = 8
+    batch = _toy_batch(d_feat)
+    backbone = TopoUNet(d_feat, [0, 1, 2])
+    wrapper = TopoUNetWrapper(
+        backbone,
+        out_channels=d_feat,
+        num_cell_dimensions=1,
+        residual_connections=False,
+    )
+    _ = wrapper.__repr__()
+
+    model_out = wrapper(batch)
+    assert model_out["x_0"].shape == (4, d_feat)
+    assert model_out["x_1"].shape == (4, d_feat)
+    assert model_out["x_2"].shape == (1, d_feat)
+    assert torch.equal(model_out["labels"], batch.y)
+    assert torch.equal(model_out["batch_0"], batch.batch_0)
+
+
+def test_topounet_wrapper_residual():
+    """The rank-0 residual connection of AbstractWrapper must apply."""
+    d_feat = 8
+    batch = _toy_batch(d_feat)
+    backbone = TopoUNet(d_feat, [0, 1, 2])
+    wrapper = TopoUNetWrapper(
+        backbone,
+        out_channels=d_feat,
+        num_cell_dimensions=1,
+        residual_connections=True,
+    )
+    model_out = wrapper(batch)
+    assert model_out["x_0"].shape == (4, d_feat)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,11 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = [
+    "combinatorial/topounet",
+    "combinatorial/topounet_edge",
+    "combinatorial/topounet_global",
+]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/test/transforms/liftings/graph2combinatorial/test_triangle_global_cc.py
+++ b/test/transforms/liftings/graph2combinatorial/test_triangle_global_cc.py
@@ -1,0 +1,105 @@
+"""Unit tests for the GraphTriangleGlobalCC lifting."""
+
+import torch
+import torch_geometric
+
+from topobench.transforms.liftings.graph2combinatorial.triangle_global_cc import (
+    GraphTriangleGlobalCC,
+)
+
+
+def _toy_graph(num_nodes=6, with_triangles=True):
+    """Build a small undirected graph.
+
+    With triangles: 6 nodes, two triangles {0, 1, 2} and {2, 3, 4}, plus a
+    pendant edge (4, 5). Without triangles: a path graph.
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes.
+    with_triangles : bool
+        Whether the graph contains triangles.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        The graph data object.
+    """
+    if with_triangles:
+        edges = [
+            (0, 1),
+            (0, 2),
+            (1, 2),
+            (2, 3),
+            (2, 4),
+            (3, 4),
+            (4, 5),
+        ]
+    else:
+        edges = [(i, i + 1) for i in range(num_nodes - 1)]
+    edge_index = torch.tensor(
+        [[u for u, v in edges] + [v for u, v in edges],
+         [v for u, v in edges] + [u for u, v in edges]],
+        dtype=torch.long,
+    )
+    return torch_geometric.data.Data(
+        x=torch.randn(num_nodes, 4),
+        edge_index=edge_index,
+        num_nodes=num_nodes,
+    )
+
+
+class TestGraphTriangleGlobalCC:
+    """Test the GraphTriangleGlobalCC lifting."""
+
+    def test_triangles_as_rank2_cells(self):
+        """Triangles (maximal 3-cliques) must become rank-2 cells."""
+        lifting = GraphTriangleGlobalCC(complex_dim=2)
+        lifted = lifting.forward(_toy_graph().clone())
+
+        # 6 nodes, 7 edges, 2 triangles.
+        assert lifted.incidence_1.shape == (6, 7)
+        assert lifted.incidence_2.shape == (7, 2)
+        # Each triangle is incident to exactly its 3 boundary edges.
+        assert (
+            lifted.incidence_2.to_dense().sum(dim=0) == torch.tensor([3.0, 3.0])
+        ).all()
+
+    def test_global_cell(self):
+        """The global rank-3 cell must be incident to all triangles.
+
+        Appendix B.4 of arXiv:2605.10091: a single global cell incident to
+        all rank-2 triangle cells, giving an all-ones incidence B_{2,3}.
+        """
+        lifting = GraphTriangleGlobalCC(complex_dim=3, add_global_cell=True)
+        lifted = lifting.forward(_toy_graph().clone())
+
+        assert lifted.incidence_3.shape == (2, 1)
+        assert (lifted.incidence_3.to_dense() == 1.0).all()
+
+    def test_no_global_cell_without_triangles(self):
+        """Triangle-free graphs must not receive a global cell."""
+        lifting = GraphTriangleGlobalCC(complex_dim=3, add_global_cell=True)
+        lifted = lifting.forward(_toy_graph(with_triangles=False).clone())
+
+        assert lifted.incidence_2.shape[1] == 0
+        assert lifted.incidence_3.shape[1] == 0
+
+    def test_edge_only_complex(self):
+        """With complex_dim=1 only nodes and edges must be materialized."""
+        lifting = GraphTriangleGlobalCC(complex_dim=1)
+        lifted = lifting.forward(_toy_graph().clone())
+
+        assert lifted.incidence_1.shape == (6, 7)
+        assert "incidence_2" not in lifted
+
+    def test_feature_lifting(self):
+        """Rank-0 features must be preserved and higher ranks seeded."""
+        data = _toy_graph()
+        lifting = GraphTriangleGlobalCC(complex_dim=2)
+        lifted = lifting.forward(data.clone())
+
+        assert torch.equal(lifted.x_0, data.x)
+        assert lifted.x_1.shape[0] == 7
+        assert lifted.x_2.shape[0] == 2

--- a/topobench/nn/backbones/combinatorial/topounet.py
+++ b/topobench/nn/backbones/combinatorial/topounet.py
@@ -69,6 +69,8 @@ class TopoUNet(torch.nn.Module):
     dropout : float, optional
         Dropout rate applied inside the within-rank refinements, following
         Appendix B.4 (default: 0.0).
+    **kwargs : dict
+        Additional keyword arguments accepted for API compatibility.
     """
 
     def __init__(
@@ -232,9 +234,7 @@ class TopoUNet(torch.nn.Module):
         # Encoder: E_{s_{i+1}} = Phi(sigma(B^T E_{s_i} W^up_i))
         # (Definition 3.3).
         encoder_states = {path[0]: x_all[path[0]]}
-        for i, (src, dst) in enumerate(
-            zip(path, path[1:], strict=False)
-        ):
+        for i, (src, dst) in enumerate(zip(path, path[1:], strict=False)):
             incidence = self._step_incidence(incidence_all, src, dst)
             up = self.act(
                 self._transport(
@@ -255,9 +255,7 @@ class TopoUNet(torch.nn.Module):
             src, dst = path[i], path[i + 1]
             incidence = self._step_incidence(incidence_all, src, dst)
             down = self.act(
-                self._transport(
-                    incidence, self.w_down[i](decoder_states[dst])
-                )
+                self._transport(incidence, self.w_down[i](decoder_states[dst]))
             )
             d_tilde = self.dropout(self.act(self.psi[i](down)))
             if self.use_skip:

--- a/topobench/nn/backbones/combinatorial/topounet.py
+++ b/topobench/nn/backbones/combinatorial/topounet.py
@@ -1,0 +1,270 @@
+"""TopoU-Net: a U-Net architecture for topological domains.
+
+Implementation of "TopoU-Net: A U-Net Architecture for Topological Domains"
+(arXiv:2605.10091). No official implementation has been released; this module
+follows the equations of the paper directly:
+
+- Incidence-convolution rank transports (Section 3.2, Section 3.5):
+  :math:`T^{\\uparrow}(H) = \\sigma(\\bar{B}^{\\top}_{s_i,s_{i+1}} H W^{\\uparrow}_i)` and
+  :math:`T^{\\downarrow}(G) = \\sigma(\\bar{B}_{s_i,s_{i+1}} G W^{\\downarrow}_i)`.
+- Encoder/decoder recursion with within-rank refinements and matched-rank
+  skip merges (Definition 3.3).
+- Additive skip merge (Section 3.5):
+  :math:`D_{s_i} = \\sigma((E_{s_i} + \\tilde{D}_{s_i}) W^m_i)`.
+"""
+
+import torch
+
+
+class TopoUNet(torch.nn.Module):
+    r"""TopoU-Net backbone (arXiv:2605.10091).
+
+    A U-shaped encoder-decoder over the ranked cells of a combinatorial
+    complex. Given an increasing encoder rank path
+    :math:`S = (s_0 < s_1 < \dots < s_L)` (Section 3.2 of the paper), the
+    encoder transports cochains upward along incidence matrices, a bottleneck
+    map is applied at rank :math:`s_L`, and the decoder transports features
+    back down, merging encoder and decoder states at matched ranks through
+    skip connections (Definition 3.3).
+
+    The canonical instantiation of Section 3.5 is used:
+
+    - Upward transport: :math:`E_{s_{i+1}} = \Phi_{s_{i+1}}(\sigma(
+      \bar{B}^{\top}_{s_i, s_{i+1}} E_{s_i} W^{\uparrow}_i))`.
+    - Bottleneck: :math:`D_{s_L} = \Omega_{s_L}(E_{s_L})`.
+    - Downward transport: :math:`\tilde{D}_{s_i} = \Psi_{s_i}(\sigma(
+      \bar{B}_{s_i, s_{i+1}} D_{s_{i+1}} W^{\downarrow}_i))`.
+    - Additive skip merge: :math:`D_{s_i} = \sigma((E_{s_i} +
+      \tilde{D}_{s_i}) W^m_i)` when ``use_skip`` is True, otherwise
+      :math:`D_{s_i} = \tilde{D}_{s_i}` (no-skip ablation, Section 4.6.3).
+
+    Within-rank refinements :math:`\Phi` and :math:`\Psi` are pointwise MLPs
+    (Section 3.5 lists this as the canonical choice). All maps act on cochain
+    spaces :math:`\mathcal{C}^{r}(\mathcal{X}; \mathbb{R}^{d})` with a shared
+    feature dimension ``in_channels`` across ranks, following the
+    hyperparameter settings of Appendix B.4.
+
+    If two consecutive ranks of the path are not consecutive integers
+    (:math:`s_{i+1} - s_i > 1`), the transport uses the direct incidence
+    matrix :math:`B_{s_i, s_{i+1}}` (Section 3.5), computed here as the
+    binarized product of the consecutive incidence matrices
+    :math:`B_{s_i, s_i+1} \cdots B_{s_{i+1}-1, s_{i+1}}`.
+
+    Parameters
+    ----------
+    in_channels : int
+        Feature dimension shared by all ranks of the path.
+    encoder_rank_path : list[int]
+        Strictly increasing encoder rank path :math:`S = (s_0 < \dots <
+        s_L)`. The full U-shaped traversal reverses it, e.g. ``[0, 1, 2]``
+        realizes the path :math:`0 \to 1 \to 2 \to 1 \to 0`.
+    use_skip : bool, optional
+        Whether to apply the additive skip merges at matched ranks. Setting
+        it to False reproduces the no-skip ablation of Section 4.6.3
+        (default: True).
+    aggr_norm : bool, optional
+        If True, incidence matrices are degree-normalized so that transports
+        average (rather than sum) over incident cells, as allowed by
+        Section 3.2 (default: True).
+    dropout : float, optional
+        Dropout rate applied inside the within-rank refinements, following
+        Appendix B.4 (default: 0.0).
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        encoder_rank_path: list[int],
+        use_skip: bool = True,
+        aggr_norm: bool = True,
+        dropout: float = 0.0,
+        **kwargs,
+    ):
+        super().__init__()
+        encoder_rank_path = list(encoder_rank_path)
+        if len(encoder_rank_path) < 2:
+            raise ValueError(
+                "encoder_rank_path must contain at least two ranks, got "
+                f"{encoder_rank_path}"
+            )
+        if any(
+            s_next <= s
+            for s, s_next in zip(
+                encoder_rank_path, encoder_rank_path[1:], strict=False
+            )
+        ):
+            raise ValueError(
+                "encoder_rank_path must be strictly increasing, got "
+                f"{encoder_rank_path}"
+            )
+
+        self.in_channels = in_channels
+        self.encoder_rank_path = encoder_rank_path
+        self.use_skip = use_skip
+        self.aggr_norm = aggr_norm
+        self.act = torch.nn.ReLU()
+        self.dropout = torch.nn.Dropout(dropout)
+
+        n_steps = len(encoder_rank_path) - 1
+        d = in_channels
+        # Per-step transport weights W^{up}_i, W^{down}_i (Section 3.5).
+        self.w_up = torch.nn.ModuleList(
+            torch.nn.Linear(d, d) for _ in range(n_steps)
+        )
+        self.w_down = torch.nn.ModuleList(
+            torch.nn.Linear(d, d) for _ in range(n_steps)
+        )
+        # Within-rank refinements Phi_{s_{i+1}} (encoder) and Psi_{s_i}
+        # (decoder), implemented as pointwise MLPs (Section 3.5).
+        self.phi = torch.nn.ModuleList(
+            torch.nn.Linear(d, d) for _ in range(n_steps)
+        )
+        self.psi = torch.nn.ModuleList(
+            torch.nn.Linear(d, d) for _ in range(n_steps)
+        )
+        # Skip-merge weights W^m_i (Section 3.5).
+        self.w_merge = torch.nn.ModuleList(
+            torch.nn.Linear(d, d) for _ in range(n_steps)
+        )
+        # Bottleneck map Omega_{s_L} (Definition 3.3).
+        self.omega = torch.nn.Linear(d, d)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(in_channels={self.in_channels}, "
+            f"encoder_rank_path={self.encoder_rank_path}, "
+            f"use_skip={self.use_skip}, aggr_norm={self.aggr_norm})"
+        )
+
+    def _step_incidence(
+        self, incidence_all: dict[int, torch.Tensor], src: int, dst: int
+    ) -> torch.Tensor:
+        r"""Return the incidence matrix :math:`B_{src, dst}` for a path step.
+
+        ``incidence_all[r]`` holds the consecutive incidence
+        :math:`B_{r-1, r}` of shape :math:`n_{r-1} \times n_r`. For a step
+        skipping ranks (:math:`dst - src > 1`), the direct incidence of
+        Section 3.5 is computed as the binarized product of consecutive
+        incidence matrices.
+
+        Parameters
+        ----------
+        incidence_all : dict[int, torch.Tensor]
+            Sparse consecutive incidence matrices keyed by their upper rank.
+        src : int
+            Lower rank of the step.
+        dst : int
+            Upper rank of the step.
+
+        Returns
+        -------
+        torch.Tensor
+            Sparse incidence matrix of shape :math:`n_{src} \times n_{dst}`.
+        """
+        incidence = incidence_all[src + 1]
+        for rank in range(src + 2, dst + 1):
+            incidence = torch.sparse.mm(incidence, incidence_all[rank])
+        if incidence._nnz() > 0:
+            incidence = torch.sparse_coo_tensor(
+                incidence._indices(),
+                torch.ones_like(incidence._values()),
+                incidence.size(),
+            ).coalesce()
+        return incidence
+
+    def _transport(
+        self, incidence: torch.Tensor, x: torch.Tensor
+    ) -> torch.Tensor:
+        r"""Aggregate features through a sparse incidence matrix.
+
+        Computes :math:`\bar{B} H` where :math:`\bar{B}` is either the raw
+        incidence matrix or, when ``aggr_norm`` is True, its degree-normalized
+        version (mean over incident cells), as permitted by Section 3.2.
+
+        Parameters
+        ----------
+        incidence : torch.Tensor
+            Sparse matrix of shape :math:`n_{dst} \times n_{src}` (already
+            oriented in the transport direction).
+        x : torch.Tensor
+            Cochain of shape :math:`n_{src} \times d`.
+
+        Returns
+        -------
+        torch.Tensor
+            Transported cochain of shape :math:`n_{dst} \times d`.
+        """
+        out = torch.sparse.mm(incidence, x)
+        if self.aggr_norm:
+            degree = torch.sparse.sum(incidence, dim=1).to_dense()
+            out = out / degree.clamp(min=1.0).unsqueeze(-1)
+        return out
+
+    def forward(
+        self,
+        x_all: dict[int, torch.Tensor],
+        incidence_all: dict[int, torch.Tensor],
+    ) -> dict[int, torch.Tensor]:
+        r"""Forward pass through the U-shaped rank traversal.
+
+        Implements the encoder/decoder recursion of Definition 3.3 with the
+        canonical maps of Section 3.5.
+
+        Parameters
+        ----------
+        x_all : dict[int, torch.Tensor]
+            Input cochains ``{rank: tensor of shape (n_rank, in_channels)}``.
+            Only the entry at the input rank :math:`s_0` is consumed; the
+            model reconstructs all higher-rank states through transport.
+        incidence_all : dict[int, torch.Tensor]
+            Sparse consecutive incidence matrices ``{r: B_{r-1, r}}`` for all
+            ranks :math:`r` up to the bottleneck rank :math:`s_L`.
+
+        Returns
+        -------
+        dict[int, torch.Tensor]
+            Decoder states ``{rank: tensor of shape (n_rank, in_channels)}``
+            for every rank of the encoder path; the entry at :math:`s_0` is
+            the output cochain :math:`D_{s_0}`.
+        """
+        path = self.encoder_rank_path
+
+        # Encoder: E_{s_{i+1}} = Phi(sigma(B^T E_{s_i} W^up_i))
+        # (Definition 3.3).
+        encoder_states = {path[0]: x_all[path[0]]}
+        for i, (src, dst) in enumerate(
+            zip(path, path[1:], strict=False)
+        ):
+            incidence = self._step_incidence(incidence_all, src, dst)
+            up = self.act(
+                self._transport(
+                    incidence.t(), self.w_up[i](encoder_states[src])
+                )
+            )
+            encoder_states[dst] = self.dropout(self.act(self.phi[i](up)))
+
+        # Bottleneck: D_{s_L} = Omega(E_{s_L}) (Definition 3.3).
+        decoder_states = {
+            path[-1]: self.act(self.omega(encoder_states[path[-1]]))
+        }
+
+        # Decoder: D~_{s_i} = Psi(sigma(B D_{s_{i+1}} W^down_i)), then
+        # D_{s_i} = sigma((E_{s_i} + D~_{s_i}) W^m_i) at matched ranks
+        # (Definition 3.3, Section 3.5).
+        for i in reversed(range(len(path) - 1)):
+            src, dst = path[i], path[i + 1]
+            incidence = self._step_incidence(incidence_all, src, dst)
+            down = self.act(
+                self._transport(
+                    incidence, self.w_down[i](decoder_states[dst])
+                )
+            )
+            d_tilde = self.dropout(self.act(self.psi[i](down)))
+            if self.use_skip:
+                decoder_states[src] = self.act(
+                    self.w_merge[i](encoder_states[src] + d_tilde)
+                )
+            else:
+                decoder_states[src] = d_tilde
+
+        return decoder_states

--- a/topobench/nn/wrappers/combinatorial/topounet_wrapper.py
+++ b/topobench/nn/wrappers/combinatorial/topounet_wrapper.py
@@ -31,8 +31,7 @@ class TopoUNetWrapper(AbstractWrapper):
         path = self.backbone.encoder_rank_path
         x_all = {path[0]: batch[f"x_{path[0]}"]}
         incidence_all = {
-            rank: batch[f"incidence_{rank}"]
-            for rank in range(1, path[-1] + 1)
+            rank: batch[f"incidence_{rank}"] for rank in range(1, path[-1] + 1)
         }
 
         decoder_states = self.backbone(x_all, incidence_all)

--- a/topobench/nn/wrappers/combinatorial/topounet_wrapper.py
+++ b/topobench/nn/wrappers/combinatorial/topounet_wrapper.py
@@ -1,0 +1,43 @@
+"""Wrapper for the TopoU-Net model."""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class TopoUNetWrapper(AbstractWrapper):
+    r"""Wrapper for the TopoU-Net model (arXiv:2605.10091).
+
+    Routes the rank-0 cochain and the consecutive incidence matrices
+    :math:`B_{r-1,r}` of the batched combinatorial complex into the
+    TopoU-Net backbone, and exposes the decoder states of every rank of the
+    encoder rank path to the readout. Following Definition 3.3 of the
+    paper, the model consumes a single input cochain at the input rank
+    :math:`s_0`; all higher-rank states are computed by the encoder through
+    incidence transport.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the TopoU-Net wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the updated model output.
+        """
+        path = self.backbone.encoder_rank_path
+        x_all = {path[0]: batch[f"x_{path[0]}"]}
+        incidence_all = {
+            rank: batch[f"incidence_{rank}"]
+            for rank in range(1, path[-1] + 1)
+        }
+
+        decoder_states = self.backbone(x_all, incidence_all)
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        for rank, x in decoder_states.items():
+            model_out[f"x_{rank}"] = x
+        return model_out

--- a/topobench/transforms/liftings/graph2combinatorial/triangle_global_cc.py
+++ b/topobench/transforms/liftings/graph2combinatorial/triangle_global_cc.py
@@ -1,0 +1,88 @@
+"""Triangle + global-cell lifting of graphs to combinatorial complexes."""
+
+import networkx as nx
+import torch_geometric
+from toponetx.classes import CombinatorialComplex
+
+from topobench.transforms.liftings.graph2combinatorial.base import (
+    Graph2CombinatorialLifting,
+)
+
+
+class GraphTriangleGlobalCC(Graph2CombinatorialLifting):
+    r"""Lift graphs to the combinatorial complexes used by TopoU-Net.
+
+    Constructs the rank structure of Section 4 of "TopoU-Net: A U-Net
+    Architecture for Topological Domains" (arXiv:2605.10091): nodes as
+    rank-0 cells, edges as rank-1 cells, triangles (maximal 3-cliques) as
+    rank-2 cells and, optionally, a single global rank-3 cell incident to
+    all rank-2 triangle cells (used by the heterophilic rank path
+    :math:`0 \to 1 \to 2 \to 3 \to 2 \to 1 \to 0`, Appendix B.4).
+
+    The ranks that are materialized are controlled by ``complex_dim``:
+    triangles are added for ``complex_dim >= 2`` and the global cell for
+    ``complex_dim >= 3`` when ``add_global_cell`` is True. The global cell
+    is realized as the set of all nodes, so every triangle is contained in
+    it and the incidence matrix :math:`B_{2,3}` is a column of ones.
+
+    Parameters
+    ----------
+    add_global_cell : bool, optional
+        Whether to add the single global rank-3 cell (default: False).
+    **kwargs : optional
+        Additional arguments for the class (e.g. ``complex_dim``).
+    """
+
+    def __init__(self, add_global_cell: bool = False, **kwargs):
+        super().__init__(**kwargs)
+        self.add_global_cell = add_global_cell
+
+    def lift_topology(
+        self, data: torch_geometric.data.Data
+    ) -> torch_geometric.data.Data | dict:
+        r"""Lift the topology of a graph to a combinatorial complex.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            The input data to be lifted.
+
+        Returns
+        -------
+        dict
+            The lifted topology.
+        """
+        graph = self._generate_graph_from_data(data)
+        assert not graph.is_directed(), (
+            "Graph supposed to be undirected for this lifting"
+        )
+
+        combinatorial_complex = CombinatorialComplex(graph)
+
+        triangles = []
+        if self.complex_dim >= 2:
+            # Triangles as maximal 3-cliques (Section 4 of the paper).
+            triangles = [
+                sorted(clique)
+                for clique in nx.find_cliques(graph)
+                if len(clique) == 3
+            ]
+            for triangle in triangles:
+                combinatorial_complex.add_cell(triangle, 2)
+
+        if self.complex_dim >= 3 and self.add_global_cell:
+            nodes = sorted(graph.nodes)
+            # The global cell is defined as incident to the rank-2 triangle
+            # cells (Appendix B.4), so it is only added when triangles exist;
+            # this also keeps the active ranks consecutive, as assumed by the
+            # connectivity extraction. The size guard avoids the degenerate
+            # case where the node set coincides with a lower-rank cell.
+            if triangles and len(nodes) > 3:
+                combinatorial_complex.add_cell(nodes, 3)
+
+        lifted_topology = self._get_lifted_topology(
+            combinatorial_complex, graph
+        )
+        lifted_topology["x_0"] = data.x
+
+        return lifted_topology


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.


## Description

This PR implements **TopoU-Net** -- *"TopoU-Net: A U-Net Architecture for Topological Domains"* ([arXiv:2605.10091](https://arxiv.org/abs/2605.10091)) -- as a Track 2 (TNN) submission for the TDL Challenge 2026.

TopoU-Net is a U-shaped encoder–decoder over the ranked cells of a **combinatorial complex**. Given an increasing *encoder rank path* `S = (s_0 < … < s_L)`, the encoder transports cochains upward along incidence matrices, a bottleneck map is applied at rank `s_L`, and the decoder transports features back down, merging encoder and decoder states at matched ranks through skip connections. Rank traversal replaces spatial scale: the rank path is the central architectural hyperparameter.

**Provenance.** No official implementation of the paper has been released (checked July 2026). The implementation follows the paper's equations directly, and every docstring cites the specific section it implements:

- Incidence-convolution transports `T↑(H) = σ(B̄ᵀ H W↑)`, `T↓(G) = σ(B̄ G W↓)` -- §3.2, §3.5
- Encoder/decoder recursion with within-rank refinements `Φ, Ψ` (pointwise MLPs, the canonical choice) and bottleneck `Ω` -- Definition 3.3, §3.5
- Additive skip merge `D_{s_i} = σ((E_{s_i} + D̃_{s_i}) W^m_i)`, with a `use_skip` flag reproducing the no-skip ablation -- §3.5, §4.6.3
- Degree-normalized incidence option (`aggr_norm`) --§3.2
- Direct incidence `B_{s_i,s_{i+1}}` for rank-skipping path steps, realized as the binarized product of consecutive incidence matrices -- §3.5
- Rank structure: nodes / edges / triangles-as-maximal-3-cliques / optional single global rank-3 cell incident to all triangles -- §4, Appendix B.4
- Shared hidden dimension across ranks and dropout inside refinements -- Appendix B.4

**Permutation equivariance** (Proposition 3.5) and **structural compatibility** of the decoder states (Proposition 3.4) are covered by dedicated unit tests.

## Model variants (one config per rank path, per challenge rules)

| Config | Encoder rank path | Full U traversal | Paper usage |
|---|---|---|---|
| `combinatorial/topounet` (default) | `[0, 1, 2]` | 0→1→2→1→0 | graph classification, general |
| `combinatorial/topounet_edge` | `[0, 1]` | 0→1→0 | homophilic graphs (minimal baseline, §4.6.4) |
| `combinatorial/topounet_global` | `[0, 1, 2, 3]` | 0→1→2→3→2→1→0 | heterophilic graphs (global bottleneck, §4) |

All variants share the same backbone class; only `encoder_rank_path` and the lifting's `complex_dim` / `add_global_cell` differ.

## What is contributed

### New modules

- **Backbone** -- `topobench/nn/backbones/combinatorial/topounet.py`
  `TopoUNet(torch.nn.Module)`; auto-discovered by `ModelExportsManager`. Takes per-rank cochains and the consecutive sparse incidence matrices `B_{r-1,r}` that TopoBench already computes. Handles empty ranks gracefully (e.g. triangle-free graphs), in which case the skip connections carry the signal -- mirroring the paper's motivation for skips under severe bottleneck compression (Proposition 3.6).

- **Lifting** -- `topobench/transforms/liftings/graph2combinatorial/triangle_global_cc.py`
  `GraphTriangleGlobalCC`: nodes (rank 0), edges (rank 1), triangles as maximal 3-cliques (rank 2, §4), and optionally a single global rank-3 cell incident to all triangles (Appendix B.4), realized as the all-nodes set so that `B_{2,3}` is a column of ones. The global cell is only added when triangles exist, which keeps active ranks consecutive as required by TopoBench's connectivity extraction. Reusable by any future combinatorial model.

- **Wrapper** -- `topobench/nn/wrappers/combinatorial/topounet_wrapper.py`
  Thin `AbstractWrapper` subclass routing `x_0` and `incidence_1..incidence_{s_L}` into the backbone and exposing the decoder states of every path rank to the readout.

### Reused TopoBench components (no modification needed)

- `AllCellFeatureEncoder` (rank 0 only -- per Definition 3.3, TopoU-Net consumes a single input cochain at rank `s_0`; higher-rank states are computed by the encoder itself)
- `ProjectionSum` feature lifting, `NoReadOut` readout (the decoder already returns the signal to rank 0; graph-level tasks use global **mean** pooling per §4.2)
- TopoBench's combinatorial-complex connectivity extraction and sparse block-diagonal batching

### Configs

- `configs/model/combinatorial/topounet{,_edge,_global}.yaml` -- full `TBModel` composition (feature_encoder / backbone / backbone_wrapper / readout)
- `configs/transforms/liftings/graph2combinatorial/topounet_cc{,_edge,_global}.yaml` -- lifting parameters per variant
- `configs/transforms/model_defaults/topounet{,_edge,_global}.yaml` -- attach the correct lifting automatically whenever the model is run on a graph dataset (same mechanism as `nsd`/`hopse`)

## Faithfulness notes (allowed modifications)

- Higher-rank input features are seeded by TopoBench's standard `ProjectionSum` (sum over the boundary via `|Bᵀ|`); the paper initializes the global cell by **mean** pooling of triangle features (App. B.4). With `aggr_norm: true` the backbone's own transports average over incident cells, matching the paper's normalized-incidence option (§3.2). These seeded features are not consumed by the backbone (Definition 3.3 takes input only at rank `s_0`).
- Linear maps use a bias term (standard practice; preserves permutation equivariance, verified by test).
- Triangles are enumerated as maximal cliques of size 3 (`nx.find_cliques`), literally following "triangles as maximal 3-cliques" (§4) and matching the convention of the existing `GraphTriangleInducedCC` lifting.

## Testing

- `test/nn/backbones/combinatorial/test_topounet.py` -- 12 tests: forward shapes for all three rank paths (Prop. 3.4), permutation equivariance (Prop. 3.5), no-skip ablation (§4.6.3), degree normalization, direct-incidence rank skipping (§3.5), empty-rank handling, input validation, repr.
- `test/nn/wrappers/combinatorial/test_topounet_wrapper.py` -- wrapper output contract, with and without residual connections.
- `test/transforms/liftings/graph2combinatorial/test_triangle_global_cc.py` -- triangle cells, global-cell incidence (all-ones `B_{2,3}`), triangle-free graphs, edge-only complex, feature lifting.
- **Coverage: 100 % on all three new source files** (17 tests, all passing).
- `test/pipeline/test_pipeline.py` filled in with `graph/MUTAG` × all three variants -- full training pipeline passes end-to-end.
- `ruff` and `numpydoc` validation pass on all new files.

## Evaluation

- `2026_tdl_challenge/run_evaluation.ipynb` run on `combinatorial/topounet`; the generated `results.json` is included in this PR.
<img width="3214" height="2171" alt="heatmap_community_detection_accuracy (1)" src="https://github.com/user-attachments/assets/2057c079-1538-4fda-a927-1ebd78a0d588" />
<img width="3094" height="2171" alt="heatmap_triangle_mse_over_triangles (1)" src="https://github.com/user-attachments/assets/5cb27626-3c64-4493-8533-959e91482a9c" />


## Reproducing

```bash
# unit tests
pytest test/nn/backbones/combinatorial/test_topounet.py \
       test/nn/wrappers/combinatorial/test_topounet_wrapper.py \
       test/transforms/liftings/graph2combinatorial/test_triangle_global_cc.py

# pipeline test
pytest test/pipeline/test_pipeline.py

# single run
python -m topobench model=combinatorial/topounet dataset=graph/MUTAG
```

---