### PR TITLE
Track: Track2; Team name: GiggioIlGriggio; Model: MPSN (Message Passing Simplicial Networks)

### DIFF
--- a/2026_tdl_challenge/outputs/2026-06-30_15-21-08/results.json
+++ b/2026_tdl_challenge/outputs/2026-06-30_15-21-08/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-06-30_15-21-08",
+    "model_config": "simplicial/mpsn",
+    "generated_at_utc": "2026-06-30T17:42:28.647484+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.287837505340576,
+      "test_best_rerun_accuracy": 0.30063411593437195,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3025059103965759,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23771870136260986,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2659102976322174,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2869585156440735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2979601323604584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.221063494682312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24612270295619965,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.280884712934494,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2944457232952118,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23363129794597626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2169760912656784,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.029558047004368,
+        "AvgTime/train_epoch_std": 0.06580965131935426,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2846763134002686,
+      "test_best_rerun_accuracy": 0.3011307120323181,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3039957284927368,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2275574952363968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26228129863739014,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2867293059825897,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29589730501174927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21116968989372253,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2449766993522644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2819543182849884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29574450850486755,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2249980866909027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21796928346157074,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.070173884547034,
+        "AvgTime/train_epoch_std": 0.05114547802563647,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2606656551361084,
+      "test_best_rerun_accuracy": 0.30636411905288696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30227673053741455,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2607533037662506,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2755749225616455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2925357222557068,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3010161221027374,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24363969266414642,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.269462913274765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29368171095848083,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3071281313896179,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2549087107181549,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2608678936958313,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1847699605501614,
+        "AvgTime/train_epoch_std": 0.2798992071634741,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.241971254348755,
+      "test_best_rerun_accuracy": 0.30796852707862854,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29303231835365295,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20807547867298126,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.269424706697464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2644205093383789,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.288486510515213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1767132729291916,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22033768892288208,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2457789033651352,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2681259214878082,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18290168046951294,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17445947229862213,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3916144810224833,
+        "AvgTime/train_epoch_std": 0.5808401449689972,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.273432970046997,
+      "test_best_rerun_accuracy": 0.30376651883125305,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2868057191371918,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.189777672290802,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2438689023256302,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25479409098625183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2843609154224396,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16418366134166718,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1991748809814453,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2354649007320404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2563984990119934,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1719764620065689,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15979066491127014,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.779232974322337,
+        "AvgTime/train_epoch_std": 0.12771878227014882,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2624924182891846,
+      "test_best_rerun_accuracy": 0.3080449104309082,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28737872838974,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18782947957515717,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2540683150291443,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2512032985687256,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28909772634506226,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15803346037864685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2021544873714447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23321110010147095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2585759162902832,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16296125948429108,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14707006514072418,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.879859175682068,
+        "AvgTime/train_epoch_std": 0.08724459247253262,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2458367347717285,
+      "test_best_rerun_accuracy": 0.312094122171402,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29532432556152344,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2876461148262024,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3087325096130371,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.296928733587265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2862709164619446,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2978837192058563,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3024677336215973,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29845672845840454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2935289144515991,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2761097252368927,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.0901610078038395,
+        "AvgTime/train_epoch_std": 0.16417408764241942,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2948851585388184,
+      "test_best_rerun_accuracy": 0.308350533246994,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2797769010066986,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2797769010066986,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3077393174171448,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30009931325912476,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2858889102935791,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3002903163433075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32076552510261536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32279011607170105,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3209947347640991,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3098021149635315,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3154939115047455,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.46752942480692,
+        "AvgTime/train_epoch_std": 0.39416830228230343,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2402331829071045,
+      "test_best_rerun_accuracy": 0.3142715394496918,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2899381220340729,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2840171158313751,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3059821128845215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30311712622642517,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2898617088794708,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3193139135837555,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32103294134140015,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3151119351387024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3075101375579834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29956451058387756,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.9882219927651543,
+        "AvgTime/train_epoch_std": 0.13152134496599485,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2428207397460938,
+      "test_best_rerun_accuracy": 0.30999311804771423,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2966613173484802,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2971579134464264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2850485146045685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2843609154224396,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2902055084705353,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23019328713417053,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27481091022491455,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2726716995239258,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2921155095100403,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22476889193058014,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21537168323993683,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.1884839779291396,
+        "AvgTime/train_epoch_std": 0.09395295959698219,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.277059555053711,
+      "test_best_rerun_accuracy": 0.3125525116920471,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30120712518692017,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3009779155254364,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2731301188468933,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28638550639152527,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2309572994709015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27767589688301086,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28474292159080505,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30674612522125244,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23305828869342804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.219153493642807,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.1446967869997025,
+        "AvgTime/train_epoch_std": 0.11888351143962694,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2343568801879883,
+      "test_best_rerun_accuracy": 0.31220871210098267,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29967913031578064,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2996409237384796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2664833068847656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2735120952129364,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28905951976776123,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21861869096755981,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2764917016029358,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2712201178073883,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28554511070251465,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2296202927827835,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22178928554058075,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.0899982085594764,
+        "AvgTime/train_epoch_std": 0.12584365910963644,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.991689682006836,
+      "test_best_rerun_accuracy": 0.4063717722892761,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24952250719070435,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23890289664268494,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2180456817150116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21823668479919434,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38383376598358154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3894873559474945,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4156925678253174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5636412501335144,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5602414011955261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5849950313568115,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6050882339477539,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.170564385021434,
+        "AvgTime/train_epoch_std": 0.10243827497450715,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9773857593536377,
+      "test_best_rerun_accuracy": 0.40725037455558777,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2465810924768448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2331346869468689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22881808876991272,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22629688680171967,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3855527639389038,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39838796854019165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42677056789398193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5614638328552246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5575292110443115,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5987852215766907,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6126136183738708,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1987621639714097,
+        "AvgTime/train_epoch_std": 0.1193647979249941,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.054309368133545,
+      "test_best_rerun_accuracy": 0.4033539593219757,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2524639070034027,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24493849277496338,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22209489345550537,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21976469457149506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38654595613479614,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3911299705505371,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.410802960395813,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5642906427383423,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5572236180305481,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5919856429100037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6057758331298828,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0651010366586537,
+        "AvgTime/train_epoch_std": 0.13434364993672687,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.053014039993286,
+      "test_best_rerun_accuracy": 0.3870043456554413,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2524639070034027,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2521583139896393,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19974787533283234,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22503629326820374,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38941094279289246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.312094122171402,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38723355531692505,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.527389407157898,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5521048307418823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5019863843917847,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5453051924705505,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8813866680743647,
+        "AvgTime/train_epoch_std": 0.1027233383288811,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.03460693359375,
+      "test_best_rerun_accuracy": 0.39132094383239746,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2509740889072418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2449766993522644,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20280387997627258,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22098708152770996,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3926197588443756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3322637379169464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40152037143707275,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5482466220855713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5632210373878479,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5412560105323792,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5848804116249084,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8492518851631565,
+        "AvgTime/train_epoch_std": 0.13626483757148294,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.047250747680664,
+      "test_best_rerun_accuracy": 0.3924669623374939,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2569715082645416,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25403010845184326,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20288027822971344,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22614409029483795,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3882649540901184,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3184735178947449,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39319276809692383,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5290319919586182,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5547788143157959,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4998854100704193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5586370229721069,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.821794015056682,
+        "AvgTime/train_epoch_std": 0.08318606341176817,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9136273860931396,
+      "test_best_rerun_accuracy": 0.44281458854675293,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2293528914451599,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21456947922706604,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2434868961572647,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23458629846572876,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3810451626777649,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33394452929496765,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46145617961883545,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5300633907318115,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5033615827560425,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6327450275421143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6573076844215393,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.577848834149978,
+        "AvgTime/train_epoch_std": 0.27943564828897377,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9625200033187866,
+      "test_best_rerun_accuracy": 0.4354037642478943,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.219688281416893,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20887768268585205,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24123309552669525,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22992588579654694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37351974844932556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33287492394447327,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46351897716522217,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5169225931167603,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4963327944278717,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6181144714355469,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6513484716415405,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.905351732716416,
+        "AvgTime/train_epoch_std": 0.17432020886175895,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9905691146850586,
+      "test_best_rerun_accuracy": 0.437466561794281,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22572389245033264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21594469249248505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23710750043392181,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2317976951599121,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3820001482963562,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33856675028800964,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46107417345046997,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5286118388175964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5060737729072571,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6205974221229553,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6515394449234009,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.785655620621472,
+        "AvgTime/train_epoch_std": 0.1331561511957127,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.789223313331604,
+      "test_best_rerun_accuracy": 0.470624178647995,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22003208100795746,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21334709227085114,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22339369356632233,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22331729531288147,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3774925470352173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3404385447502136,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4161509573459625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5200932025909424,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5158147811889648,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6137978434562683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6667430400848389,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.5415785047743054,
+        "AvgTime/train_epoch_std": 0.10982682141490192,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7446037530899048,
+      "test_best_rerun_accuracy": 0.4818167984485626,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2249980866909027,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21877148747444153,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22599129378795624,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23099549114704132,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3850943446159363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35109633207321167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.424172967672348,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5280770063400269,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5203223824501038,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6156314611434937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6680800914764404,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.381316771109899,
+        "AvgTime/train_epoch_std": 1.1395435559968985,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7841846942901611,
+      "test_best_rerun_accuracy": 0.4748261868953705,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2347772866487503,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22996409237384796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2330200970172882,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.241424098610878,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38750094175338745,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3591947555541992,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41278937458992004,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5214301943778992,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5184888243675232,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5991290211677551,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6558942794799805,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.604251704897199,
+        "AvgTime/train_epoch_std": 0.9996267550213186,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4107046127319336,
+      "test_best_rerun_accuracy": 0.5989762544631958,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2089540809392929,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1977996826171875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18045687675476074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.184085875749588,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3942241668701172,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37348154187202454,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3597295582294464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41145235300064087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.592176616191864,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6435556411743164,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6678890585899353,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6063288418022363,
+        "AvgTime/train_epoch_std": 0.1361076648401877,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4099948406219482,
+      "test_best_rerun_accuracy": 0.6005042195320129,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21338528394699097,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2037970870733261,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1948200762271881,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19310107827186584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3983497619628906,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3735579550266266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3820001482963562,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4227595627307892,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.596760630607605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.650928258895874,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6733898520469666,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6002179940541583,
+        "AvgTime/train_epoch_std": 0.1611747223585378,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4256922006607056,
+      "test_best_rerun_accuracy": 0.597562849521637,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21930629014968872,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21006187796592712,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19531667232513428,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20639468729496002,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4007563591003418,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3708457350730896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38341355323791504,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4339139759540558,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5911070108413696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6502788662910461,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6756054759025574,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.531808503130649,
+        "AvgTime/train_epoch_std": 0.10671203211565118,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4139848947525024,
+      "test_best_rerun_accuracy": 0.6042096614837646,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2142638862133026,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20333868265151978,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18721827864646912,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18603406846523285,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38425394892692566,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3743601441383362,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3442203402519226,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40194055438041687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5976774096488953,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6298800706863403,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6842004656791687,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9946948672240634,
+        "AvgTime/train_epoch_std": 0.08549191111763857,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3761098384857178,
+      "test_best_rerun_accuracy": 0.6023378372192383,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21663229167461395,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20628008246421814,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18756207823753357,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1946672797203064,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3883795440196991,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37634655833244324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3544197380542755,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4173351526260376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.589999258518219,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6412254571914673,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6887844800949097,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9188310584506474,
+        "AvgTime/train_epoch_std": 0.09390698124817776,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4147982597351074,
+      "test_best_rerun_accuracy": 0.5932462215423584,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2079990804195404,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19856368005275726,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17602567374706268,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18049506843090057,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.382267564535141,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3704255521297455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3429597318172455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4018641710281372,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5875162482261658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6309114694595337,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6834364533424377,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.903139317035675,
+        "AvgTime/train_epoch_std": 0.052895021615209974,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1672461032867432,
+      "test_best_rerun_accuracy": 0.6728550791740417,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1957750767469406,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18729467689990997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19527848064899445,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.184047669172287,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37458935379981995,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3304683268070221,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4109939634799957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43632057309150696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5745664238929749,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5491251945495605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6971502900123596,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 9.835601624320535,
+        "AvgTime/train_epoch_std": 0.20156303544315538,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1693519353866577,
+      "test_best_rerun_accuracy": 0.6656734943389893,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19149667024612427,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1817556768655777,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19596607983112335,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1809534728527069,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37325236201286316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3288257420063019,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41156697273254395,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43807777762413025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5640231966972351,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.543433427810669,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6908090710639954,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 10.192155370345482,
+        "AvgTime/train_epoch_std": 1.3855182824206103,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1754728555679321,
+      "test_best_rerun_accuracy": 0.6693788766860962,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19661547243595123,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1877530813217163,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18893727660179138,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18893727660179138,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3845977485179901,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3462831377983093,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4025517702102661,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.443196564912796,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5812514424324036,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5588662028312683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6979143023490906,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 13.56114314448449,
+        "AvgTime/train_epoch_std": 2.3261026628212296,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.055918574333191,
+      "test_best_rerun_accuracy": 0.7092978954315186,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1943998783826828,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18729467689990997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17335167527198792,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1610894650220871,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37336695194244385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3522041440010071,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3892199695110321,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42757275700569153,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5700206160545349,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5698678493499756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6572312712669373,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.16630333662033,
+        "AvgTime/train_epoch_std": 0.24265480900643818,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0096505880355835,
+      "test_best_rerun_accuracy": 0.7031477093696594,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1977996826171875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18370386958122253,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18389487266540527,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17029567062854767,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36981433629989624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3428451418876648,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38807395100593567,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43807777762413025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.557108998298645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.554129421710968,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6487890481948853,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.518351658530857,
+        "AvgTime/train_epoch_std": 0.24935257941334416,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0300045013427734,
+      "test_best_rerun_accuracy": 0.6984490752220154,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19432348012924194,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18695087730884552,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17705707252025604,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1759110689163208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3735961616039276,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.349109947681427,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38643136620521545,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44583237171173096,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5573382377624512,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5570326447486877,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6434792280197144,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 13.351604494181545,
+        "AvgTime/train_epoch_std": 0.22249129903734177,
+        "model/params/total": 117220,
+        "model/params/trainable": 117220,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 3.7097065448760986,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.5967655181884766,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0025913296240550983,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.3650413751602173,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.007184428290316933
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1145.009765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.08684184798065984
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.097525119781494,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0020551146342371062
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2970.074462890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.39680353545632935
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.229759216308594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.01746956754430794
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97012.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.252758612181869
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5108.4208984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3581840484109872
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28148.904296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4428676147867652
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1375.0799560546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.24445865885416668
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 589836.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.67213570240829
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164661.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7401124611019587
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.5546541494481705,
+        "AvgTime/train_epoch_std": 0.10418740056315184,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.0974392890930176,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.04327392578125,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.001472099370159402,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.4545966684818268,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0023926140446411935
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1321.0408935546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.10019271092564941
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.524687767028809,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0015250043030093725
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3256.985595703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.435135016126002
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.31036376953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.014084942806158247
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103604.8515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.4058343758707967
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5436.5283203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.38118975741919087
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28495.1796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.460617135040238
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1395.441650390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.248078515625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 596723.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.750036763458254
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166100.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7640649181269032
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.686952407969985,
+        "AvgTime/train_epoch_std": 0.43011101547669184,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 4.044600486755371,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.6933295726776123,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0026609002684997206,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4236125946044922,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.007492697866339433
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2065.489013671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.15665445685793516
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.240453243255615,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.002103287240733271
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3671.51953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.49051697144288575
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.772489547729492,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.025710267312374347
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112642.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6157013398662454
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6497.8994140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4556092703731945
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31804.123046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6302282560292685
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1720.7283935546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3059072699652778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 625684.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.077642302863025
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183326.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0507146215033365
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4243208765983582,
+        "AvgTime/train_epoch_std": 0.1443132558690153,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.24895115196704865,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.25508248805999756,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0013425394108420923,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.90593147277832,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02154606013888928
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5401.3779296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.40966082136423965
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.853652954101562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007702613061712694
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5706.8203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.762434243486974
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.14041519165039,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.054525401719905345
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146078.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3921336557217163
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9645.2802734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.676292264299362
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39050.234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.001652282279973
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2441.51708984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.43404748263888887
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 696532.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.87906165514745
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218431.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6348950792937615
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.5376110133670626,
+        "AvgTime/train_epoch_std": 0.1810068203694743,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.19872036576271057,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.19958838820457458,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0010504652010767084,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.083072662353516,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.015909994713511177
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4998.197265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3790820830963216
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.603740692138672,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007955423219460286
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5480.89892578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.732251025488477
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.4443359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05478785486830743
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142378.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.306201598202675
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9415.04296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6601488549116533
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38695.38671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9834633614613768
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2415.2197265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4293723958333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 693263.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.842076202165085
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 217558.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.62037019702794
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.5929683492383884,
+        "AvgTime/train_epoch_std": 0.09447548873040917,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.3672899305820465,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.3663853108882904,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.001928343741517318,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.57328796386719,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03283378095379481
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5990.93701171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.45437519997866893
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.164005279541016,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01488507087278093
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6015.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8036072144288577
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.51139068603516,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06693557054061758
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148878.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4571422766115547
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10524.591796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7379464168331931
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40241.01171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0626896160105592
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2642.84033203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.46983828125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 705751.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.983346860400665
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225516.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7527938466210706
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.2031327572735875,
+        "AvgTime/train_epoch_std": 0.80149645543981,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 106.59942626953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 105.8456039428711,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.008027728778374751,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.392143249511719,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.011089440381492593
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.709590911865234,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09847153111508018
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.388647079467773,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0031643569529719493
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1586.4757080078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21195400240585338
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.123029708862305,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02255874758969111
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65067.01953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5109376632744287
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2530.60498046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.17743689387664774
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21030.89453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0780098688425854
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764.0269165039062,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13582700737847223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 509613.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.764657308009909
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126286.6640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1015203777894262
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.3032790422439575,
+        "AvgTime/train_epoch_std": 0.12028850830329418,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 109.83921813964844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108.47077178955078,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.008226831383356146,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.740933418273926,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.009179346843136834
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.831132888793945,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07805859415154708
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.233251571655273,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.00816759405852891
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1652.695068359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22080094433658984
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.230812072753906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.020924708180271076
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65339.74609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5172707155338565
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2776.044677734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1946462402001385
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20471.7578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.049349418857963
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 784.5700073242188,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13947911241319444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 502381.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.682855078447564
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126017.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.09704112271812
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.513404051462809,
+        "AvgTime/train_epoch_std": 0.09474698072613366,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 102.5676498413086,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 102.43241119384766,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.007768859400367665,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.334637641906738,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.005284321067656151
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.575044631958008,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05039497174714741
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.24276065826416,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0041263096252996834
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1713.69287109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22895028337925852
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.519350051879883,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.016856088127702836
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68231.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5844255787897084
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2772.33251953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.19438595705590028
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20573.9375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0545869854938745
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 739.9579467773438,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13154807942708333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 508139.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.747987200660611
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126045.8515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.097513047484732
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.310863812764486,
+        "AvgTime/train_epoch_std": 0.10224679088326089,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 0.843176543712616,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.8736848831176758,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.00029446743617043335,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.479189872741699,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.003227082040880187
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.7419305443763733,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0039048976019809122
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1412.509033203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.10712999872606181
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3885.186767578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5190630284005511
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.857622146606445,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.021465994945255997
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117423.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7267134381385842
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5986.64794921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.41976216163362434
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32906.08203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6867129033394843
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1753.704345703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.31176966145833335
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 641844.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.260436580206554
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184426.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.069016461983925
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.64679291844368,
+        "AvgTime/train_epoch_std": 0.10170741684039572,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.3730075359344482,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.245302677154541,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0007567585699880489,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54.382598876953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.039180546741320696
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94.95558166503906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4997662192896793
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1890.663330078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14339501934608456
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4770.65185546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6373616373371743
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111.61494445800781,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09638596239897047
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126490.0546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9372574467652797
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7171.93310546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5028700817184651
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35689.921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8294080616638475
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2105.335693359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.37428190104166664
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 662382.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.492765375609425
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194690.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.239826446091891
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.64453775954969,
+        "AvgTime/train_epoch_std": 0.10115628344909583,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.9569101333618164,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.8967981338500977,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0009763391081395678,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.004955291748047,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.018735558567541822
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.32435607910156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.21223345304790295
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1783.765380859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.13528747674322147
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4212.2685546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5627613299515698
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.83969497680664,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.049084365264945286
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120213.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7915041783740477
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6627.15087890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.46467191690550064
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33931.91015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7392952050976473
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1891.029541015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3361830295138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 647872.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.328624311392147
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189016.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.145396250395221
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.671800603469213,
+        "AvgTime/train_epoch_std": 0.11008559661682873,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 423.78857421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 451.2832336425781,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.060291681181373166,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.23695945739746,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.020343630732995287
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.94269371032715,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08917207215961657
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 590.5635375976562,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.04479056030319729
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30.573841094970703,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.010304631309393563
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.46734619140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.016811179785324915
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26910.044921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6248849368817342
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1117.17724609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.07833243907542771
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12213.9697265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6260684671978318
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250.8623504638672,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.04459775119357639
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 363850.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.115810549415744
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78523.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.306700395636763
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7655943702248966,
+        "AvgTime/train_epoch_std": 0.22759134888377527,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 450.13275146484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 477.8226013183594,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.06383735488555235,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34.48652267456055,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02484619789233469
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.869876861572266,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1203677729556435
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312.2294616699219,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.02368065693363078
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115.10884094238281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.038796373758807824
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.188522338867188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.019161072831491526
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32375.154296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7517916193775543
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1099.93701171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.07712361602291053
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11689.533203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5991866934812138
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 287.7993469238281,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.05116432834201389
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361453.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.088705982828637
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81988.2109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3643554313730384
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5991851091384888,
+        "AvgTime/train_epoch_std": 0.09215347956746582,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 449.52337646484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 466.91473388671875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.062380057967497494,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.2063045501709,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.020321545064964624
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.758344650268555,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08820181394878186
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 436.9079284667969,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.03313674087726939
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.82365417480469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.014096277106439058
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.976587295532227,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.019841612517730766
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28618.013671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6645461097871772
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1073.2611083984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.07525319789639864
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11696.939453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.599566325958532
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 277.7939758300781,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.049385595703125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 358512.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.055431871655939
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81293.5234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3527952246933919
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7718141697071217,
+        "AvgTime/train_epoch_std": 0.14755354715522534,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 11.16146183013916,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11.002628326416016,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.009501406154072552,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.009193420410156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04539567249309089
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.5152850151062012,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.007975184290032638
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2444.011962890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.18536306127346416
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.865119457244873,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0016397436660751173
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1857.7987060546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.248202899940506
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66153.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5361612948170165
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3091.291748046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.21675022774133187
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22677.373046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.16240571258778
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 980.1281127929688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1742449978298611
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 525736.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.9470415313959935
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137505.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.288216025577022
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5027330186631944,
+        "AvgTime/train_epoch_std": 0.18336874802709605,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 13.681363105773926,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 13.624862670898438,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.011765857228755127,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.38923645019531,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03702394556930498
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.967653274536133,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.01561922776071649
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 792.4898681640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.06010541283003887
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.927570343017578,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0033459960711215296
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2130.90771484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2846904094647629
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74371.0078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7269879205949286
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4009.732177734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.2811479580517722
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23359.037109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1973467173804397
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1092.757080078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19426792534722223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 535386.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.056205671753221
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144201.4375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.399637852994525
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2849697801801894,
+        "AvgTime/train_epoch_std": 0.02839934101000567,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 18.234622955322266,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18.99406623840332,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.016402475162697168,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.04606246948242,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.029572091116341803
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.6883344650268555,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.014149128763299238
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 748.3148193359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.05675501094698047
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.554545402526855,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.004231393799301266
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2136.1923828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.28539644392952573
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77212.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7929671172557125
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3957.367919921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.277476365160698
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24843.494140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.27343760011405
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1161.2840576171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.20645049913194444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 552894.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.254251128355373
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151842.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.5267886858702346
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4659604592756792,
+        "AvgTime/train_epoch_std": 0.1798385885451354,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 3568.52734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2247.458251953125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.05218879463015802,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.9189453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1137744562770173
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137.49314880371094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7236481515984786
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 340.35791015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.02581402428185438
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 378.39990234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1275361989699191
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 286.3814697265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.03826071739833834
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174.55435180664062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15073778221644268
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 540.9345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.03792838103439209
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2503.1796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.12830896957814342
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 332.28985595703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.05907375217013889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160016.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.81007467223963
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24006.4609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.39948847515517616
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.769276790618896,
+        "AvgTime/train_epoch_std": 0.17860173965629988,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 3676.489013671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3184.646240234375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.07395147316167507,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 548.6091918945312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.39525157917473436
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 469.5804748535156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.471476183439556
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 936.8182373046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.07105181928742416
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1148.1270751953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.38696564718412957
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 643.2539672851562,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.08593907378559201
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 538.42041015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.464957176300734
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 850.2643432617188,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.05961746902690498
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4459.54052734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.22858888345603312
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 820.9906005859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1459538845486111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155471.140625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.7586636270827913
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23692.205078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.39425898321143893
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.957474417984486,
+        "AvgTime/train_epoch_std": 0.14239921677851977,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2392.43408203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2362.84033203125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.054868110998310654,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.2577896118164,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0729522979912222
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167.80641174316406,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8831916407534951
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 462.8872375488281,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.03510710940832978
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.5814208984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0480557535889577
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.7601776123047,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.017603230141924473
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113.62641906738281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09812298710482108
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 400.07489013671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.028051808311367183
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2182.394775390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.1118660503045069
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176.4940643310547,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.031376722547743055
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145378.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.6444938237390134
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22829.66796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.3799056124465412
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.17017810685294,
+        "AvgTime/train_epoch_std": 0.13151693121658176,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 314.36767578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 309.6919250488281,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.02171448079153191,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.33026123046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05355206140523685
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.9429874420166,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1207525654842979
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6591.9833984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4999608189941221
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.975231170654297,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01077695691629737
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 931.7901000976562,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.12448765532366816
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.591114044189453,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.01950873406233977
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23532.345703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5464505318392393
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11360.314453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.582311469225742
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201.07977294921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.035747515190972225
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 330042.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.733385744827664
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71743.4296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1938733244720683
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.662735798779656,
+        "AvgTime/train_epoch_std": 0.1031009455739721,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 409.2842102050781,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 418.5837097167969,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.029349579982947474,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.81494140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10217214798721182
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.91689682006836,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1311415622108861
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9867.2490234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7483692850540387
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.736377716064453,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008337168087652327
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 999.8389282226562,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1335790151266074
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.455432891845703,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.023709354828882298
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22090.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.512958909994427
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9872.5810546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5060526451733816
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 238.9152069091797,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.04247381456163195
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312731.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.5375711938508876
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66601.6796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1083101141147886
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.75627154774136,
+        "AvgTime/train_epoch_std": 0.08143866715969374,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 237.2249298095703,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 217.86854553222656,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.01527615660722385,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.09513092041016,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0541031202596615
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.5504150390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.22394955283717105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8092.4326171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6137605322098976
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.631847381591797,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008976018665855004
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 698.655029296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0933406852768036
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.835933685302734,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03699130715483828
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21504.966796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.49937225517543654
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9014.017578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.46204406059382847
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143.3577117919922,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0254858154296875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 288039.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.258257284820651
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60196.19921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0017173251252225
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.755992243164464,
+        "AvgTime/train_epoch_std": 0.09523384585218725,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 3179.888427734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3314.06884765625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.16987384528454816,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119.87373352050781,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08636436132601427
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96.6310806274414,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5085846348812706
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1022.690185546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.07756467087955063
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117.59568786621094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03963454259056654
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 296.9083557128906,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.039667114991702154
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88.1514892578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0761239112761766
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7467.4033203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.17340245495802759
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348.8846435546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.02446253285336471
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.9174041748047,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.031807538519965275
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173092.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.95798926507019
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28249.92578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4701034360283228
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4397888841300177,
+        "AvgTime/train_epoch_std": 0.11254613856076705,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 3324.685546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3542.004150390625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.181557442738768,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.65813446044922,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07252026978418531
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80.16943359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4219443873355263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1885.9248046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14303563175483505
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108.70162200927734,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03663687967956769
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 669.5271606445312,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0894491864588552
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.31526184082031,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07453822266046659
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5920.3564453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.13747808947874093
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 478.2204284667969,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.033531091604739646
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.12904357910156,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.026334052191840276
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179007.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.0249083034512405
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31214.005859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5194283170980813
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.411443740129471,
+        "AvgTime/train_epoch_std": 0.10270195532468811,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 3093.749755859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3249.32763671875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.16655531481463684,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116.10527038574219,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0836493302490938
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70.40946960449219,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.37057615581311676
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6231.6650390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4726329191552901
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165.18138122558594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.055672861889311066
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 840.2189331054688,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.11225369847768453
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.76837921142578,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06715749500123125
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10313.2265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.23948603386819617
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205.82789611816406,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.01443190969837078
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96.17517852783203,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.017097809516059027
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174191.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.9704248583192878
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28271.552734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.47046332741542274
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.441785076686314,
+        "AvgTime/train_epoch_std": 0.09008476557557665,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 202.19503784179688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 208.45947265625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.037059461805555555,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212.58016967773438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1531557418427481
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.166872024536133,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0798256422344007
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10108.236328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7666466687997725
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65.45793151855469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02206199242283609
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1282.081298828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.17128674667042418
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.718788146972656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.019618988037109375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27970.630859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6495130702994381
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 827.91357421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.058050313716081194
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11649.923828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5971563805487211
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 338455.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.828547603022522
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71934.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1970474410497063
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8448637568432351,
+        "AvgTime/train_epoch_std": 0.05137894999908988,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 121.3056869506836,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 127.51045227050781,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.022668524848090277,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 387.9585876464844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2795090689095709
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.690643310546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.06679285952919407
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17029.560546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.291585934537353
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.45729637145996,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.006220861601435781
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2545.249267578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.34004666233508685
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.38775634765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.01587889149193113
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35221.05859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8178770804790544
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 509.2686462402344,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.03570808065069656
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12047.666015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6175440061317853
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 353377.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.9973477285838714
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74718.1015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.243374462291781
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7718735195341564,
+        "AvgTime/train_epoch_std": 0.19497103918613756,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 130.5321807861328,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 135.942138671875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.024167491319444446,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 305.00048828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.21974098579340778
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.056705474853516,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.11082476565712376
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12192.45703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9247218074516496
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30.884462356567383,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.010409323342287625
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1663.594482421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22225711188001002
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.812339782714844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.024017564579201074
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33263.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7724157649080439
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 623.399658203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.04371053556325375
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12505.9951171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6410372196005689
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 358311.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.053160314129611
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76176.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2676484261894063
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7898157027459913,
+        "AvgTime/train_epoch_std": 0.11665237634341992,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 26738.51953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15008.26171875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.16977095481770982,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5274.8359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.8003140760086453
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3347.60302734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.61896330180921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21927.84375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.6630901592718998
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18206.841796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.136448195778565
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5230.84375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6988435203740815
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4238.2490234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.659973249946028
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17409.2890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4042654900264722
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25336.73046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.7765201562719113
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2252.95947265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.11548308332852786
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4237.52587890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7533379340277778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18330.4609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.30503487823040953
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 10.27099545105644,
+        "AvgTime/train_epoch_std": 0.24793898123087765,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 9072.6806640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7045.0341796875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.07969225229559518,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 517.189208984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.37261470387923273
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207.4522705078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.0918540553042764
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4635.55712890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3515780909295601
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 604.7913208007812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.20383933966996334
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 901.8673095703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.12048995451841182
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 418.8031921386719,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.36166078768451804
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5594.11474609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.12990234873894088
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 921.2368774414062,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.06459380714075208
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1196.772216796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0613446212925765
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1135.3043212890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.20183187934027777
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8891.3984375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.14796063497412343
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 10.308171401421228,
+        "AvgTime/train_epoch_std": 0.23452224084395534,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 5382.3349609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5258.71728515625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.059485733347920886,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1172.4957275390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8447375558638779
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1380.018798828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.2632568359375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13182.3564453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9997995028678422
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1085.4912109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3658548065175261
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1289.6978759765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.17230432544777055
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1137.3433837890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9821618167435773
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19339.255859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4490817355418679
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2291.35107421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.16066127290834034
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 840.4722900390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0430812594207321
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 854.30078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.15187569444444443
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10664.7529296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.17747080241771088
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 10.24231568249789,
+        "AvgTime/train_epoch_std": 0.19778783662280988,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 4682.73046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3492.79052734375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.05812308467448372,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349.20819091796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2515909156469516
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115.79536437988281,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6094492862099096
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21293.82421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.6150037329351536
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.8525848388672,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04443969829419184
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3715.69921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4964194013026052
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.91343688964844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12341402149365151
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88795.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0619455926063535
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 366.1231384277344,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.02567123393827895
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5872.0576171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3009922403602184
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 290.21478271484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.051593739149305554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83539.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.9449834847233691
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.588777360462007,
+        "AvgTime/train_epoch_std": 0.14507611084524985,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 4732.7939453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3641.96240234375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.06060543494822608,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 698.7297973632812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5034076349879548
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 344.08636474609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.8109808670847038
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13297.3271484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0085193134954493
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 945.5708618164062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3186959426411885
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4248.697265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5676282252004008
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 456.2998962402344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.39404136117464106
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71527.9765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6609691752391789
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610.5007934570312,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.04280611369071878
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4959.90478515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.2542367515073171
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 678.603759765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.12064066840277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87743.265625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.9925371947218986
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.766407159658579,
+        "AvgTime/train_epoch_std": 0.1561699070206689,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mpsn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 4886.81103515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3513.46923828125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.05846719648347145,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 490.5380859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.35341360658321325
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160.91256713867188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.846908248098273
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28159.9375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.1357555934774366
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174.47915649414062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05880659133607705
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6610.2099609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8831275832915831
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185.32501220703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.16003887064510472
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123458.9609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.866871654688371
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 582.912841796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.04087174602418139
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8561.3662109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4388418786681788
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 360.076904296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.064013671875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79319.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.8972461341809667
+        }
+      },
+      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 8.759645109176637,
+        "AvgTime/train_epoch_std": 0.13420225075146433,
+        "model/params/total": 115985,
+        "model/params/trainable": 115985,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/2026_tdl_challenge/outputs/2026-07-31_15-44-23/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-31_15-44-23/results.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "study_id": "2026-06-30_15-21-08",
+    "study_id": "2026-07-31_15-44-23",
     "model_config": "simplicial/mpsn",
-    "generated_at_utc": "2026-06-30T17:42:28.647484+00:00",
+    "generated_at_utc": "2026-07-31T15:39:57.696986+00:00",
     "n_runs": 72,
     "train_seeds": [
       42,
@@ -21,64 +21,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.287837505340576,
-      "test_best_rerun_accuracy": 0.30063411593437195,
+      "test_loss": 2.244597911834717,
+      "test_best_rerun_accuracy": 0.31450071930885315,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3025059103965759,
+          "test_best_rerun_accuracy": 0.3105279207229614,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23771870136260986,
+          "test_best_rerun_accuracy": 0.28787532448768616,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2659102976322174,
+          "test_best_rerun_accuracy": 0.2926885187625885,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2869585156440735,
+          "test_best_rerun_accuracy": 0.30919092893600464,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2979601323604584,
+          "test_best_rerun_accuracy": 0.30892351269721985,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.221063494682312,
+          "test_best_rerun_accuracy": 0.2664833068847656,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.24612270295619965,
+          "test_best_rerun_accuracy": 0.2676292955875397,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.280884712934494,
+          "test_best_rerun_accuracy": 0.323515921831131,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2944457232952118,
+          "test_best_rerun_accuracy": 0.33272212743759155,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23363129794597626,
+          "test_best_rerun_accuracy": 0.2935289144515991,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2169760912656784,
+          "test_best_rerun_accuracy": 0.27794331312179565,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__00__h_lo__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.029558047004368,
-        "AvgTime/train_epoch_std": 0.06580965131935426,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2025740451001106,
+        "AvgTime/train_epoch_std": 0.015442050292666501
       }
     },
     {
@@ -90,64 +90,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.2846763134002686,
-      "test_best_rerun_accuracy": 0.3011307120323181,
+      "test_loss": 2.2223401069641113,
+      "test_best_rerun_accuracy": 0.3201543390750885,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3039957284927368,
+          "test_best_rerun_accuracy": 0.3166017234325409,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2275574952363968,
+          "test_best_rerun_accuracy": 0.2860035002231598,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.26228129863739014,
+          "test_best_rerun_accuracy": 0.28989991545677185,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2867293059825897,
+          "test_best_rerun_accuracy": 0.31194132566452026,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29589730501174927,
+          "test_best_rerun_accuracy": 0.31152111291885376,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.21116968989372253,
+          "test_best_rerun_accuracy": 0.2565512955188751,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2449766993522644,
+          "test_best_rerun_accuracy": 0.26594850420951843,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2819543182849884,
+          "test_best_rerun_accuracy": 0.32576972246170044,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29574450850486755,
+          "test_best_rerun_accuracy": 0.3269539177417755,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2249980866909027,
+          "test_best_rerun_accuracy": 0.2765299081802368,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.21796928346157074,
+          "test_best_rerun_accuracy": 0.2659102976322174,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__00__h_lo__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.070173884547034,
-        "AvgTime/train_epoch_std": 0.05114547802563647,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2451442409964169,
+        "AvgTime/train_epoch_std": 0.018863438306641545
       }
     },
     {
@@ -159,64 +159,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.2606656551361084,
-      "test_best_rerun_accuracy": 0.30636411905288696,
+      "test_loss": 2.215437173843384,
+      "test_best_rerun_accuracy": 0.3167163133621216,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.30227673053741455,
+          "test_best_rerun_accuracy": 0.31488272547721863,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2607533037662506,
+          "test_best_rerun_accuracy": 0.2833295166492462,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2755749225616455,
+          "test_best_rerun_accuracy": 0.2820689082145691,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2925357222557068,
+          "test_best_rerun_accuracy": 0.31194132566452026,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3010161221027374,
+          "test_best_rerun_accuracy": 0.30785393714904785,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24363969266414642,
+          "test_best_rerun_accuracy": 0.2653754949569702,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.269462913274765,
+          "test_best_rerun_accuracy": 0.259110689163208,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29368171095848083,
+          "test_best_rerun_accuracy": 0.32947513461112976,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3071281313896179,
+          "test_best_rerun_accuracy": 0.3224845230579376,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2549087107181549,
+          "test_best_rerun_accuracy": 0.2803499102592468,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2608678936958313,
+          "test_best_rerun_accuracy": 0.2645350992679596,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__00__h_lo__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.1847699605501614,
-        "AvgTime/train_epoch_std": 0.2798992071634741,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3051152340201444,
+        "AvgTime/train_epoch_std": 0.018376410847094942
       }
     },
     {
@@ -228,64 +228,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.241971254348755,
-      "test_best_rerun_accuracy": 0.30796852707862854,
+      "test_loss": 2.2162933349609375,
+      "test_best_rerun_accuracy": 0.31396591663360596,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29303231835365295,
+          "test_best_rerun_accuracy": 0.30919092893600464,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.20807547867298126,
+          "test_best_rerun_accuracy": 0.2459316998720169,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.269424706697464,
+          "test_best_rerun_accuracy": 0.27970051765441895,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2644205093383789,
+          "test_best_rerun_accuracy": 0.2793567180633545,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.288486510515213,
+          "test_best_rerun_accuracy": 0.29696691036224365,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1767132729291916,
+          "test_best_rerun_accuracy": 0.21712888777256012,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22033768892288208,
+          "test_best_rerun_accuracy": 0.2383299022912979,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2457789033651352,
+          "test_best_rerun_accuracy": 0.2664833068847656,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2681259214878082,
+          "test_best_rerun_accuracy": 0.2879517078399658,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18290168046951294,
+          "test_best_rerun_accuracy": 0.21796928346157074,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.17445947229862213,
+          "test_best_rerun_accuracy": 0.2104438841342926,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__01__h_lo__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.3916144810224833,
-        "AvgTime/train_epoch_std": 0.5808401449689972,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2545840867928095,
+        "AvgTime/train_epoch_std": 0.02637207250598389
       }
     },
     {
@@ -297,64 +297,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.273432970046997,
-      "test_best_rerun_accuracy": 0.30376651883125305,
+      "test_loss": 2.2147762775421143,
+      "test_best_rerun_accuracy": 0.3156467378139496,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2868057191371918,
+          "test_best_rerun_accuracy": 0.3110627233982086,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.189777672290802,
+          "test_best_rerun_accuracy": 0.23970510065555573,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2438689023256302,
+          "test_best_rerun_accuracy": 0.28225991129875183,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.25479409098625183,
+          "test_best_rerun_accuracy": 0.28516310453414917,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2843609154224396,
+          "test_best_rerun_accuracy": 0.30334633588790894,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.16418366134166718,
+          "test_best_rerun_accuracy": 0.2100236862897873,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1991748809814453,
+          "test_best_rerun_accuracy": 0.23619069159030914,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2354649007320404,
+          "test_best_rerun_accuracy": 0.27561309933662415,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2563984990119934,
+          "test_best_rerun_accuracy": 0.29494231939315796,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1719764620065689,
+          "test_best_rerun_accuracy": 0.21987928450107574,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.15979066491127014,
+          "test_best_rerun_accuracy": 0.2073114812374115,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__01__h_lo__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.779232974322337,
-        "AvgTime/train_epoch_std": 0.12771878227014882,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.252277711342121,
+        "AvgTime/train_epoch_std": 0.018349983062552023
       }
     },
     {
@@ -366,64 +366,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 2.2624924182891846,
-      "test_best_rerun_accuracy": 0.3080449104309082,
+      "test_loss": 2.188103199005127,
+      "test_best_rerun_accuracy": 0.319734126329422,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.28737872838974,
+          "test_best_rerun_accuracy": 0.310260534286499,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18782947957515717,
+          "test_best_rerun_accuracy": 0.25181451439857483,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2540683150291443,
+          "test_best_rerun_accuracy": 0.2886393070220947,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2512032985687256,
+          "test_best_rerun_accuracy": 0.2929559051990509,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28909772634506226,
+          "test_best_rerun_accuracy": 0.30705171823501587,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.15803346037864685,
+          "test_best_rerun_accuracy": 0.22503629326820374,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2021544873714447,
+          "test_best_rerun_accuracy": 0.24535870552062988,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.23321110010147095,
+          "test_best_rerun_accuracy": 0.28634729981422424,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2585759162902832,
+          "test_best_rerun_accuracy": 0.29738712310791016,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.16296125948429108,
+          "test_best_rerun_accuracy": 0.2320650964975357,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.14707006514072418,
+          "test_best_rerun_accuracy": 0.21449308097362518,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__01__h_lo__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.879859175682068,
-        "AvgTime/train_epoch_std": 0.08724459247253262,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2600683569908142,
+        "AvgTime/train_epoch_std": 0.03531941660597934
       }
     },
     {
@@ -435,64 +435,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.2458367347717285,
-      "test_best_rerun_accuracy": 0.312094122171402,
+      "test_loss": 2.1392147541046143,
+      "test_best_rerun_accuracy": 0.3417755365371704,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29532432556152344,
+          "test_best_rerun_accuracy": 0.2926885187625885,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2876461148262024,
+          "test_best_rerun_accuracy": 0.2782489061355591,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3087325096130371,
+          "test_best_rerun_accuracy": 0.3274887204170227,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.296928733587265,
+          "test_best_rerun_accuracy": 0.323515921831131,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2862709164619446,
+          "test_best_rerun_accuracy": 0.30120712518692017,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2978837192058563,
+          "test_best_rerun_accuracy": 0.3612193465232849,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3024677336215973,
+          "test_best_rerun_accuracy": 0.360531747341156,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30418673157691956,
+          "test_best_rerun_accuracy": 0.39116814732551575,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.29845672845840454,
+          "test_best_rerun_accuracy": 0.3742837607860565,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2935289144515991,
+          "test_best_rerun_accuracy": 0.44201236963272095,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2761097252368927,
+          "test_best_rerun_accuracy": 0.4493085741996765,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__02__h_lo__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 4.0901610078038395,
-        "AvgTime/train_epoch_std": 0.16417408764241942,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5576833114027977,
+        "AvgTime/train_epoch_std": 0.01792423365899006
       }
     },
     {
@@ -504,64 +504,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.2948851585388184,
-      "test_best_rerun_accuracy": 0.308350533246994,
+      "test_loss": 2.1510350704193115,
+      "test_best_rerun_accuracy": 0.3455573320388794,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2797769010066986,
+          "test_best_rerun_accuracy": 0.29750171303749084,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2797769010066986,
+          "test_best_rerun_accuracy": 0.28734052181243896,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3077393174171448,
+          "test_best_rerun_accuracy": 0.33146151900291443,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30009931325912476,
+          "test_best_rerun_accuracy": 0.3195813298225403,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2858889102935791,
+          "test_best_rerun_accuracy": 0.30006110668182373,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3002903163433075,
+          "test_best_rerun_accuracy": 0.35243335366249084,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.32076552510261536,
+          "test_best_rerun_accuracy": 0.3542287349700928,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.32279011607170105,
+          "test_best_rerun_accuracy": 0.3791351616382599,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3209947347640991,
+          "test_best_rerun_accuracy": 0.3675987422466278,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3098021149635315,
+          "test_best_rerun_accuracy": 0.4116433560848236,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3154939115047455,
+          "test_best_rerun_accuracy": 0.4268851578235626,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__02__h_lo__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 4.46752942480692,
-        "AvgTime/train_epoch_std": 0.39416830228230343,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5583712577819824,
+        "AvgTime/train_epoch_std": 0.020111332909827192
       }
     },
     {
@@ -573,64 +573,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 2.2402331829071045,
-      "test_best_rerun_accuracy": 0.3142715394496918,
+      "test_loss": 2.158174991607666,
+      "test_best_rerun_accuracy": 0.3367331326007843,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2899381220340729,
+          "test_best_rerun_accuracy": 0.28516310453414917,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2840171158313751,
+          "test_best_rerun_accuracy": 0.27137291431427,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3059821128845215,
+          "test_best_rerun_accuracy": 0.32065093517303467,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30311712622642517,
+          "test_best_rerun_accuracy": 0.3138895332813263,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2898617088794708,
+          "test_best_rerun_accuracy": 0.29249751567840576,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_accuracy": 0.35648253560066223,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.3193139135837555,
+          "test_best_rerun_accuracy": 0.3538849353790283,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.32103294134140015,
+          "test_best_rerun_accuracy": 0.3752387464046478,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3151119351387024,
+          "test_best_rerun_accuracy": 0.35908013582229614,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3075101375579834,
+          "test_best_rerun_accuracy": 0.4321949779987335,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.29956451058387756,
+          "test_best_rerun_accuracy": 0.4461761713027954,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__02__h_lo__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.9882219927651543,
-        "AvgTime/train_epoch_std": 0.13152134496599485,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5904049124036517,
+        "AvgTime/train_epoch_std": 0.015384683335861654
       }
     },
     {
@@ -642,64 +642,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.2428207397460938,
-      "test_best_rerun_accuracy": 0.30999311804771423,
+      "test_loss": 2.1880412101745605,
+      "test_best_rerun_accuracy": 0.3337153196334839,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2966613173484802,
+          "test_best_rerun_accuracy": 0.30869433283805847,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2971579134464264,
+          "test_best_rerun_accuracy": 0.3004431128501892,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2850485146045685,
+          "test_best_rerun_accuracy": 0.3174421191215515,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2843609154224396,
+          "test_best_rerun_accuracy": 0.30063411593437195,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2902055084705353,
+          "test_best_rerun_accuracy": 0.3017801344394684,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23019328713417053,
+          "test_best_rerun_accuracy": 0.280884712934494,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.27481091022491455,
+          "test_best_rerun_accuracy": 0.30743372440338135,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2726716995239258,
+          "test_best_rerun_accuracy": 0.3186645209789276,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2921155095100403,
+          "test_best_rerun_accuracy": 0.3352433443069458,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22476889193058014,
+          "test_best_rerun_accuracy": 0.29341432452201843,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.21537168323993683,
+          "test_best_rerun_accuracy": 0.3028879165649414,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__03__h_lo__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.1884839779291396,
-        "AvgTime/train_epoch_std": 0.09395295959698219,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4346021931126434,
+        "AvgTime/train_epoch_std": 0.018434973431701033
       }
     },
     {
@@ -711,64 +711,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.277059555053711,
-      "test_best_rerun_accuracy": 0.3125525116920471,
+      "test_loss": 2.136186361312866,
+      "test_best_rerun_accuracy": 0.3363129198551178,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.30120712518692017,
+          "test_best_rerun_accuracy": 0.3061349093914032,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3009779155254364,
+          "test_best_rerun_accuracy": 0.299908310174942,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2731301188468933,
+          "test_best_rerun_accuracy": 0.3248911201953888,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.28638550639152527,
+          "test_best_rerun_accuracy": 0.31343111395835876,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_accuracy": 0.3039575219154358,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2309572994709015,
+          "test_best_rerun_accuracy": 0.31136831641197205,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.27767589688301086,
+          "test_best_rerun_accuracy": 0.3288257420063019,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.28474292159080505,
+          "test_best_rerun_accuracy": 0.3488425314426422,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.30674612522125244,
+          "test_best_rerun_accuracy": 0.3470853269100189,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23305828869342804,
+          "test_best_rerun_accuracy": 0.3448697328567505,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.219153493642807,
+          "test_best_rerun_accuracy": 0.34781113266944885,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__03__h_lo__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.1446967869997025,
-        "AvgTime/train_epoch_std": 0.11888351143962694,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4598984884661297,
+        "AvgTime/train_epoch_std": 0.017783188946389646
       }
     },
     {
@@ -780,64 +780,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.2343568801879883,
-      "test_best_rerun_accuracy": 0.31220871210098267,
+      "test_loss": 2.1463489532470703,
+      "test_best_rerun_accuracy": 0.3374207317829132,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.29967913031578064,
+          "test_best_rerun_accuracy": 0.3107571303844452,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2996409237384796,
+          "test_best_rerun_accuracy": 0.30334633588790894,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2664833068847656,
+          "test_best_rerun_accuracy": 0.32130032777786255,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2735120952129364,
+          "test_best_rerun_accuracy": 0.31045153737068176,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28905951976776123,
+          "test_best_rerun_accuracy": 0.30227673053741455,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.21861869096755981,
+          "test_best_rerun_accuracy": 0.294980525970459,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2764917016029358,
+          "test_best_rerun_accuracy": 0.3166399300098419,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2712201178073883,
+          "test_best_rerun_accuracy": 0.34047672152519226,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.28554511070251465,
+          "test_best_rerun_accuracy": 0.3372679352760315,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2296202927827835,
+          "test_best_rerun_accuracy": 0.3239743411540985,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22178928554058075,
+          "test_best_rerun_accuracy": 0.32309573888778687,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__03__h_lo__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.0899982085594764,
-        "AvgTime/train_epoch_std": 0.12584365910963644,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4839015474506454,
+        "AvgTime/train_epoch_std": 0.06802511928875483
       }
     },
     {
@@ -849,64 +849,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 1.991689682006836,
-      "test_best_rerun_accuracy": 0.4063717722892761,
+      "test_loss": 1.9385874271392822,
+      "test_best_rerun_accuracy": 0.41129955649375916,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.24952250719070435,
+          "test_best_rerun_accuracy": 0.2546030879020691,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.23890289664268494,
+          "test_best_rerun_accuracy": 0.24023990333080292,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2180456817150116,
+          "test_best_rerun_accuracy": 0.24383069574832916,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.21823668479919434,
+          "test_best_rerun_accuracy": 0.21712888777256012,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.38383376598358154,
+          "test_best_rerun_accuracy": 0.37837114930152893,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3894873559474945,
+          "test_best_rerun_accuracy": 0.41038277745246887,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4156925678253174,
+          "test_best_rerun_accuracy": 0.39663076400756836,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5636412501335144,
+          "test_best_rerun_accuracy": 0.5639086365699768,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5602414011955261,
+          "test_best_rerun_accuracy": 0.551073431968689,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5849950313568115,
+          "test_best_rerun_accuracy": 0.5999312400817871,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6050882339477539,
+          "test_best_rerun_accuracy": 0.5758270025253296,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__04__h_mid__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.170564385021434,
-        "AvgTime/train_epoch_std": 0.10243827497450715,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.445860733857026,
+        "AvgTime/train_epoch_std": 0.02258014908635077
       }
     },
     {
@@ -918,64 +918,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 1.9773857593536377,
-      "test_best_rerun_accuracy": 0.40725037455558777,
+      "test_loss": 1.9520881175994873,
+      "test_best_rerun_accuracy": 0.4173351526260376,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2465810924768448,
+          "test_best_rerun_accuracy": 0.2607150971889496,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2331346869468689,
+          "test_best_rerun_accuracy": 0.24826189875602722,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22881808876991272,
+          "test_best_rerun_accuracy": 0.249064102768898,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22629688680171967,
+          "test_best_rerun_accuracy": 0.2304224967956543,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3855527639389038,
+          "test_best_rerun_accuracy": 0.3931163549423218,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.39838796854019165,
+          "test_best_rerun_accuracy": 0.41561615467071533,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.42677056789398193,
+          "test_best_rerun_accuracy": 0.4105737507343292,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5614638328552246,
+          "test_best_rerun_accuracy": 0.570097029209137,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5575292110443115,
+          "test_best_rerun_accuracy": 0.5595538020133972,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5987852215766907,
+          "test_best_rerun_accuracy": 0.6162808537483215,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6126136183738708,
+          "test_best_rerun_accuracy": 0.6034074425697327,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__04__h_mid__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.1987621639714097,
-        "AvgTime/train_epoch_std": 0.1193647979249941,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.44648058274213,
+        "AvgTime/train_epoch_std": 0.01380070033366874
       }
     },
     {
@@ -987,64 +987,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 2.054309368133545,
-      "test_best_rerun_accuracy": 0.4033539593219757,
+      "test_loss": 1.9532794952392578,
+      "test_best_rerun_accuracy": 0.4090457558631897,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2524639070034027,
+          "test_best_rerun_accuracy": 0.2544502913951874,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.24493849277496338,
+          "test_best_rerun_accuracy": 0.23867370188236237,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22209489345550537,
+          "test_best_rerun_accuracy": 0.25227290391921997,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.21976469457149506,
+          "test_best_rerun_accuracy": 0.23053708672523499,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.38654595613479614,
+          "test_best_rerun_accuracy": 0.38291695713996887,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3911299705505371,
+          "test_best_rerun_accuracy": 0.41225457191467285,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.410802960395813,
+          "test_best_rerun_accuracy": 0.40423256158828735,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5642906427383423,
+          "test_best_rerun_accuracy": 0.558789849281311,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5572236180305481,
+          "test_best_rerun_accuracy": 0.554167628288269,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5919856429100037,
+          "test_best_rerun_accuracy": 0.6025288701057434,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6057758331298828,
+          "test_best_rerun_accuracy": 0.5776224136352539,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__04__h_mid__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.0651010366586537,
-        "AvgTime/train_epoch_std": 0.13434364993672687,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4458597929049761,
+        "AvgTime/train_epoch_std": 0.020718190146984505
       }
     },
     {
@@ -1056,64 +1056,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.053014039993286,
-      "test_best_rerun_accuracy": 0.3870043456554413,
+      "test_loss": 2.0182290077209473,
+      "test_best_rerun_accuracy": 0.3900603652000427,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2524639070034027,
+          "test_best_rerun_accuracy": 0.2582702934741974,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2521583139896393,
+          "test_best_rerun_accuracy": 0.2509740889072418,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19974787533283234,
+          "test_best_rerun_accuracy": 0.22686989605426788,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22503629326820374,
+          "test_best_rerun_accuracy": 0.22912369668483734,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.38941094279289246,
+          "test_best_rerun_accuracy": 0.3983497619628906,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.312094122171402,
+          "test_best_rerun_accuracy": 0.3606463372707367,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.38723355531692505,
+          "test_best_rerun_accuracy": 0.41141417622566223,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.527389407157898,
+          "test_best_rerun_accuracy": 0.5414470434188843,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5521048307418823,
+          "test_best_rerun_accuracy": 0.5528688430786133,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5019863843917847,
+          "test_best_rerun_accuracy": 0.5457636117935181,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5453051924705505,
+          "test_best_rerun_accuracy": 0.5812132358551025,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__05__h_mid__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.8813866680743647,
-        "AvgTime/train_epoch_std": 0.1027233383288811,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3192255127018895,
+        "AvgTime/train_epoch_std": 0.01633644364428812
       }
     },
     {
@@ -1125,64 +1125,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.03460693359375,
-      "test_best_rerun_accuracy": 0.39132094383239746,
+      "test_loss": 2.001335620880127,
+      "test_best_rerun_accuracy": 0.3916647434234619,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2509740889072418,
+          "test_best_rerun_accuracy": 0.261861115694046,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2449766993522644,
+          "test_best_rerun_accuracy": 0.25578731298446655,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.20280387997627258,
+          "test_best_rerun_accuracy": 0.22984948754310608,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22098708152770996,
+          "test_best_rerun_accuracy": 0.23091909289360046,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3926197588443756,
+          "test_best_rerun_accuracy": 0.39930474758148193,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3322637379169464,
+          "test_best_rerun_accuracy": 0.3535793423652649,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.40152037143707275,
+          "test_best_rerun_accuracy": 0.403239369392395,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5482466220855713,
+          "test_best_rerun_accuracy": 0.5372450351715088,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5632210373878479,
+          "test_best_rerun_accuracy": 0.5526013970375061,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5412560105323792,
+          "test_best_rerun_accuracy": 0.5450378060340881,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5848804116249084,
+          "test_best_rerun_accuracy": 0.5755214095115662,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__05__h_mid__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.8492518851631565,
-        "AvgTime/train_epoch_std": 0.13626483757148294,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3208981706545904,
+        "AvgTime/train_epoch_std": 0.013688473183623893
       }
     },
     {
@@ -1194,64 +1194,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 2.047250747680664,
-      "test_best_rerun_accuracy": 0.3924669623374939,
+      "test_loss": 1.984795331954956,
+      "test_best_rerun_accuracy": 0.39514094591140747,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2569715082645416,
+          "test_best_rerun_accuracy": 0.26610130071640015,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.25403010845184326,
+          "test_best_rerun_accuracy": 0.25716251134872437,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.20288027822971344,
+          "test_best_rerun_accuracy": 0.23175948858261108,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22614409029483795,
+          "test_best_rerun_accuracy": 0.23485369980335236,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3882649540901184,
+          "test_best_rerun_accuracy": 0.40327757596969604,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3184735178947449,
+          "test_best_rerun_accuracy": 0.352929949760437,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.39319276809692383,
+          "test_best_rerun_accuracy": 0.41657117009162903,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5290319919586182,
+          "test_best_rerun_accuracy": 0.5451142191886902,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5547788143157959,
+          "test_best_rerun_accuracy": 0.5608144402503967,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4998854100704193,
+          "test_best_rerun_accuracy": 0.5390785932540894,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.5586370229721069,
+          "test_best_rerun_accuracy": 0.5906486511230469,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__05__h_mid__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.821794015056682,
-        "AvgTime/train_epoch_std": 0.08318606341176817,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3081457004990689,
+        "AvgTime/train_epoch_std": 0.020250964876051117
       }
     },
     {
@@ -1263,64 +1263,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 1.9136273860931396,
-      "test_best_rerun_accuracy": 0.44281458854675293,
+      "test_loss": 1.8160829544067383,
+      "test_best_rerun_accuracy": 0.46008098125457764,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2293528914451599,
+          "test_best_rerun_accuracy": 0.2339750975370407,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.21456947922706604,
+          "test_best_rerun_accuracy": 0.21651768684387207,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2434868961572647,
+          "test_best_rerun_accuracy": 0.26151731610298157,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.23458629846572876,
+          "test_best_rerun_accuracy": 0.2500954866409302,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3810451626777649,
+          "test_best_rerun_accuracy": 0.3790205419063568,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.33394452929496765,
+          "test_best_rerun_accuracy": 0.33382993936538696,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.46145617961883545,
+          "test_best_rerun_accuracy": 0.47070059180259705,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5300633907318115,
+          "test_best_rerun_accuracy": 0.5348765850067139,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5033615827560425,
+          "test_best_rerun_accuracy": 0.511421799659729,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6327450275421143,
+          "test_best_rerun_accuracy": 0.6418366432189941,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6573076844215393,
+          "test_best_rerun_accuracy": 0.6748796701431274,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__06__h_mid__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 6.577848834149978,
-        "AvgTime/train_epoch_std": 0.27943564828897377,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.7492022881141076,
+        "AvgTime/train_epoch_std": 0.02374976731208539
       }
     },
     {
@@ -1332,64 +1332,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 1.9625200033187866,
-      "test_best_rerun_accuracy": 0.4354037642478943,
+      "test_loss": 1.8261512517929077,
+      "test_best_rerun_accuracy": 0.4570631682872772,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.219688281416893,
+          "test_best_rerun_accuracy": 0.23244708776474,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20887768268585205,
+          "test_best_rerun_accuracy": 0.21865688264369965,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.24123309552669525,
+          "test_best_rerun_accuracy": 0.2689281105995178,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22992588579654694,
+          "test_best_rerun_accuracy": 0.2510887086391449,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.37351974844932556,
+          "test_best_rerun_accuracy": 0.3746657371520996,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.33287492394447327,
+          "test_best_rerun_accuracy": 0.3342883288860321,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.46351897716522217,
+          "test_best_rerun_accuracy": 0.46787378191947937,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5169225931167603,
+          "test_best_rerun_accuracy": 0.5260906219482422,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.4963327944278717,
+          "test_best_rerun_accuracy": 0.5071052312850952,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6181144714355469,
+          "test_best_rerun_accuracy": 0.6404996514320374,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6513484716415405,
+          "test_best_rerun_accuracy": 0.6684620380401611,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__06__h_mid__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 5.905351732716416,
-        "AvgTime/train_epoch_std": 0.17432020886175895,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.7140566825866699,
+        "AvgTime/train_epoch_std": 0.011767750543951249
       }
     },
     {
@@ -1401,64 +1401,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 1.9905691146850586,
-      "test_best_rerun_accuracy": 0.437466561794281,
+      "test_loss": 1.8151594400405884,
+      "test_best_rerun_accuracy": 0.466804176568985,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.22572389245033264,
+          "test_best_rerun_accuracy": 0.2387118935585022,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.21594469249248505,
+          "test_best_rerun_accuracy": 0.22541828453540802,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.23710750043392181,
+          "test_best_rerun_accuracy": 0.2706853151321411,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.2317976951599121,
+          "test_best_rerun_accuracy": 0.25212010741233826,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3820001482963562,
+          "test_best_rerun_accuracy": 0.3905569612979889,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.33856675028800964,
+          "test_best_rerun_accuracy": 0.34548094868659973,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.46107417345046997,
+          "test_best_rerun_accuracy": 0.46814119815826416,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5286118388175964,
+          "test_best_rerun_accuracy": 0.5428985953330994,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5060737729072571,
+          "test_best_rerun_accuracy": 0.5215066075325012,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6205974221229553,
+          "test_best_rerun_accuracy": 0.6485598683357239,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6515394449234009,
+          "test_best_rerun_accuracy": 0.6681182384490967,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__06__h_mid__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 5.785655620621472,
-        "AvgTime/train_epoch_std": 0.1331561511957127,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.74397873878479,
+        "AvgTime/train_epoch_std": 0.02336606711790698
       }
     },
     {
@@ -1470,64 +1470,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1.789223313331604,
-      "test_best_rerun_accuracy": 0.470624178647995,
+      "test_loss": 1.7164475917816162,
+      "test_best_rerun_accuracy": 0.4884635806083679,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.22003208100795746,
+          "test_best_rerun_accuracy": 0.23733669519424438,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.21334709227085114,
+          "test_best_rerun_accuracy": 0.22977308928966522,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22339369356632233,
+          "test_best_rerun_accuracy": 0.2526930868625641,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.22331729531288147,
+          "test_best_rerun_accuracy": 0.24234089255332947,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3774925470352173,
+          "test_best_rerun_accuracy": 0.38818854093551636,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3404385447502136,
+          "test_best_rerun_accuracy": 0.35594773292541504,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4161509573459625,
+          "test_best_rerun_accuracy": 0.44625258445739746,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5200932025909424,
+          "test_best_rerun_accuracy": 0.5277714133262634,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5158147811889648,
+          "test_best_rerun_accuracy": 0.5241042375564575,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6137978434562683,
+          "test_best_rerun_accuracy": 0.6268622279167175,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6667430400848389,
+          "test_best_rerun_accuracy": 0.6884024739265442,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__07__h_mid__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.5415785047743054,
-        "AvgTime/train_epoch_std": 0.10982682141490192,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5706756503082986,
+        "AvgTime/train_epoch_std": 0.013977529787693318
       }
     },
     {
@@ -1539,64 +1539,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1.7446037530899048,
-      "test_best_rerun_accuracy": 0.4818167984485626,
+      "test_loss": 1.7127301692962646,
+      "test_best_rerun_accuracy": 0.487775981426239,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2249980866909027,
+          "test_best_rerun_accuracy": 0.24543510377407074,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.21877148747444153,
+          "test_best_rerun_accuracy": 0.2351974993944168,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.22599129378795624,
+          "test_best_rerun_accuracy": 0.25548169016838074,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.23099549114704132,
+          "test_best_rerun_accuracy": 0.2406218945980072,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3850943446159363,
+          "test_best_rerun_accuracy": 0.38983115553855896,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.35109633207321167,
+          "test_best_rerun_accuracy": 0.36889755725860596,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.424172967672348,
+          "test_best_rerun_accuracy": 0.4519061744213104,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5280770063400269,
+          "test_best_rerun_accuracy": 0.5344564318656921,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5203223824501038,
+          "test_best_rerun_accuracy": 0.5379708409309387,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6156314611434937,
+          "test_best_rerun_accuracy": 0.6285430788993835,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6680800914764404,
+          "test_best_rerun_accuracy": 0.6878677010536194,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__07__h_mid__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 4.381316771109899,
-        "AvgTime/train_epoch_std": 1.1395435559968985,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.6053346465615665,
+        "AvgTime/train_epoch_std": 0.03306664020506286
       }
     },
     {
@@ -1608,64 +1608,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 1.7841846942901611,
-      "test_best_rerun_accuracy": 0.4748261868953705,
+      "test_loss": 1.7100054025650024,
+      "test_best_rerun_accuracy": 0.4899151921272278,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2347772866487503,
+          "test_best_rerun_accuracy": 0.23928490281105042,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.22996409237384796,
+          "test_best_rerun_accuracy": 0.2289326936006546,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.2330200970172882,
+          "test_best_rerun_accuracy": 0.2540683150291443,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.241424098610878,
+          "test_best_rerun_accuracy": 0.2384444922208786,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.38750094175338745,
+          "test_best_rerun_accuracy": 0.3876155614852905,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3591947555541992,
+          "test_best_rerun_accuracy": 0.3596913516521454,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.41278937458992004,
+          "test_best_rerun_accuracy": 0.44281458854675293,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5214301943778992,
+          "test_best_rerun_accuracy": 0.5296432375907898,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5184888243675232,
+          "test_best_rerun_accuracy": 0.5320116281509399,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.5991290211677551,
+          "test_best_rerun_accuracy": 0.6228894591331482,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6558942794799805,
+          "test_best_rerun_accuracy": 0.6909618973731995,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__07__h_mid__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 5.604251704897199,
-        "AvgTime/train_epoch_std": 0.9996267550213186,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5935965505513279,
+        "AvgTime/train_epoch_std": 0.015680404110076804
       }
     },
     {
@@ -1677,64 +1677,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.4107046127319336,
-      "test_best_rerun_accuracy": 0.5989762544631958,
+      "test_loss": 1.3822553157806396,
+      "test_best_rerun_accuracy": 0.6033692359924316,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2089540809392929,
+          "test_best_rerun_accuracy": 0.2160210907459259,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1977996826171875,
+          "test_best_rerun_accuracy": 0.20330047607421875,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18045687675476074,
+          "test_best_rerun_accuracy": 0.1990220844745636,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.184085875749588,
+          "test_best_rerun_accuracy": 0.18725647032260895,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3942241668701172,
+          "test_best_rerun_accuracy": 0.3970509469509125,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.37348154187202454,
+          "test_best_rerun_accuracy": 0.37023454904556274,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3597295582294464,
+          "test_best_rerun_accuracy": 0.3853999674320221,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.41145235300064087,
+          "test_best_rerun_accuracy": 0.4120635688304901,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.592176616191864,
+          "test_best_rerun_accuracy": 0.5961494445800781,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6435556411743164,
+          "test_best_rerun_accuracy": 0.6666284799575806,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6678890585899353,
+          "test_best_rerun_accuracy": 0.6886316537857056,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__08__h_hi__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.6063288418022363,
-        "AvgTime/train_epoch_std": 0.1361076648401877,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.544898863349642,
+        "AvgTime/train_epoch_std": 0.017912462877955344
       }
     },
     {
@@ -1746,64 +1746,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.4099948406219482,
-      "test_best_rerun_accuracy": 0.6005042195320129,
+      "test_loss": 1.354374647140503,
+      "test_best_rerun_accuracy": 0.6061578392982483,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.21338528394699097,
+          "test_best_rerun_accuracy": 0.21892428398132324,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.2037970870733261,
+          "test_best_rerun_accuracy": 0.20734968781471252,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.1948200762271881,
+          "test_best_rerun_accuracy": 0.20288027822971344,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.19310107827186584,
+          "test_best_rerun_accuracy": 0.187867671251297,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3983497619628906,
+          "test_best_rerun_accuracy": 0.40163496136665344,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3735579550266266,
+          "test_best_rerun_accuracy": 0.3727557361125946,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3820001482963562,
+          "test_best_rerun_accuracy": 0.3901367485523224,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4227595627307892,
+          "test_best_rerun_accuracy": 0.4098479747772217,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.596760630607605,
+          "test_best_rerun_accuracy": 0.5946214199066162,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.650928258895874,
+          "test_best_rerun_accuracy": 0.6718618869781494,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6733898520469666,
+          "test_best_rerun_accuracy": 0.698219895362854,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__08__h_hi__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.6002179940541583,
-        "AvgTime/train_epoch_std": 0.1611747223585378,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5474248452620072,
+        "AvgTime/train_epoch_std": 0.01746543633367355
       }
     },
     {
@@ -1815,64 +1815,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 1.4256922006607056,
-      "test_best_rerun_accuracy": 0.597562849521637,
+      "test_loss": 1.345699429512024,
+      "test_best_rerun_accuracy": 0.609061062335968,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.21930629014968872,
+          "test_best_rerun_accuracy": 0.2180456817150116,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.21006187796592712,
+          "test_best_rerun_accuracy": 0.20521047711372375,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19531667232513428,
+          "test_best_rerun_accuracy": 0.20494307577610016,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.20639468729496002,
+          "test_best_rerun_accuracy": 0.18668347597122192,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.4007563591003418,
+          "test_best_rerun_accuracy": 0.4030865728855133,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3708457350730896,
+          "test_best_rerun_accuracy": 0.37145695090293884,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.38341355323791504,
+          "test_best_rerun_accuracy": 0.3912445604801178,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4339139759540558,
+          "test_best_rerun_accuracy": 0.4169531762599945,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5911070108413696,
+          "test_best_rerun_accuracy": 0.5998548269271851,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6502788662910461,
+          "test_best_rerun_accuracy": 0.6738482713699341,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6756054759025574,
+          "test_best_rerun_accuracy": 0.6964626908302307,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__08__h_hi__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.531808503130649,
-        "AvgTime/train_epoch_std": 0.10671203211565118,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5580898032468908,
+        "AvgTime/train_epoch_std": 0.024904852930931407
       }
     },
     {
@@ -1884,64 +1884,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.4139848947525024,
-      "test_best_rerun_accuracy": 0.6042096614837646,
+      "test_loss": 1.3582239151000977,
+      "test_best_rerun_accuracy": 0.6032164692878723,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2142638862133026,
+          "test_best_rerun_accuracy": 0.2164030820131302,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20333868265151978,
+          "test_best_rerun_accuracy": 0.19986248016357422,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18721827864646912,
+          "test_best_rerun_accuracy": 0.19420887529850006,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.18603406846523285,
+          "test_best_rerun_accuracy": 0.17312246561050415,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.38425394892692566,
+          "test_best_rerun_accuracy": 0.39090076088905334,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3743601441383362,
+          "test_best_rerun_accuracy": 0.37076935172080994,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3442203402519226,
+          "test_best_rerun_accuracy": 0.37298494577407837,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.40194055438041687,
+          "test_best_rerun_accuracy": 0.3925051689147949,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5976774096488953,
+          "test_best_rerun_accuracy": 0.6036748290061951,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6298800706863403,
+          "test_best_rerun_accuracy": 0.6649476885795593,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6842004656791687,
+          "test_best_rerun_accuracy": 0.7067002654075623,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__09__h_hi__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9946948672240634,
-        "AvgTime/train_epoch_std": 0.08549191111763857,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4174534678459167,
+        "AvgTime/train_epoch_std": 0.018197780178053576
       }
     },
     {
@@ -1953,64 +1953,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.3761098384857178,
-      "test_best_rerun_accuracy": 0.6023378372192383,
+      "test_loss": 1.3362782001495361,
+      "test_best_rerun_accuracy": 0.5971044301986694,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.21663229167461395,
+          "test_best_rerun_accuracy": 0.21510428190231323,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.20628008246421814,
+          "test_best_rerun_accuracy": 0.19673007726669312,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18756207823753357,
+          "test_best_rerun_accuracy": 0.19329208135604858,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1946672797203064,
+          "test_best_rerun_accuracy": 0.17812667787075043,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3883795440196991,
+          "test_best_rerun_accuracy": 0.38776835799217224,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.37634655833244324,
+          "test_best_rerun_accuracy": 0.37283214926719666,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3544197380542755,
+          "test_best_rerun_accuracy": 0.3728703558444977,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4173351526260376,
+          "test_best_rerun_accuracy": 0.4025517702102661,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.589999258518219,
+          "test_best_rerun_accuracy": 0.5948888659477234,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6412254571914673,
+          "test_best_rerun_accuracy": 0.6588356494903564,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6887844800949097,
+          "test_best_rerun_accuracy": 0.7033386826515198,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__09__h_hi__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.9188310584506474,
-        "AvgTime/train_epoch_std": 0.09390698124817776,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4015621021389961,
+        "AvgTime/train_epoch_std": 0.01951894717877603
       }
     },
     {
@@ -2022,64 +2022,64 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 1.4147982597351074,
-      "test_best_rerun_accuracy": 0.5932462215423584,
+      "test_loss": 1.3389414548873901,
+      "test_best_rerun_accuracy": 0.6065780520439148,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.2079990804195404,
+          "test_best_rerun_accuracy": 0.21728168427944183,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.19856368005275726,
+          "test_best_rerun_accuracy": 0.20463748276233673,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.17602567374706268,
+          "test_best_rerun_accuracy": 0.2018870860338211,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.18049506843090057,
+          "test_best_rerun_accuracy": 0.1776682734489441,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.382267564535141,
+          "test_best_rerun_accuracy": 0.3933073580265045,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3704255521297455,
+          "test_best_rerun_accuracy": 0.37386354804039,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3429597318172455,
+          "test_best_rerun_accuracy": 0.38005194067955017,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.4018641710281372,
+          "test_best_rerun_accuracy": 0.40583696961402893,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5875162482261658,
+          "test_best_rerun_accuracy": 0.6020704507827759,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6309114694595337,
+          "test_best_rerun_accuracy": 0.6692260503768921,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6834364533424377,
+          "test_best_rerun_accuracy": 0.710443913936615,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__09__h_hi__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.903139317035675,
-        "AvgTime/train_epoch_std": 0.052895021615209974,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4114426021222715,
+        "AvgTime/train_epoch_std": 0.020160586526377436
       }
     },
     {
@@ -2091,64 +2091,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.1672461032867432,
-      "test_best_rerun_accuracy": 0.6728550791740417,
+      "test_loss": 1.1019620895385742,
+      "test_best_rerun_accuracy": 0.6845442652702332,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1957750767469406,
+          "test_best_rerun_accuracy": 0.20394988358020782,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18729467689990997,
+          "test_best_rerun_accuracy": 0.1919550746679306,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19527848064899445,
+          "test_best_rerun_accuracy": 0.20012988150119781,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.184047669172287,
+          "test_best_rerun_accuracy": 0.1892428696155548,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.37458935379981995,
+          "test_best_rerun_accuracy": 0.387997567653656,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3304683268070221,
+          "test_best_rerun_accuracy": 0.3447169363498688,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4109939634799957,
+          "test_best_rerun_accuracy": 0.406982958316803,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.43632057309150696,
+          "test_best_rerun_accuracy": 0.4259301722049713,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5745664238929749,
+          "test_best_rerun_accuracy": 0.589158833026886,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5491251945495605,
+          "test_best_rerun_accuracy": 0.5733058452606201,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6971502900123596,
+          "test_best_rerun_accuracy": 0.714225709438324,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__10__h_hi__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 9.835601624320535,
-        "AvgTime/train_epoch_std": 0.20156303544315538,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 2.0351638891259016,
+        "AvgTime/train_epoch_std": 0.013251032219172195
       }
     },
     {
@@ -2160,64 +2160,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.1693519353866577,
-      "test_best_rerun_accuracy": 0.6656734943389893,
+      "test_loss": 1.0850143432617188,
+      "test_best_rerun_accuracy": 0.690579891204834,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19149667024612427,
+          "test_best_rerun_accuracy": 0.20032088458538055,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1817556768655777,
+          "test_best_rerun_accuracy": 0.1827106773853302,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.19596607983112335,
+          "test_best_rerun_accuracy": 0.208266481757164,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1809534728527069,
+          "test_best_rerun_accuracy": 0.18790587782859802,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.37325236201286316,
+          "test_best_rerun_accuracy": 0.38398656249046326,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3288257420063019,
+          "test_best_rerun_accuracy": 0.33680954575538635,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.41156697273254395,
+          "test_best_rerun_accuracy": 0.4204675555229187,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.43807777762413025,
+          "test_best_rerun_accuracy": 0.43849796056747437,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5640231966972351,
+          "test_best_rerun_accuracy": 0.5833142399787903,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.543433427810669,
+          "test_best_rerun_accuracy": 0.5710138082504272,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6908090710639954,
+          "test_best_rerun_accuracy": 0.7225533127784729,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__10__h_hi__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 10.192155370345482,
-        "AvgTime/train_epoch_std": 1.3855182824206103,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 2.042202079997343,
+        "AvgTime/train_epoch_std": 0.015101357318071391
       }
     },
     {
@@ -2229,64 +2229,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 1.1754728555679321,
-      "test_best_rerun_accuracy": 0.6693788766860962,
+      "test_loss": 1.1221460103988647,
+      "test_best_rerun_accuracy": 0.6853464841842651,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19661547243595123,
+          "test_best_rerun_accuracy": 0.19783787429332733,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.1877530813217163,
+          "test_best_rerun_accuracy": 0.17843227088451385,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18893727660179138,
+          "test_best_rerun_accuracy": 0.19844907522201538,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.18893727660179138,
+          "test_best_rerun_accuracy": 0.17423026263713837,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3845977485179901,
+          "test_best_rerun_accuracy": 0.3772633373737335,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3462831377983093,
+          "test_best_rerun_accuracy": 0.33627474308013916,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.4025517702102661,
+          "test_best_rerun_accuracy": 0.4075559675693512,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.443196564912796,
+          "test_best_rerun_accuracy": 0.422224760055542,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5812514424324036,
+          "test_best_rerun_accuracy": 0.5852242112159729,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5588662028312683,
+          "test_best_rerun_accuracy": 0.5680724382400513,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.6979143023490906,
+          "test_best_rerun_accuracy": 0.7198792695999146,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__10__h_hi__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 13.56114314448449,
-        "AvgTime/train_epoch_std": 2.3261026628212296,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 2.0388943450204255,
+        "AvgTime/train_epoch_std": 0.018113363564649366
       }
     },
     {
@@ -2298,64 +2298,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 1.055918574333191,
-      "test_best_rerun_accuracy": 0.7092978954315186,
+      "test_loss": 0.9453447461128235,
+      "test_best_rerun_accuracy": 0.7274047136306763,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1943998783826828,
+          "test_best_rerun_accuracy": 0.19718848168849945,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18729467689990997,
+          "test_best_rerun_accuracy": 0.18507906794548035,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.17335167527198792,
+          "test_best_rerun_accuracy": 0.18450607359409332,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1610894650220871,
+          "test_best_rerun_accuracy": 0.1586446613073349,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.37336695194244385,
+          "test_best_rerun_accuracy": 0.37963175773620605,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3522041440010071,
+          "test_best_rerun_accuracy": 0.3504469394683838,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.3892199695110321,
+          "test_best_rerun_accuracy": 0.3916265666484833,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.42757275700569153,
+          "test_best_rerun_accuracy": 0.42233937978744507,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5700206160545349,
+          "test_best_rerun_accuracy": 0.5735350251197815,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5698678493499756,
+          "test_best_rerun_accuracy": 0.5751012563705444,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6572312712669373,
+          "test_best_rerun_accuracy": 0.674574077129364,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__11__h_hi__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 8.16630333662033,
-        "AvgTime/train_epoch_std": 0.24265480900643818,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.7849514016918107,
+        "AvgTime/train_epoch_std": 0.019466829410601
       }
     },
     {
@@ -2367,64 +2367,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 1.0096505880355835,
-      "test_best_rerun_accuracy": 0.7031477093696594,
+      "test_loss": 0.920893669128418,
+      "test_best_rerun_accuracy": 0.7330964803695679,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.1977996826171875,
+          "test_best_rerun_accuracy": 0.2013140767812729,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18370386958122253,
+          "test_best_rerun_accuracy": 0.1842004805803299,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.18389487266540527,
+          "test_best_rerun_accuracy": 0.18798227608203888,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.17029567062854767,
+          "test_best_rerun_accuracy": 0.16452746093273163,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.36981433629989624,
+          "test_best_rerun_accuracy": 0.3819619417190552,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.3428451418876648,
+          "test_best_rerun_accuracy": 0.35419052839279175,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.38807395100593567,
+          "test_best_rerun_accuracy": 0.39850255846977234,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.43807777762413025,
+          "test_best_rerun_accuracy": 0.4310489594936371,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.557108998298645,
+          "test_best_rerun_accuracy": 0.5793796181678772,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.554129421710968,
+          "test_best_rerun_accuracy": 0.5783864259719849,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6487890481948853,
+          "test_best_rerun_accuracy": 0.6789670586585999,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__11__h_hi__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 8.518351658530857,
-        "AvgTime/train_epoch_std": 0.24935257941334416,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.7706166669434191,
+        "AvgTime/train_epoch_std": 0.016012753716662387
       }
     },
     {
@@ -2436,64 +2436,64 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 1.0300045013427734,
-      "test_best_rerun_accuracy": 0.6984490752220154,
+      "test_loss": 0.9559637308120728,
+      "test_best_rerun_accuracy": 0.7282450795173645,
       "test_best_rerun_mse": null,
       "test_triangles_total_structural": null,
       "test_mse_by_total_triangles": null,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.19432348012924194,
+          "test_best_rerun_accuracy": 0.19203147292137146,
           "test_best_rerun_mse": null
         },
         "h_lo__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.18695087730884552,
+          "test_best_rerun_accuracy": 0.1814882755279541,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.17705707252025604,
+          "test_best_rerun_accuracy": 0.18129727244377136,
           "test_best_rerun_mse": null
         },
         "h_lo__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.1759110689163208,
+          "test_best_rerun_accuracy": 0.1605546623468399,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.3735961616039276,
+          "test_best_rerun_accuracy": 0.3725265562534332,
           "test_best_rerun_mse": null
         },
         "h_mid__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.349109947681427,
+          "test_best_rerun_accuracy": 0.34509894251823425,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.38643136620521545,
+          "test_best_rerun_accuracy": 0.39934295415878296,
           "test_best_rerun_mse": null
         },
         "h_mid__d_hi__pl_hi": {
-          "test_best_rerun_accuracy": 0.44583237171173096,
+          "test_best_rerun_accuracy": 0.42612117528915405,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_lo": {
-          "test_best_rerun_accuracy": 0.5573382377624512,
+          "test_best_rerun_accuracy": 0.5749866366386414,
           "test_best_rerun_mse": null
         },
         "h_hi__d_lo__pl_hi": {
-          "test_best_rerun_accuracy": 0.5570326447486877,
+          "test_best_rerun_accuracy": 0.5775460600852966,
           "test_best_rerun_mse": null
         },
         "h_hi__d_hi__pl_lo": {
-          "test_best_rerun_accuracy": 0.6434792280197144,
+          "test_best_rerun_accuracy": 0.6726258397102356,
           "test_best_rerun_mse": null
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__community_detection__11__h_hi__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 13.351604494181545,
-        "AvgTime/train_epoch_std": 0.22249129903734177,
-        "model/params/total": 117220,
-        "model/params/trainable": 117220,
-        "model/params/non_trainable": 0
+        "model/params/total": 315931,
+        "model/params/trainable": 315931,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.7687446117401122,
+        "AvgTime/train_epoch_std": 0.0176307450103709
       }
     },
     {
@@ -2505,86 +2505,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 3.7097065448760986,
+      "test_loss": 1.3682172298431396,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3.5967655181884766,
+      "test_best_rerun_mse": 1.3281364440917969,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.0025913296240550983,
+      "test_mse_by_total_triangles": 0.0009568706369537442,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.3650413751602173,
+          "test_best_rerun_mse": 0.891405463218689,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.007184428290316933
+          "test_mse_by_total_triangles": 0.0046916077011509945
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1145.009765625,
+          "test_best_rerun_mse": 763.6039428710938,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.08684184798065984
+          "test_mse_by_total_triangles": 0.057914595591285076
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6.097525119781494,
+          "test_best_rerun_mse": 1.900726079940796,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0020551146342371062
+          "test_mse_by_total_triangles": 0.0006406222042267596
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2970.074462890625,
+          "test_best_rerun_mse": 3206.4111328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.39680353545632935
+          "test_mse_by_total_triangles": 0.42837824085671344
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20.229759216308594,
+          "test_best_rerun_mse": 21.058921813964844,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.01746956754430794
+          "test_mse_by_total_triangles": 0.018185597421385875
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 97012.796875,
+          "test_best_rerun_mse": 100636.515625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.252758612181869
+          "test_mse_by_total_triangles": 2.336905898778562
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5108.4208984375,
+          "test_best_rerun_mse": 5245.70751953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.3581840484109872
+          "test_mse_by_total_triangles": 0.3678100911184441
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28148.904296875,
+          "test_best_rerun_mse": 29079.70703125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.4428676147867652
+          "test_mse_by_total_triangles": 1.4905790676738941
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1375.0799560546875,
+          "test_best_rerun_mse": 1441.42578125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.24445865885416668
+          "test_mse_by_total_triangles": 0.2562534722222222
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 589836.8125,
+          "test_best_rerun_mse": 600442.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.67213570240829
+          "test_mse_by_total_triangles": 6.792106885512935
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 164661.578125,
+          "test_best_rerun_mse": 168469.25,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.7401124611019587
+          "test_mse_by_total_triangles": 2.8034754463914267
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.5546541494481705,
-        "AvgTime/train_epoch_std": 0.10418740056315184,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.0297719292018725,
+        "AvgTime/train_epoch_std": 0.016886919688941036
       }
     },
     {
@@ -2596,86 +2596,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 2.0974392890930176,
+      "test_loss": 1.300964117050171,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2.04327392578125,
+      "test_best_rerun_mse": 1.3238285779953003,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.001472099370159402,
+      "test_mse_by_total_triangles": 0.0009537669870283143,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 0.4545966684818268,
+          "test_best_rerun_mse": 0.3171965479850769,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.0023926140446411935
+          "test_mse_by_total_triangles": 0.001669455515710931
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1321.0408935546875,
+          "test_best_rerun_mse": 490.123291015625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.10019271092564941
+          "test_mse_by_total_triangles": 0.0371727941612154
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4.524687767028809,
+          "test_best_rerun_mse": 2.2230236530303955,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0015250043030093725
+          "test_mse_by_total_triangles": 0.0007492496302765068
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3256.985595703125,
+          "test_best_rerun_mse": 2758.475341796875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.435135016126002
+          "test_mse_by_total_triangles": 0.36853377979918167
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16.31036376953125,
+          "test_best_rerun_mse": 15.62049674987793,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.014084942806158247
+          "test_mse_by_total_triangles": 0.01348920272010184
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 103604.8515625,
+          "test_best_rerun_mse": 92494.984375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.4058343758707967
+          "test_mse_by_total_triangles": 2.14784934922441
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5436.5283203125,
+          "test_best_rerun_mse": 4542.1123046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.38118975741919087
+          "test_mse_by_total_triangles": 0.3184765323718623
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28495.1796875,
+          "test_best_rerun_mse": 27439.541015625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.460617135040238
+          "test_mse_by_total_triangles": 1.4065067925380594
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1395.441650390625,
+          "test_best_rerun_mse": 1307.77978515625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.248078515625
+          "test_mse_by_total_triangles": 0.23249418402777777
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 596723.5,
+          "test_best_rerun_mse": 582109.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.750036763458254
+          "test_mse_by_total_triangles": 6.584727045462258
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 166100.953125,
+          "test_best_rerun_mse": 160336.90625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.7640649181269032
+          "test_mse_by_total_triangles": 2.6681461443096532
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.686952407969985,
-        "AvgTime/train_epoch_std": 0.43011101547669184,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.0898912123271398,
+        "AvgTime/train_epoch_std": 0.02450187740307565
       }
     },
     {
@@ -2687,86 +2687,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_lo__pl_lo",
-      "test_loss": 4.044600486755371,
+      "test_loss": 1.4745278358459473,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3.6933295726776123,
+      "test_best_rerun_mse": 1.5316267013549805,
       "test_triangles_total_structural": 1388.0,
-      "test_mse_by_total_triangles": 0.0026609002684997206,
+      "test_mse_by_total_triangles": 0.001103477450543934,
       "ood_test": {
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.4236125946044922,
+          "test_best_rerun_mse": 0.5332655310630798,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.007492697866339433
+          "test_mse_by_total_triangles": 0.0028066606898056834
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2065.489013671875,
+          "test_best_rerun_mse": 451.638427734375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.15665445685793516
+          "test_mse_by_total_triangles": 0.03425395735565984
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6.240453243255615,
+          "test_best_rerun_mse": 3.3618242740631104,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.002103287240733271
+          "test_mse_by_total_triangles": 0.0011330718820569971
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3671.51953125,
+          "test_best_rerun_mse": 2652.1171875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.49051697144288575
+          "test_mse_by_total_triangles": 0.35432427354709417
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29.772489547729492,
+          "test_best_rerun_mse": 14.326996803283691,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.025710267312374347
+          "test_mse_by_total_triangles": 0.012372190676410787
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 112642.5625,
+          "test_best_rerun_mse": 90559.671875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.6157013398662454
+          "test_mse_by_total_triangles": 2.102908969789151
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6497.8994140625,
+          "test_best_rerun_mse": 4405.29248046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.4556092703731945
+          "test_mse_by_total_triangles": 0.3088832197776434
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 31804.123046875,
+          "test_best_rerun_mse": 27110.00390625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.6302282560292685
+          "test_mse_by_total_triangles": 1.3896152496924496
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1720.7283935546875,
+          "test_best_rerun_mse": 1243.3974609375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.3059072699652778
+          "test_mse_by_total_triangles": 0.2210484375
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 625684.8125,
+          "test_best_rerun_mse": 578798.5,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.077642302863025
+          "test_mse_by_total_triangles": 6.547272151397577
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 183326.59375,
+          "test_best_rerun_mse": 158131.21875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.0507146215033365
+          "test_mse_by_total_triangles": 2.6314415780540164
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.4243208765983582,
-        "AvgTime/train_epoch_std": 0.1443132558690153,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.079524278640747,
+        "AvgTime/train_epoch_std": 0.014555735992084066
       }
     },
     {
@@ -2778,86 +2778,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.24895115196704865,
+      "test_loss": 0.05653106048703194,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.25508248805999756,
+      "test_best_rerun_mse": 0.055496443063020706,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.0013425394108420923,
+      "test_mse_by_total_triangles": 0.0002920865424369511,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 29.90593147277832,
+          "test_best_rerun_mse": 54.184085845947266,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.02154606013888928
+          "test_mse_by_total_triangles": 0.039037525825610424
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5401.3779296875,
+          "test_best_rerun_mse": 6912.6455078125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.40966082136423965
+          "test_mse_by_total_triangles": 0.5242810396520667
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.853652954101562,
+          "test_best_rerun_mse": 38.04389953613281,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.007702613061712694
+          "test_mse_by_total_triangles": 0.012822345647500104
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5706.8203125,
+          "test_best_rerun_mse": 6438.546875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.762434243486974
+          "test_mse_by_total_triangles": 0.8601933032732131
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 63.14041519165039,
+          "test_best_rerun_mse": 76.78341674804688,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.054525401719905345
+          "test_mse_by_total_triangles": 0.0663069229257745
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 146078.84375,
+          "test_best_rerun_mse": 156824.0,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.3921336557217163
+          "test_mse_by_total_triangles": 3.6416496377484675
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9645.2802734375,
+          "test_best_rerun_mse": 10856.498046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.676292264299362
+          "test_mse_by_total_triangles": 0.7612184859679568
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 39050.234375,
+          "test_best_rerun_mse": 41767.66015625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.001652282279973
+          "test_mse_by_total_triangles": 2.1409431624506636
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2441.51708984375,
+          "test_best_rerun_mse": 2716.0869140625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.43404748263888887
+          "test_mse_by_total_triangles": 0.48285989583333333
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 696532.6875,
+          "test_best_rerun_mse": 721043.3125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.87906165514745
+          "test_mse_by_total_triangles": 8.156321759442553
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 218431.75,
+          "test_best_rerun_mse": 230864.984375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.6348950792937615
+          "test_mse_by_total_triangles": 3.8417949573993644
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.5376110133670626,
-        "AvgTime/train_epoch_std": 0.1810068203694743,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 0.9923320267651532,
+        "AvgTime/train_epoch_std": 0.015254867504656275
       }
     },
     {
@@ -2869,86 +2869,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.19872036576271057,
+      "test_loss": 0.06702949851751328,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.19958838820457458,
+      "test_best_rerun_mse": 0.06787318736314774,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.0010504652010767084,
+      "test_mse_by_total_triangles": 0.00035722730191130385,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.083072662353516,
+          "test_best_rerun_mse": 43.75030517578125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.015909994713511177
+          "test_mse_by_total_triangles": 0.03152039277794038
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4998.197265625,
+          "test_best_rerun_mse": 6025.60693359375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.3790820830963216
+          "test_mse_by_total_triangles": 0.45700469727673493
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23.603740692138672,
+          "test_best_rerun_mse": 36.205440521240234,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.007955423219460286
+          "test_mse_by_total_triangles": 0.01220270998356597
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5480.89892578125,
+          "test_best_rerun_mse": 6003.91064453125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.732251025488477
+          "test_mse_by_total_triangles": 0.8021256706120574
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 63.4443359375,
+          "test_best_rerun_mse": 73.03194427490234,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.05478785486830743
+          "test_mse_by_total_triangles": 0.06306730939110738
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 142378.265625,
+          "test_best_rerun_mse": 149573.3125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.306201598202675
+          "test_mse_by_total_triangles": 3.4732795954857885
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9415.04296875,
+          "test_best_rerun_mse": 10382.5986328125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.6601488549116533
+          "test_mse_by_total_triangles": 0.7279903683082667
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 38695.38671875,
+          "test_best_rerun_mse": 40042.484375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.9834633614613768
+          "test_mse_by_total_triangles": 2.052513423291814
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2415.2197265625,
+          "test_best_rerun_mse": 2596.75634765625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.4293723958333333
+          "test_mse_by_total_triangles": 0.4616455729166667
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 693263.0625,
+          "test_best_rerun_mse": 705418.3125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.842076202165085
+          "test_mse_by_total_triangles": 7.979574363992172
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 217558.90625,
+          "test_best_rerun_mse": 224263.515625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.62037019702794
+          "test_mse_by_total_triangles": 3.731940752250678
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.5929683492383884,
-        "AvgTime/train_epoch_std": 0.09447548873040917,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 0.9925909914621492,
+        "AvgTime/train_epoch_std": 0.02050007736676949
       }
     },
     {
@@ -2960,86 +2960,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_lo__pl_hi",
-      "test_loss": 0.3672899305820465,
+      "test_loss": 0.04705289378762245,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.3663853108882904,
+      "test_best_rerun_mse": 0.04657778888940811,
       "test_triangles_total_structural": 190.0,
-      "test_mse_by_total_triangles": 0.001928343741517318,
+      "test_mse_by_total_triangles": 0.0002451462573126743,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 45.57328796386719,
+          "test_best_rerun_mse": 32.579166412353516,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.03283378095379481
+          "test_mse_by_total_triangles": 0.023472021910917518
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5990.93701171875,
+          "test_best_rerun_mse": 5610.546875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.45437519997866893
+          "test_mse_by_total_triangles": 0.42552498103905956
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 44.164005279541016,
+          "test_best_rerun_mse": 24.40069007873535,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.01488507087278093
+          "test_mse_by_total_triangles": 0.008224027663881143
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6015.0,
+          "test_best_rerun_mse": 5878.91015625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.8036072144288577
+          "test_mse_by_total_triangles": 0.7854255385771544
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 77.51139068603516,
+          "test_best_rerun_mse": 67.47640991210938,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.06693557054061758
+          "test_mse_by_total_triangles": 0.058269784034636764
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 148878.375,
+          "test_best_rerun_mse": 148034.0,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 3.4571422766115547
+          "test_mse_by_total_triangles": 3.4375348318781347
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10524.591796875,
+          "test_best_rerun_mse": 9954.3564453125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.7379464168331931
+          "test_mse_by_total_triangles": 0.6979635706992358
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 40241.01171875,
+          "test_best_rerun_mse": 39853.43359375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 2.0626896160105592
+          "test_mse_by_total_triangles": 2.0428229839433083
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2642.84033203125,
+          "test_best_rerun_mse": 2532.86865234375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.46983828125
+          "test_mse_by_total_triangles": 0.4502877604166667
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 705751.8125,
+          "test_best_rerun_mse": 703198.5,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.983346860400665
+          "test_mse_by_total_triangles": 7.954464215015328
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 225516.640625,
+          "test_best_rerun_mse": 222450.796875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.7527938466210706
+          "test_mse_by_total_triangles": 3.701775529179771
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.2031327572735875,
-        "AvgTime/train_epoch_std": 0.80149645543981,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 0.9891534428191341,
+        "AvgTime/train_epoch_std": 0.014884132692522653
       }
     },
     {
@@ -3051,86 +3051,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 106.59942626953125,
+      "test_loss": 23.64792251586914,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 105.8456039428711,
+      "test_best_rerun_mse": 24.830549240112305,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.008027728778374751,
+      "test_mse_by_total_triangles": 0.0018832422631863712,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15.392143249511719,
+          "test_best_rerun_mse": 6.955718517303467,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.011089440381492593
+          "test_mse_by_total_triangles": 0.005011324580189817
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.709590911865234,
+          "test_best_rerun_mse": 8.060225486755371,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.09847153111508018
+          "test_mse_by_total_triangles": 0.04242223940397564
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.388647079467773,
+          "test_best_rerun_mse": 17.82306671142578,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0031643569529719493
+          "test_mse_by_total_triangles": 0.006007100340891736
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1586.4757080078125,
+          "test_best_rerun_mse": 1230.7691650390625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.21195400240585338
+          "test_mse_by_total_triangles": 0.16443141817489146
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26.123029708862305,
+          "test_best_rerun_mse": 7.615236759185791,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.02255874758969111
+          "test_mse_by_total_triangles": 0.006576197546792566
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 65067.01953125,
+          "test_best_rerun_mse": 53866.46484375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.5109376632744287
+          "test_mse_by_total_triangles": 1.2508467593291381
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2530.60498046875,
+          "test_best_rerun_mse": 1936.72119140625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.17743689387664774
+          "test_mse_by_total_triangles": 0.13579590460007362
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21030.89453125,
+          "test_best_rerun_mse": 18052.41015625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.0780098688425854
+          "test_mse_by_total_triangles": 0.9253375445307294
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 764.0269165039062,
+          "test_best_rerun_mse": 528.7156982421875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.13582700737847223
+          "test_mse_by_total_triangles": 0.09399390190972222
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 509613.0,
+          "test_best_rerun_mse": 467964.375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.764657308009909
+          "test_mse_by_total_triangles": 5.293535004468175
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126286.6640625,
+          "test_best_rerun_mse": 110207.09375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.1015203777894262
+          "test_mse_by_total_triangles": 1.833942285291132
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 6.3032790422439575,
-        "AvgTime/train_epoch_std": 0.12028850830329418,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3656781008749297,
+        "AvgTime/train_epoch_std": 0.024853272035491276
       }
     },
     {
@@ -3142,86 +3142,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 109.83921813964844,
+      "test_loss": 54.99650192260742,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 108.47077178955078,
+      "test_best_rerun_mse": 56.10652160644531,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.008226831383356146,
+      "test_mse_by_total_triangles": 0.004255329662984097,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12.740933418273926,
+          "test_best_rerun_mse": 18.07282066345215,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.009179346843136834
+          "test_mse_by_total_triangles": 0.013020764166752269
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 14.831132888793945,
+          "test_best_rerun_mse": 21.286012649536133,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.07805859415154708
+          "test_mse_by_total_triangles": 0.11203164552387439
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24.233251571655273,
+          "test_best_rerun_mse": 22.387676239013672,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.00816759405852891
+          "test_mse_by_total_triangles": 0.007545559905296148
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1652.695068359375,
+          "test_best_rerun_mse": 1511.53125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.22080094433658984
+          "test_mse_by_total_triangles": 0.20194138276553106
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24.230812072753906,
+          "test_best_rerun_mse": 25.343626022338867,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.020924708180271076
+          "test_mse_by_total_triangles": 0.021885687411346173
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 65339.74609375,
+          "test_best_rerun_mse": 60398.90625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.5172707155338565
+          "test_mse_by_total_triangles": 1.402538227986253
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2776.044677734375,
+          "test_best_rerun_mse": 2377.92626953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.1946462402001385
+          "test_mse_by_total_triangles": 0.16673161334534076
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20471.7578125,
+          "test_best_rerun_mse": 19940.607421875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.049349418857963
+          "test_mse_by_total_triangles": 1.0221235030947255
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 784.5700073242188,
+          "test_best_rerun_mse": 673.9656372070312,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.13947911241319444
+          "test_mse_by_total_triangles": 0.11981611328125
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 502381.4375,
+          "test_best_rerun_mse": 493982.9375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.682855078447564
+          "test_mse_by_total_triangles": 5.587852646403403
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126017.4921875,
+          "test_best_rerun_mse": 120831.84375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.09704112271812
+          "test_mse_by_total_triangles": 2.010747404023763
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.513404051462809,
-        "AvgTime/train_epoch_std": 0.09474698072613366,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3396921839032854,
+        "AvgTime/train_epoch_std": 0.016823259106340728
       }
     },
     {
@@ -3233,86 +3233,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_lo__d_hi__pl_lo",
-      "test_loss": 102.5676498413086,
+      "test_loss": 43.843170166015625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 102.43241119384766,
+      "test_best_rerun_mse": 45.82380294799805,
       "test_triangles_total_structural": 13185.0,
-      "test_mse_by_total_triangles": 0.007768859400367665,
+      "test_mse_by_total_triangles": 0.0034754495978762266,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7.334637641906738,
+          "test_best_rerun_mse": 13.123404502868652,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.005284321067656151
+          "test_mse_by_total_triangles": 0.009454902379588367
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.575044631958008,
+          "test_best_rerun_mse": 6.918139457702637,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.05039497174714741
+          "test_mse_by_total_triangles": 0.03641126030369809
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12.24276065826416,
+          "test_best_rerun_mse": 12.773262023925781,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0041263096252996834
+          "test_mse_by_total_triangles": 0.004305110220399657
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1713.69287109375,
+          "test_best_rerun_mse": 1353.99853515625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.22895028337925852
+          "test_mse_by_total_triangles": 0.1808949278765865
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19.519350051879883,
+          "test_best_rerun_mse": 12.864917755126953,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.016856088127702836
+          "test_mse_by_total_triangles": 0.011109600824807386
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 68231.703125,
+          "test_best_rerun_mse": 56496.80078125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.5844255787897084
+          "test_mse_by_total_triangles": 1.3119264532149824
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2772.33251953125,
+          "test_best_rerun_mse": 2069.091796875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.19438595705590028
+          "test_mse_by_total_triangles": 0.14507725402292806
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 20573.9375,
+          "test_best_rerun_mse": 18702.66796875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.0545869854938745
+          "test_mse_by_total_triangles": 0.9586687154005843
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 739.9579467773438,
+          "test_best_rerun_mse": 578.3665161132812,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.13154807942708333
+          "test_mse_by_total_triangles": 0.10282071397569445
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 508139.3125,
+          "test_best_rerun_mse": 478630.25,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.747987200660611
+          "test_mse_by_total_triangles": 5.414185604560931
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126045.8515625,
+          "test_best_rerun_mse": 113674.71875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.097513047484732
+          "test_mse_by_total_triangles": 1.8916465936132327
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.310863812764486,
-        "AvgTime/train_epoch_std": 0.10224679088326089,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3780377440982394,
+        "AvgTime/train_epoch_std": 0.01033965625081435
       }
     },
     {
@@ -3324,86 +3324,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 0.843176543712616,
+      "test_loss": 0.812641441822052,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 0.8736848831176758,
+      "test_best_rerun_mse": 0.8094510436058044,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.00029446743617043335,
+      "test_mse_by_total_triangles": 0.0002728180126746897,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4.479189872741699,
+          "test_best_rerun_mse": 4.339816570281982,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.003227082040880187
+          "test_mse_by_total_triangles": 0.0031266689987622352
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 0.7419305443763733,
+          "test_best_rerun_mse": 0.6916689276695251,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.0039048976019809122
+          "test_mse_by_total_triangles": 0.003640362777208027
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1412.509033203125,
+          "test_best_rerun_mse": 1716.9375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.10712999872606181
+          "test_mse_by_total_triangles": 0.13021899886234356
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3885.186767578125,
+          "test_best_rerun_mse": 3921.27294921875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.5190630284005511
+          "test_mse_by_total_triangles": 0.5238841615522712
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24.857622146606445,
+          "test_best_rerun_mse": 22.76167106628418,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.021465994945255997
+          "test_mse_by_total_triangles": 0.019656019919070965
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 117423.1875,
+          "test_best_rerun_mse": 117863.5234375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.7267134381385842
+          "test_mse_by_total_triangles": 2.73693858994752
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5986.64794921875,
+          "test_best_rerun_mse": 6045.19482421875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.41976216163362434
+          "test_mse_by_total_triangles": 0.423867257342501
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 32906.08203125,
+          "test_best_rerun_mse": 31274.1171875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.6867129033394843
+          "test_mse_by_total_triangles": 1.6030610070992874
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1753.704345703125,
+          "test_best_rerun_mse": 1606.9332275390625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.31176966145833335
+          "test_mse_by_total_triangles": 0.2856770182291667
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 641844.375,
+          "test_best_rerun_mse": 626813.625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.260436580206554
+          "test_mse_by_total_triangles": 7.090411241699942
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 184426.40625,
+          "test_best_rerun_mse": 176695.71875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.069016461983925
+          "test_mse_by_total_triangles": 2.940371070673789
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.64679291844368,
-        "AvgTime/train_epoch_std": 0.10170741684039572,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.214093712397984,
+        "AvgTime/train_epoch_std": 0.013038023444779626
       }
     },
     {
@@ -3415,86 +3415,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.3730075359344482,
+      "test_loss": 0.5958913564682007,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2.245302677154541,
+      "test_best_rerun_mse": 0.6282797455787659,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.0007567585699880489,
+      "test_mse_by_total_triangles": 0.00021175589672354765,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 54.382598876953125,
+          "test_best_rerun_mse": 5.070685863494873,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.039180546741320696
+          "test_mse_by_total_triangles": 0.0036532318901259892
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 94.95558166503906,
+          "test_best_rerun_mse": 0.399434357881546,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.4997662192896793
+          "test_mse_by_total_triangles": 0.0021022860941134003
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1890.663330078125,
+          "test_best_rerun_mse": 1453.3734130859375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.14339501934608456
+          "test_mse_by_total_triangles": 0.11022930702206579
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4770.65185546875,
+          "test_best_rerun_mse": 3887.6279296875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.6373616373371743
+          "test_mse_by_total_triangles": 0.5193891689629259
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 111.61494445800781,
+          "test_best_rerun_mse": 21.2260799407959,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.09638596239897047
+          "test_mse_by_total_triangles": 0.01832994813540233
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 126490.0546875,
+          "test_best_rerun_mse": 116339.2109375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.9372574467652797
+          "test_mse_by_total_triangles": 2.701542145121215
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7171.93310546875,
+          "test_best_rerun_mse": 6012.04248046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.5028700817184651
+          "test_mse_by_total_triangles": 0.42154273457220237
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35689.921875,
+          "test_best_rerun_mse": 31469.310546875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.8294080616638475
+          "test_mse_by_total_triangles": 1.6130663051348095
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2105.335693359375,
+          "test_best_rerun_mse": 1608.604736328125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.37428190104166664
+          "test_mse_by_total_triangles": 0.28597417534722225
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 662382.9375,
+          "test_best_rerun_mse": 628310.8125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.492765375609425
+          "test_mse_by_total_triangles": 7.107347177131998
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 194690.890625,
+          "test_best_rerun_mse": 177385.375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.239826446091891
+          "test_mse_by_total_triangles": 2.9518475529595793
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.64453775954969,
-        "AvgTime/train_epoch_std": 0.10115628344909583,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2192414866553412,
+        "AvgTime/train_epoch_std": 0.01251923263603201
       }
     },
     {
@@ -3506,86 +3506,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_lo__d_hi__pl_hi",
-      "test_loss": 2.9569101333618164,
+      "test_loss": 0.78651362657547,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2.8967981338500977,
+      "test_best_rerun_mse": 0.8062180280685425,
       "test_triangles_total_structural": 2967.0,
-      "test_mse_by_total_triangles": 0.0009763391081395678,
+      "test_mse_by_total_triangles": 0.0002717283545900042,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26.004955291748047,
+          "test_best_rerun_mse": 3.6906135082244873,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.018735558567541822
+          "test_mse_by_total_triangles": 0.0026589434497294577
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 40.32435607910156,
+          "test_best_rerun_mse": 1.2816780805587769,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.21223345304790295
+          "test_mse_by_total_triangles": 0.006745674108204089
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1783.765380859375,
+          "test_best_rerun_mse": 1695.90966796875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.13528747674322147
+          "test_mse_by_total_triangles": 0.1286241689775313
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4212.2685546875,
+          "test_best_rerun_mse": 4121.7197265625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.5627613299515698
+          "test_mse_by_total_triangles": 0.5506639581245825
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 56.83969497680664,
+          "test_best_rerun_mse": 24.573131561279297,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.049084365264945286
+          "test_mse_by_total_triangles": 0.021220320864662606
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 120213.3359375,
+          "test_best_rerun_mse": 120743.171875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.7915041783740477
+          "test_mse_by_total_triangles": 2.8038076322450305
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6627.15087890625,
+          "test_best_rerun_mse": 6209.9560546875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.46467191690550064
+          "test_mse_by_total_triangles": 0.43541972056426165
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 33931.91015625,
+          "test_best_rerun_mse": 32719.240234375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.7392952050976473
+          "test_mse_by_total_triangles": 1.6771356929814445
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1891.029541015625,
+          "test_best_rerun_mse": 1703.8800048828125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.3361830295138889
+          "test_mse_by_total_triangles": 0.30291200086805553
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 647872.375,
+          "test_best_rerun_mse": 639944.1875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 7.328624311392147
+          "test_mse_by_total_triangles": 7.238941975951042
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 189016.296875,
+          "test_best_rerun_mse": 181814.8125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 3.145396250395221
+          "test_mse_by_total_triangles": 3.02555726124507
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.671800603469213,
-        "AvgTime/train_epoch_std": 0.11008559661682873,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2168803461666764,
+        "AvgTime/train_epoch_std": 0.026235519988301766
       }
     },
     {
@@ -3597,86 +3597,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 423.78857421875,
+      "test_loss": 168.80712890625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 451.2832336425781,
+      "test_best_rerun_mse": 174.10655212402344,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.060291681181373166,
+      "test_mse_by_total_triangles": 0.023260728406683157,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28.23695945739746,
+          "test_best_rerun_mse": 26.660953521728516,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.020343630732995287
+          "test_mse_by_total_triangles": 0.01920817977069778
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16.94269371032715,
+          "test_best_rerun_mse": 20.03929901123047,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.08917207215961657
+          "test_mse_by_total_triangles": 0.10546999479594983
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 590.5635375976562,
+          "test_best_rerun_mse": 150.2632598876953,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.04479056030319729
+          "test_mse_by_total_triangles": 0.011396530897815345
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 30.573841094970703,
+          "test_best_rerun_mse": 96.70697021484375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.010304631309393563
+          "test_mse_by_total_triangles": 0.03259419285973837
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19.46734619140625,
+          "test_best_rerun_mse": 22.815153121948242,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.016811179785324915
+          "test_mse_by_total_triangles": 0.0197022047685218
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26910.044921875,
+          "test_best_rerun_mse": 16293.7734375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.6248849368817342
+          "test_mse_by_total_triangles": 0.37836182048811073
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1117.17724609375,
+          "test_best_rerun_mse": 514.660400390625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.07833243907542771
+          "test_mse_by_total_triangles": 0.036086131004811735
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12213.9697265625,
+          "test_best_rerun_mse": 8898.767578125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.6260684671978318
+          "test_mse_by_total_triangles": 0.4561365307358142
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 250.8623504638672,
+          "test_best_rerun_mse": 132.9398956298828,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.04459775119357639
+          "test_mse_by_total_triangles": 0.023633759223090276
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 363850.0,
+          "test_best_rerun_mse": 312475.6875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.115810549415744
+          "test_mse_by_total_triangles": 3.534672890060292
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 78523.546875,
+          "test_best_rerun_mse": 62416.10546875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.306700395636763
+          "test_mse_by_total_triangles": 1.0386585037982794
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.7655943702248966,
-        "AvgTime/train_epoch_std": 0.22759134888377527,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.1762187083562214,
+        "AvgTime/train_epoch_std": 0.014983636810474477
       }
     },
     {
@@ -3688,86 +3688,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 450.13275146484375,
+      "test_loss": 420.9881286621094,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 477.8226013183594,
+      "test_best_rerun_mse": 443.5925598144531,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.06383735488555235,
+      "test_mse_by_total_triangles": 0.05926420304802313,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 34.48652267456055,
+          "test_best_rerun_mse": 90.2286148071289,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.02484619789233469
+          "test_mse_by_total_triangles": 0.06500620663337818
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.869876861572266,
+          "test_best_rerun_mse": 101.2309341430664,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.1203677729556435
+          "test_mse_by_total_triangles": 0.5327943902266653
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 312.2294616699219,
+          "test_best_rerun_mse": 398.0180358886719,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.02368065693363078
+          "test_mse_by_total_triangles": 0.030187185126179135
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 115.10884094238281,
+          "test_best_rerun_mse": 39.12833023071289,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.038796373758807824
+          "test_mse_by_total_triangles": 0.013187843016755272
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.188522338867188,
+          "test_best_rerun_mse": 88.27596282958984,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.019161072831491526
+          "test_mse_by_total_triangles": 0.07623140140724512
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 32375.154296875,
+          "test_best_rerun_mse": 25360.302734375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.7517916193775543
+          "test_mse_by_total_triangles": 0.5888979828714239
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1099.93701171875,
+          "test_best_rerun_mse": 868.1486206054688,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.07712361602291053
+          "test_mse_by_total_triangles": 0.060871450049464926
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11689.533203125,
+          "test_best_rerun_mse": 12011.6142578125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.5991866934812138
+          "test_mse_by_total_triangles": 0.6156960509412323
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 287.7993469238281,
+          "test_best_rerun_mse": 233.62237548828125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.05116432834201389
+          "test_mse_by_total_triangles": 0.041532866753472224
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 361453.875,
+          "test_best_rerun_mse": 352589.21875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.088705982828637
+          "test_mse_by_total_triangles": 3.988430468988609
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 81988.2109375,
+          "test_best_rerun_mse": 77890.8984375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.3643554313730384
+          "test_mse_by_total_triangles": 1.2961725731366383
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.5991851091384888,
-        "AvgTime/train_epoch_std": 0.09215347956746582,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.1831437179020472,
+        "AvgTime/train_epoch_std": 0.018077647888651738
       }
     },
     {
@@ -3779,86 +3779,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_lo__pl_lo",
-      "test_loss": 449.52337646484375,
+      "test_loss": 144.6749725341797,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 466.91473388671875,
+      "test_best_rerun_mse": 151.10401916503906,
       "test_triangles_total_structural": 7485.0,
-      "test_mse_by_total_triangles": 0.062380057967497494,
+      "test_mse_by_total_triangles": 0.02018757771076006,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28.2063045501709,
+          "test_best_rerun_mse": 8.777859687805176,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.020321545064964624
+          "test_mse_by_total_triangles": 0.00632410640331785
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 16.758344650268555,
+          "test_best_rerun_mse": 7.6250529289245605,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.08820181394878186
+          "test_mse_by_total_triangles": 0.04013185752065558
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 436.9079284667969,
+          "test_best_rerun_mse": 97.33702850341797,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.03313674087726939
+          "test_mse_by_total_triangles": 0.007382406409057108
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 41.82365417480469,
+          "test_best_rerun_mse": 11.797733306884766,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.014096277106439058
+          "test_mse_by_total_triangles": 0.003976317258808482
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.976587295532227,
+          "test_best_rerun_mse": 9.800439834594727,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.019841612517730766
+          "test_mse_by_total_triangles": 0.008463246834710472
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28618.013671875,
+          "test_best_rerun_mse": 16222.134765625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.6645461097871772
+          "test_mse_by_total_triangles": 0.37669828082911483
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1073.2611083984375,
+          "test_best_rerun_mse": 531.5183715820312,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.07525319789639864
+          "test_mse_by_total_triangles": 0.037268151141637305
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11696.939453125,
+          "test_best_rerun_mse": 8260.09375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.599566325958532
+          "test_mse_by_total_triangles": 0.42339913629606846
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 277.7939758300781,
+          "test_best_rerun_mse": 95.54150390625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.049385595703125
+          "test_mse_by_total_triangles": 0.01698515625
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 358512.34375,
+          "test_best_rerun_mse": 299263.78125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.055431871655939
+          "test_mse_by_total_triangles": 3.3852220088684772
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 81293.5234375,
+          "test_best_rerun_mse": 60326.19140625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.3527952246933919
+          "test_mse_by_total_triangles": 1.0038805086490938
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.7718141697071217,
-        "AvgTime/train_epoch_std": 0.14755354715522534,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.1857942086231859,
+        "AvgTime/train_epoch_std": 0.021108332532194737
       }
     },
     {
@@ -3870,86 +3870,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 11.16146183013916,
+      "test_loss": 20.285322189331055,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 11.002628326416016,
+      "test_best_rerun_mse": 20.846712112426758,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.009501406154072552,
+      "test_mse_by_total_triangles": 0.018002342065998926,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 63.009193420410156,
+          "test_best_rerun_mse": 126.72498321533203,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.04539567249309089
+          "test_mse_by_total_triangles": 0.0913004201839568
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1.5152850151062012,
+          "test_best_rerun_mse": 6.013873100280762,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.007975184290032638
+          "test_mse_by_total_triangles": 0.03165196368568822
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2444.011962890625,
+          "test_best_rerun_mse": 1141.356689453125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.18536306127346416
+          "test_mse_by_total_triangles": 0.0865647849414581
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4.865119457244873,
+          "test_best_rerun_mse": 32.550331115722656,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0016397436660751173
+          "test_mse_by_total_triangles": 0.010970789051473763
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1857.7987060546875,
+          "test_best_rerun_mse": 2821.827880859375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.248202899940506
+          "test_mse_by_total_triangles": 0.376997712873664
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 66153.25,
+          "test_best_rerun_mse": 91291.7734375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.5361612948170165
+          "test_mse_by_total_triangles": 2.1199092847273824
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3091.291748046875,
+          "test_best_rerun_mse": 4261.7373046875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.21675022774133187
+          "test_mse_by_total_triangles": 0.2988176486248422
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22677.373046875,
+          "test_best_rerun_mse": 27561.30859375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.16240571258778
+          "test_mse_by_total_triangles": 1.4127484029806756
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 980.1281127929688,
+          "test_best_rerun_mse": 1365.3343505859375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.1742449978298611
+          "test_mse_by_total_triangles": 0.24272610677083334
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 525736.3125,
+          "test_best_rerun_mse": 584166.1875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 5.9470415313959935
+          "test_mse_by_total_triangles": 6.607990537651437
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 137505.765625,
+          "test_best_rerun_mse": 159776.484375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.288216025577022
+          "test_mse_by_total_triangles": 2.6588202348859267
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.5027330186631944,
-        "AvgTime/train_epoch_std": 0.18336874802709605,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.0300902366638183,
+        "AvgTime/train_epoch_std": 0.013206939237750737
       }
     },
     {
@@ -3961,86 +3961,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 13.681363105773926,
+      "test_loss": 15.254923820495605,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 13.624862670898438,
+      "test_best_rerun_mse": 16.127870559692383,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.011765857228755127,
+      "test_mse_by_total_triangles": 0.01392734936070154,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 51.38923645019531,
+          "test_best_rerun_mse": 102.82929992675781,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.03702394556930498
+          "test_mse_by_total_triangles": 0.07408451003368718
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2.967653274536133,
+          "test_best_rerun_mse": 3.836463212966919,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.01561922776071649
+          "test_mse_by_total_triangles": 0.020191911647194312
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 792.4898681640625,
+          "test_best_rerun_mse": 1502.171630859375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.06010541283003887
+          "test_mse_by_total_triangles": 0.1139303474296075
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9.927570343017578,
+          "test_best_rerun_mse": 12.80052375793457,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0033459960711215296
+          "test_mse_by_total_triangles": 0.004314298536546872
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2130.90771484375,
+          "test_best_rerun_mse": 2462.10302734375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.2846904094647629
+          "test_mse_by_total_triangles": 0.3289382802062458
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74371.0078125,
+          "test_best_rerun_mse": 83669.5,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.7269879205949286
+          "test_mse_by_total_triangles": 1.9429105517369496
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4009.732177734375,
+          "test_best_rerun_mse": 3825.029541015625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.2811479580517722
+          "test_mse_by_total_triangles": 0.2681972753481717
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23359.037109375,
+          "test_best_rerun_mse": 26215.904296875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.1973467173804397
+          "test_mse_by_total_triangles": 1.343785140031524
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1092.757080078125,
+          "test_best_rerun_mse": 1225.5263671875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.19426792534722223
+          "test_mse_by_total_triangles": 0.21787135416666667
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 535386.75,
+          "test_best_rerun_mse": 570254.5,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.056205671753221
+          "test_mse_by_total_triangles": 6.450623847606981
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 144201.4375,
+          "test_best_rerun_mse": 154624.859375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.399637852994525
+          "test_mse_by_total_triangles": 2.573092695904681
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.2849697801801894,
-        "AvgTime/train_epoch_std": 0.02839934101000567,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.034751832485199,
+        "AvgTime/train_epoch_std": 0.01811828060594082
       }
     },
     {
@@ -4052,86 +4052,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_lo__pl_hi",
-      "test_loss": 18.234622955322266,
+      "test_loss": 24.030488967895508,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 18.99406623840332,
+      "test_best_rerun_mse": 24.305025100708008,
       "test_triangles_total_structural": 1158.0,
-      "test_mse_by_total_triangles": 0.016402475162697168,
+      "test_mse_by_total_triangles": 0.020988795423754758,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 41.04606246948242,
+          "test_best_rerun_mse": 56.244510650634766,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.029572091116341803
+          "test_mse_by_total_triangles": 0.04052198173676856
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2.6883344650268555,
+          "test_best_rerun_mse": 3.742255926132202,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.014149128763299238
+          "test_mse_by_total_triangles": 0.019696083821748433
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 748.3148193359375,
+          "test_best_rerun_mse": 904.3204956054688,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.05675501094698047
+          "test_mse_by_total_triangles": 0.0685870683053067
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12.554545402526855,
+          "test_best_rerun_mse": 10.451412200927734,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.004231393799301266
+          "test_mse_by_total_triangles": 0.0035225521405216494
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2136.1923828125,
+          "test_best_rerun_mse": 2917.034912109375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.28539644392952573
+          "test_mse_by_total_triangles": 0.389717423127505
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 77212.3359375,
+          "test_best_rerun_mse": 94893.8515625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.7929671172557125
+          "test_mse_by_total_triangles": 2.2035540489155676
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3957.367919921875,
+          "test_best_rerun_mse": 4847.3134765625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.277476365160698
+          "test_mse_by_total_triangles": 0.33987613774803677
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24843.494140625,
+          "test_best_rerun_mse": 28895.513671875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 1.27343760011405
+          "test_mse_by_total_triangles": 1.4811376119675534
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1161.2840576171875,
+          "test_best_rerun_mse": 1461.865478515625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.20645049913194444
+          "test_mse_by_total_triangles": 0.25988719618055556
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 552894.5625,
+          "test_best_rerun_mse": 598135.8125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 6.254251128355373
+          "test_mse_by_total_triangles": 6.766012607038222
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 151842.3125,
+          "test_best_rerun_mse": 168747.015625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 2.5267886858702346
+          "test_mse_by_total_triangles": 2.808097708967767
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.4659604592756792,
-        "AvgTime/train_epoch_std": 0.1798385885451354,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.0519530375798543,
+        "AvgTime/train_epoch_std": 0.03951520360625382
       }
     },
     {
@@ -4143,86 +4143,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 3568.52734375,
+      "test_loss": 3091.553466796875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2247.458251953125,
+      "test_best_rerun_mse": 1479.232177734375,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.05218879463015802,
+      "test_mse_by_total_triangles": 0.03434962329868045,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 157.9189453125,
+          "test_best_rerun_mse": 587.6528930664062,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.1137744562770173
+          "test_mse_by_total_triangles": 0.4233810468778143
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 137.49314880371094,
+          "test_best_rerun_mse": 617.875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.7236481515984786
+          "test_mse_by_total_triangles": 3.2519736842105265
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 340.35791015625,
+          "test_best_rerun_mse": 279.2880859375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.02581402428185438
+          "test_mse_by_total_triangles": 0.021182259077550246
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 378.39990234375,
+          "test_best_rerun_mse": 164.93553161621094,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.1275361989699191
+          "test_mse_by_total_triangles": 0.055590000544729
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 286.3814697265625,
+          "test_best_rerun_mse": 665.01611328125,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.03826071739833834
+          "test_mse_by_total_triangles": 0.08884650812040748
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 174.55435180664062,
+          "test_best_rerun_mse": 632.60546875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.15073778221644268
+          "test_mse_by_total_triangles": 0.546291423791019
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 540.9345703125,
+          "test_best_rerun_mse": 207.10385131835938,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.03792838103439209
+          "test_mse_by_total_triangles": 0.014521375074909505
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2503.1796875,
+          "test_best_rerun_mse": 1679.461181640625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.12830896957814342
+          "test_mse_by_total_triangles": 0.08608648222054564
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 332.28985595703125,
+          "test_best_rerun_mse": 637.8358154296875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.05907375217013889
+          "test_mse_by_total_triangles": 0.11339303385416667
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 160016.03125,
+          "test_best_rerun_mse": 148785.5,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.81007467223963
+          "test_mse_by_total_triangles": 1.683036774770087
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24006.4609375,
+          "test_best_rerun_mse": 15531.5732421875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.39948847515517616
+          "test_mse_by_total_triangles": 0.2584589426753116
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 5.769276790618896,
-        "AvgTime/train_epoch_std": 0.17860173965629988,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5082241694132488,
+        "AvgTime/train_epoch_std": 0.01381404994414763
       }
     },
     {
@@ -4234,86 +4234,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 3676.489013671875,
+      "test_loss": 8049.0078125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3184.646240234375,
+      "test_best_rerun_mse": 3522.273681640625,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.07395147316167507,
+      "test_mse_by_total_triangles": 0.08179160509104182,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 548.6091918945312,
+          "test_best_rerun_mse": 235.40098571777344,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.39525157917473436
+          "test_mse_by_total_triangles": 0.16959725195805003
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 469.5804748535156,
+          "test_best_rerun_mse": 309.88616943359375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 2.471476183439556
+          "test_mse_by_total_triangles": 1.6309798391241777
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 936.8182373046875,
+          "test_best_rerun_mse": 244.5260467529297,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.07105181928742416
+          "test_mse_by_total_triangles": 0.018545775256194896
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1148.1270751953125,
+          "test_best_rerun_mse": 967.7383422851562,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.38696564718412957
+          "test_mse_by_total_triangles": 0.3261672875918963
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 643.2539672851562,
+          "test_best_rerun_mse": 285.47509765625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.08593907378559201
+          "test_mse_by_total_triangles": 0.03813962560537742
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 538.42041015625,
+          "test_best_rerun_mse": 261.5950012207031,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.464957176300734
+          "test_mse_by_total_triangles": 0.22590241901615124
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 850.2643432617188,
+          "test_best_rerun_mse": 514.0546875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.05961746902690498
+          "test_mse_by_total_triangles": 0.03604366060159865
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4459.54052734375,
+          "test_best_rerun_mse": 1450.3922119140625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.22858888345603312
+          "test_mse_by_total_triangles": 0.07434477481747206
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 820.9906005859375,
+          "test_best_rerun_mse": 249.18629455566406,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.1459538845486111
+          "test_mse_by_total_triangles": 0.04429978569878472
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 155471.140625,
+          "test_best_rerun_mse": 139081.5625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.7586636270827913
+          "test_mse_by_total_triangles": 1.5732674513308371
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23692.205078125,
+          "test_best_rerun_mse": 14879.0166015625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.39425898321143893
+          "test_mse_by_total_triangles": 0.24759983028909358
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 5.957474417984486,
-        "AvgTime/train_epoch_std": 0.14239921677851977,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.4982327885097928,
+        "AvgTime/train_epoch_std": 0.018637682998846564
       }
     },
     {
@@ -4325,86 +4325,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_mid__d_hi__pl_lo",
-      "test_loss": 2392.43408203125,
+      "test_loss": 4976.6044921875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 2362.84033203125,
+      "test_best_rerun_mse": 2249.318359375,
       "test_triangles_total_structural": 43064.0,
-      "test_mse_by_total_triangles": 0.054868110998310654,
+      "test_mse_by_total_triangles": 0.0522319886535157,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 101.2577896118164,
+          "test_best_rerun_mse": 634.0326538085938,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.0729522979912222
+          "test_mse_by_total_triangles": 0.4567958600926468
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 167.80641174316406,
+          "test_best_rerun_mse": 527.337158203125,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.8831916407534951
+          "test_mse_by_total_triangles": 2.7754587273848683
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 462.8872375488281,
+          "test_best_rerun_mse": 304.3285827636719,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.03510710940832978
+          "test_mse_by_total_triangles": 0.023081424555454824
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 142.5814208984375,
+          "test_best_rerun_mse": 254.43942260742188,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.0480557535889577
+          "test_mse_by_total_triangles": 0.08575646195059719
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 131.7601776123047,
+          "test_best_rerun_mse": 747.4257202148438,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.017603230141924473
+          "test_mse_by_total_triangles": 0.09985647564660571
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 113.62641906738281,
+          "test_best_rerun_mse": 636.219482421875,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.09812298710482108
+          "test_mse_by_total_triangles": 0.5494123336976469
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 400.07489013671875,
+          "test_best_rerun_mse": 291.1845397949219,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.028051808311367183
+          "test_mse_by_total_triangles": 0.020416809689729483
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2182.394775390625,
+          "test_best_rerun_mse": 1950.79541015625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.1118660503045069
+          "test_mse_by_total_triangles": 0.09999463889262648
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 176.4940643310547,
+          "test_best_rerun_mse": 727.5797119140625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.031376722547743055
+          "test_mse_by_total_triangles": 0.12934750434027778
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 145378.1875,
+          "test_best_rerun_mse": 146463.8125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.6444938237390134
+          "test_mse_by_total_triangles": 1.6567742327749058
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22829.66796875,
+          "test_best_rerun_mse": 14704.93359375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.3799056124465412
+          "test_mse_by_total_triangles": 0.2447029370101343
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 6.17017810685294,
-        "AvgTime/train_epoch_std": 0.13151693121658176,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5160071207926824,
+        "AvgTime/train_epoch_std": 0.018016107030652425
       }
     },
     {
@@ -4416,86 +4416,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 314.36767578125,
+      "test_loss": 122.38432312011719,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 309.6919250488281,
+      "test_best_rerun_mse": 118.36290740966797,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.02171448079153191,
+      "test_mse_by_total_triangles": 0.008299180157738603,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74.33026123046875,
+          "test_best_rerun_mse": 73.35107421875,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.05355206140523685
+          "test_mse_by_total_triangles": 0.05284659525846542
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.9429874420166,
+          "test_best_rerun_mse": 49.035552978515625,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.1207525654842979
+          "test_mse_by_total_triangles": 0.2580818577816612
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6591.9833984375,
+          "test_best_rerun_mse": 5530.80126953125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.4999608189941221
+          "test_mse_by_total_triangles": 0.41947677432925673
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 31.975231170654297,
+          "test_best_rerun_mse": 47.19366455078125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.01077695691629737
+          "test_mse_by_total_triangles": 0.01590618960255519
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 931.7901000976562,
+          "test_best_rerun_mse": 205.04739379882812,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.12448765532366816
+          "test_mse_by_total_triangles": 0.027394441389288995
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.591114044189453,
+          "test_best_rerun_mse": 52.80594253540039,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.01950873406233977
+          "test_mse_by_total_triangles": 0.04560098664542348
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 23532.345703125,
+          "test_best_rerun_mse": 18200.88671875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.5464505318392393
+          "test_mse_by_total_triangles": 0.42264737875603753
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11360.314453125,
+          "test_best_rerun_mse": 6723.04052734375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.582311469225742
+          "test_mse_by_total_triangles": 0.34461225728349737
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 201.07977294921875,
+          "test_best_rerun_mse": 141.02392578125,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.035747515190972225
+          "test_mse_by_total_triangles": 0.02507092013888889
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 330042.5,
+          "test_best_rerun_mse": 245371.0625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.733385744827664
+          "test_mse_by_total_triangles": 2.775596557809124
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71743.4296875,
+          "test_best_rerun_mse": 49190.546875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.1938733244720683
+          "test_mse_by_total_triangles": 0.8185736587456109
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.662735798779656,
-        "AvgTime/train_epoch_std": 0.1031009455739721,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3205879559883704,
+        "AvgTime/train_epoch_std": 0.019627283714881035
       }
     },
     {
@@ -4507,86 +4507,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 409.2842102050781,
+      "test_loss": 68.01207733154297,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 418.5837097167969,
+      "test_best_rerun_mse": 69.13778686523438,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.029349579982947474,
+      "test_mse_by_total_triangles": 0.00484769224970091,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 141.81494140625,
+          "test_best_rerun_mse": 114.76589965820312,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.10217214798721182
+          "test_mse_by_total_triangles": 0.08268436574798496
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24.91689682006836,
+          "test_best_rerun_mse": 55.88288879394531,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.1311415622108861
+          "test_mse_by_total_triangles": 0.2941204673365543
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9867.2490234375,
+          "test_best_rerun_mse": 2660.7861328125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.7483692850540387
+          "test_mse_by_total_triangles": 0.20180402979237771
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 24.736377716064453,
+          "test_best_rerun_mse": 37.54071044921875,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.008337168087652327
+          "test_mse_by_total_triangles": 0.012652750404185625
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 999.8389282226562,
+          "test_best_rerun_mse": 284.2269287109375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.1335790151266074
+          "test_mse_by_total_triangles": 0.037972869567259517
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27.455432891845703,
+          "test_best_rerun_mse": 62.29571533203125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.023709354828882298
+          "test_mse_by_total_triangles": 0.0537959545181617
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22090.0625,
+          "test_best_rerun_mse": 13846.8984375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.512958909994427
+          "test_mse_by_total_triangles": 0.3215423192806056
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9872.5810546875,
+          "test_best_rerun_mse": 6287.93115234375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.5060526451733816
+          "test_mse_by_total_triangles": 0.3223092496972551
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 238.9152069091797,
+          "test_best_rerun_mse": 119.70745086669922,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.04247381456163195
+          "test_mse_by_total_triangles": 0.021281324598524307
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 312731.90625,
+          "test_best_rerun_mse": 233648.53125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.5375711938508876
+          "test_mse_by_total_triangles": 2.6429932383516395
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 66601.6796875,
+          "test_best_rerun_mse": 47277.66015625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.1083101141147886
+          "test_mse_by_total_triangles": 0.7867415531967118
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.75627154774136,
-        "AvgTime/train_epoch_std": 0.08143866715969374,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3532448702080304,
+        "AvgTime/train_epoch_std": 0.016549617246774343
       }
     },
     {
@@ -4598,86 +4598,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_mid__d_hi__pl_hi",
-      "test_loss": 237.2249298095703,
+      "test_loss": 101.68169403076172,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 217.86854553222656,
+      "test_best_rerun_mse": 103.60504150390625,
       "test_triangles_total_structural": 14262.0,
-      "test_mse_by_total_triangles": 0.01527615660722385,
+      "test_mse_by_total_triangles": 0.007264411828909427,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 75.09513092041016,
+          "test_best_rerun_mse": 39.40272903442383,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.0541031202596615
+          "test_mse_by_total_triangles": 0.028388133310103623
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42.5504150390625,
+          "test_best_rerun_mse": 30.262714385986328,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.22394955283717105
+          "test_mse_by_total_triangles": 0.15927744413677014
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8092.4326171875,
+          "test_best_rerun_mse": 3750.6591796875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.6137605322098976
+          "test_mse_by_total_triangles": 0.2844641016069397
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 26.631847381591797,
+          "test_best_rerun_mse": 21.697628021240234,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.008976018665855004
+          "test_mse_by_total_triangles": 0.007312985514405202
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 698.655029296875,
+          "test_best_rerun_mse": 141.35523986816406,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.0933406852768036
+          "test_mse_by_total_triangles": 0.018885135586929065
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 42.835933685302734,
+          "test_best_rerun_mse": 27.855201721191406,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.03699130715483828
+          "test_mse_by_total_triangles": 0.02405457834299776
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21504.966796875,
+          "test_best_rerun_mse": 14305.138671875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.49937225517543654
+          "test_mse_by_total_triangles": 0.33218323128076815
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 9014.017578125,
+          "test_best_rerun_mse": 5935.03466796875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.46204406059382847
+          "test_mse_by_total_triangles": 0.3042203428145343
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 143.3577117919922,
+          "test_best_rerun_mse": 56.39433670043945,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.0254858154296875
+          "test_mse_by_total_triangles": 0.010025659857855904
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 288039.71875,
+          "test_best_rerun_mse": 229869.59375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.258257284820651
+          "test_mse_by_total_triangles": 2.600246527267174
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 60196.19921875,
+          "test_best_rerun_mse": 44029.390625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.0017173251252225
+          "test_mse_by_total_triangles": 0.7326875114406004
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 3.755992243164464,
-        "AvgTime/train_epoch_std": 0.09523384585218725,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.3502976072245632,
+        "AvgTime/train_epoch_std": 0.012735310449701404
       }
     },
     {
@@ -4689,86 +4689,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 3179.888427734375,
+      "test_loss": 1604.7841796875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3314.06884765625,
+      "test_best_rerun_mse": 1696.1109619140625,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.16987384528454816,
+      "test_mse_by_total_triangles": 0.08693992321052142,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 119.87373352050781,
+          "test_best_rerun_mse": 74.47406005859375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.08636436132601427
+          "test_mse_by_total_triangles": 0.05365566286642201
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 96.6310806274414,
+          "test_best_rerun_mse": 57.845794677734375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.5085846348812706
+          "test_mse_by_total_triangles": 0.30445155093544407
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1022.690185546875,
+          "test_best_rerun_mse": 784.6987915039062,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.07756467087955063
+          "test_mse_by_total_triangles": 0.05951450826726631
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 117.59568786621094,
+          "test_best_rerun_mse": 70.3576431274414,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03963454259056654
+          "test_mse_by_total_triangles": 0.023713395054749377
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 296.9083557128906,
+          "test_best_rerun_mse": 239.72128295898438,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.039667114991702154
+          "test_mse_by_total_triangles": 0.032026891510886356
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 88.1514892578125,
+          "test_best_rerun_mse": 59.991092681884766,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.0761239112761766
+          "test_mse_by_total_triangles": 0.0518057795180352
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 7467.4033203125,
+          "test_best_rerun_mse": 2040.3121337890625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.17340245495802759
+          "test_mse_by_total_triangles": 0.047378602400823484
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 348.8846435546875,
+          "test_best_rerun_mse": 230.43385314941406,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.02446253285336471
+          "test_mse_by_total_triangles": 0.01615719065694952
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 178.9174041748047,
+          "test_best_rerun_mse": 94.30339050292969,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.031807538519965275
+          "test_mse_by_total_triangles": 0.016765047200520834
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 173092.125,
+          "test_best_rerun_mse": 126293.3359375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.95798926507019
+          "test_mse_by_total_triangles": 1.4286091641403573
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28249.92578125,
+          "test_best_rerun_mse": 17917.4609375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.4701034360283228
+          "test_mse_by_total_triangles": 0.29816219755212753
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.4397888841300177,
-        "AvgTime/train_epoch_std": 0.11254613856076705,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.301867823851736,
+        "AvgTime/train_epoch_std": 0.019417809299266783
       }
     },
     {
@@ -4780,86 +4780,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 3324.685546875,
+      "test_loss": 2134.81591796875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3542.004150390625,
+      "test_best_rerun_mse": 2257.16943359375,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.181557442738768,
+      "test_mse_by_total_triangles": 0.11569887916314266,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 100.65813446044922,
+          "test_best_rerun_mse": 203.49205017089844,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.07252026978418531
+          "test_mse_by_total_triangles": 0.14660810531044555
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 80.16943359375,
+          "test_best_rerun_mse": 133.06900024414062,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.4219443873355263
+          "test_mse_by_total_triangles": 0.7003631591796875
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1885.9248046875,
+          "test_best_rerun_mse": 872.5615844726562,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.14303563175483505
+          "test_mse_by_total_triangles": 0.06617835301271568
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 108.70162200927734,
+          "test_best_rerun_mse": 158.62655639648438,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.03663687967956769
+          "test_mse_by_total_triangles": 0.053463618603466254
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 669.5271606445312,
+          "test_best_rerun_mse": 289.0039978027344,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.0894491864588552
+          "test_mse_by_total_triangles": 0.03861108855079952
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 86.31526184082031,
+          "test_best_rerun_mse": 146.78163146972656,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.07453822266046659
+          "test_mse_by_total_triangles": 0.1267544313210074
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5920.3564453125,
+          "test_best_rerun_mse": 2381.58935546875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.13747808947874093
+          "test_mse_by_total_triangles": 0.055303486797992525
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 478.2204284667969,
+          "test_best_rerun_mse": 199.64791870117188,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.033531091604739646
+          "test_mse_by_total_triangles": 0.013998591971755145
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 148.12904357910156,
+          "test_best_rerun_mse": 176.3007354736328,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.026334052191840276
+          "test_mse_by_total_triangles": 0.03134235297309028
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 179007.96875,
+          "test_best_rerun_mse": 118802.5625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 2.0249083034512405
+          "test_mse_by_total_triangles": 1.343874783661188
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 31214.005859375,
+          "test_best_rerun_mse": 17251.208984375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.5194283170980813
+          "test_mse_by_total_triangles": 0.28707518320561465
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.411443740129471,
-        "AvgTime/train_epoch_std": 0.10270195532468811,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2950940430164337,
+        "AvgTime/train_epoch_std": 0.013621072425355459
       }
     },
     {
@@ -4871,86 +4871,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_lo__pl_lo",
-      "test_loss": 3093.749755859375,
+      "test_loss": 1779.434326171875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3249.32763671875,
+      "test_best_rerun_mse": 1841.7435302734375,
       "test_triangles_total_structural": 19509.0,
-      "test_mse_by_total_triangles": 0.16655531481463684,
+      "test_mse_by_total_triangles": 0.09440481471492324,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 116.10527038574219,
+          "test_best_rerun_mse": 245.4445037841797,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.0836493302490938
+          "test_mse_by_total_triangles": 0.17683321598283838
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 70.40946960449219,
+          "test_best_rerun_mse": 320.7359924316406,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.37057615581311676
+          "test_mse_by_total_triangles": 1.6880841706928453
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6231.6650390625,
+          "test_best_rerun_mse": 623.2399291992188,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.4726329191552901
+          "test_mse_by_total_triangles": 0.04726886076596274
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 165.18138122558594,
+          "test_best_rerun_mse": 779.3821411132812,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.055672861889311066
+          "test_mse_by_total_triangles": 0.26268356626669404
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 840.2189331054688,
+          "test_best_rerun_mse": 417.4663391113281,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.11225369847768453
+          "test_mse_by_total_triangles": 0.05577372600017744
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 77.76837921142578,
+          "test_best_rerun_mse": 286.6671447753906,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.06715749500123125
+          "test_mse_by_total_triangles": 0.24755366560914563
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10313.2265625,
+          "test_best_rerun_mse": 4334.01806640625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.23948603386819617
+          "test_mse_by_total_triangles": 0.10064132608225548
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 205.82789611816406,
+          "test_best_rerun_mse": 485.1497497558594,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.01443190969837078
+          "test_mse_by_total_triangles": 0.03401695062094092
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 96.17517852783203,
+          "test_best_rerun_mse": 272.2900390625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.017097809516059027
+          "test_mse_by_total_triangles": 0.04840711805555555
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 174191.46875,
+          "test_best_rerun_mse": 122177.0546875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 1.9704248583192878
+          "test_mse_by_total_triangles": 1.382046476788118
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28271.552734375,
+          "test_best_rerun_mse": 16275.9833984375,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.47046332741542274
+          "test_mse_by_total_triangles": 0.2708465777784018
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 2.441785076686314,
-        "AvgTime/train_epoch_std": 0.09008476557557665,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.2876607036590577,
+        "AvgTime/train_epoch_std": 0.0135456545091304
       }
     },
     {
@@ -4962,86 +4962,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 202.19503784179688,
+      "test_loss": 68.77897644042969,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 208.45947265625,
+      "test_best_rerun_mse": 67.72727966308594,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.037059461805555555,
+      "test_mse_by_total_triangles": 0.0120404052734375,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 212.58016967773438,
+          "test_best_rerun_mse": 128.19715881347656,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.1531557418427481
+          "test_mse_by_total_triangles": 0.09236106542757677
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 15.166872024536133,
+          "test_best_rerun_mse": 45.56234359741211,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.0798256422344007
+          "test_mse_by_total_triangles": 0.23980180840743215
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10108.236328125,
+          "test_best_rerun_mse": 9148.76171875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.7666466687997725
+          "test_mse_by_total_triangles": 0.6938765050246493
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 65.45793151855469,
+          "test_best_rerun_mse": 118.77662658691406,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.02206199242283609
+          "test_mse_by_total_triangles": 0.040032567100409186
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1282.081298828125,
+          "test_best_rerun_mse": 526.0733032226562,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.17128674667042418
+          "test_mse_by_total_triangles": 0.07028367444524465
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 22.718788146972656,
+          "test_best_rerun_mse": 48.54209518432617,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.019618988037109375
+          "test_mse_by_total_triangles": 0.04191890775848547
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27970.630859375,
+          "test_best_rerun_mse": 23613.908203125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.6495130702994381
+          "test_mse_by_total_triangles": 0.5483445152128228
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 827.91357421875,
+          "test_best_rerun_mse": 308.7260437011719,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.058050313716081194
+          "test_mse_by_total_triangles": 0.0216467566751628
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 11649.923828125,
+          "test_best_rerun_mse": 7812.6142578125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.5971563805487211
+          "test_mse_by_total_triangles": 0.40046205637462196
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 338455.09375,
+          "test_best_rerun_mse": 292611.1875,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.828547603022522
+          "test_mse_by_total_triangles": 3.3099689772971503
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71934.171875,
+          "test_best_rerun_mse": 54431.546875,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.1970474410497063
+          "test_mse_by_total_triangles": 0.9057884757792088
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.8448637568432351,
-        "AvgTime/train_epoch_std": 0.05137894999908988,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.1554274320602418,
+        "AvgTime/train_epoch_std": 0.01862502659335622
       }
     },
     {
@@ -5053,86 +5053,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 121.3056869506836,
+      "test_loss": 93.17463684082031,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 127.51045227050781,
+      "test_best_rerun_mse": 96.3698959350586,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.022668524848090277,
+      "test_mse_by_total_triangles": 0.017132425944010418,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 387.9585876464844,
+          "test_best_rerun_mse": 221.74554443359375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.2795090689095709
+          "test_mse_by_total_triangles": 0.15975903777636438
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12.690643310546875,
+          "test_best_rerun_mse": 36.8603630065918,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.06679285952919407
+          "test_mse_by_total_triangles": 0.19400191056100946
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17029.560546875,
+          "test_best_rerun_mse": 13310.9970703125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 1.291585934537353
+          "test_mse_by_total_triangles": 1.009556091794653
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.45729637145996,
+          "test_best_rerun_mse": 57.0678596496582,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.006220861601435781
+          "test_mse_by_total_triangles": 0.019234196039655614
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2545.249267578125,
+          "test_best_rerun_mse": 1071.822265625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.34004666233508685
+          "test_mse_by_total_triangles": 0.1431960274716099
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18.38775634765625,
+          "test_best_rerun_mse": 37.1409912109375,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.01587889149193113
+          "test_mse_by_total_triangles": 0.03207339482809801
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 35221.05859375,
+          "test_best_rerun_mse": 29088.005859375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.8178770804790544
+          "test_mse_by_total_triangles": 0.6754599168534042
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 509.2686462402344,
+          "test_best_rerun_mse": 488.345458984375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.03570808065069656
+          "test_mse_by_total_triangles": 0.03424102222580108
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12047.666015625,
+          "test_best_rerun_mse": 10362.3779296875,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.6175440061317853
+          "test_mse_by_total_triangles": 0.5311588461575427
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 353377.53125,
+          "test_best_rerun_mse": 332059.15625,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 3.9973477285838714
+          "test_mse_by_total_triangles": 3.756197824168863
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 74718.1015625,
+          "test_best_rerun_mse": 67498.7265625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.243374462291781
+          "test_mse_by_total_triangles": 1.1232377575175145
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.7718735195341564,
-        "AvgTime/train_epoch_std": 0.19497103918613756,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.144404617945353,
+        "AvgTime/train_epoch_std": 0.015073752470582456
       }
     },
     {
@@ -5144,86 +5144,86 @@
       "avg_degree": "d_lo",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_lo__pl_hi",
-      "test_loss": 130.5321807861328,
+      "test_loss": 51.18621826171875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 135.942138671875,
+      "test_best_rerun_mse": 46.233924865722656,
       "test_triangles_total_structural": 5625.0,
-      "test_mse_by_total_triangles": 0.024167491319444446,
+      "test_mse_by_total_triangles": 0.008219364420572917,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 305.00048828125,
+          "test_best_rerun_mse": 76.14424133300781,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.21974098579340778
+          "test_mse_by_total_triangles": 0.054858963496403325
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21.056705474853516,
+          "test_best_rerun_mse": 26.55804443359375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.11082476565712376
+          "test_mse_by_total_triangles": 0.1397791812294408
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12192.45703125,
+          "test_best_rerun_mse": 8861.28515625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.9247218074516496
+          "test_mse_by_total_triangles": 0.6720732010807736
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 30.884462356567383,
+          "test_best_rerun_mse": 37.98617172241211,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.010409323342287625
+          "test_mse_by_total_triangles": 0.012802889020024303
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1663.594482421875,
+          "test_best_rerun_mse": 479.47088623046875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.22225711188001002
+          "test_mse_by_total_triangles": 0.06405756663065715
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 27.812339782714844,
+          "test_best_rerun_mse": 24.525461196899414,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.024017564579201074
+          "test_mse_by_total_triangles": 0.021179154746890687
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 33263.3125,
+          "test_best_rerun_mse": 24329.3359375,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.7724157649080439
+          "test_mse_by_total_triangles": 0.5649576429848597
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 623.399658203125,
+          "test_best_rerun_mse": 268.6585693359375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.04371053556325375
+          "test_mse_by_total_triangles": 0.01883736988752892
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 12505.9951171875,
+          "test_best_rerun_mse": 7597.94677734375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.6410372196005689
+          "test_mse_by_total_triangles": 0.3894585461758035
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 358311.53125,
+          "test_best_rerun_mse": 288353.75,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 4.053160314129611
+          "test_mse_by_total_triangles": 3.2618095539744125
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 76176.796875,
+          "test_best_rerun_mse": 52804.78515625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 1.2676484261894063
+          "test_mse_by_total_triangles": 0.8787177401070008
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 1.7898157027459913,
-        "AvgTime/train_epoch_std": 0.11665237634341992,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.1420753717422485,
+        "AvgTime/train_epoch_std": 0.018802227504182395
       }
     },
     {
@@ -5235,86 +5235,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 26738.51953125,
+      "test_loss": 13203.390625,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 15008.26171875,
+      "test_best_rerun_mse": 6976.91064453125,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.16977095481770982,
+      "test_mse_by_total_triangles": 0.07892165022149984,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5274.8359375,
+          "test_best_rerun_mse": 2577.362548828125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 3.8003140760086453
+          "test_mse_by_total_triangles": 1.8568894444006665
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3347.60302734375,
+          "test_best_rerun_mse": 2798.295654296875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 17.61896330180921
+          "test_mse_by_total_triangles": 14.727871864720395
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21927.84375,
+          "test_best_rerun_mse": 2126.9423828125,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 1.6630901592718998
+          "test_mse_by_total_triangles": 0.16131531155195297
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18206.841796875,
+          "test_best_rerun_mse": 2548.2841796875,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 6.136448195778565
+          "test_mse_by_total_triangles": 0.8588756925134816
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5230.84375,
+          "test_best_rerun_mse": 2536.909912109375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.6988435203740815
+          "test_mse_by_total_triangles": 0.3389325199878925
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4238.2490234375,
+          "test_best_rerun_mse": 2914.124267578125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 3.659973249946028
+          "test_mse_by_total_triangles": 2.516514911552785
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 17409.2890625,
+          "test_best_rerun_mse": 2153.067138671875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.4042654900264722
+          "test_mse_by_total_triangles": 0.04999691479360661
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 25336.73046875,
+          "test_best_rerun_mse": 2157.455322265625,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 1.7765201562719113
+          "test_mse_by_total_triangles": 0.15127298571488046
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2252.95947265625,
+          "test_best_rerun_mse": 2600.774658203125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.11548308332852786
+          "test_mse_by_total_triangles": 0.13331153099611076
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4237.52587890625,
+          "test_best_rerun_mse": 2576.34375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.7533379340277778
+          "test_mse_by_total_triangles": 0.4580166666666667
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 18330.4609375,
+          "test_best_rerun_mse": 2939.76416015625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.30503487823040953
+          "test_mse_by_total_triangles": 0.048920242959350504
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 10.27099545105644,
-        "AvgTime/train_epoch_std": 0.24793898123087765,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.8105340083440145,
+        "AvgTime/train_epoch_std": 0.0151309083453215
       }
     },
     {
@@ -5326,86 +5326,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 9072.6806640625,
+      "test_loss": 10608.794921875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 7045.0341796875,
+      "test_best_rerun_mse": 7302.22998046875,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.07969225229559518,
+      "test_mse_by_total_triangles": 0.08260160832176228,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 517.189208984375,
+          "test_best_rerun_mse": 22181.9609375,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.37261470387923273
+          "test_mse_by_total_triangles": 15.98123986851585
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 207.4522705078125,
+          "test_best_rerun_mse": 26852.90625,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.0918540553042764
+          "test_mse_by_total_triangles": 141.3310855263158
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4635.55712890625,
+          "test_best_rerun_mse": 7855.24853515625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.3515780909295601
+          "test_mse_by_total_triangles": 0.5957715991775692
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 604.7913208007812,
+          "test_best_rerun_mse": 22654.443359375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.20383933966996334
+          "test_mse_by_total_triangles": 7.635471304137176
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 901.8673095703125,
+          "test_best_rerun_mse": 15711.3369140625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.12048995451841182
+          "test_mse_by_total_triangles": 2.0990430078907814
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 418.8031921386719,
+          "test_best_rerun_mse": 23270.80078125,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.36166078768451804
+          "test_mse_by_total_triangles": 20.095682885362695
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5594.11474609375,
+          "test_best_rerun_mse": 5654.7119140625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.12990234873894088
+          "test_mse_by_total_triangles": 0.131309490852278
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 921.2368774414062,
+          "test_best_rerun_mse": 8706.0546875,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.06459380714075208
+          "test_mse_by_total_triangles": 0.6104371538003085
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1196.772216796875,
+          "test_best_rerun_mse": 11989.78515625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.0613446212925765
+          "test_mse_by_total_triangles": 0.6145771262622379
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1135.3043212890625,
+          "test_best_rerun_mse": 14735.6103515625,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.20183187934027777
+          "test_mse_by_total_triangles": 2.6196640625
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8891.3984375,
+          "test_best_rerun_mse": 2408.781494140625,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.14796063497412343
+          "test_mse_by_total_triangles": 0.04008422768276879
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 10.308171401421228,
-        "AvgTime/train_epoch_std": 0.23452224084395534,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.7880723336163689,
+        "AvgTime/train_epoch_std": 0.02074340677306439
       }
     },
     {
@@ -5417,86 +5417,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_lo",
       "run_slug": "h_hi__d_hi__pl_lo",
-      "test_loss": 5382.3349609375,
+      "test_loss": 15180.0361328125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 5258.71728515625,
+      "test_best_rerun_mse": 8105.01904296875,
       "test_triangles_total_structural": 88403.0,
-      "test_mse_by_total_triangles": 0.059485733347920886,
+      "test_mse_by_total_triangles": 0.09168262437890966,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1172.4957275390625,
+          "test_best_rerun_mse": 2686.822509765625,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.8447375558638779
+          "test_mse_by_total_triangles": 1.9357510877273956
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1380.018798828125,
+          "test_best_rerun_mse": 2379.142333984375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 7.2632568359375
+          "test_mse_by_total_triangles": 12.5218017578125
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13182.3564453125,
+          "test_best_rerun_mse": 2984.2373046875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 0.9997995028678422
+          "test_mse_by_total_triangles": 0.22633578344235875
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1085.4912109375,
+          "test_best_rerun_mse": 3970.421630859375,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.3658548065175261
+          "test_mse_by_total_triangles": 1.3381940110749495
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1289.6978759765625,
+          "test_best_rerun_mse": 2811.27734375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.17230432544777055
+          "test_mse_by_total_triangles": 0.3755881554776219
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 1137.3433837890625,
+          "test_best_rerun_mse": 2838.341552734375,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.9821618167435773
+          "test_mse_by_total_triangles": 2.4510721526203585
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 19339.255859375,
+          "test_best_rerun_mse": 3102.359619140625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 0.4490817355418679
+          "test_mse_by_total_triangles": 0.07204067478962997
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 2291.35107421875,
+          "test_best_rerun_mse": 3246.40380859375,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.16066127290834034
+          "test_mse_by_total_triangles": 0.22762612597067383
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 840.4722900390625,
+          "test_best_rerun_mse": 3108.6484375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.0430812594207321
+          "test_mse_by_total_triangles": 0.15934432505510276
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 854.30078125,
+          "test_best_rerun_mse": 3102.7451171875,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.15187569444444443
+          "test_mse_by_total_triangles": 0.5515991319444444
         },
         "h_hi__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 10664.7529296875,
+          "test_best_rerun_mse": 3281.622314453125,
           "test_triangles_total_structural": 60093.0,
-          "test_mse_by_total_triangles": 0.17747080241771088
+          "test_mse_by_total_triangles": 0.054609061196031566
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 10.24231568249789,
-        "AvgTime/train_epoch_std": 0.19778783662280988,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.8062100685559785,
+        "AvgTime/train_epoch_std": 0.017495403732798485
       }
     },
     {
@@ -5508,86 +5508,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 4682.73046875,
+      "test_loss": 1801.9046630859375,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3492.79052734375,
+      "test_best_rerun_mse": 1574.770263671875,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.05812308467448372,
+      "test_mse_by_total_triangles": 0.026205552454892832,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 349.20819091796875,
+          "test_best_rerun_mse": 714.6988525390625,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.2515909156469516
+          "test_mse_by_total_triangles": 0.5149127179676243
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 115.79536437988281,
+          "test_best_rerun_mse": 708.2310180664062,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.6094492862099096
+          "test_mse_by_total_triangles": 3.727531674033717
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 21293.82421875,
+          "test_best_rerun_mse": 1749.586669921875,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 1.6150037329351536
+          "test_mse_by_total_triangles": 0.13269523473051764
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 131.8525848388672,
+          "test_best_rerun_mse": 1533.0040283203125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.04443969829419184
+          "test_mse_by_total_triangles": 0.5166848764139914
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 3715.69921875,
+          "test_best_rerun_mse": 1514.8450927734375,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.4964194013026052
+          "test_mse_by_total_triangles": 0.202384113930987
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 142.91343688964844,
+          "test_best_rerun_mse": 722.9554443359375,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.12341402149365151
+          "test_mse_by_total_triangles": 0.6243138552123813
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 88795.625,
+          "test_best_rerun_mse": 49251.98828125,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.0619455926063535
+          "test_mse_by_total_triangles": 1.1436928358083318
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 366.1231384277344,
+          "test_best_rerun_mse": 902.6958618164062,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.02567123393827895
+          "test_mse_by_total_triangles": 0.06329377799862616
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 5872.0576171875,
+          "test_best_rerun_mse": 2144.603271484375,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.3009922403602184
+          "test_mse_by_total_triangles": 0.10992891852398252
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 290.21478271484375,
+          "test_best_rerun_mse": 803.0345458984375,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.051593739149305554
+          "test_mse_by_total_triangles": 0.1427616970486111
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 83539.375,
+          "test_best_rerun_mse": 51303.5703125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.9449834847233691
+          "test_mse_by_total_triangles": 0.5803374355225501
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 8.588777360462007,
-        "AvgTime/train_epoch_std": 0.14507611084524985,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5341220283508301,
+        "AvgTime/train_epoch_std": 0.011009135455748656
       }
     },
     {
@@ -5599,86 +5599,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 4732.7939453125,
+      "test_loss": 2491.788330078125,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3641.96240234375,
+      "test_best_rerun_mse": 2178.808837890625,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.06060543494822608,
+      "test_mse_by_total_triangles": 0.036257281844651205,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 698.7297973632812,
+          "test_best_rerun_mse": 710.169921875,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.5034076349879548
+          "test_mse_by_total_triangles": 0.5116497996217579
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 344.08636474609375,
+          "test_best_rerun_mse": 646.224365234375,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 1.8109808670847038
+          "test_mse_by_total_triangles": 3.4011808696546053
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 13297.3271484375,
+          "test_best_rerun_mse": 2690.041259765625,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 1.0085193134954493
+          "test_mse_by_total_triangles": 0.20402284867391923
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 945.5708618164062,
+          "test_best_rerun_mse": 2792.01953125,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.3186959426411885
+          "test_mse_by_total_triangles": 0.9410244459892146
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4248.697265625,
+          "test_best_rerun_mse": 2568.74853515625,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.5676282252004008
+          "test_mse_by_total_triangles": 0.34318617704158316
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 456.2998962402344,
+          "test_best_rerun_mse": 636.0930786132812,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.39404136117464106
+          "test_mse_by_total_triangles": 0.549303176695407
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 71527.9765625,
+          "test_best_rerun_mse": 83130.6171875,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 1.6609691752391789
+          "test_mse_by_total_triangles": 1.930397018100966
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 610.5007934570312,
+          "test_best_rerun_mse": 1552.5255126953125,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.04280611369071878
+          "test_mse_by_total_triangles": 0.10885748932094465
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 4959.90478515625,
+          "test_best_rerun_mse": 2734.47119140625,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.2542367515073171
+          "test_mse_by_total_triangles": 0.1401646005129043
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 678.603759765625,
+          "test_best_rerun_mse": 748.4413452148438,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.12064066840277778
+          "test_mse_by_total_triangles": 0.13305623914930556
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 87743.265625,
+          "test_best_rerun_mse": 33559.36328125,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.9925371947218986
+          "test_mse_by_total_triangles": 0.37961792338778094
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 8.766407159658579,
-        "AvgTime/train_epoch_std": 0.1561699070206689,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5371109114752874,
+        "AvgTime/train_epoch_std": 0.018164389484326266
       }
     },
     {
@@ -5690,86 +5690,86 @@
       "avg_degree": "d_hi",
       "power_law": "pl_hi",
       "run_slug": "h_hi__d_hi__pl_hi",
-      "test_loss": 4886.81103515625,
+      "test_loss": 2113.63671875,
       "test_best_rerun_accuracy": null,
-      "test_best_rerun_mse": 3513.46923828125,
+      "test_best_rerun_mse": 1572.2396240234375,
       "test_triangles_total_structural": 60093.0,
-      "test_mse_by_total_triangles": 0.05846719648347145,
+      "test_mse_by_total_triangles": 0.026163440401102248,
       "ood_test": {
         "h_lo__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 490.5380859375,
+          "test_best_rerun_mse": 523.65283203125,
           "test_triangles_total_structural": 1388.0,
-          "test_mse_by_total_triangles": 0.35341360658321325
+          "test_mse_by_total_triangles": 0.37727149281790345
         },
         "h_lo__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 160.91256713867188,
+          "test_best_rerun_mse": 552.58544921875,
           "test_triangles_total_structural": 190.0,
-          "test_mse_by_total_triangles": 0.846908248098273
+          "test_mse_by_total_triangles": 2.9083444695723686
         },
         "h_lo__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 28159.9375,
+          "test_best_rerun_mse": 5195.4208984375,
           "test_triangles_total_structural": 13185.0,
-          "test_mse_by_total_triangles": 2.1357555934774366
+          "test_mse_by_total_triangles": 0.3940402653346606
         },
         "h_lo__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 174.47915649414062,
+          "test_best_rerun_mse": 1336.8035888671875,
           "test_triangles_total_structural": 2967.0,
-          "test_mse_by_total_triangles": 0.05880659133607705
+          "test_mse_by_total_triangles": 0.4505573268847953
         },
         "h_mid__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 6610.2099609375,
+          "test_best_rerun_mse": 1194.291748046875,
           "test_triangles_total_structural": 7485.0,
-          "test_mse_by_total_triangles": 0.8831275832915831
+          "test_mse_by_total_triangles": 0.15955801577112558
         },
         "h_mid__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 185.32501220703125,
+          "test_best_rerun_mse": 501.5467224121094,
           "test_triangles_total_structural": 1158.0,
-          "test_mse_by_total_triangles": 0.16003887064510472
+          "test_mse_by_total_triangles": 0.43311461348195973
         },
         "h_mid__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 123458.9609375,
+          "test_best_rerun_mse": 59707.44140625,
           "test_triangles_total_structural": 43064.0,
-          "test_mse_by_total_triangles": 2.866871654688371
+          "test_mse_by_total_triangles": 1.3864815485382223
         },
         "h_mid__d_hi__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 582.912841796875,
+          "test_best_rerun_mse": 855.0122680664062,
           "test_triangles_total_structural": 14262.0,
-          "test_mse_by_total_triangles": 0.04087174602418139
+          "test_mse_by_total_triangles": 0.05995037638945493
         },
         "h_hi__d_lo__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 8561.3662109375,
+          "test_best_rerun_mse": 1403.2784423828125,
           "test_triangles_total_structural": 19509.0,
-          "test_mse_by_total_triangles": 0.4388418786681788
+          "test_mse_by_total_triangles": 0.07192979867665245
         },
         "h_hi__d_lo__pl_hi": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 360.076904296875,
+          "test_best_rerun_mse": 486.4194641113281,
           "test_triangles_total_structural": 5625.0,
-          "test_mse_by_total_triangles": 0.064013671875
+          "test_mse_by_total_triangles": 0.08647457139756945
         },
         "h_hi__d_hi__pl_lo": {
           "test_best_rerun_accuracy": null,
-          "test_best_rerun_mse": 79319.25,
+          "test_best_rerun_mse": 40809.2734375,
           "test_triangles_total_structural": 88403.0,
-          "test_mse_by_total_triangles": 0.8972461341809667
+          "test_mse_by_total_triangles": 0.46162769857923375
         }
       },
-      "output_dir": "/home/compa/Documents/working_dir/TopoBenchChallenge/topobench/logs/train/runs/notebook_gu_grid_2026-06-30_15-21-08__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "output_dir": "/tmp/topobench-mpsn-eval/logs/train/runs/notebook_gu_grid_2026-07-31_15-44-23__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
       "wandb_config": {
-        "AvgTime/train_epoch_mean": 8.759645109176637,
-        "AvgTime/train_epoch_std": 0.13420225075146433,
-        "model/params/total": 115985,
-        "model/params/trainable": 115985,
-        "model/params/non_trainable": 0
+        "model/params/total": 314696,
+        "model/params/trainable": 314696,
+        "model/params/non_trainable": 0,
+        "AvgTime/train_epoch_mean": 1.5371758937835693,
+        "AvgTime/train_epoch_std": 0.017408210445270012
       }
     }
   ]

--- a/configs/model/simplicial/mpsn.yaml
+++ b/configs/model/simplicial/mpsn.yaml
@@ -1,0 +1,43 @@
+_target_: topobench.model.TBModel
+
+model_name: mpsn
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
+
+backbone:
+  _target_: topobench.nn.backbones.simplicial.MPSN
+  in_channels_all:
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  n_layers: 3
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.MPSNWrapper
+  _partial_: true
+  wrapper_name: MPSNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/simplicial/test_mpsn.py
+++ b/test/nn/backbones/simplicial/test_mpsn.py
@@ -4,13 +4,11 @@ MPSN: Bodnar et al., "Weisfeiler and Lehman Go Topological: Message Passing
 Simplicial Networks", ICML 2021, arXiv:2103.03212.
 
 These tests assert behaviour on tiny, hand-built simplicial complexes (NO
-GraphUniverse loading). The central capability being verified is the one the
-model exists for: a complex *with* a filled triangle (2-simplex) yields a
-different rank-2 signal / graph-level readout than one *without* it, because the
-2-cell becomes a first-class object that boundary + upper-adjacency message
-passing can read. Plain 1-WL GNNs provably cannot do this.
+GraphUniverse loading), including an explicit numerical oracle for Supplement
+Equation 35 and a valid ``C6`` versus ``2K3`` higher-order example.
 """
 
+import pytest
 import torch
 
 from topobench.nn.backbones.simplicial.mpsn import MPSN
@@ -49,31 +47,41 @@ def _triangle_complex():
     return (x_0, x_1, x_2), (incidence_1, incidence_2)
 
 
-def _open_triad_complex():
-    """The SAME three nodes / three edges but the triangle is NOT filled.
-
-    Identical 1-skeleton to ``_triangle_complex`` but with zero 2-simplices, so
-    the only structural difference is the presence of the 2-cell.
-
-    Returns
-    -------
-    tuple
-        ((x_0, x_1, x_2), (incidence_1, incidence_2)).
-    """
-    incidence_1 = torch.tensor(
+def _c6_and_two_triangles():
+    """Return clique complexes for the cycle C6 and disjoint union 2K3."""
+    incidence_1_c6 = torch.tensor(
         [
-            [1.0, 1.0, 0.0],
-            [1.0, 0.0, 1.0],
-            [0.0, 1.0, 1.0],
+            [1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
         ]
     )
-    # No triangles: edges x 0-triangles.
-    incidence_2 = torch.zeros(3, 0)
-
-    x_0 = torch.arange(1, 4, dtype=torch.float).unsqueeze(1)
-    x_1 = torch.arange(1, 4, dtype=torch.float).unsqueeze(1)
-    x_2 = torch.zeros(0, 1)
-    return (x_0, x_1, x_2), (incidence_1, incidence_2)
+    incidence_1_2k3 = torch.block_diag(
+        torch.tensor([[1.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0]]),
+        torch.tensor([[1.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0]]),
+    )
+    incidence_2_2k3 = torch.tensor(
+        [
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 1.0],
+            [0.0, 1.0],
+        ]
+    )
+    c6 = (
+        (torch.ones(6, 1), torch.ones(6, 1), torch.empty(0, 1)),
+        (incidence_1_c6, torch.empty(6, 0)),
+    )
+    two_triangles = (
+        (torch.ones(6, 1), torch.ones(6, 1), torch.ones(2, 1)),
+        (incidence_1_2k3, incidence_2_2k3),
+    )
+    return c6, two_triangles
 
 
 def _make_model(in_channels_all=(1, 1, 1), hidden_dim=8, n_layers=3):
@@ -128,55 +136,350 @@ def test_forward_runs_end_to_end_and_is_finite():
     assert all(torch.isfinite(o).all() for o in outs)
 
 
-def test_learnable_epsilon_and_rank_specific_mlps_exist():
-    """Each layer has a learnable per-rank epsilon (init 0) and 3 distinct MLPs."""
-    n_layers = 3
-    model = _make_model(n_layers=n_layers)
+def test_mpsn_is_exported_without_private_layer_helpers():
+    """Auto-discovery exports the public backbone and no private layer type."""
+    import topobench.nn.backbones as backbones
 
-    assert len(model.layers) == n_layers
-    for layer in model.layers:
-        # learnable epsilons, one per rank, init 0.0
-        for r in range(3):
-            eps = getattr(layer, f"eps_{r}")
-            assert isinstance(eps, torch.nn.Parameter)
-            assert eps.requires_grad
-            assert eps.shape == torch.Size([])
-            assert float(eps) == 0.0
-        # one distinct MLP per rank
-        mlp_ids = {id(getattr(layer, f"mlp_{r}")) for r in range(3)}
-        assert len(mlp_ids) == 3
+    assert backbones.MODEL_CLASSES["MPSN"] is backbones.MPSN
+    assert backbones.MPSN.__name__ == MPSN.__name__
+    assert "_MPSNLayer" not in backbones.MODEL_CLASSES
+    assert not hasattr(backbones, "_MPSNLayer")
 
 
-def test_triangle_presence_changes_rank2_and_readout():
-    """A filled triangle yields a different rank-2 signal and graph readout
-    than the identical open 1-skeleton without the 2-cell.
+def test_one_layer_matches_supplement_equation_35_hand_calculation():
+    """A deterministic layer matches every term of Supplement Eq. 35.
 
-    This is the SWL > 1-WL capability: the 2-cell is read by the model. Two
-    complexes with identical node/edge structure but differing only in whether
-    the triangle is filled MUST produce different higher-rank signals; a 1-WL
-    GNN sees no difference.
+    Deliberately asymmetric maps make branch collapse, reversed pair fields,
+    lost neighbour/coface pairings, or reordered combine inputs observable.
+    Negative upper-message, upper-branch, and combine preactivations exercise
+    ELU's negative branch rather than reducing the oracle to linear arithmetic.
     """
-    model = _make_model()
+    model = MPSN(in_channels_all=(1, 1, 1), hidden_dim=1, n_layers=1)
+    with torch.no_grad():
+        for projection in (
+            model.in_linear_0,
+            model.in_linear_1,
+            model.in_linear_2,
+        ):
+            projection.weight.fill_(1.0)
+            projection.bias.zero_()
 
-    x_tri, inc_tri = _triangle_complex()
-    x_open, inc_open = _open_triad_complex()
+        for update in model.layers[0].rank_updates:
+            # M_B(z) = ELU(0.5 * ELU(2z - 1) + 1)
+            update.boundary_mlp[0].weight.fill_(2.0)
+            update.boundary_mlp[0].bias.fill_(-1.0)
+            update.boundary_mlp[2].weight.fill_(0.5)
+            update.boundary_mlp[2].bias.fill_(1.0)
 
-    out_tri = model(x_tri, inc_tri)
-    out_open = model(x_open, inc_open)
+            # M_up(z) = ELU(0.5 * ELU(0.5z - 2) + 1)
+            update.upper_mlp[0].weight.fill_(0.5)
+            update.upper_mlp[0].bias.fill_(-2.0)
+            update.upper_mlp[2].weight.fill_(0.5)
+            update.upper_mlp[2].bias.fill_(1.0)
 
-    # Rank-2 signal exists only when the triangle is filled.
-    assert out_tri[2].shape[0] == 1
-    assert out_open[2].shape[0] == 0
+            # M_U(b || u) = ELU(0.5b - 2u + 0.25)
+            update.combine_mlp[0].weight.copy_(torch.tensor([[0.5, -2.0]]))
+            update.combine_mlp[0].bias.fill_(0.25)
 
-    # Graph-level sum readout over all ranks differs because the 2-cell feeds in.
-    def _graph_readout(outs):
-        return sum(o.sum() for o in outs)
+            if update.upper_message_mlp is not None:
+                # M_M(h_neighbour || h_coface) = ELU(2h_neighbour - h_coface)
+                update.upper_message_mlp[0].weight.copy_(
+                    torch.tensor([[2.0, -1.0]])
+                )
+                update.upper_message_mlp[0].bias.zero_()
 
-    assert not torch.allclose(_graph_readout(out_tri), _graph_readout(out_open))
+    incidence_1 = torch.tensor(
+        [[1.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0]]
+    )
+    incidence_2 = torch.ones(3, 1)
+    features = (
+        torch.tensor([[1.0], [2.0], [4.0]]),
+        torch.tensor([[3.0], [5.0], [7.0]]),
+        torch.tensor([[11.0]]),
+    )
 
-    # The edge (rank-1) signal also differs: upper-adjacency among edges is
-    # routed through the shared triangle, present only in the filled complex.
-    assert not torch.allclose(out_tri[1], out_open[1])
+    actual = model(features, (incidence_1, incidence_2))
+
+    # Write E(z) = z for z >= 0 and exp(z)-1 otherwise.  The four maps above
+    # are therefore:
+    #   M_M(n,c)=E(2n-c), B(z)=E(0.5E(2z-1)+1),
+    #   U(z)=E(0.5E(0.5z-2)+1), C(b,u)=E(0.5b-2u+0.25).
+    #
+    # Rank 0 has no boundary.  Its ordered (neighbour, shared-edge) messages
+    # give upper inputs
+    #   [1 + 3, E(-1) + 1, E(-3) + E(-3)] + self
+    # = [5, 2.3678794412, 2.0995741367].
+    # Thus B=[1.5,2.5,4.5], U=[1.25,0.7210851274,0.6933293414],
+    # and C=[E(-1.5),0.0578297453,1.1133413172].
+    #
+    # Rank 1 boundary sums are [1+2,1+4,2+4]=[3,5,6], so its boundary inputs
+    # [6,10,13] yield B=[6.5,10.5,13.5].  Ordered messages through triangle 11
+    # give upper inputs [5.3678794412,7.0067379470,5.3746173882], hence
+    # U=[1.3419698603,1.7516844867,1.3436543470] and the listed final outputs.
+    # Rank 2 has boundary input 11+(3+5+7)=26 and empty-upper input 11:
+    # B=26.5, U=2.75, C=8.0.
+    expected = (
+        torch.tensor([[-0.77686984], [0.05782975], [1.11334133]]),
+        torch.tensor([[0.81606030], [1.99663103], [4.31269121]]),
+        torch.tensor([[8.0]]),
+    )
+
+    for actual_rank, expected_rank in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            actual_rank, expected_rank, atol=1e-6, rtol=0
+        )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA is required for accelerator routing",
+)
+def test_dense_cuda_incidence_requires_sparse_input():
+    """CUDA topology requires and correctly routes canonical sparse support."""
+    model = _make_model(hidden_dim=4, n_layers=1).cuda()
+    features, incidence = _triangle_complex()
+    cuda_features = tuple(feature.cuda() for feature in features)
+    dense_cuda_incidence = tuple(item.cuda() for item in incidence)
+
+    with pytest.raises(
+        ValueError, match="Dense accelerator incidence.*sparse"
+    ):
+        model(cuda_features, dense_cuda_incidence)
+
+    sparse_cuda_incidence = tuple(
+        item.to_sparse_coo().cuda() for item in incidence
+    )
+    outputs = model(cuda_features, sparse_cuda_incidence)
+    assert all(torch.isfinite(output).all() for output in outputs)
+
+
+def test_upper_messages_preserve_neighbor_shared_coface_pairing():
+    """Equal marginals with different upper pairings remain distinguishable.
+
+    The target edge belongs to both triangles.  Swapping the two coface feature
+    assignments preserves its four neighbours and both marginal feature sums,
+    but changes which coface feature is paired with each neighbour.
+    """
+    model = _make_model(hidden_dim=4, n_layers=1)
+    incidence_1 = torch.tensor(
+        [
+            [1.0, 1.0, 0.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 1.0],
+        ]
+    )
+    pairing_a = torch.tensor(
+        [
+            [1.0, 1.0],
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 1.0],
+        ]
+    )
+    features_a = (
+        torch.zeros(4, 1),
+        torch.tensor([[0.0], [1.0], [2.0], [4.0], [8.0]]),
+        torch.tensor([[2.0], [5.0]]),
+    )
+    features_b = (features_a[0], features_a[1], features_a[2].flip(0))
+
+    target_a = model(features_a, (incidence_1, pairing_a))[1][0]
+    target_b = model(features_b, (incidence_1, pairing_a))[1][0]
+
+    assert not torch.allclose(target_a, target_b, atol=1e-6, rtol=0)
+
+
+def test_dense_and_sparse_incidence_supports_are_equivalent():
+    """Dense and sparse COO representations define identical routing."""
+    model = _make_model(n_layers=2).eval()
+    features, dense_incidence = _triangle_complex()
+    sparse_incidence = tuple(
+        incidence.to_sparse_coo() for incidence in dense_incidence
+    )
+
+    dense_out = model(features, dense_incidence)
+    sparse_out = model(features, sparse_incidence)
+
+    for dense_rank, sparse_rank in zip(dense_out, sparse_out, strict=True):
+        torch.testing.assert_close(
+            dense_rank, sparse_rank, atol=1e-6, rtol=1e-6
+        )
+
+
+def test_incidence_signs_do_not_change_support_routing():
+    """Orientation signs do not affect the unsigned topological routes."""
+    model = _make_model(n_layers=2).eval()
+    features, unsigned = _triangle_complex()
+    signed = (
+        torch.tensor([[-1.0, -1.0, 0.0], [1.0, 0.0, -1.0], [0.0, 1.0, 1.0]]),
+        torch.tensor([[1.0], [-1.0], [1.0]]),
+    )
+    expected = model(features, unsigned)
+
+    for incidence in (signed, tuple(item.to_sparse() for item in signed)):
+        actual = model(features, incidence)
+        for expected_rank, actual_rank in zip(expected, actual, strict=True):
+            torch.testing.assert_close(
+                expected_rank, actual_rank, atol=1e-6, rtol=1e-6
+            )
+
+
+def test_simplex_permutation_equivariance():
+    """Consistent independent rank permutations only permute the outputs."""
+    model = _make_model(hidden_dim=4, n_layers=2).eval()
+    features = (
+        torch.tensor([[1.0], [2.0], [3.0], [4.0]]),
+        torch.tensor([[5.0], [6.0], [7.0], [8.0], [9.0]]),
+        torch.tensor([[10.0], [11.0]]),
+    )
+    incidence_1 = torch.tensor(
+        [
+            [1.0, 1.0, 0.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 1.0],
+        ]
+    )
+    incidence_2 = torch.tensor(
+        [
+            [1.0, 1.0],
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 1.0],
+        ]
+    )
+    permutations = (
+        torch.tensor([3, 1, 0, 2]),
+        torch.tensor([4, 2, 0, 3, 1]),
+        torch.tensor([1, 0]),
+    )
+
+    expected = model(features, (incidence_1, incidence_2))
+    permuted_features = tuple(
+        x[permutation]
+        for x, permutation in zip(features, permutations, strict=True)
+    )
+    permuted_incidence = (
+        incidence_1[permutations[0]][:, permutations[1]],
+        incidence_2[permutations[1]][:, permutations[2]],
+    )
+    actual = model(permuted_features, permuted_incidence)
+
+    for rank in range(3):
+        torch.testing.assert_close(
+            actual[rank],
+            expected[rank][permutations[rank]],
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+
+def test_disjoint_union_matches_concatenated_individual_outputs():
+    """Block-diagonal batching cannot pass messages between complexes."""
+    model = _make_model(hidden_dim=4, n_layers=2).eval()
+    features_a, incidence_a = _triangle_complex()
+    features_b = tuple(
+        feature + offset
+        for feature, offset in zip(features_a, (3.0, 5.0, 7.0), strict=True)
+    )
+    incidence_b = tuple(item.clone() for item in incidence_a)
+
+    outputs_a = model(features_a, incidence_a)
+    outputs_b = model(features_b, incidence_b)
+    union_features = tuple(
+        torch.cat((first, second), dim=0)
+        for first, second in zip(features_a, features_b, strict=True)
+    )
+    union_incidence = tuple(
+        torch.block_diag(first, second)
+        for first, second in zip(incidence_a, incidence_b, strict=True)
+    )
+    union_outputs = model(union_features, union_incidence)
+
+    for union_rank, first, second in zip(
+        union_outputs, outputs_a, outputs_b, strict=True
+    ):
+        torch.testing.assert_close(
+            union_rank,
+            torch.cat((first, second), dim=0),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+
+def test_empty_and_minimal_higher_ranks_work_in_train_and_eval():
+    """A lone vertex and a single edge need no artificial higher cells."""
+    cases = (
+        (
+            (torch.tensor([[1.0]]), torch.empty(0, 1), torch.empty(0, 1)),
+            (torch.empty(1, 0), torch.empty(0, 0)),
+        ),
+        (
+            (
+                torch.tensor([[1.0], [2.0]]),
+                torch.tensor([[3.0]]),
+                torch.empty(0, 1),
+            ),
+            (torch.ones(2, 1), torch.empty(1, 0)),
+        ),
+    )
+    model = _make_model(hidden_dim=4, n_layers=2)
+
+    for training in (True, False):
+        model.train(training)
+        for features, incidence in cases:
+            outputs = model(features, incidence)
+            for output, inputs in zip(outputs, features, strict=True):
+                assert output.shape == (inputs.shape[0], 4)
+                assert torch.isfinite(output).all()
+
+
+def test_every_trainable_branch_has_finite_gradients():
+    """A filled triangle exercises every registered trainable map."""
+    model = _make_model(hidden_dim=4, n_layers=1).train()
+    base_features, incidence = _triangle_complex()
+    features = tuple(x.clone().requires_grad_() for x in base_features)
+
+    outputs = model(features, incidence)
+    loss = sum(output.square().sum() for output in outputs)
+    loss.backward()
+
+    assert all(torch.isfinite(output).all() for output in outputs)
+    for feature in features:
+        assert feature.grad is not None
+        assert torch.isfinite(feature.grad).all()
+    for name, parameter in model.named_parameters():
+        assert parameter.grad is not None, f"no gradient reached {name}"
+        assert torch.isfinite(parameter.grad).all(), name
+
+
+def test_c6_and_two_disjoint_triangles_have_different_higher_order_readouts():
+    """The valid 1-WL-indistinguishable pair C6 and 2K3 separates after lift.
+
+    Both graphs have six vertices, six edges, degree two, and constant features.
+    Clique lifting creates no 2-simplices for C6 and two for 2K3.  This example
+    verifies that the backbone consumes that higher-order structure; it is not
+    a claim that this finite learned model realizes the full SWL test.
+    """
+    model = MPSN(in_channels_all=(1, 1, 1), hidden_dim=1, n_layers=1)
+    with torch.no_grad():
+        for module in model.modules():
+            if isinstance(module, torch.nn.Linear):
+                module.weight.fill_(1.0)
+                module.bias.zero_()
+    c6, two_triangles = _c6_and_two_triangles()
+
+    out_c6 = model(*c6)
+    out_2k3 = model(*two_triangles)
+    readout_c6 = sum(rank.sum() for rank in out_c6)
+    readout_2k3 = sum(rank.sum() for rank in out_2k3)
+
+    assert out_c6[2].shape[0] == 0
+    assert out_2k3[2].shape[0] == 2
+    assert not torch.allclose(readout_c6, readout_2k3)
 
 
 def test_upper_adjacency_uses_shared_coface_feature():

--- a/test/nn/backbones/simplicial/test_mpsn.py
+++ b/test/nn/backbones/simplicial/test_mpsn.py
@@ -326,6 +326,30 @@ def test_incidence_signs_do_not_change_support_routing():
             )
 
 
+def test_explicit_sparse_zeros_do_not_create_topological_routes():
+    """Explicit sparse zeros are excluded from incidence support."""
+    model = _make_model(n_layers=2).eval()
+    features, dense_incidence = _triangle_complex()
+    expected = model(features, dense_incidence)
+
+    sparse_with_zero = []
+    for incidence in dense_incidence:
+        canonical = incidence.to_sparse_coo().coalesce()
+        indices = torch.cat(
+            (canonical.indices(), torch.tensor([[0], [0]])), dim=1
+        )
+        values = torch.cat((canonical.values(), torch.zeros(1)))
+        sparse_with_zero.append(
+            torch.sparse_coo_tensor(indices, values, incidence.shape)
+        )
+
+    actual = model(features, tuple(sparse_with_zero))
+    for expected_rank, actual_rank in zip(expected, actual, strict=True):
+        torch.testing.assert_close(
+            expected_rank, actual_rank, atol=1e-6, rtol=1e-6
+        )
+
+
 def test_simplex_permutation_equivariance():
     """Consistent independent rank permutations only permute the outputs."""
     model = _make_model(hidden_dim=4, n_layers=2).eval()

--- a/test/nn/backbones/simplicial/test_mpsn.py
+++ b/test/nn/backbones/simplicial/test_mpsn.py
@@ -1,0 +1,224 @@
+"""Unit tests for the MPSN (Message Passing Simplicial Network) backbone.
+
+MPSN: Bodnar et al., "Weisfeiler and Lehman Go Topological: Message Passing
+Simplicial Networks", ICML 2021, arXiv:2103.03212.
+
+These tests assert behaviour on tiny, hand-built simplicial complexes (NO
+GraphUniverse loading). The central capability being verified is the one the
+model exists for: a complex *with* a filled triangle (2-simplex) yields a
+different rank-2 signal / graph-level readout than one *without* it, because the
+2-cell becomes a first-class object that boundary + upper-adjacency message
+passing can read. Plain 1-WL GNNs provably cannot do this.
+"""
+
+import torch
+
+from topobench.nn.backbones.simplicial.mpsn import MPSN
+
+
+# --------------------------------------------------------------------------- #
+# Helpers: tiny hand-built complexes (unsigned 0/1 incidences, as the clique  #
+# lifting produces with signed=False).                                         #
+# --------------------------------------------------------------------------- #
+def _triangle_complex():
+    """A single filled triangle on nodes {0,1,2}.
+
+    Nodes: 0,1,2 ; Edges: (0,1),(0,2),(1,2) ; Triangles: (0,1,2).
+
+    Returns
+    -------
+    tuple
+        ((x_0, x_1, x_2), (incidence_1, incidence_2)).
+    """
+    # incidence_1: nodes x edges  (node belongs to edge -> 1)
+    #   edge0=(0,1), edge1=(0,2), edge2=(1,2)
+    incidence_1 = torch.tensor(
+        [
+            [1.0, 1.0, 0.0],  # node 0 in e0, e1
+            [1.0, 0.0, 1.0],  # node 1 in e0, e2
+            [0.0, 1.0, 1.0],  # node 2 in e1, e2
+        ]
+    )
+    # incidence_2: edges x triangles  (edge belongs to triangle -> 1)
+    #   tri0 = (0,1,2) -> all three edges
+    incidence_2 = torch.tensor([[1.0], [1.0], [1.0]])
+
+    x_0 = torch.arange(1, 4, dtype=torch.float).unsqueeze(1)  # (3, 1)
+    x_1 = torch.arange(1, 4, dtype=torch.float).unsqueeze(1)  # (3, 1)
+    x_2 = torch.ones(1, 1)  # (1, 1)
+    return (x_0, x_1, x_2), (incidence_1, incidence_2)
+
+
+def _open_triad_complex():
+    """The SAME three nodes / three edges but the triangle is NOT filled.
+
+    Identical 1-skeleton to ``_triangle_complex`` but with zero 2-simplices, so
+    the only structural difference is the presence of the 2-cell.
+
+    Returns
+    -------
+    tuple
+        ((x_0, x_1, x_2), (incidence_1, incidence_2)).
+    """
+    incidence_1 = torch.tensor(
+        [
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ]
+    )
+    # No triangles: edges x 0-triangles.
+    incidence_2 = torch.zeros(3, 0)
+
+    x_0 = torch.arange(1, 4, dtype=torch.float).unsqueeze(1)
+    x_1 = torch.arange(1, 4, dtype=torch.float).unsqueeze(1)
+    x_2 = torch.zeros(0, 1)
+    return (x_0, x_1, x_2), (incidence_1, incidence_2)
+
+
+def _make_model(in_channels_all=(1, 1, 1), hidden_dim=8, n_layers=3):
+    """Construct an MPSN backbone with fixed seed for reproducibility.
+
+    Parameters
+    ----------
+    in_channels_all : tuple of int
+        Input channels on (nodes, edges, triangles).
+    hidden_dim : int
+        Hidden width (shared across ranks).
+    n_layers : int
+        Number of MPSN layers.
+
+    Returns
+    -------
+    MPSN
+        The constructed backbone.
+    """
+    torch.manual_seed(0)
+    return MPSN(
+        in_channels_all=in_channels_all,
+        hidden_dim=hidden_dim,
+        n_layers=n_layers,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                        #
+# --------------------------------------------------------------------------- #
+def test_per_rank_output_shapes():
+    """Forward returns one tensor per rank with hidden_dim width."""
+    hidden_dim = 8
+    model = _make_model(hidden_dim=hidden_dim)
+    x_all, inc_all = _triangle_complex()
+
+    x_0, x_1, x_2 = model(x_all, inc_all)
+
+    assert x_0.shape == (3, hidden_dim)
+    assert x_1.shape == (3, hidden_dim)
+    assert x_2.shape == (1, hidden_dim)
+
+
+def test_forward_runs_end_to_end_and_is_finite():
+    """The forward pass runs on a toy complex and produces finite outputs."""
+    model = _make_model()
+    x_all, inc_all = _triangle_complex()
+
+    outs = model(x_all, inc_all)
+
+    assert len(outs) == 3
+    assert all(torch.isfinite(o).all() for o in outs)
+
+
+def test_learnable_epsilon_and_rank_specific_mlps_exist():
+    """Each layer has a learnable per-rank epsilon (init 0) and 3 distinct MLPs."""
+    n_layers = 3
+    model = _make_model(n_layers=n_layers)
+
+    assert len(model.layers) == n_layers
+    for layer in model.layers:
+        # learnable epsilons, one per rank, init 0.0
+        for r in range(3):
+            eps = getattr(layer, f"eps_{r}")
+            assert isinstance(eps, torch.nn.Parameter)
+            assert eps.requires_grad
+            assert eps.shape == torch.Size([])
+            assert float(eps) == 0.0
+        # one distinct MLP per rank
+        mlp_ids = {id(getattr(layer, f"mlp_{r}")) for r in range(3)}
+        assert len(mlp_ids) == 3
+
+
+def test_triangle_presence_changes_rank2_and_readout():
+    """A filled triangle yields a different rank-2 signal and graph readout
+    than the identical open 1-skeleton without the 2-cell.
+
+    This is the SWL > 1-WL capability: the 2-cell is read by the model. Two
+    complexes with identical node/edge structure but differing only in whether
+    the triangle is filled MUST produce different higher-rank signals; a 1-WL
+    GNN sees no difference.
+    """
+    model = _make_model()
+
+    x_tri, inc_tri = _triangle_complex()
+    x_open, inc_open = _open_triad_complex()
+
+    out_tri = model(x_tri, inc_tri)
+    out_open = model(x_open, inc_open)
+
+    # Rank-2 signal exists only when the triangle is filled.
+    assert out_tri[2].shape[0] == 1
+    assert out_open[2].shape[0] == 0
+
+    # Graph-level sum readout over all ranks differs because the 2-cell feeds in.
+    def _graph_readout(outs):
+        return sum(o.sum() for o in outs)
+
+    assert not torch.allclose(_graph_readout(out_tri), _graph_readout(out_open))
+
+    # The edge (rank-1) signal also differs: upper-adjacency among edges is
+    # routed through the shared triangle, present only in the filled complex.
+    assert not torch.allclose(out_tri[1], out_open[1])
+
+
+def test_upper_adjacency_uses_shared_coface_feature():
+    """The rank-1 upper message reads the shared triangle's feature.
+
+    Two complexes identical except for the *feature value* on the filled
+    triangle must produce different edge embeddings, proving the upper message
+    incorporates h_{shared coface} (paper's M_up term), not just the
+    edge-edge adjacency pattern.
+    """
+    model = _make_model()
+
+    x_all, inc_all = _triangle_complex()
+    (x_0, x_1, x_2), (inc_1, inc_2) = x_all, inc_all
+
+    out_a = model((x_0, x_1, x_2), (inc_1, inc_2))
+    # Same topology, different triangle feature.
+    x_2_b = x_2 + 5.0
+    out_b = model((x_0, x_1, x_2_b), (inc_1, inc_2))
+
+    # Edge embeddings depend on the triangle feature via the upper message.
+    assert not torch.allclose(out_a[1], out_b[1])
+
+
+def test_node_upper_adjacency_through_shared_edge():
+    """Node (rank-0) embeddings depend on edge features via upper-adjacency.
+
+    Nodes have no boundary; their only neighbourhood is upper-adjacency through
+    a shared edge whose feature the message reads. Changing an edge feature must
+    change node embeddings.
+    """
+    model = _make_model()
+    (x_0, x_1, x_2), (inc_1, inc_2) = _triangle_complex()
+
+    out_a = model((x_0, x_1, x_2), (inc_1, inc_2))
+    x_1_b = x_1 + 3.0
+    out_b = model((x_0, x_1_b, x_2), (inc_1, inc_2))
+
+    assert not torch.allclose(out_a[0], out_b[0])
+
+
+def test_n_layers_configurable():
+    """n_layers controls the number of stacked MPSN layers."""
+    assert len(_make_model(n_layers=1).layers) == 1
+    assert len(_make_model(n_layers=4).layers) == 4

--- a/test/nn/wrappers/simplicial/test_mpsn_wrapper.py
+++ b/test/nn/wrappers/simplicial/test_mpsn_wrapper.py
@@ -111,7 +111,8 @@ def test_wrapper_also_handles_signed_fixture(sg1_clique_lifted):
     """The wrapper is robust to signed incidences (it uses the support only).
 
     The shared ``sg1_clique_lifted`` fixture lifts with ``signed=True``; the
-    backbone takes the absolute value, so the wrapper must still run end-to-end.
+    backbone extracts the nonzero support, so the wrapper must still run
+    end-to-end.
 
     Parameters
     ----------

--- a/test/nn/wrappers/simplicial/test_mpsn_wrapper.py
+++ b/test/nn/wrappers/simplicial/test_mpsn_wrapper.py
@@ -1,0 +1,127 @@
+"""Unit tests for the MPSN model wrapper.
+
+The wrapper unpacks the lifted batch (``x_0/x_1/x_2``, ``incidence_1/2``,
+``batch_0``, ``y``), calls the MPSN backbone using *only* the unsigned incidence
+matrices for routing, and returns the per-rank embeddings consumed by the
+readout. These tests run on a tiny clique-lifted graph (NO GraphUniverse).
+"""
+
+import pytest
+
+from topobench.nn.backbones.simplicial.mpsn import MPSN
+from topobench.nn.wrappers.simplicial.mpsn_wrapper import MPSNWrapper
+from topobench.transforms.liftings.graph2simplicial import (
+    SimplicialCliqueLifting,
+)
+
+
+def test_wrapper_is_auto_discovered():
+    """MPSNWrapper is exported via the wrappers auto-discovery (no manual init)."""
+    import topobench.nn.wrappers as wrappers
+
+    assert hasattr(wrappers, "MPSNWrapper")
+    assert "MPSNWrapper" in wrappers.WRAPPER_CLASSES
+
+
+@pytest.fixture
+def sg1_clique_lifted_unsigned(simple_graph_1):
+    """Clique-lift simple_graph_1 exactly as production does (unsigned, dim 2).
+
+    Parameters
+    ----------
+    simple_graph_1 : torch_geometric.data.Data
+        A simple graph data object (from the shared conftest).
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Lifted complex with unsigned 0/1 incidences and ``complex_dim = 2``.
+    """
+    lifting = SimplicialCliqueLifting(complex_dim=2, signed=False)
+    data = lifting(simple_graph_1)
+    data.batch_0 = "null"
+    return data
+
+
+def _build_wrapper(data, out_dim):
+    """Construct an MPSNWrapper around an MPSN backbone for the given complex.
+
+    Parameters
+    ----------
+    data : torch_geometric.data.Data
+        A clique-lifted complex carrying x_0/x_1/x_2.
+    out_dim : int
+        Hidden width / output channels.
+
+    Returns
+    -------
+    MPSNWrapper
+        The wrapper instance.
+    """
+    backbone = MPSN(
+        in_channels_all=(
+            data.x_0.shape[1],
+            data.x_1.shape[1],
+            data.x_2.shape[1],
+        ),
+        hidden_dim=out_dim,
+        n_layers=3,
+    )
+    return MPSNWrapper(backbone, out_channels=out_dim, num_cell_dimensions=3)
+
+
+def test_wrapper_returns_expected_keys(sg1_clique_lifted_unsigned):
+    """The wrapper output exposes labels, batch_0 and per-rank embeddings.
+
+    Parameters
+    ----------
+    sg1_clique_lifted_unsigned : torch_geometric.data.Data
+        Unsigned clique-lifted complex.
+    """
+    data = sg1_clique_lifted_unsigned
+    wrapper = _build_wrapper(data, out_dim=8)
+
+    out = wrapper(data)
+
+    for key in ["labels", "batch_0", "x_0", "x_1", "x_2"]:
+        assert key in out
+
+
+def test_wrapper_per_rank_shapes(sg1_clique_lifted_unsigned):
+    """Per-rank embeddings have the right cell counts and hidden width.
+
+    Parameters
+    ----------
+    sg1_clique_lifted_unsigned : torch_geometric.data.Data
+        Unsigned clique-lifted complex.
+    """
+    data = sg1_clique_lifted_unsigned
+    out_dim = 8
+    wrapper = _build_wrapper(data, out_dim=out_dim)
+
+    out = wrapper(data)
+
+    assert out["x_0"].shape == (data.x_0.shape[0], out_dim)
+    assert out["x_1"].shape == (data.x_1.shape[0], out_dim)
+    assert out["x_2"].shape == (data.x_2.shape[0], out_dim)
+    assert out["labels"] is data.y
+
+
+def test_wrapper_also_handles_signed_fixture(sg1_clique_lifted):
+    """The wrapper is robust to signed incidences (it uses the support only).
+
+    The shared ``sg1_clique_lifted`` fixture lifts with ``signed=True``; the
+    backbone takes the absolute value, so the wrapper must still run end-to-end.
+
+    Parameters
+    ----------
+    sg1_clique_lifted : torch_geometric.data.Data
+        Signed clique-lifted complex (from the shared conftest).
+    """
+    data = sg1_clique_lifted
+    wrapper = _build_wrapper(data, out_dim=4)
+
+    out = wrapper(data)
+
+    for key in ["labels", "batch_0", "x_0", "x_1", "x_2"]:
+        assert key in out

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "simplicial/mpsn"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/simplicial/mpsn.py
+++ b/topobench/nn/backbones/simplicial/mpsn.py
@@ -8,9 +8,9 @@ shared coface before aggregation.
 
 Routing is derived solely from the support of the two incidence matrices. It
 is therefore independent of incidence signs and orientations, and it never
-constructs a dense or square adjacency matrix. Sparse inputs must use canonical
-incidence storage without explicit zero values. For sparse input on a rank-two
-simplicial complex with ``I`` incidence entries and ``P`` ordered upper routes,
+constructs a dense or square adjacency matrix. Explicitly stored sparse zeros
+are excluded from the incidence support. For sparse input on a rank-two
+simplicial complex with ``I`` nonzero incidences and ``P`` ordered upper routes,
 construction takes ``O(I log I + P)`` time and ``O(I + P)`` memory. Dense CPU
 input is supported, but extracting its support necessarily scans the dense
 incidence storage. Accelerator incidence must be sparse.
@@ -65,18 +65,17 @@ class _SimplicialRoutes:
 def _incidence_routes(incidence: torch.Tensor) -> _IncidenceRoutes:
     """Extract face/coface indices from dense or sparse incidence support.
 
-    Incidence values are intentionally ignored: signed and unsigned matrices
-    with the same stored pattern define the same topology. Sparse incidence
-    must not store explicit zeros. Dense incidence is supported on CPU only;
-    accelerators require a sparse tensor so extracting support cannot introduce
-    a device-to-host synchronization.
+    Incidence signs and magnitudes are intentionally ignored: signed and
+    unsigned matrices with the same nonzero support define the same topology.
+    Explicitly stored sparse zeros are filtered from that support. Dense
+    incidence is supported on CPU only; accelerators require a sparse tensor so
+    extracting support cannot introduce a device-to-host synchronization.
 
     Parameters
     ----------
     incidence : torch.Tensor
         Rank-two face-to-coface incidence matrix. Dense CPU and sparse tensors
-        on any supported device are accepted. Sparse tensors must use canonical
-        storage without explicit zero values.
+        on any supported device are accepted.
 
     Returns
     -------
@@ -98,7 +97,7 @@ def _incidence_routes(incidence: torch.Tensor) -> _IncidenceRoutes:
         indices = torch.nonzero(incidence, as_tuple=False).transpose(0, 1)
     else:
         coalesced = incidence.to_sparse_coo().coalesce()
-        indices = coalesced.indices()
+        indices = coalesced.indices()[:, coalesced.values() != 0]
     return _IncidenceRoutes(face=indices[0], coface=indices[1])
 
 
@@ -437,8 +436,7 @@ class MPSN(torch.nn.Module):
             and ``[N_1, N_2]``. They may be signed or unsigned. Sparse tensors
             are accepted on any device; dense tensors are CPU-only. Each valid
             edge column of ``B_1`` must contain two nonzeros and each valid
-            triangle column of ``B_2`` must contain three nonzeros. Sparse
-            tensors must not contain explicitly stored zero values.
+            triangle column of ``B_2`` must contain three nonzeros.
 
         Returns
         -------

--- a/topobench/nn/backbones/simplicial/mpsn.py
+++ b/topobench/nn/backbones/simplicial/mpsn.py
@@ -1,338 +1,463 @@
-"""Message Passing Simplicial Network (MPSN) backbone.
+"""Sparse boundary-plus-upper SIN/MPSN backbone.
 
-Native implementation of the boundary + upper-adjacency, GIN-style MPSN variant.
+This module implements the concrete Simplicial Isomorphism Network (SIN)
+update from Supplement Equation 35 of Bodnar et al. [1]_.  For each simplex,
+the boundary and upper-adjacency multisets are transformed independently.  An
+upper message receives the *paired* features of an upper neighbour and their
+shared coface before aggregation.
 
-Plain message-passing GNNs are bounded by the 1-Weisfeiler-Lehman (1-WL) test and
-cannot count triangles. MPSN lifts each triangle to a 2-simplex (clique lifting)
-and runs message passing over the resulting simplicial complex; its Simplicial-WL
-colour refinement is strictly more powerful than 1-WL and no less powerful than
-3-WL, so triangles become first-class cells the network can read and count [1].
+Routing is derived solely from the support of the two incidence matrices. It
+is therefore independent of incidence signs and orientations, and it never
+constructs a dense or square adjacency matrix. Sparse inputs must use canonical
+incidence storage without explicit zero values. For sparse input on a rank-two
+simplicial complex with ``I`` incidence entries and ``P`` ordered upper routes,
+construction takes ``O(I log I + P)`` time and ``O(I + P)`` memory. Dense CPU
+input is supported, but extracting its support necessarily scans the dense
+incidence storage. Accelerator incidence must be sparse.
 
-We implement the canonical efficient variant (matching CIN): for a simplex of rank
-r we use boundary and upper-adjacency messages only (co-boundary and lower-adjacency
-are dropped, which the paper proves retains full SWL power). With an injective,
-GIN-style update (Xu et al., 2019) and a learnable per-rank epsilon, one layer is
-
-    h_r^{t+1} = MLP_r( (1 + eps_r) h_r + m_boundary + m_upper ),
-
-where the boundary message sums the features of a simplex's (r-1)-faces and the
-upper message sums, over rank-r neighbours sharing a common (r+1)-coface, both the
-neighbour feature and the shared-coface feature.
-
-Routing uses only the unsigned clique-lifted incidence matrices B1 (node-to-edge)
-and B2 (edge-to-triangle); the boundary, upper-adjacency and shared-coface terms
-are all derived from these (no Hodge Laplacians). The lifting is unsigned, so no
-orientation/sign handling is needed and the MLP activation is a plain ReLU.
+The boundary, upper-adjacency, and generic message-passing definitions are
+given by main-paper Equations 2, 5, and 6, respectively.  Theorem 6 shows that
+boundary and upper messages suffice for the corresponding colour refinement.
+Theorem 10's expressivity conclusion is conditional on injective aggregation;
+this finite learned network does not claim guaranteed injectivity or automatic
+equivalence to the full SWL procedure.  The implementation was derived from
+the paper and checked against the authors' public ``SparseCINCochainConv`` and
+``SparseCINConv`` implementation.
 
 References
 ----------
-.. [1] Bodnar, Frasca, Wang, Otter, Montúfar, Liò, Bronstein.
-   Weisfeiler and Lehman Go Topological: Message Passing Simplicial Networks.
-   ICML 2021 (Spotlight). https://arxiv.org/abs/2103.03212
+.. [1] Bodnar, Frasca, Wang, Otter, Montufar, Lio, Bronstein. "Weisfeiler and
+   Lehman Go Topological: Message Passing Simplicial Networks." ICML 2021.
+   Supplement Eq. 35. https://proceedings.mlr.press/v139/bodnar21a.html
 """
+
+from dataclasses import dataclass
 
 import torch
 
 
-def _to_dense(matrix: torch.Tensor) -> torch.Tensor:
-    """Return a dense, unsigned (0/1) version of an incidence matrix.
+@dataclass(frozen=True)
+class _IncidenceRoutes:
+    """Stored support of one face-to-coface incidence matrix."""
 
-    The clique lifting emits sparse COO incidence matrices with ``signed=False``,
-    i.e. already 0/1. We densify (toy/complex-sized routing operators) and take
-    the absolute value so the support is used regardless of any sign convention.
+    face: torch.Tensor
+    coface: torch.Tensor
+
+
+@dataclass(frozen=True)
+class _RankRoutes:
+    """Sparse senders and receivers used to update one simplex rank."""
+
+    boundary_sender: torch.Tensor
+    boundary_receiver: torch.Tensor
+    upper_receiver: torch.Tensor
+    upper_neighbor: torch.Tensor
+    upper_coface: torch.Tensor
+
+
+@dataclass(frozen=True)
+class _SimplicialRoutes:
+    """Routing for all ranks, built once and reused by every MPSN layer."""
+
+    by_rank: tuple[_RankRoutes, _RankRoutes, _RankRoutes]
+
+
+def _incidence_routes(incidence: torch.Tensor) -> _IncidenceRoutes:
+    """Extract face/coface indices from dense or sparse incidence support.
+
+    Incidence values are intentionally ignored: signed and unsigned matrices
+    with the same stored pattern define the same topology. Sparse incidence
+    must not store explicit zeros. Dense incidence is supported on CPU only;
+    accelerators require a sparse tensor so extracting support cannot introduce
+    a device-to-host synchronization.
 
     Parameters
     ----------
-    matrix : torch.Tensor
-        Sparse or dense incidence matrix.
+    incidence : torch.Tensor
+        Rank-two face-to-coface incidence matrix. Dense CPU and sparse tensors
+        on any supported device are accepted. Sparse tensors must use canonical
+        storage without explicit zero values.
+
+    Returns
+    -------
+    _IncidenceRoutes
+        Row (face) and column (coface) indices of nonzero entries.
+
+    Raises
+    ------
+    ValueError
+        If a dense accelerator incidence tensor is supplied.
+    """
+    if incidence.layout == torch.strided:
+        if incidence.device.type != "cpu":
+            msg = (
+                "Dense accelerator incidence is unsupported; provide sparse "
+                "incidence for accelerator routing."
+            )
+            raise ValueError(msg)
+        indices = torch.nonzero(incidence, as_tuple=False).transpose(0, 1)
+    else:
+        coalesced = incidence.to_sparse_coo().coalesce()
+        indices = coalesced.indices()
+    return _IncidenceRoutes(face=indices[0], coface=indices[1])
+
+
+def _upper_routes(
+    incidence: _IncidenceRoutes,
+    faces_per_coface: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Expand grouped incidences into ordered upper-neighbour routes.
+
+    A valid simplicial incidence has exactly ``faces_per_coface`` entries per
+    column (two vertices per edge or three edges per triangle).  Grouping by
+    coface and applying a fixed-size off-diagonal expansion produces the two
+    ordered vertex routes per edge and six ordered edge routes per triangle.
+
+    Parameters
+    ----------
+    incidence : _IncidenceRoutes
+        Nonzero face/coface incidence indices grouped by this function.
+    faces_per_coface : int
+        Required number of faces in each coface: two for edges or three for
+        triangles.
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        Receiver-simplex, neighbour-simplex, and shared-coface indices for
+        every ordered upper route.
+    """
+    order = torch.argsort(incidence.coface)
+    grouped_faces = incidence.face[order].reshape(-1, faces_per_coface)
+    grouped_cofaces = incidence.coface[order].reshape(-1, faces_per_coface)
+    off_diagonal = ~torch.eye(
+        faces_per_coface,
+        dtype=torch.bool,
+        device=incidence.face.device,
+    )
+
+    receiver = grouped_faces[:, :, None].expand(
+        -1, faces_per_coface, faces_per_coface
+    )[:, off_diagonal]
+    neighbor = grouped_faces[:, None, :].expand(
+        -1, faces_per_coface, faces_per_coface
+    )[:, off_diagonal]
+    route_count = faces_per_coface * (faces_per_coface - 1)
+    coface = grouped_cofaces[:, :1].expand(-1, route_count)
+    return receiver.reshape(-1), neighbor.reshape(-1), coface.reshape(-1)
+
+
+def _build_routes(
+    incidence_1: torch.Tensor,
+    incidence_2: torch.Tensor,
+) -> _SimplicialRoutes:
+    """Build sparse boundary and upper routes for ranks zero through two.
+
+    Parameters
+    ----------
+    incidence_1 : torch.Tensor
+        Vertex-to-edge incidence matrix.
+    incidence_2 : torch.Tensor
+        Edge-to-triangle incidence matrix.
+
+    Returns
+    -------
+    _SimplicialRoutes
+        Boundary and ordered upper routes for all three simplex ranks.
+    """
+    b1 = _incidence_routes(incidence_1)
+    b2 = _incidence_routes(incidence_2)
+    empty = b1.face.new_empty(0)
+
+    upper_0 = _upper_routes(b1, faces_per_coface=2)
+    upper_1 = _upper_routes(b2, faces_per_coface=3)
+    return _SimplicialRoutes(
+        by_rank=(
+            _RankRoutes(empty, empty, *upper_0),
+            _RankRoutes(b1.face, b1.coface, *upper_1),
+            _RankRoutes(b2.face, b2.coface, empty, empty, empty),
+        )
+    )
+
+
+def _scatter_sum(
+    messages: torch.Tensor,
+    receiver: torch.Tensor,
+    output_size: int,
+) -> torch.Tensor:
+    """Sum messages at receiver indices without materializing adjacency.
+
+    Parameters
+    ----------
+    messages : torch.Tensor
+        Route messages shaped ``[num_routes, hidden_dim]``.
+    receiver : torch.Tensor
+        Destination simplex index for every route.
+    output_size : int
+        Number of destination simplices.
 
     Returns
     -------
     torch.Tensor
-        Dense unsigned incidence matrix.
+        Summed messages shaped ``[output_size, hidden_dim]``.
     """
-    if matrix.is_sparse:
-        matrix = matrix.to_dense()
-    return matrix.abs()
+    output = messages.new_zeros((output_size, messages.shape[-1]))
+    return output.index_add_(0, receiver, messages)
 
 
-def _upper_adjacency(boundary_next: torch.Tensor) -> torch.Tensor:
-    """Build the rank-r upper-adjacency neighbour operator.
-
-    Two rank-r simplices are upper-adjacent when they share a common (r+1)-coface.
-    With ``boundary_next`` the unsigned rank-r to rank-(r+1) incidence B (shape
-    ``[N_r, N_{r+1}]``), the co-adjacency counts are the off-diagonal of
-    ``boundary_next @ boundary_next.T``; the diagonal (a simplex's own coface
-    count) is removed so a simplex is not its own neighbour.
+def _two_layer_mlp(input_dim: int, output_dim: int) -> torch.nn.Sequential:
+    """Return the two-layer ELU perceptron used by Eq. 35 branches.
 
     Parameters
     ----------
-    boundary_next : torch.Tensor
-        Dense unsigned incidence of shape ``[N_r, N_{r+1}]``.
+    input_dim : int
+        Input feature width.
+    output_dim : int
+        Hidden and output feature width.
 
     Returns
     -------
-    torch.Tensor
-        Dense ``[N_r, N_r]`` upper-adjacency operator (zero diagonal). Applying it
-        to rank-r features sums, for each simplex, its upper-adjacent neighbours.
+    torch.nn.Sequential
+        Two linear layers, each followed by ELU.
     """
-    adjacency = boundary_next @ boundary_next.transpose(0, 1)
-    adjacency = adjacency - torch.diag(torch.diagonal(adjacency))
-    return adjacency
+    return torch.nn.Sequential(
+        torch.nn.Linear(input_dim, output_dim),
+        torch.nn.ELU(),
+        torch.nn.Linear(output_dim, output_dim),
+        torch.nn.ELU(),
+    )
 
 
-class MPSNLayer(torch.nn.Module):
-    """One MPSN layer: boundary + upper-adjacency messages, GIN-style update.
+def _linear_elu(input_dim: int, output_dim: int) -> torch.nn.Sequential:
+    """Return the dense-layer-plus-ELU maps used by Eq. 35.
 
-    Applies, for every rank r in {0, 1, 2} simultaneously, the boundary + upper
-    update of Bodnar et al. (2021),
+    Parameters
+    ----------
+    input_dim : int
+        Input feature width.
+    output_dim : int
+        Output feature width.
 
-        h_r^{t+1} = MLP_r( (1 + eps_r) h_r + m_boundary + m_upper ).
+    Returns
+    -------
+    torch.nn.Sequential
+        One linear layer followed by ELU.
+    """
+    return torch.nn.Sequential(
+        torch.nn.Linear(input_dim, output_dim),
+        torch.nn.ELU(),
+    )
 
-    Each rank owns a distinct MLP and a learnable scalar epsilon (initialised to
-    0.0), matching the injective GIN-style aggregator of Xu et al. (2019). Ranks
-    whose boundary or upper neighbourhood is empty simply omit that term (rank 0
-    has no boundary; rank 2 has no upper-adjacency).
+
+class _SINRankUpdate(torch.nn.Module):
+    """Equation 35 update for one rank in one layer.
+
+    All applicable maps are private to this rank/layer; the top rank omits the
+    structurally unreachable pair-message map.  Both self coefficients are
+    fixed to ``1 + eps = 1`` as in the SIN experiment; they are not parameters.
+    Empty neighbourhoods contribute an all-zero aggregate while their branch
+    still transforms the simplex's own representation.
 
     Parameters
     ----------
     hidden_dim : int
-        Feature width shared by all ranks.
+        Feature width shared by all simplex ranks.
+    has_upper_messages : bool
+        Whether this rank can have higher-dimensional cofaces and therefore
+        needs the pair-message map.
+    """
+
+    def __init__(self, hidden_dim: int, has_upper_messages: bool) -> None:
+        super().__init__()
+        self.boundary_mlp = _two_layer_mlp(hidden_dim, hidden_dim)
+        self.upper_message_mlp = (
+            _linear_elu(2 * hidden_dim, hidden_dim)
+            if has_upper_messages
+            else None
+        )
+        self.upper_mlp = _two_layer_mlp(hidden_dim, hidden_dim)
+        self.combine_mlp = _linear_elu(2 * hidden_dim, hidden_dim)
+
+    def forward(
+        self,
+        x_self: torch.Tensor,
+        x_boundary: torch.Tensor | None,
+        x_coface: torch.Tensor | None,
+        routes: _RankRoutes,
+    ) -> torch.Tensor:
+        """Apply the separate boundary and upper branches for one rank.
+
+        Parameters
+        ----------
+        x_self : torch.Tensor
+            Features for the simplices being updated.
+        x_boundary : torch.Tensor or None
+            Features for their boundary faces, or ``None`` at rank zero.
+        x_coface : torch.Tensor or None
+            Features for their cofaces, or ``None`` at the top rank.
+        routes : _RankRoutes
+            Sparse boundary and ordered upper routes for this rank.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated simplex features with the same shape as ``x_self``.
+        """
+        boundary_sum = x_self.new_zeros(x_self.shape)
+        if x_boundary is not None:
+            boundary_sum = _scatter_sum(
+                x_boundary[routes.boundary_sender],
+                routes.boundary_receiver,
+                x_self.shape[0],
+            )
+
+        upper_sum = x_self.new_zeros(x_self.shape)
+        if x_coface is not None:
+            if self.upper_message_mlp is None:
+                msg = "Upper cofaces require an upper-message map."
+                raise RuntimeError(msg)
+            upper_inputs = torch.cat(
+                (
+                    x_self[routes.upper_neighbor],
+                    x_coface[routes.upper_coface],
+                ),
+                dim=-1,
+            )
+            upper_sum = _scatter_sum(
+                self.upper_message_mlp(upper_inputs),
+                routes.upper_receiver,
+                x_self.shape[0],
+            )
+
+        boundary_branch = self.boundary_mlp(x_self + boundary_sum)
+        upper_branch = self.upper_mlp(x_self + upper_sum)
+        return self.combine_mlp(
+            torch.cat((boundary_branch, upper_branch), dim=-1)
+        )
+
+
+class _MPSNLayer(torch.nn.Module):
+    """One sparse boundary-plus-upper SIN layer for ranks zero to two.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Feature width shared by all simplex ranks.
     """
 
     def __init__(self, hidden_dim: int) -> None:
         super().__init__()
         self.hidden_dim = hidden_dim
+        self.rank_updates = torch.nn.ModuleList(
+            _SINRankUpdate(hidden_dim, has_upper_messages=rank < 2)
+            for rank in range(3)
+        )
 
-        # One distinct MLP per rank (0, 1, 2): Linear -> ReLU -> Linear, no norm.
-        for r in range(3):
-            mlp = torch.nn.Sequential(
-                torch.nn.Linear(hidden_dim, hidden_dim),
-                torch.nn.ReLU(),
-                torch.nn.Linear(hidden_dim, hidden_dim),
-            )
-            setattr(self, f"mlp_{r}", mlp)
-            # Learnable per-rank epsilon, init 0.0 (GIN-style injective update).
-            setattr(
-                self,
-                f"eps_{r}",
-                torch.nn.Parameter(torch.zeros(())),
-            )
-
-    def _boundary_message(
-        self, boundary: torch.Tensor, x_face: torch.Tensor
-    ) -> torch.Tensor:
-        """Boundary message: sum of the features of a simplex's (r-1)-faces.
-
-        With ``boundary`` the rank-(r-1) to rank-r incidence B (shape
-        ``[N_{r-1}, N_r]``), ``boundary.T @ x_face`` gathers, for each rank-r
-        simplex, the sum of its faces' features.
-
-        Parameters
-        ----------
-        boundary : torch.Tensor
-            Dense unsigned incidence of shape ``[N_{r-1}, N_r]``.
-        x_face : torch.Tensor
-            Features of the (r-1)-faces, shape ``[N_{r-1}, hidden]``.
-
-        Returns
-        -------
-        torch.Tensor
-            Boundary message per rank-r simplex, shape ``[N_r, hidden]``.
-        """
-        return boundary.transpose(0, 1) @ x_face
-
-    def _upper_message(
+    def forward(
         self,
-        upper_adjacency: torch.Tensor,
-        boundary_next: torch.Tensor,
-        x_self: torch.Tensor,
-        x_coface: torch.Tensor,
-        coface_multiplicity: float,
-    ) -> torch.Tensor:
-        """Upper-adjacency message for one rank.
-
-        Sums, over each rank-r simplex's upper-adjacent neighbours, both the
-        neighbour feature and the shared-coface feature. The neighbour term is the
-        upper-adjacency operator applied to the rank's own features. The
-        shared-coface term is computed exactly from the coface multiplicity: in a
-        simple-graph clique complex with ``complex_dim = 2`` two upper-adjacent
-        simplices share exactly one coface, so summing cofaces (via
-        ``boundary_next @ x_coface``) weighted by ``|faces_r(coface)| - 1`` gives
-        the shared-coface contribution -- multiplicity 1 for rank 0 (each edge has
-        2 nodes) and 2 for rank 1 (each triangle has 3 edges).
-
-        Parameters
-        ----------
-        upper_adjacency : torch.Tensor
-            Dense ``[N_r, N_r]`` upper-adjacency operator (zero diagonal).
-        boundary_next : torch.Tensor
-            Dense unsigned incidence of shape ``[N_r, N_{r+1}]``.
-        x_self : torch.Tensor
-            Features of the rank-r simplices, shape ``[N_r, hidden]``.
-        x_coface : torch.Tensor
-            Features of the rank-(r+1) cofaces, shape ``[N_{r+1}, hidden]``.
-        coface_multiplicity : float
-            ``|faces_r(coface)| - 1``: 1 for rank 0, 2 for rank 1.
-
-        Returns
-        -------
-        torch.Tensor
-            Upper message per rank-r simplex, shape ``[N_r, hidden]``.
-        """
-        neighbour_term = upper_adjacency @ x_self
-        coface_term = coface_multiplicity * (boundary_next @ x_coface)
-        return neighbour_term + coface_term
-
-    def _update(
-        self, rank: int, x_self: torch.Tensor, message: torch.Tensor
-    ) -> torch.Tensor:
-        """GIN-style injective update for one rank.
-
-        Returns ``MLP_r( (1 + eps_r) * x_self + message )``, where ``message`` is
-        the sum of the available boundary and upper messages for the rank.
-
-        Parameters
-        ----------
-        rank : int
-            Rank r in {0, 1, 2}.
-        x_self : torch.Tensor
-            Current features of the rank-r simplices.
-        message : torch.Tensor
-            Aggregated boundary + upper message for this rank.
-
-        Returns
-        -------
-        torch.Tensor
-            Updated rank-r features.
-        """
-        eps = getattr(self, f"eps_{rank}")
-        mlp = getattr(self, f"mlp_{rank}")
-        return mlp((1.0 + eps) * x_self + message)
-
-    def forward(self, x_all, incidence_all):
-        """Apply one MPSN layer to all three ranks.
+        x_all: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        routes: _SimplicialRoutes,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Update all ranks from the same precomputed sparse routes.
 
         Parameters
         ----------
         x_all : tuple of torch.Tensor
-            Current features ``(x_0, x_1, x_2)``.
-        incidence_all : tuple of torch.Tensor
-            Dense unsigned operators ``(B1, B2, upper_adj_0, upper_adj_1)`` where
-            ``B1`` is the node-to-edge incidence, ``B2`` the edge-to-triangle
-            incidence, and ``upper_adj_0`` / ``upper_adj_1`` the precomputed rank-0
-            / rank-1 upper-adjacency operators.
+            Hidden features for vertices, edges, and triangles, each shaped
+            ``[num_simplices_at_rank, hidden_dim]``.
+        routes : _SimplicialRoutes
+            Boundary and ordered upper routes shared by all network layers.
 
         Returns
         -------
         tuple of torch.Tensor
-            Updated features ``(x_0, x_1, x_2)``.
+            Updated vertex, edge, and triangle features with the same shapes as
+            ``x_all``.
         """
         x_0, x_1, x_2 = x_all
-        b1, b2, upper_adj_0, upper_adj_1 = incidence_all
-
-        # ---- rank 0 (nodes): no boundary; upper-adjacency via shared edge ----
-        msg_0 = self._upper_message(
-            upper_adjacency=upper_adj_0,
-            boundary_next=b1,
-            x_self=x_0,
-            x_coface=x_1,
-            coface_multiplicity=1.0,  # each edge-coface has 2 nodes -> 2-1 = 1
+        return (
+            self.rank_updates[0](x_0, None, x_1, routes.by_rank[0]),
+            self.rank_updates[1](x_1, x_0, x_2, routes.by_rank[1]),
+            self.rank_updates[2](x_2, x_1, None, routes.by_rank[2]),
         )
-        new_x_0 = self._update(0, x_0, msg_0)
-
-        # ---- rank 1 (edges): boundary = 2 nodes; upper via shared triangle ----
-        msg_1 = self._boundary_message(b1, x_0)
-        if x_2.shape[0] > 0:
-            msg_1 = (
-                msg_1
-                + self._upper_message(
-                    upper_adjacency=upper_adj_1,
-                    boundary_next=b2,
-                    x_self=x_1,
-                    x_coface=x_2,
-                    coface_multiplicity=2.0,  # each tri-coface has 3 edges -> 3-1 = 2
-                )
-            )
-        new_x_1 = self._update(1, x_1, msg_1)
-
-        # ---- rank 2 (triangles): boundary = 3 edges; upper is empty ----
-        if x_2.shape[0] > 0:
-            msg_2 = self._boundary_message(b2, x_1)
-            new_x_2 = self._update(2, x_2, msg_2)
-        else:
-            new_x_2 = x_2
-
-        return new_x_0, new_x_1, new_x_2
 
 
 class MPSN(torch.nn.Module):
-    """Message Passing Simplicial Network (boundary + upper-adjacency variant).
+    """Boundary-plus-upper SIN instantiation of the MPSN framework.
 
-    Lifts node features to higher-rank cells with per-rank input projections, then
-    stacks ``n_layers`` :class:`MPSNLayer` blocks. Each layer performs the
-    injective, GIN-style simplicial update of Bodnar et al. (2021) (boundary +
-    upper-adjacency messages), whose SWL colour refinement is strictly more
-    powerful than 1-WL and no weaker than 3-WL, so the 2-cells (triangles) become
-    countable, first-class objects.
+    The public TopoBench seam is unchanged: input and output features are
+    tuples ordered by simplex rank, while topology is provided by node-edge
+    and edge-triangle incidence matrices.  The sparse routes are constructed
+    once per forward pass and reused by every layer.
+
+    This is the concrete update from Supplement Equation 35, adapted to
+    TopoBench's rank-zero-through-two interface.  The architecture uses the
+    boundary and upper neighbourhoods justified by Theorem 6.  It does not
+    assert the injective-aggregation premise required by Theorem 10.
 
     Parameters
     ----------
     in_channels_all : tuple of int
-        Input feature dimensions on ``(nodes, edges, triangles)``.
+        Input feature dimensions on nodes, edges, and triangles.
     hidden_dim : int
-        Hidden width shared across all ranks (default 64).
+        Hidden width shared by all ranks.
     n_layers : int
-        Number of stacked MPSN layers (default 3).
+        Number of stacked SIN layers.
     """
 
     def __init__(
-        self, in_channels_all, hidden_dim: int = 64, n_layers: int = 3
+        self,
+        in_channels_all: tuple[int, int, int],
+        hidden_dim: int = 64,
+        n_layers: int = 3,
     ) -> None:
         super().__init__()
         self.hidden_dim = hidden_dim
-
-        # Per-rank input projection to the shared hidden width.
         self.in_linear_0 = torch.nn.Linear(in_channels_all[0], hidden_dim)
         self.in_linear_1 = torch.nn.Linear(in_channels_all[1], hidden_dim)
         self.in_linear_2 = torch.nn.Linear(in_channels_all[2], hidden_dim)
-
         self.layers = torch.nn.ModuleList(
-            MPSNLayer(hidden_dim) for _ in range(n_layers)
+            _MPSNLayer(hidden_dim) for _ in range(n_layers)
         )
 
-    def forward(self, x_all, incidence_all):
-        """Forward pass over the simplicial complex.
+    def forward(
+        self,
+        x_all: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        incidence_all: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project features, build routes once, then apply all SIN layers.
 
         Parameters
         ----------
         x_all : tuple of torch.Tensor
-            Input features ``(x_0, x_1, x_2)`` on nodes, edges, triangles.
+            Features ``(x_0, x_1, x_2)`` shaped ``[N_r, in_channels_r]`` for
+            vertices, edges, and triangles.
         incidence_all : tuple of torch.Tensor
-            ``(incidence_1, incidence_2)``: the unsigned clique-lifted incidence
-            matrices B1 (node-to-edge) and B2 (edge-to-triangle). May be sparse
-            COO; densified and ``.abs()``-ed internally. Used only for routing.
+            Face-to-coface matrices ``(B_1, B_2)`` with shapes ``[N_0, N_1]``
+            and ``[N_1, N_2]``. They may be signed or unsigned. Sparse tensors
+            are accepted on any device; dense tensors are CPU-only. Each valid
+            edge column of ``B_1`` must contain two nonzeros and each valid
+            triangle column of ``B_2`` must contain three nonzeros. Sparse
+            tensors must not contain explicitly stored zero values.
 
         Returns
         -------
         tuple of torch.Tensor
-            Final hidden states ``(x_0, x_1, x_2)``, each of width ``hidden_dim``.
+            Hidden features ``(h_0, h_1, h_2)``, with each tensor shaped
+            ``[N_r, hidden_dim]``.
+
+        Raises
+        ------
+        ValueError
+            If either incidence matrix is dense on an accelerator.
         """
+        routes = _build_routes(incidence_all[0], incidence_all[1])
         x_0, x_1, x_2 = x_all
-        b1 = _to_dense(incidence_all[0])
-        b2 = _to_dense(incidence_all[1])
-
-        # Precompute the rank-0 and rank-1 upper-adjacency operators once.
-        upper_adj_0 = _upper_adjacency(b1)
-        upper_adj_1 = _upper_adjacency(b2)
-
-        x_0 = self.in_linear_0(x_0)
-        x_1 = self.in_linear_1(x_1)
-        x_2 = self.in_linear_2(x_2)
-
-        packed_incidence = (b1, b2, upper_adj_0, upper_adj_1)
-        x_all = (x_0, x_1, x_2)
+        hidden_all = (
+            self.in_linear_0(x_0),
+            self.in_linear_1(x_1),
+            self.in_linear_2(x_2),
+        )
         for layer in self.layers:
-            x_all = layer(x_all, packed_incidence)
-
-        return x_all
+            hidden_all = layer(hidden_all, routes)
+        return hidden_all

--- a/topobench/nn/backbones/simplicial/mpsn.py
+++ b/topobench/nn/backbones/simplicial/mpsn.py
@@ -1,0 +1,338 @@
+"""Message Passing Simplicial Network (MPSN) backbone.
+
+Native implementation of the boundary + upper-adjacency, GIN-style MPSN variant.
+
+Plain message-passing GNNs are bounded by the 1-Weisfeiler-Lehman (1-WL) test and
+cannot count triangles. MPSN lifts each triangle to a 2-simplex (clique lifting)
+and runs message passing over the resulting simplicial complex; its Simplicial-WL
+colour refinement is strictly more powerful than 1-WL and no less powerful than
+3-WL, so triangles become first-class cells the network can read and count [1].
+
+We implement the canonical efficient variant (matching CIN): for a simplex of rank
+r we use boundary and upper-adjacency messages only (co-boundary and lower-adjacency
+are dropped, which the paper proves retains full SWL power). With an injective,
+GIN-style update (Xu et al., 2019) and a learnable per-rank epsilon, one layer is
+
+    h_r^{t+1} = MLP_r( (1 + eps_r) h_r + m_boundary + m_upper ),
+
+where the boundary message sums the features of a simplex's (r-1)-faces and the
+upper message sums, over rank-r neighbours sharing a common (r+1)-coface, both the
+neighbour feature and the shared-coface feature.
+
+Routing uses only the unsigned clique-lifted incidence matrices B1 (node-to-edge)
+and B2 (edge-to-triangle); the boundary, upper-adjacency and shared-coface terms
+are all derived from these (no Hodge Laplacians). The lifting is unsigned, so no
+orientation/sign handling is needed and the MLP activation is a plain ReLU.
+
+References
+----------
+.. [1] Bodnar, Frasca, Wang, Otter, Montúfar, Liò, Bronstein.
+   Weisfeiler and Lehman Go Topological: Message Passing Simplicial Networks.
+   ICML 2021 (Spotlight). https://arxiv.org/abs/2103.03212
+"""
+
+import torch
+
+
+def _to_dense(matrix: torch.Tensor) -> torch.Tensor:
+    """Return a dense, unsigned (0/1) version of an incidence matrix.
+
+    The clique lifting emits sparse COO incidence matrices with ``signed=False``,
+    i.e. already 0/1. We densify (toy/complex-sized routing operators) and take
+    the absolute value so the support is used regardless of any sign convention.
+
+    Parameters
+    ----------
+    matrix : torch.Tensor
+        Sparse or dense incidence matrix.
+
+    Returns
+    -------
+    torch.Tensor
+        Dense unsigned incidence matrix.
+    """
+    if matrix.is_sparse:
+        matrix = matrix.to_dense()
+    return matrix.abs()
+
+
+def _upper_adjacency(boundary_next: torch.Tensor) -> torch.Tensor:
+    """Build the rank-r upper-adjacency neighbour operator.
+
+    Two rank-r simplices are upper-adjacent when they share a common (r+1)-coface.
+    With ``boundary_next`` the unsigned rank-r to rank-(r+1) incidence B (shape
+    ``[N_r, N_{r+1}]``), the co-adjacency counts are the off-diagonal of
+    ``boundary_next @ boundary_next.T``; the diagonal (a simplex's own coface
+    count) is removed so a simplex is not its own neighbour.
+
+    Parameters
+    ----------
+    boundary_next : torch.Tensor
+        Dense unsigned incidence of shape ``[N_r, N_{r+1}]``.
+
+    Returns
+    -------
+    torch.Tensor
+        Dense ``[N_r, N_r]`` upper-adjacency operator (zero diagonal). Applying it
+        to rank-r features sums, for each simplex, its upper-adjacent neighbours.
+    """
+    adjacency = boundary_next @ boundary_next.transpose(0, 1)
+    adjacency = adjacency - torch.diag(torch.diagonal(adjacency))
+    return adjacency
+
+
+class MPSNLayer(torch.nn.Module):
+    """One MPSN layer: boundary + upper-adjacency messages, GIN-style update.
+
+    Applies, for every rank r in {0, 1, 2} simultaneously, the boundary + upper
+    update of Bodnar et al. (2021),
+
+        h_r^{t+1} = MLP_r( (1 + eps_r) h_r + m_boundary + m_upper ).
+
+    Each rank owns a distinct MLP and a learnable scalar epsilon (initialised to
+    0.0), matching the injective GIN-style aggregator of Xu et al. (2019). Ranks
+    whose boundary or upper neighbourhood is empty simply omit that term (rank 0
+    has no boundary; rank 2 has no upper-adjacency).
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Feature width shared by all ranks.
+    """
+
+    def __init__(self, hidden_dim: int) -> None:
+        super().__init__()
+        self.hidden_dim = hidden_dim
+
+        # One distinct MLP per rank (0, 1, 2): Linear -> ReLU -> Linear, no norm.
+        for r in range(3):
+            mlp = torch.nn.Sequential(
+                torch.nn.Linear(hidden_dim, hidden_dim),
+                torch.nn.ReLU(),
+                torch.nn.Linear(hidden_dim, hidden_dim),
+            )
+            setattr(self, f"mlp_{r}", mlp)
+            # Learnable per-rank epsilon, init 0.0 (GIN-style injective update).
+            setattr(
+                self,
+                f"eps_{r}",
+                torch.nn.Parameter(torch.zeros(())),
+            )
+
+    def _boundary_message(
+        self, boundary: torch.Tensor, x_face: torch.Tensor
+    ) -> torch.Tensor:
+        """Boundary message: sum of the features of a simplex's (r-1)-faces.
+
+        With ``boundary`` the rank-(r-1) to rank-r incidence B (shape
+        ``[N_{r-1}, N_r]``), ``boundary.T @ x_face`` gathers, for each rank-r
+        simplex, the sum of its faces' features.
+
+        Parameters
+        ----------
+        boundary : torch.Tensor
+            Dense unsigned incidence of shape ``[N_{r-1}, N_r]``.
+        x_face : torch.Tensor
+            Features of the (r-1)-faces, shape ``[N_{r-1}, hidden]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Boundary message per rank-r simplex, shape ``[N_r, hidden]``.
+        """
+        return boundary.transpose(0, 1) @ x_face
+
+    def _upper_message(
+        self,
+        upper_adjacency: torch.Tensor,
+        boundary_next: torch.Tensor,
+        x_self: torch.Tensor,
+        x_coface: torch.Tensor,
+        coface_multiplicity: float,
+    ) -> torch.Tensor:
+        """Upper-adjacency message for one rank.
+
+        Sums, over each rank-r simplex's upper-adjacent neighbours, both the
+        neighbour feature and the shared-coface feature. The neighbour term is the
+        upper-adjacency operator applied to the rank's own features. The
+        shared-coface term is computed exactly from the coface multiplicity: in a
+        simple-graph clique complex with ``complex_dim = 2`` two upper-adjacent
+        simplices share exactly one coface, so summing cofaces (via
+        ``boundary_next @ x_coface``) weighted by ``|faces_r(coface)| - 1`` gives
+        the shared-coface contribution -- multiplicity 1 for rank 0 (each edge has
+        2 nodes) and 2 for rank 1 (each triangle has 3 edges).
+
+        Parameters
+        ----------
+        upper_adjacency : torch.Tensor
+            Dense ``[N_r, N_r]`` upper-adjacency operator (zero diagonal).
+        boundary_next : torch.Tensor
+            Dense unsigned incidence of shape ``[N_r, N_{r+1}]``.
+        x_self : torch.Tensor
+            Features of the rank-r simplices, shape ``[N_r, hidden]``.
+        x_coface : torch.Tensor
+            Features of the rank-(r+1) cofaces, shape ``[N_{r+1}, hidden]``.
+        coface_multiplicity : float
+            ``|faces_r(coface)| - 1``: 1 for rank 0, 2 for rank 1.
+
+        Returns
+        -------
+        torch.Tensor
+            Upper message per rank-r simplex, shape ``[N_r, hidden]``.
+        """
+        neighbour_term = upper_adjacency @ x_self
+        coface_term = coface_multiplicity * (boundary_next @ x_coface)
+        return neighbour_term + coface_term
+
+    def _update(
+        self, rank: int, x_self: torch.Tensor, message: torch.Tensor
+    ) -> torch.Tensor:
+        """GIN-style injective update for one rank.
+
+        Returns ``MLP_r( (1 + eps_r) * x_self + message )``, where ``message`` is
+        the sum of the available boundary and upper messages for the rank.
+
+        Parameters
+        ----------
+        rank : int
+            Rank r in {0, 1, 2}.
+        x_self : torch.Tensor
+            Current features of the rank-r simplices.
+        message : torch.Tensor
+            Aggregated boundary + upper message for this rank.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated rank-r features.
+        """
+        eps = getattr(self, f"eps_{rank}")
+        mlp = getattr(self, f"mlp_{rank}")
+        return mlp((1.0 + eps) * x_self + message)
+
+    def forward(self, x_all, incidence_all):
+        """Apply one MPSN layer to all three ranks.
+
+        Parameters
+        ----------
+        x_all : tuple of torch.Tensor
+            Current features ``(x_0, x_1, x_2)``.
+        incidence_all : tuple of torch.Tensor
+            Dense unsigned operators ``(B1, B2, upper_adj_0, upper_adj_1)`` where
+            ``B1`` is the node-to-edge incidence, ``B2`` the edge-to-triangle
+            incidence, and ``upper_adj_0`` / ``upper_adj_1`` the precomputed rank-0
+            / rank-1 upper-adjacency operators.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Updated features ``(x_0, x_1, x_2)``.
+        """
+        x_0, x_1, x_2 = x_all
+        b1, b2, upper_adj_0, upper_adj_1 = incidence_all
+
+        # ---- rank 0 (nodes): no boundary; upper-adjacency via shared edge ----
+        msg_0 = self._upper_message(
+            upper_adjacency=upper_adj_0,
+            boundary_next=b1,
+            x_self=x_0,
+            x_coface=x_1,
+            coface_multiplicity=1.0,  # each edge-coface has 2 nodes -> 2-1 = 1
+        )
+        new_x_0 = self._update(0, x_0, msg_0)
+
+        # ---- rank 1 (edges): boundary = 2 nodes; upper via shared triangle ----
+        msg_1 = self._boundary_message(b1, x_0)
+        if x_2.shape[0] > 0:
+            msg_1 = (
+                msg_1
+                + self._upper_message(
+                    upper_adjacency=upper_adj_1,
+                    boundary_next=b2,
+                    x_self=x_1,
+                    x_coface=x_2,
+                    coface_multiplicity=2.0,  # each tri-coface has 3 edges -> 3-1 = 2
+                )
+            )
+        new_x_1 = self._update(1, x_1, msg_1)
+
+        # ---- rank 2 (triangles): boundary = 3 edges; upper is empty ----
+        if x_2.shape[0] > 0:
+            msg_2 = self._boundary_message(b2, x_1)
+            new_x_2 = self._update(2, x_2, msg_2)
+        else:
+            new_x_2 = x_2
+
+        return new_x_0, new_x_1, new_x_2
+
+
+class MPSN(torch.nn.Module):
+    """Message Passing Simplicial Network (boundary + upper-adjacency variant).
+
+    Lifts node features to higher-rank cells with per-rank input projections, then
+    stacks ``n_layers`` :class:`MPSNLayer` blocks. Each layer performs the
+    injective, GIN-style simplicial update of Bodnar et al. (2021) (boundary +
+    upper-adjacency messages), whose SWL colour refinement is strictly more
+    powerful than 1-WL and no weaker than 3-WL, so the 2-cells (triangles) become
+    countable, first-class objects.
+
+    Parameters
+    ----------
+    in_channels_all : tuple of int
+        Input feature dimensions on ``(nodes, edges, triangles)``.
+    hidden_dim : int
+        Hidden width shared across all ranks (default 64).
+    n_layers : int
+        Number of stacked MPSN layers (default 3).
+    """
+
+    def __init__(
+        self, in_channels_all, hidden_dim: int = 64, n_layers: int = 3
+    ) -> None:
+        super().__init__()
+        self.hidden_dim = hidden_dim
+
+        # Per-rank input projection to the shared hidden width.
+        self.in_linear_0 = torch.nn.Linear(in_channels_all[0], hidden_dim)
+        self.in_linear_1 = torch.nn.Linear(in_channels_all[1], hidden_dim)
+        self.in_linear_2 = torch.nn.Linear(in_channels_all[2], hidden_dim)
+
+        self.layers = torch.nn.ModuleList(
+            MPSNLayer(hidden_dim) for _ in range(n_layers)
+        )
+
+    def forward(self, x_all, incidence_all):
+        """Forward pass over the simplicial complex.
+
+        Parameters
+        ----------
+        x_all : tuple of torch.Tensor
+            Input features ``(x_0, x_1, x_2)`` on nodes, edges, triangles.
+        incidence_all : tuple of torch.Tensor
+            ``(incidence_1, incidence_2)``: the unsigned clique-lifted incidence
+            matrices B1 (node-to-edge) and B2 (edge-to-triangle). May be sparse
+            COO; densified and ``.abs()``-ed internally. Used only for routing.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Final hidden states ``(x_0, x_1, x_2)``, each of width ``hidden_dim``.
+        """
+        x_0, x_1, x_2 = x_all
+        b1 = _to_dense(incidence_all[0])
+        b2 = _to_dense(incidence_all[1])
+
+        # Precompute the rank-0 and rank-1 upper-adjacency operators once.
+        upper_adj_0 = _upper_adjacency(b1)
+        upper_adj_1 = _upper_adjacency(b2)
+
+        x_0 = self.in_linear_0(x_0)
+        x_1 = self.in_linear_1(x_1)
+        x_2 = self.in_linear_2(x_2)
+
+        packed_incidence = (b1, b2, upper_adj_0, upper_adj_1)
+        x_all = (x_0, x_1, x_2)
+        for layer in self.layers:
+            x_all = layer(x_all, packed_incidence)
+
+        return x_all

--- a/topobench/nn/wrappers/simplicial/mpsn_wrapper.py
+++ b/topobench/nn/wrappers/simplicial/mpsn_wrapper.py
@@ -11,11 +11,11 @@ class MPSNWrapper(AbstractWrapper):
     r"""Wrapper for the MPSN model.
 
     Unpacks the lifted batch and drives the MPSN backbone. Only the per-rank
-    features (``x_0/x_1/x_2``) and the **unsigned** clique-lifted incidence
-    matrices (``incidence_1``, ``incidence_2``) are passed to the backbone; the
-    incidences are used solely for routing the boundary + upper-adjacency
-    messages (no Hodge Laplacians). The backbone returns the embeddings of the
-    cells of rank 0, 1 and 2, which the readout consumes.
+    features (``x_0/x_1/x_2``) and the signed or unsigned clique-lifted
+    incidence matrices (``incidence_1``, ``incidence_2``) are passed to the
+    backbone. Their nonzero support is used solely for routing the boundary and
+    upper-adjacency messages (no Hodge Laplacians). The backbone returns the
+    embeddings of the cells of rank 0, 1 and 2, which the readout consumes.
     """
 
     def forward(self, batch):

--- a/topobench/nn/wrappers/simplicial/mpsn_wrapper.py
+++ b/topobench/nn/wrappers/simplicial/mpsn_wrapper.py
@@ -1,0 +1,47 @@
+"""Wrapper for the MPSN (Message Passing Simplicial Network) model.
+
+MPSN: Bodnar et al., "Weisfeiler and Lehman Go Topological: Message Passing
+Simplicial Networks", ICML 2021, arXiv:2103.03212.
+"""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class MPSNWrapper(AbstractWrapper):
+    r"""Wrapper for the MPSN model.
+
+    Unpacks the lifted batch and drives the MPSN backbone. Only the per-rank
+    features (``x_0/x_1/x_2``) and the **unsigned** clique-lifted incidence
+    matrices (``incidence_1``, ``incidence_2``) are passed to the backbone; the
+    incidences are used solely for routing the boundary + upper-adjacency
+    messages (no Hodge Laplacians). The backbone returns the embeddings of the
+    cells of rank 0, 1 and 2, which the readout consumes.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the MPSN wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data. Must carry ``x_0``,
+            ``x_1``, ``x_2``, ``incidence_1``, ``incidence_2``, ``batch_0`` and
+            ``y``.
+
+        Returns
+        -------
+        dict
+            Dictionary with ``labels``, ``batch_0`` and the per-rank embeddings
+            ``x_0``, ``x_1``, ``x_2``.
+        """
+        x_all = (batch.x_0, batch.x_1, batch.x_2)
+        incidence_all = (batch.incidence_1, batch.incidence_2)
+
+        x_0, x_1, x_2 = self.backbone(x_all, incidence_all)
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+        model_out["x_1"] = x_1
+        model_out["x_2"] = x_2
+
+        return model_out


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the linting and pre-commit checks.
- [x] I added appropriate unit tests and ran the relevant pipeline test.
- [x] My PR follows PEP 8 guidelines.
- [x] My code uses NumPy-style documentation.
- [x] I linked the publication and reference implementation.

## Description

This Track 2 submission from team `GiggioIlGriggio` integrates the boundary-plus-upper Simplicial Isomorphism Network (SIN) variant from Supplement Equation 35 of Bodnar et al. into TopoBench.

> **Implemented scope — Supplement Eq. 35, not Definition 4.** This submission implements the boundary-plus-upper SIN experiment from Supplement Eq. 35. It does **not** implement the full four-adjacency MPSN framework of Definition 4: the coboundary and lower-adjacency message families are not present.

> Cristian Bodnar, Fabrizio Frasca, Yuguang Wang, Nina Otter, Guido Montufar, Pietro Lio, Michael Bronstein. *Weisfeiler and Lehman Go Topological: Message Passing Simplicial Networks.* ICML 2021 (Spotlight). [Paper and supplement](https://proceedings.mlr.press/v139/bodnar21a.html). [Authors' reference implementation](https://github.com/twitter-research/cwn).

### Included components

- `topobench/nn/backbones/simplicial/mpsn.py`: sparse Supplement Eq. 35 boundary-plus-upper SIN backbone.
- `topobench/nn/wrappers/simplicial/mpsn_wrapper.py`: wrapper for rank-0, rank-1, and rank-2 features and incidences.
- `configs/model/simplicial/mpsn.yaml`: complete `TBModel` composition using the standard TopoBench encoder and readout.
- `test/nn/backbones/simplicial/test_mpsn.py`: 17 numerical, structural, sparse-routing, equivariance, gradient, and edge-case tests.
- `test/nn/wrappers/simplicial/test_mpsn_wrapper.py`: four wrapper integration tests.
- `test/pipeline/test_pipeline.py`: registers `simplicial/mpsn` in the shared MUTAG pipeline test.
- `2026_tdl_challenge/outputs/2026-07-31_15-44-23/results.json`: complete official 72-run GraphUniverse evaluation.

## Implemented architecture: Supplement Eq. 35 SIN

The backbone implements the concrete boundary-plus-upper Simplicial Isomorphism Network update in Supplement Equation 35 of Bodnar et al., adapted to TopoBench's rank-0/1/2 interface. Throughout this PR, `MPSN` is the TopoBench model/configuration name; it must not be read as a claim that all four adjacency families from Definition 4 are implemented.

For a simplex `sigma`, the layer forms:

```text
m_B(sigma) = sum_{delta in B(sigma)} h_delta

m_up(sigma) = sum_{tau in N_up(sigma)}
              M_up(h_tau || h_shared_coface(sigma,tau))

b_sigma = MLP_B(h_sigma + m_B(sigma))
u_sigma = MLP_up(h_sigma + m_up(sigma))
h_sigma_next = MLP_U(b_sigma || u_sigma)
```

The boundary and upper multisets are transformed separately. Each upper message preserves the pairing between an upper neighbour and the coface it shares with the receiving simplex. Consistent with the Supplement Eq. 35 experiment, both epsilon values are fixed to zero, the boundary and upper update maps are two-layer ELU MLPs, and the pair-message and combination maps are a dense layer followed by ELU.

This corresponds to the main-paper boundary definition (Eq. 2), upper adjacency (Eq. 5), and generic message-passing update (Eq. 6). Theorem 6 justifies using boundary and upper neighbourhoods. The implementation does not claim that its finite learned maps satisfy the injectivity premise of Theorem 10, nor that it automatically realizes the complete Simplicial-WL procedure.

## Sparse implementation

Routing is built from the nonzero support of `incidence_1` and `incidence_2` once per forward pass and reused by all layers:

- each edge creates two ordered vertex upper-neighbour routes;
- each triangle creates six ordered edge upper-neighbour routes;
- boundary and upper aggregation use indexed on-device reductions;
- signed and unsigned incidences with the same nonzero support are equivalent;
- explicitly stored sparse zero values are excluded from support;
- no dense or square adjacency matrix is constructed;
- no `.tolist()`, `.cpu()`, or per-simplex Python routing loop is used.

For sparse rank-at-most-two clique complexes with `I` incidence entries and `P` ordered upper routes, route construction uses `O(I log I + P)` time and `O(I + P)` memory. Dense CPU incidence is accepted for compatibility and testing; accelerator incidence must be sparse to avoid dense support extraction and device synchronization.

## TopoBench adaptation

- Public backbone interface: `MPSN(in_channels_all, hidden_dim=64, n_layers=3)`.
- Inputs and outputs remain tuples ordered by simplex rank.
- The existing `AllCellFeatureEncoder`, `MPSNWrapper`, and standard `PropagateSignalDown` sum readout are retained.
- The model receives lifted features and incidence support only; triangle counts, degrees, clustering coefficients, and other target-derived structural features are not injected.
- This PR contains one core architecture and one model configuration.

## Tests

The test suite includes:

- an exact deterministic one-layer numerical oracle for every term of Supplement Eq. 35 and ranks 0, 1, and 2;
- a regression showing that neighbour/shared-coface pairings are preserved even when their marginal sums agree;
- dense/sparse and signed/unsigned support equivalence;
- explicit sparse-zero filtering;
- independent simplex-permutation equivariance;
- disjoint-union batching equivalence;
- empty and minimal higher-rank complexes in train and evaluation modes;
- finite outputs and gradients through every trainable branch;
- a valid `C6` versus `2K3` clique-lifting example: the graphs are 1-WL-indistinguishable with constant features, while their clique complexes contain zero versus two 2-simplices;
- public export, wrapper, and end-to-end pipeline coverage.

The structural example demonstrates that the backbone consumes higher-order lifted structure; it is not presented as a proof that a finite learned instance realizes full SWL.

## Official GraphUniverse results

The official evaluation contains 72 unique runs: two tasks, 12 GraphUniverse settings per task, and seeds 42/43/44. Every run contains 11 OOD evaluations.

| Task | In-distribution metric, mean over 36 runs | Value |
|---|---|---:|
| `triangle_counting` | `mse_per_triangle` (lower) | 0.02875 |
| `community_detection` | accuracy (higher) | 0.47421 |

No minimum performance is required by the challenge; these values are reported for reproducibility rather than used as correctness claims.

## Reproduction and validation

The result file was generated by the current official `2026_tdl_challenge/run_evaluation.ipynb` with `MODEL_CONFIG = "simplicial/mpsn"`; the notebook and evaluation utilities are not changed by this PR.

The artifact was generated after the Supplement Eq. 35 architecture commit. The only later functional change filters explicitly stored zero entries from sparse incidence support; the official clique-lifted incidence tensors used for these runs contain no such entries, so the final revision executes exactly the same computation on every evaluated input. The remaining later change is documentation-only. The results are therefore applicable to the final code without claiming that the 72-run grid was rerun after those no-op/documentation commits.

Before submission, the following checks were run locally:

- 20 CPU backbone/wrapper tests passed; one CUDA-specific test was skipped only in the sandboxed CPU run.
- The CUDA sparse-routing test passed separately on the RTX A4000.
- The shared pipeline test passed end to end.
- All pre-commit hooks passed.
- The complete CPU challenge smoke grid passed all 24 configurations.
- The result artifact was independently checked for run uniqueness, seeds, task/settings coverage, OOD entries, and finite required metrics.

## Issue

Submission to the TDL Challenge 2026, Track 2 (Topological Neural Networks).
