### PR TITLE
Track: Track1;  Team name: TripleA;  Model: OGFormer 

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-14_22-36-06/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-14_22-36-06/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-14_22-36-06",
+    "model_config": "graph/ogformer",
+    "generated_at_utc": "2026-07-14T21:42:15.730179+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.168543577194214,
+      "test_best_rerun_accuracy": 0.32458552718162537,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3239743411540985,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33432653546333313,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33745893836021423,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3733287453651428,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36622354388237,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39093896746635437,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4055313766002655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46241119503974915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4543509781360626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5404156446456909,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5802582502365112,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.544115546502565,
+        "AvgTime/train_epoch_std": 0.09219279751082893,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.162858724594116,
+      "test_best_rerun_accuracy": 0.32920771837234497,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3271831274032593,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3391397297382355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34280693531036377,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3794407546520233,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3726411461830139,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3996867537498474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41022995114326477,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4685995876789093,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4612651765346527,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5477499961853027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5887004137039185,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5478417409790888,
+        "AvgTime/train_epoch_std": 0.07979059151046049,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.165911912918091,
+      "test_best_rerun_accuracy": 0.32607534527778625,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32091832160949707,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33654212951660156,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33787912130355835,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3752005398273468,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3661089539527893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39739474654197693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41049736738204956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4662693738937378,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4595079720020294,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5457636117935181,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5836962461471558,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.55269715014626,
+        "AvgTime/train_epoch_std": 0.0799868365704456,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1644341945648193,
+      "test_best_rerun_accuracy": 0.3262663185596466,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3250439167022705,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3318053185939789,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3394453227519989,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37443655729293823,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3674459457397461,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3927725553512573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40778517723083496,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4676445722579956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46103599667549133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5467950105667114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5894262194633484,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5635830389486778,
+        "AvgTime/train_epoch_std": 0.0781417463139784,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.166830062866211,
+      "test_best_rerun_accuracy": 0.32454732060432434,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3269157409667969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33478492498397827,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34116435050964355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3775307536125183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36996716260910034,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3965543508529663,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.408892959356308,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4686377942562103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46187639236450195,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5454198122024536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5885858535766602,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5566223859786987,
+        "AvgTime/train_epoch_std": 0.07883451178498789,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1653358936309814,
+      "test_best_rerun_accuracy": 0.32321032881736755,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32576972246170044,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3334861397743225,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33719152212142944,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3748949468135834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3664909601211548,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39414775371551514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40854915976524353,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4654671847820282,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45939338207244873,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.542669415473938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5827794075012207,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.54955876500983,
+        "AvgTime/train_epoch_std": 0.08281500940574871,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.131319761276245,
+      "test_best_rerun_accuracy": 0.33554893732070923,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3221789300441742,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33803194761276245,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36832454800605774,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3594239354133606,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39051875472068787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4044617712497711,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4587821960449219,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44907939434051514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5410268306732178,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5796088576316833,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.560908264127271,
+        "AvgTime/train_epoch_std": 0.08927174620484442,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.0966498851776123,
+      "test_best_rerun_accuracy": 0.34769654273986816,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32825273275375366,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3280235230922699,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34647414088249207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3695087432861328,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3594239354133606,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3939567506313324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4019787609577179,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45129498839378357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4435785710811615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5330430269241333,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5678431987762451,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5608995790066926,
+        "AvgTime/train_epoch_std": 0.08743376196550422,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.12424373626709,
+      "test_best_rerun_accuracy": 0.33623653650283813,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32267552614212036,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31721293926239014,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3373061418533325,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3706165552139282,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3591947555541992,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39388036727905273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40598976612091064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46569639444351196,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4551149904727936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5470241904258728,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5799144506454468,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5688100437964163,
+        "AvgTime/train_epoch_std": 0.08717610403184639,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.091688871383667,
+      "test_best_rerun_accuracy": 0.34525173902511597,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32496753334999084,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3227137327194214,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33654212951660156,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36465734243392944,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35950034856796265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38356634974479675,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39854076504707336,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46134158968925476,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45492398738861084,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.541867196559906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5822828412055969,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5656164169311524,
+        "AvgTime/train_epoch_std": 0.0993019133348696,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.09706974029541,
+      "test_best_rerun_accuracy": 0.3436473309993744,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32321032881736755,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3208419382572174,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3366949260234833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37004354596138,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36060813069343567,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3907097578048706,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40583696961402893,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4686377942562103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46088317036628723,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5486668348312378,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5934372544288635,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5516912747513165,
+        "AvgTime/train_epoch_std": 0.09430583495962488,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1249191761016846,
+      "test_best_rerun_accuracy": 0.3348613381385803,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31136831641197205,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31232333183288574,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3229811191558838,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3613721430301666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35652074217796326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38303154706954956,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40083277225494385,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4721522033214569,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46378639340400696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5538620352745056,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5956146121025085,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5517799815823954,
+        "AvgTime/train_epoch_std": 0.08972549510300502,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9368728399276733,
+      "test_best_rerun_accuracy": 0.4113377630710602,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2940637171268463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2898235023021698,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.293108731508255,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30009931325912476,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39999234676361084,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43357017636299133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45901137590408325,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5402246117591858,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5386584401130676,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6225456595420837,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6717090606689453,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5462091525395711,
+        "AvgTime/train_epoch_std": 0.09057251820250857,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9656842947006226,
+      "test_best_rerun_accuracy": 0.4074031710624695,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28485751152038574,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28283292055130005,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28390252590179443,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2913515269756317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3952937722206116,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4288715720176697,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4539307951927185,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5371304154396057,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5352585911750793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6207884550094604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6652532815933228,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5502702840944615,
+        "AvgTime/train_epoch_std": 0.09489795027628015,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9232864379882812,
+      "test_best_rerun_accuracy": 0.4153105616569519,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2984185218811035,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2947131097316742,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3003285229206085,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3049507141113281,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40316295623779297,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4411719739437103,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4631369709968567,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5460309982299805,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5431660413742065,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6308732628822327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6736190915107727,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5491161169829193,
+        "AvgTime/train_epoch_std": 0.08742503937225146,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9699910879135132,
+      "test_best_rerun_accuracy": 0.3984643518924713,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28951790928840637,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28611811995506287,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2888685166835785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2997173070907593,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.406982958316803,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42245396971702576,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4538925886154175,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5382764339447021,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5379708409309387,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6194896697998047,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6673924922943115,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.552971512079239,
+        "AvgTime/train_epoch_std": 0.0894627692817208,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.982717514038086,
+      "test_best_rerun_accuracy": 0.3958667516708374,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2869967222213745,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28543052077293396,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2872641086578369,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2959355115890503,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4061807692050934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42489877343177795,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45629918575286865,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5382000207901001,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5374742150306702,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6202918291091919,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6654442548751831,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5520359337329865,
+        "AvgTime/train_epoch_std": 0.08669306462273423,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9608711004257202,
+      "test_best_rerun_accuracy": 0.40029796957969666,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2940637171268463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2920391261577606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2925739288330078,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30376651883125305,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40996256470680237,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42936816811561584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46088317036628723,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5407975912094116,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5400718450546265,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6244174242019653,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6700282692909241,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5510013580322266,
+        "AvgTime/train_epoch_std": 0.08858554353576469,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.86328125,
+      "test_best_rerun_accuracy": 0.44449537992477417,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29058751463890076,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2848193049430847,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30239132046699524,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.306402325630188,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4045381546020508,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38807395100593567,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4629077911376953,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5334632396697998,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5226144194602966,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6260982751846313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6642600893974304,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5567127172497734,
+        "AvgTime/train_epoch_std": 0.09171248431515912,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8528039455413818,
+      "test_best_rerun_accuracy": 0.4494231939315796,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29261210560798645,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2858507037162781,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3024677336215973,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3057529330253601,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4042707681655884,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3910917639732361,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4645121991634369,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5316678285598755,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5239132046699524,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6285812258720398,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6674688458442688,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5683011942439609,
+        "AvgTime/train_epoch_std": 0.08278310111894896,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8241392374038696,
+      "test_best_rerun_accuracy": 0.4543127715587616,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2994881272315979,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3074719309806824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3110627233982086,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4121781587600708,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3946061432361603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4695545732975006,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5360608100891113,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5251356363296509,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6325922608375549,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6668576598167419,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5674296701163577,
+        "AvgTime/train_epoch_std": 0.09992699833709305,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8116848468780518,
+      "test_best_rerun_accuracy": 0.4632897973060608,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2869585156440735,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28229811787605286,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28772252798080444,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2984949052333832,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41019177436828613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39758574962615967,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43574756383895874,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5452670454978943,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5404156446456909,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6266330480575562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6747650504112244,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.569176430795707,
+        "AvgTime/train_epoch_std": 0.08146845975059377,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8033497333526611,
+      "test_best_rerun_accuracy": 0.4681793749332428,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2923829257488251,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28554511070251465,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29631751775741577,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3023531138896942,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4114905595779419,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39838796854019165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44147756695747375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5460692048072815,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5367866158485413,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6329742670059204,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6747650504112244,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5710559487342834,
+        "AvgTime/train_epoch_std": 0.10902456100077125,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8079417943954468,
+      "test_best_rerun_accuracy": 0.46474137902259827,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2855833172798157,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28416991233825684,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2889831066131592,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3019329309463501,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4097333550453186,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39876994490623474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.434486985206604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.543433427810669,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5414851903915405,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6308732628822327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6744212508201599,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.570099405447642,
+        "AvgTime/train_epoch_std": 0.08777893831424882,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5134351253509521,
+      "test_best_rerun_accuracy": 0.5570326447486877,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2649935185909271,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26445871591567993,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26694169640541077,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2824891209602356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3999159634113312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3908625543117523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42161357402801514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45152416825294495,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5543203949928284,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.635610044002533,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6802276968955994,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5665442326973225,
+        "AvgTime/train_epoch_std": 0.08993205316981445,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.521072268486023,
+      "test_best_rerun_accuracy": 0.5551226139068604,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2607533037662506,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26079151034355164,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2641530930995941,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27454352378845215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39579036831855774,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38765376806259155,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41756436228752136,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45003437995910645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.550347626209259,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6376728415489197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6796928644180298,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5573304533958434,
+        "AvgTime/train_epoch_std": 0.08648431446441565,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5108692646026611,
+      "test_best_rerun_accuracy": 0.5602031946182251,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26243409514427185,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26163190603256226,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27928030490875244,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4022461473941803,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39525556564331055,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42065855860710144,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45763617753982544,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5581022500991821,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6397738456726074,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6853846907615662,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5631616155306498,
+        "AvgTime/train_epoch_std": 0.08937571139338898,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5299603939056396,
+      "test_best_rerun_accuracy": 0.5486668348312378,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2569715082645416,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2549087107181549,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25578731298446655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2727099061012268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38750094175338745,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.380357563495636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4074413776397705,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4427381753921509,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5475972294807434,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6254106760025024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6770952939987183,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.560862872335646,
+        "AvgTime/train_epoch_std": 0.0928319709462695,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5074946880340576,
+      "test_best_rerun_accuracy": 0.5535564422607422,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.261020690202713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2606005072593689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2626633048057556,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2777141034603119,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3966689705848694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38899075984954834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41553977131843567,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45236459374427795,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5545496344566345,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6353426575660706,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6806860566139221,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5507062911987304,
+        "AvgTime/train_epoch_std": 0.10101375848735109,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4958518743515015,
+      "test_best_rerun_accuracy": 0.5583314299583435,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26300710439682007,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26354190707206726,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2653754949569702,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2796241044998169,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39999234676361084,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3932691514492035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4158453643321991,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4521735906600952,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5573764443397522,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6374436616897583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6837420463562012,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5490377426147461,
+        "AvgTime/train_epoch_std": 0.09715690964067926,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2672938108444214,
+      "test_best_rerun_accuracy": 0.6381694674491882,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2626250982284546,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26052409410476685,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2691573202610016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28122851252555847,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39468255639076233,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38272595405578613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4242493808269501,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4540835916996002,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5501947999000549,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5441592335700989,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6809152960777283,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5484022816946341,
+        "AvgTime/train_epoch_std": 0.09349422293574985,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2882661819458008,
+      "test_best_rerun_accuracy": 0.638627827167511,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25781190395355225,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2566277086734772,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26189929246902466,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27316829562187195,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38818854093551636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3786003589630127,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4195125699043274,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4473603665828705,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5480556488037109,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5410268306732178,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6797692775726318,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.561762204537025,
+        "AvgTime/train_epoch_std": 0.09655775874338358,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.260369062423706,
+      "test_best_rerun_accuracy": 0.6411872506141663,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2622049152851105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2608678936958313,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26216670870780945,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27549850940704346,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39468255639076233,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3876919448375702,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4188631772994995,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4537779688835144,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.553288996219635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5497364401817322,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6842004656791687,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.55643341143926,
+        "AvgTime/train_epoch_std": 0.10866507899236909,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1150295734405518,
+      "test_best_rerun_accuracy": 0.6834746599197388,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2641530930995941,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26082971692085266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26281610131263733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2755749225616455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3908625543117523,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3837573528289795,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4133623540401459,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44827717542648315,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5501565933227539,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5517228245735168,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.632706880569458,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5410412510236104,
+        "AvgTime/train_epoch_std": 0.0964013180492286,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.174360990524292,
+      "test_best_rerun_accuracy": 0.6752234697341919,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2447092980146408,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24363969266414642,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24757429957389832,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26231950521469116,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3813125491142273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37405455112457275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4098479747772217,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44552677869796753,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5420964360237122,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5406830310821533,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6293834447860718,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.568240110690777,
+        "AvgTime/train_epoch_std": 0.09937072312627558,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.126185417175293,
+      "test_best_rerun_accuracy": 0.6854611039161682,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2600274980068207,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2614026963710785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26258689165115356,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2739323079586029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3952173590660095,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3881503641605377,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41970357298851013,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.455382376909256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5531744360923767,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5508441925048828,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6370234489440918,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.56575460506208,
+        "AvgTime/train_epoch_std": 0.09456829426130763,
+        "model/params/total": 19137,
+        "model/params/trainable": 19137,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 138.52891540527344,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 135.1397705078125,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09736294705173812,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.60009002685547,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.39789521066766037
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11593.28515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8792783584565794
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 195.37255859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0658485199170037
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7394.91357421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9879644053732465
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156.854736328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13545314017972798
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173130.578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.020308799112948
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14737.955078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0333722534094096
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45526.45703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.333613051988826
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3497.566162109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6217895399305555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754141.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.530720818298022
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260259.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.330946668081141
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.978695445590549,
+        "AvgTime/train_epoch_std": 0.034987701252243195,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 144.26992797851562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 141.6593475341797,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.10206004865574905,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66.9747543334961,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.35249870701840047
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11961.1787109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9071807896046644
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231.5359649658203,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0780370626780655
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7466.818359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9975709230961923
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.4864501953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13340798807885362
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174326.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.048087221925506
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15024.341796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.053452657192189
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45722.38671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3436560930211696
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3511.38427734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.62424609375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 756102.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.552901909437463
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261407.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.35005221074002
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9169299602508545,
+        "AvgTime/train_epoch_std": 0.012254714965820312,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 129.12132263183594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 127.77275848388672,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09205530150135931,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77.35124969482422,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.40711184049907484
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11146.8203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8454167851725446
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160.36468505859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05404943884684656
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7315.65087890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9773748669213427
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150.36802673339844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12985149113419553
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171751.390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.988282338496192
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14378.7001953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.008182596782534
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45332.78515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3236857427981956
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3459.780517578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6150720920138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752098.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.50761710575433
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258866.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.30775943121495
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9709914525349935,
+        "AvgTime/train_epoch_std": 0.04645298399180304,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.5382957458496094,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.4962093830108643,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.018401102015846653,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206.41055297851562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14871077303927638
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13128.2978515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9956994957574896
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 405.0801696777344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13652853713438975
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8175.6015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0922647378089512
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.11184692382812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15467344293940252
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178549.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.146144038524057
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16185.6015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1348760035408778
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47726.80859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.446399538354093
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3978.389892578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7072693142361111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765168.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.655454990215263
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266787.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.439581149218711
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9608098136054145,
+        "AvgTime/train_epoch_std": 0.04327026281920525,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.292379379272461,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.3324739933013916,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012276178912112587,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205.29159545898438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14790460767938354
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13023.43359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9877461959613196
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 398.1992492675781,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.13420938633892085
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8170.33154296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0915606603832666
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.4990692138672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1541442739325278
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178188.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.137749555893554
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16139.2216796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.131624013440436
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47759.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4480850584986418
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3986.374267578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7086887586805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765065.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.654295527301109
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266762.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.439160967167557
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9632671624422073,
+        "AvgTime/train_epoch_std": 0.060115861551071646,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.359978199005127,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.2943737506866455,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.012075651319403398,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 198.15682983398438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14276428662390805
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12942.7158203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9816242563756162
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 385.1943359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12982620018115942
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8147.36083984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0884917621701737
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175.35240173339844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1514269445020712
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177927.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.131689897594279
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16068.046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1266334928481279
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47706.98828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4453835809754474
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3972.39990234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7062044270833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764585.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.648858777417056
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266497.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.434745935466693
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9698182284832001,
+        "AvgTime/train_epoch_std": 0.05269025075791833,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 4950.8505859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4667.794921875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3540231264220705,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5549.85107421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.9984517825783503
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6721.220703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 35.374845805921055
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5072.35107421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7095891723015673
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6242.18115234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8339587377880762
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5846.6083984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.0488846273208114
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131183.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0462447607049974
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8360.8955078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5862358370363554
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31351.994140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.607052854611974
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4934.453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8772361111111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 661385.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.481481114894291
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207465.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.452405542242857
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9718607555736195,
+        "AvgTime/train_epoch_std": 0.04183929621350785,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5263.70068359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5025.63427734375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.38116300927901026,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4000.068359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.881893630673631
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4668.56103515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 24.57137386924342
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4867.7265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.640622366868891
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5674.716796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7581451966432866
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4048.299560546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.4959408985724307
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133761.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1061149539058146
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8636.8251953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6055830315041719
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33594.34375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.721992093392793
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3834.7861328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6817397569444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 674141.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.625771325633745
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212731.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.540038981245736
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9717696456166057,
+        "AvgTime/train_epoch_std": 0.0522390480060293,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 4844.42236328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4663.359375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3536867178612059,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2990.956787109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.1548680022401836
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3399.38623046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.891506476151317
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4885.041015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.6464580436889114
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5432.94677734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7258445928314963
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2931.093017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.5311684089621114
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134083.21875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.113580223620658
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8617.83984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6042518471287337
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35392.9765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8141871219693475
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3493.034912109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.620983984375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 678450.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.674513308371888
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214947.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5769216568485516
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9645522736954963,
+        "AvgTime/train_epoch_std": 0.049197847772997585,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 123.11119079589844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 123.87763214111328,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.041751814001049305,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147.22140502929688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10606729468969515
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172.7260284423828,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9090843602230675
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9834.9599609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7459203610874099
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6842.84912109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9142082994113226
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188.06011962890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.16240079415276878
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166899.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8756164516765743
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13374.7880859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9377919005705722
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44242.17578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.267782858232098
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3249.891357421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5777584635416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 746090.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.439650662307841
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255030.421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.243928941390844
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9671847120920817,
+        "AvgTime/train_epoch_std": 0.04737066123934348,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 132.44996643066406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 131.36581420898438,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04427563674047333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205.6321563720703,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.148149968567774
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.7747802734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.53565673828125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10059.87890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7629790600113766
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6641.337890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8872862913326653
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 269.1662292480469,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.23244061247672443
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167224.453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8831611816134126
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13331.3095703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9347433438727036
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43254.78125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2171706007483727
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3080.898681640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5477153211805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742841.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.40290205083538
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253405.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.216888822325395
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9705460456109816,
+        "AvgTime/train_epoch_std": 0.05614519158529203,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 127.56733703613281,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 126.68864440917969,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.042699239773906196,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160.09249877929688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11534041698796604
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.14915466308594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.1376271298057155
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9823.48046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7450497132157755
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6711.14794921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8966129524674349
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211.58343505859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.18271453804714485
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166650.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.869823112112205
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13234.5166015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.927956570015601
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43666.01953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.238250014416423
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3140.1572265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5582501736111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743469.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.410004468174156
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253569.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.219612465262177
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9677639625690602,
+        "AvgTime/train_epoch_std": 0.0479304829524467,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5094.3583984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5169.03271484375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.6905855330452572,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1403.83984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0114119911743515
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1632.8746337890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.594077019942434
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5563.47265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.42195469520288204
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2341.436767578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7891596789949865
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1313.023193359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.1338714968561097
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142342.328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.305367084455694
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8829.578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.619098171715047
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37143.15625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9038985211953456
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2604.3046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4629875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 698989.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.906847052701831
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224598.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7375193450152264
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.968950531217787,
+        "AvgTime/train_epoch_std": 0.04034742383359622,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5219.5595703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5336.97216796875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7130223337299599,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1381.4049072265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9952484922381574
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1828.317138671875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.622721782483552
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6634.720703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5032021769529769
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1244.8338623046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.4195597783298576
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1497.691650390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2933433941197108
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149620.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4743865961127622
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9808.3271484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6877245230989693
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37066.5390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8999712472448613
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2743.455810546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.48772547743055555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706214.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.988582118253905
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230659.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8383768180154094
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9659826859183933,
+        "AvgTime/train_epoch_std": 0.06106806312167268,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5225.9580078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5322.92578125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7111457289579158,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1199.983154296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8645411774473163
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1541.146484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.111297286184211
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6220.681640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4717998968998862
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1567.069580078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5281663566154786
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1231.4215087890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.063403720888655
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147540.96875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.42608602893368
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9483.494140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6649484041947132
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37770.0546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9360323280280896
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2716.962158203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.48301549479166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 705400.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.979377820888431
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229587.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.82054300209675
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9812086200714112,
+        "AvgTime/train_epoch_std": 0.029384379446195524,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 145.88888549804688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 154.35458374023438,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13329411376531466,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153.78076171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11079305599333573
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.84221267700195,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17285375093158922
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12343.1220703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9361488107935153
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281.0897521972656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09473870987437331
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7715.630859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0308124060621242
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175772.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.0816658781116475
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15424.8916015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0815377647989413
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46432.81640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.380071577541135
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3684.38623046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6550019965277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759158.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.587477234935466
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263237.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.380498248548084
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9993405342102051,
+        "AvgTime/train_epoch_std": 0,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 145.5837860107422,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 152.87730407714844,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.132018397303237,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167.67724609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12080493234420028
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.897127151489258,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08893224816573293
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12529.4931640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.950283895643724
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 311.76446533203125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1050773391749347
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7839.455078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0473553878590514
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176436.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.097071001880922
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15614.587890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0948385843938437
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46859.98046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4019673211722794
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3746.57958984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.66605859375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 761338.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.612133496600794
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 264327.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.398640960677616
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9900093078613281,
+        "AvgTime/train_epoch_std": 0.007994252133037212,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 139.17672729492188,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.09706115722656,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12616326524803675,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.50570678710938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1134767339964765
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.727514266967773,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.13014481193140934
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11853.1728515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8989892189277588
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222.7874755859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07508846497672313
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7687.1484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0270071392785571
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174014.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.040824775334386
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14982.6728515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.050530981037898
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46479.6015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3824697094930545
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3661.126220703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6508668836805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757666.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.57059573770121
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261878.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.357879141497346
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9968391180038452,
+        "AvgTime/train_epoch_std": 0.05805361667769947,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112560.546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78796.7109375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8297582885356678,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72326.71875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 52.108586995677236
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76429.9296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 402.26278782894735
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40661.93359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.0839540078687904
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68533.703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.098652890124704
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55639.875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.433517034068136
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73134.3359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 63.15573051597582
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43616.8515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.0582563148576636
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45510.90625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3328159439233174
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61094.9140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.861318055555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 473641.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.357758998563397
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122627.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.040629472234703
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9684738801873248,
+        "AvgTime/train_epoch_std": 0.0344744987069324,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 114697.0234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 79682.7265625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8503326807193945,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70727.1328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 50.95614755943804
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74128.2421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 390.14864309210526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42112.8671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.1939982698141827
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69371.0234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.38086398297944
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54328.9140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.258371952237809
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71087.546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 61.388209736614854
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44247.98046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.102508797416211
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45039.2265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.308638400866267
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59831.375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.636688888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 475972.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.384123700553149
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122555.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.039427949178773
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.962311939759688,
+        "AvgTime/train_epoch_std": 0.040756301867504716,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112448.7265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78770.5546875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.829150907660691,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71913.953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 51.811205421469744
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76406.9453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 402.1418174342105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39274.0546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.978692050625711
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67624.3828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.79217486097068
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55339.671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.393409736138945
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73209.3515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 63.2205108484456
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43143.65625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.025077566259992
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45438.06640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.329082290545389
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61100.1015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.862240277777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 473757.59375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.35906692928973
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122980.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0465027904664437
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.008772763338956,
+        "AvgTime/train_epoch_std": 0.041223747154701805,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8822.015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8398.1171875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5888456869653625,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4692.3466796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.380653227440562
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5845.0,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 30.763157894736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5011.18603515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3800672002393819
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3610.0595703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.216737300408662
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5962.48681640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7965914250375752
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5123.083984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.4240794338298794
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136119.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1608594185398475
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31950.07421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6377094786380644
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4499.50732421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7999124131944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 670283.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.582134514665792
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212313.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5330875164328623
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0149130821228027,
+        "AvgTime/train_epoch_std": 0.016578197479248047,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8699.193359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8321.646484375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5834838370757959,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4040.577392578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.9110788130966316
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4893.48681640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 25.75519377055921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5936.43017578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.45024119649459615
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3692.875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.244649477586788
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5880.56640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7856468144622578
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4256.021484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.6753207982512954
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137811.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.200161024869961
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33211.7109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7023789500999538
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3970.195068359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7058124565972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 676797.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.655816968881147
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211925.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5266311176010516
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9737708047032356,
+        "AvgTime/train_epoch_std": 0.04053420649796108,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8802.533203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8448.490234375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5923776633273734,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2906.32275390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.0938924739958575
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3382.983154296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 17.80517449629934
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6318.72705078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.47923602963832007
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3846.844482421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.2965434723363245
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5694.82470703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7608316241858717
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2903.258056640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.50713130970693
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138356.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.212810801945941
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35268.8515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.807824673868471
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3473.746826171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6175549913194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 682036.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.715080370575659
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214635.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5717297043748855
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9652871131896973,
+        "AvgTime/train_epoch_std": 0.052737876947598294,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 28364.52734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27571.50390625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4132709983212877,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16084.2119140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 11.588048929439841
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12595.0908203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 66.28995168585526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25967.890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.9695025123246113
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34992.93359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 11.794045700623526
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10804.1943359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.4434461370657983
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11398.2880859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 9.843081248650691
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92858.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1562891858629016
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19996.318359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.4020697208929322
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9949.4560546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.7687921875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 584188.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.608237277015486
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160487.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.6706581361389845
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9692743651720942,
+        "AvgTime/train_epoch_std": 0.04952810960244611,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 28324.009765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27850.220703125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4275575735878312,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11718.3115234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.442587552908861
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11343.333984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 59.7017578125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11674.8837890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8854671057309442
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18159.98046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.12065401710482
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8669.78125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1582874081496326
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10413.134765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 8.992344357189118
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107446.9609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.495052966224689
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11914.92578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8354316211786565
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8466.095703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.5050836805555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612335.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.926637812065201
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176378.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.93509695388814
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9760669513984963,
+        "AvgTime/train_epoch_std": 0.044414727004596186,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 28873.140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28160.3671875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4434551841457788,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15281.76171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 11.009914782961095
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13769.623046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 72.47170024671053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17659.7734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.3393836509290862
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26365.857421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.886369201845298
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10719.595703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.4321437145123581
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12677.501953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 10.947756436204664
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99979.4765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.3216486290753298
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16095.3701171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1285493000411935
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10631.9541015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.890125173611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 594534.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.725271625397328
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167709.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.7908348830146608
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9581964612007141,
+        "AvgTime/train_epoch_std": 0.042880066731541704,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2647.632568359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2806.4375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4989222222222222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 628.5335083007812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4528339396979692
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 965.7579345703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.082936497738487
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8464.228515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6419589317880167
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 332.6206359863281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11210671924042066
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5907.42041015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7892345237349699
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 779.8712768554688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6734639696506639
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160023.578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7159478479704626
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11672.0537109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8184023075962348
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40017.12890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.051213742695679
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 725554.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.207350146488242
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243458.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.051362575507962
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9984252452850342,
+        "AvgTime/train_epoch_std": 0.005923271179199219,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2550.49072265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2700.91748046875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.48016310763888886,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 514.5326538085938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3707007592280935
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 697.3203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.670106907894737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8220.359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6234629787637467
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434.5138854980469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1464488997297091
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6012.92724609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8033302933992986
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 553.598876953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.4780646605812824
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158724.96875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6857925123072635
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11319.7568359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7937005213811177
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40724.94140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0874950743887437
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 726657.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.219825684648711
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 242260.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.031432529579153
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9751348614692688,
+        "AvgTime/train_epoch_std": 0.03561893233628407,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2681.667724609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2829.7392578125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5030647569444444,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668.696044921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.481769484814031
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 686.8935546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.6152292351973685
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6924.09521484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5251494285054039
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1128.1275634765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.38022499611613164
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6107.22900390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8159290586381096
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 602.962158203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5206927100199698
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151608.03125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5205283125116105
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10243.671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7182493251297153
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40803.6328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0915286694602493
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 716843.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.108810645566328
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 235814.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9241592198758593
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9689160773628637,
+        "AvgTime/train_epoch_std": 0.03967117907625173,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 540233.5625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 340952.96875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.8568031486488015,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 334574.15625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 241.04766300432277
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 330509.0625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1739.5213815789473
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 310432.90625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 23.544399412210847
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 365385.84375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 123.14993048533873
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 289253.34375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 38.64440130260521
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 323386.5625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 279.2630073402418
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178633.890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.148102606005016
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285696.71875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 20.03202347146263
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222434.84375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 11.401652762827412
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 300010.03125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 53.335116666666664
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154900.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.577680116652522
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9868080615997314,
+        "AvgTime/train_epoch_std": 0.031034064817874928,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 595182.25,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 369149.875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 4.175761851973349,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 274959.625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 198.09771253602307
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256819.234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1351.6801809210526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 319551.125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 24.23595942358741
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349846.21875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 117.91244312436805
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233585.8125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 31.207189378757516
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253137.390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 218.59878292314335
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188562.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.378661701188928
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 271797.71875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 19.05747572219885
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180925.859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 9.273968905377005
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244118.34375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 43.39881666666667
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153121.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.548078603165094
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9707168102264404,
+        "AvgTime/train_epoch_std": 0.03788040178121151,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 520410.3125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 332124.375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.756935567797473,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 355977.78125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 256.468142110951
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361176.0625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1900.926644736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279570.46875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.203676052332195
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 346411.0625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 116.75465537580047
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 308942.34375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 41.274862224448896
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 353090.0625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 304.9136981865285
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166007.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.854900554987925
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 274221.4375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 19.227418139110924
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240313.84375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 12.318101581321441
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 325033.5,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 57.78373333333333
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150270.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.500634433295059
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9619303246339163,
+        "AvgTime/train_epoch_std": 0.032342001894526545,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 116447.953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107434.03125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7877961035395138,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104267.3515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 75.1205702899856
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105450.6796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 555.0035773026316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90698.15625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.878889362912401
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118398.9296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 39.90526784209639
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80588.0703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 10.76660926018704
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97370.671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 84.085208873057
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88184.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0477624872283116
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78679.65625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.5167337154676765
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64504.98828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.3064220760290124
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91462.7265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 16.26004027777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 450220.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.092822783163467
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9720412200351931,
+        "AvgTime/train_epoch_std": 0.05673807884511274,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 112569.6015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 105942.53125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7629762409931273,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117497.9453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 84.65269835194525
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123354.5234375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 649.2343338815789
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80384.890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.096692500948047
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115573.265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 38.952903816986854
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93447.8984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 12.48468917000668
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117532.6640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 101.49625566709845
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84812.4609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9694515357955602
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79142.53125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.54918884097602
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73546.4765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.7698742407350454
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104705.0234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 18.614226388888888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434249.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.9121544234924155
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9674953707942257,
+        "AvgTime/train_epoch_std": 0.04034962613313413,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ogformer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 113899.703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107821.8984375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7942505522689831,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126528.8125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 91.15908681556196
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133218.765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 701.1513980263157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94993.0390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 7.204629432119833
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127933.25,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 43.11872261543647
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103024.8828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 13.764179400467603
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126423.34375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 109.17387197754749
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91289.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1198485103566784
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88569.8828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.210200730086944
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80955.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.1496372667743096
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115586.9609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.548793055555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 427802.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.8392305690983335
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench/logs/train/runs/notebook_gu_grid_2026-07-14_22-36-06__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.9716241307880568,
+        "AvgTime/train_epoch_std": 0.056574067292383255,
+        "model/params/total": 17902,
+        "model/params/trainable": 17902,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/graph/ogformer.yaml
+++ b/configs/model/graph/ogformer.yaml
@@ -1,0 +1,55 @@
+_target_: topobench.model.TBModel
+
+model_name: OGFormer
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.OGFormer
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  n_layers: 2
+  # Structural encoding weight (Eq. (10)): the paper recommends
+  # values in [0.7, 1] for homophilous graphs and [0, 0.2] for heterophilous
+  # graphs. A list (one value per layer) is also accepted, e.g. [0.8, 0.9].
+  alpha: 0.8
+  # Random-walk (false) or symmetric GCN-style (true) normalization of the
+  # attention score matrix (Eq. (7)).
+  sym_norm: false
+  dropout: 0.0
+  # Neighborhood Maximum Homogeneity loss (Eq. (16)), summed
+  # with the task loss by TBLoss. Set both lambdas to 0 to disable.
+  loss:
+    _target_: topobench.loss.model.OGFormerLoss
+    lambda_kl: 1.0e-4
+    lambda_h: 1.0e-4
+    kl_norm_p: 1.0
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.OGFormerWrapper
+  _partial_: true
+  wrapper_name: OGFormerWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  # OGFormer applies its own residual connections (Eq. (5)).
+  residual_connections: false
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  # Like NoReadOut, but additionally exposes unmasked node logits so that
+  # OGFormerLoss can build pseudo-labels in transductive settings.
+  readout_name: OGFormerReadOut
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/loss/test_ogformer_loss.py
+++ b/test/loss/test_ogformer_loss.py
@@ -1,0 +1,179 @@
+"""Unit tests for the OGFormer loss (topobench/loss/model/OGFormerLoss.py)."""
+
+import pytest
+import torch
+import torch_geometric
+
+from topobench.loss.model import OGFormerLoss
+from topobench.nn.backbones.graph import OGFormer
+from topobench.nn.readouts import OGFormerReadOut
+from topobench.nn.wrappers.graph import OGFormerWrapper
+
+
+@pytest.fixture
+def two_graph_batch():
+    """Create a deterministic batch of two graphs with node labels.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Batch with 10 nodes (5 per graph), block-structured edges,
+        node features, labels and a batch vector.
+    """
+    torch.manual_seed(42)
+    x = torch.randn(10, 12)
+    edges_g1 = torch.tensor([[0, 1, 2, 3, 4, 1], [1, 2, 3, 4, 0, 3]])
+    edges_g2 = edges_g1 + 5
+    edge_index = torch.cat([edges_g1, edges_g2], dim=1)
+    batch_0 = torch.tensor([0] * 5 + [1] * 5)
+    y = torch.tensor([0, 0, 1, 1, 2, 0, 1, 1, 2, 2])
+    return torch_geometric.data.Data(
+        x=x,
+        x_0=x,
+        edge_index=edge_index,
+        batch_0=batch_0,
+        y=y,
+        num_nodes=10,
+    )
+
+
+def build_model_out(two_graph_batch, training=True):
+    """Run OGFormer wrapper and readout to build a model output dict.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    training : bool, optional
+        Whether to run the backbone in training mode (default: True).
+
+    Returns
+    -------
+    tuple[dict, OGFormer]
+        The model output dictionary and the backbone module.
+    """
+    torch.manual_seed(0)
+    model = OGFormer(12, 12, n_layers=2)
+    wrapper = OGFormerWrapper(
+        model,
+        out_channels=12,
+        num_cell_dimensions=1,
+        residual_connections=False,
+    )
+    readout = OGFormerReadOut(
+        hidden_dim=12, out_channels=3, task_level="node", pooling_type="sum"
+    )
+    wrapper.train(training)
+    model_out = readout(wrapper(two_graph_batch), two_graph_batch)
+    return model_out, model
+
+
+def test_ogformer_loss_training_and_eval(two_graph_batch):
+    """Test the NMH loss end-to-end in training and eval modes.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    """
+    loss_fn = OGFormerLoss(lambda_kl=1e-4, lambda_h=1e-4)
+    _ = loss_fn.__repr__()
+
+    model_out, model = build_model_out(two_graph_batch, training=True)
+    loss = loss_fn(model_out, two_graph_batch)
+    assert loss.item() > 0
+    loss.backward()  # Loss must be differentiable
+    assert model.layers[0].attention.lin_q.weight.grad is not None
+
+    # Validation and test: no auxiliary outputs, loss is zero
+    model_out, _ = build_model_out(two_graph_batch, training=False)
+    loss = loss_fn(model_out, two_graph_batch)
+    assert loss == torch.tensor(0.0)
+
+
+def test_ogformer_loss_disabled_terms(two_graph_batch):
+    """Test that zero lambdas disable the corresponding loss terms.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    """
+    model_out, _ = build_model_out(two_graph_batch, training=True)
+
+    loss = OGFormerLoss(lambda_kl=0.0, lambda_h=0.0)(
+        model_out, two_graph_batch
+    )
+    assert loss.item() == 0.0
+
+    kl_only = OGFormerLoss(lambda_kl=1e-4, lambda_h=0.0)(
+        model_out, two_graph_batch
+    )
+    h_only = OGFormerLoss(lambda_kl=0.0, lambda_h=1e-4)(
+        model_out, two_graph_batch
+    )
+    assert kl_only.item() > 0
+    assert h_only.item() > 0
+
+
+def test_ogformer_loss_kl_matrix_properties():
+    """Test that the KL divergence matrix has a zero diagonal and is >= 0."""
+    torch.manual_seed(0)
+    loss_fn = OGFormerLoss()
+    queries = torch.sigmoid(torch.randn(6, 16))
+    kl = loss_fn.kl_divergence_matrix(queries)
+    assert kl.shape == (6, 6)
+    assert torch.allclose(torch.diagonal(kl), torch.zeros(6), atol=1e-6)
+    assert (kl > -1e-6).all()  # KL divergence is non-negative
+
+
+def test_ogformer_loss_weighted_homophily():
+    """Test the weighted homophily rate on a perfectly homophilous graph."""
+    attention = torch.tensor(
+        [[0.5, 0.5, 0.0], [0.5, 0.5, 0.0], [0.0, 0.0, 1.0]]
+    )
+    y_same = torch.tensor([0, 0, 1])
+    h = OGFormerLoss.weighted_homophily(attention, y_same)
+    assert torch.allclose(h, torch.ones(3))
+
+    y_mixed = torch.tensor([0, 1, 1])
+    h = OGFormerLoss.weighted_homophily(attention, y_mixed)
+    assert torch.allclose(h, torch.tensor([0.5, 0.5, 1.0]))
+
+
+def test_ogformer_loss_transductive_pseudo_labels(two_graph_batch):
+    """Test pseudo-labels replace ground truth outside the training mask.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    """
+    train_mask = torch.tensor([True] * 5 + [False] * 5)
+    two_graph_batch.train_mask = train_mask
+    node_logits = torch.zeros(10, 3)
+    node_logits[:, 2] = 1.0  # All nodes predicted as class 2
+    model_out = {"node_logits": node_logits}
+
+    y = OGFormerLoss._effective_labels(model_out, two_graph_batch)
+    assert torch.equal(y[:5], two_graph_batch.y[:5])
+    assert (y[5:] == 2).all()
+    # The original labels are untouched
+    assert not torch.equal(y, two_graph_batch.y)
+
+
+def test_ogformer_loss_skips_non_node_labels(two_graph_batch):
+    """Test that the homophily term is skipped without per-node labels.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    """
+    # Graph-level labels: one per graph
+    two_graph_batch.y = torch.tensor([0, 1])
+    assert OGFormerLoss._effective_labels({}, two_graph_batch) is None
+
+    # Float (regression) labels
+    two_graph_batch.y = torch.rand(10)
+    assert OGFormerLoss._effective_labels({}, two_graph_batch) is None

--- a/test/nn/backbones/graph/test_ogformer.py
+++ b/test/nn/backbones/graph/test_ogformer.py
@@ -1,0 +1,215 @@
+"""Unit tests for the OGFormer backbone (topobench/nn/backbones/graph/ogformer.py)."""
+
+import hydra
+import pytest
+import torch
+
+from topobench.loss.model import OGFormerLoss
+from topobench.nn.backbones.graph import OGFormer
+from topobench.nn.backbones.graph.ogformer import (
+    OGFormerAttention,
+    OGFormerLayer,
+    OGFormerPropagation,
+    standardize_rows,
+    symmetric_normalize,
+)
+
+
+@pytest.fixture
+def two_graph_batch():
+    """Create a deterministic batch of two graphs.
+
+    Returns
+    -------
+    dict
+        Dictionary with node features ``x``, block-structured
+        ``edge_index`` and a ``batch`` vector for two 5-node graphs.
+    """
+    torch.manual_seed(42)
+    x = torch.randn(10, 12)
+    edges_g1 = torch.tensor([[0, 1, 2, 3, 4, 1], [1, 2, 3, 4, 0, 3]])
+    edges_g2 = edges_g1 + 5
+    edge_index = torch.cat([edges_g1, edges_g2], dim=1)
+    batch = torch.tensor([0] * 5 + [1] * 5)
+    return {"x": x, "edge_index": edge_index, "batch": batch}
+
+
+def test_standardize_rows():
+    """Test that standardize_rows yields zero-mean, unit-std rows."""
+    torch.manual_seed(0)
+    x = torch.randn(6, 32) * 3.0 + 1.0
+    x_hat = standardize_rows(x)
+    assert torch.allclose(x_hat.mean(dim=1), torch.zeros(6), atol=1e-6)
+    assert torch.allclose(x_hat.std(dim=1), torch.ones(6), atol=1e-4)
+
+
+def test_symmetric_normalize():
+    """Test symmetric normalization, including zero-degree rows."""
+    adjacency = torch.tensor(
+        [[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+    )
+    normalized = symmetric_normalize(adjacency)
+    expected = torch.tensor(
+        [[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+    )
+    assert torch.allclose(normalized, expected)
+    assert not torch.isnan(normalized).any()
+
+
+def test_build_dense_adjacency():
+    """Test the dense adjacency construction is binary and symmetric."""
+    edge_index = torch.tensor([[0, 1, 1], [1, 2, 2]])
+    adjacency = OGFormer.build_dense_adjacency(edge_index, 4, torch.float32)
+    assert adjacency.shape == (4, 4)
+    assert torch.equal(adjacency, adjacency.T)
+    # Duplicated edges are not accumulated
+    assert adjacency.max() == 1.0
+    assert adjacency[3].sum() == 0.0
+
+
+def test_ogformer_attention_scores():
+    """Test the attention module output shapes and score properties."""
+    torch.manual_seed(0)
+    attention = OGFormerAttention(12, 16, alpha=0.5)
+    x = torch.randn(8, 12)
+    se = torch.eye(8)
+    q, r = attention(x, se)
+    assert q.shape == (8, 16)
+    assert r.shape == (8, 8)
+    assert (q > 0).all() and (q < 1).all()  # Sigmoid queries
+    # Kernel part is row L1-normalized; SE bias adds alpha on the diagonal
+    assert torch.allclose(r.sum(dim=1), torch.full((8,), 1.0 + 0.5), atol=1e-5)
+
+
+def test_ogformer_propagation_norms():
+    """Test random-walk and symmetric normalization propagation paths."""
+    torch.manual_seed(0)
+    x = torch.randn(6, 12)
+    r = torch.rand(6, 6)
+    for sym_norm in (False, True):
+        propagation = OGFormerPropagation(12, 16, sym_norm=sym_norm)
+        out = propagation(r, x)
+        assert out.shape == (6, 16)
+        assert not torch.isnan(out).any()
+
+
+def test_ogformer_layer_activation_flag():
+    """Test that the last-layer variant skips the ReLU activation."""
+    torch.manual_seed(0)
+    x = torch.randn(6, 12)
+    se = torch.eye(6)
+    layer = OGFormerLayer(12, 16, alpha=0.8, apply_activation=False)
+    h, q, r = layer(x, se)
+    assert h.shape == (6, 16)
+    assert q.shape == (6, 16)
+    assert r.shape == (6, 6)
+    # Without ReLU the pre-residual messages can be negative: h - q < 0 somewhere
+    assert ((h - q) < 0).any()
+
+
+def test_ogformer_forward_shapes_and_aux(two_graph_batch):
+    """Test the backbone forward pass in training and eval modes.
+
+    Parameters
+    ----------
+    two_graph_batch : dict
+        Deterministic two-graph batch fixture.
+    """
+    model = OGFormer(12, 16, n_layers=2, alpha=[0.8, 0.9], dropout=0.2)
+    assert model.out_channels == 16
+
+    model.train()
+    out, aux = model(
+        two_graph_batch["x"],
+        two_graph_batch["edge_index"],
+        two_graph_batch["batch"],
+    )
+    assert out.shape == (10, 16)
+    assert len(aux["queries"]) == 2
+    assert len(aux["attention_scores"]) == 2
+    assert aux["attention_scores"][0].shape == (10, 10)
+
+    model.eval()
+    out_eval, aux_eval = model(
+        two_graph_batch["x"],
+        two_graph_batch["edge_index"],
+        two_graph_batch["batch"],
+    )
+    assert out_eval.shape == (10, 16)
+    assert aux_eval is None
+
+
+def test_ogformer_blocks_cross_graph_attention(two_graph_batch):
+    """Test that attention never crosses graph boundaries in a batch.
+
+    Parameters
+    ----------
+    two_graph_batch : dict
+        Deterministic two-graph batch fixture.
+    """
+    model = OGFormer(12, 16, n_layers=2)
+    model.train()
+    _, aux = model(
+        two_graph_batch["x"],
+        two_graph_batch["edge_index"],
+        two_graph_batch["batch"],
+    )
+    for attention in aux["attention_scores"]:
+        assert attention[:5, 5:].abs().sum() == 0.0
+        assert attention[5:, :5].abs().sum() == 0.0
+
+
+def test_ogformer_permutation_equivariance():
+    """Test that node permutations permute the output accordingly."""
+    torch.manual_seed(1)
+    x = torch.randn(9, 12)
+    edge_index = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7, 8]]
+    )
+    model = OGFormer(12, 16, n_layers=2)
+    model.eval()
+
+    perm = torch.randperm(9)
+    inverse = torch.empty_like(perm)
+    inverse[perm] = torch.arange(9)
+
+    out, _ = model(x, edge_index)
+    out_perm, _ = model(x[perm], inverse[edge_index])
+    assert torch.allclose(out, out_perm[inverse], atol=1e-5)
+
+
+def test_ogformer_alpha_validation():
+    """Test that a wrong number of per-layer alphas raises an error."""
+    with pytest.raises(ValueError):
+        OGFormer(12, 16, n_layers=2, alpha=[0.8, 0.9, 1.0])
+
+
+def test_ogformer_reset_parameters():
+    """Test that parameters can be re-initialized."""
+    model = OGFormer(12, 16, n_layers=2)
+    model.reset_parameters()
+    for layer in model.layers:
+        assert (layer.propagation.lin.bias == 0).all()
+
+
+def test_ogformer_hydra_instantiation():
+    """Test that the Hydra config instantiates the backbone and its loss."""
+    from topobench.utils.config_resolvers import register_all_resolvers
+
+    register_all_resolvers()
+    hydra.core.global_hydra.GlobalHydra.instance().clear()
+    with hydra.initialize(
+        version_base="1.3", config_path="../../../../configs", job_name="job"
+    ):
+        cfg = hydra.compose(
+            config_name="run.yaml",
+            overrides=["model=graph/ogformer", "dataset=graph/MUTAG"],
+            return_hydra_config=True,
+        )
+        backbone = hydra.utils.instantiate(cfg.model.backbone)
+        # The exports manager re-loads backbone modules, so compare by name
+        assert type(backbone).__name__ == OGFormer.__name__
+        assert len(backbone.layers) == cfg.model.backbone.n_layers
+        assert backbone.out_channels == cfg.model.feature_encoder.out_channels
+        loss = hydra.utils.instantiate(cfg.model.backbone.loss)
+        assert isinstance(loss, OGFormerLoss)

--- a/test/nn/readouts/test_ogformer_readout.py
+++ b/test/nn/readouts/test_ogformer_readout.py
@@ -1,0 +1,57 @@
+"""Unit tests for the OGFormer readout (topobench/nn/readouts/ogformer_readout.py)."""
+
+import pytest
+import torch
+import torch_geometric
+
+from topobench.nn.readouts import OGFormerReadOut
+
+
+@pytest.fixture
+def two_graph_batch():
+    """Create a deterministic batch of two graphs.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Batch with 10 nodes (5 per graph), node features and a batch
+        vector.
+    """
+    torch.manual_seed(42)
+    x = torch.randn(10, 12)
+    batch_0 = torch.tensor([0] * 5 + [1] * 5)
+    return torch_geometric.data.Data(
+        x=x, x_0=x, batch_0=batch_0, num_nodes=10
+    )
+
+
+def test_ogformer_readout_node_level(two_graph_batch):
+    """Test that the node-level readout exposes unmasked node logits.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    """
+    readout = OGFormerReadOut(
+        hidden_dim=12, out_channels=3, task_level="node", pooling_type="sum"
+    )
+    _ = readout.__repr__()
+    model_out = readout({"x_0": two_graph_batch.x_0}, two_graph_batch)
+    assert model_out["logits"].shape == (10, 3)
+    assert model_out["node_logits"] is model_out["logits"]
+
+
+def test_ogformer_readout_graph_level(two_graph_batch):
+    """Test that the graph-level readout pools the node embeddings.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    """
+    readout = OGFormerReadOut(
+        hidden_dim=12, out_channels=3, task_level="graph", pooling_type="sum"
+    )
+    model_out = readout({"x_0": two_graph_batch.x_0}, two_graph_batch)
+    assert model_out["logits"].shape == (2, 3)

--- a/test/nn/wrappers/graph/__init__.py
+++ b/test/nn/wrappers/graph/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for graph wrappers."""

--- a/test/nn/wrappers/graph/test_ogformer_wrapper.py
+++ b/test/nn/wrappers/graph/test_ogformer_wrapper.py
@@ -1,0 +1,67 @@
+"""Unit tests for the OGFormer wrapper (topobench/nn/wrappers/graph/ogformer_wrapper.py)."""
+
+import pytest
+import torch
+import torch_geometric
+
+from topobench.nn.backbones.graph import OGFormer
+from topobench.nn.wrappers.graph import OGFormerWrapper
+
+
+@pytest.fixture
+def two_graph_batch():
+    """Create a deterministic batch of two graphs with node labels.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Batch with 10 nodes (5 per graph), block-structured edges,
+        node features, labels and a batch vector.
+    """
+    torch.manual_seed(42)
+    x = torch.randn(10, 12)
+    edges_g1 = torch.tensor([[0, 1, 2, 3, 4, 1], [1, 2, 3, 4, 0, 3]])
+    edges_g2 = edges_g1 + 5
+    edge_index = torch.cat([edges_g1, edges_g2], dim=1)
+    batch_0 = torch.tensor([0] * 5 + [1] * 5)
+    y = torch.tensor([0, 0, 1, 1, 2, 0, 1, 1, 2, 2])
+    return torch_geometric.data.Data(
+        x=x,
+        x_0=x,
+        edge_index=edge_index,
+        batch_0=batch_0,
+        y=y,
+        num_nodes=10,
+    )
+
+
+def test_ogformer_wrapper(two_graph_batch):
+    """Test the wrapper output dictionary in training and eval modes.
+
+    Parameters
+    ----------
+    two_graph_batch : torch_geometric.data.Data
+        Deterministic two-graph batch fixture.
+    """
+    model = OGFormer(12, 12, n_layers=2)
+    wrapper = OGFormerWrapper(
+        model,
+        out_channels=12,
+        num_cell_dimensions=1,
+        residual_connections=False,
+    )
+    _ = wrapper.__repr__()
+
+    wrapper.train()
+    model_out = wrapper(two_graph_batch)
+    assert model_out["x_0"].shape == (10, 12)
+    assert torch.equal(model_out["labels"], two_graph_batch.y)
+    assert torch.equal(model_out["batch_0"], two_graph_batch.batch_0)
+    assert len(model_out["ogformer_queries"]) == 2
+    assert len(model_out["ogformer_attention"]) == 2
+
+    wrapper.eval()
+    model_out = wrapper(two_graph_batch)
+    assert model_out["x_0"].shape == (10, 12)
+    assert "ogformer_queries" not in model_out
+    assert "ogformer_attention" not in model_out

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/ogformer"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/loss/model/OGFormerLoss.py
+++ b/topobench/loss/model/OGFormerLoss.py
@@ -1,0 +1,198 @@
+"""OGFormer Neighborhood Maximum Homogeneity loss function.
+
+Implements Eqs. (13)-(16) of Zhang et al. "A graph transformer with
+optimized attention scores for node classification" (Scientific Reports,
+2025).
+"""
+
+import torch
+import torch.nn.functional as F
+import torch_geometric
+
+from topobench.loss.base import AbstractLoss
+
+
+class OGFormerLoss(AbstractLoss):
+    r"""Neighborhood Maximum Homogeneity loss for OGFormer.
+
+    Combines, for every OGFormer layer (Eq. (16)):
+
+    - a KL-divergence term :math:`\mathcal{L}_{KL} = \sum_{i,j}
+      \hat{R}_{ij} D_{KL}(Q_i \| Q_j)` (Eqs. (13)-(14)) that suppresses
+      attention between nodes with dissimilar query distributions, and
+    - a neighborhood homogeneity term :math:`\mathcal{L}_h =
+      \|1 - h(\hat{R}, Y_{train} \| Y_{pred})\|_2` (Eq. (15)) that
+      increases the attention mass placed on same-label nodes.
+
+    The homogeneity term uses ground-truth labels for training nodes and
+    model predictions for the remaining nodes (to prevent label leakage in
+    transductive settings), and is only applied to node-level
+    classification tasks. Both terms are computed only during training.
+
+    Parameters
+    ----------
+    lambda_kl : float, optional
+        Weight of the KL-divergence term; the paper recommends searching
+        in {0, 1e-3, 1e-4, 1e-5, 1e-7} (default: 1e-4).
+    lambda_h : float, optional
+        Weight of the neighborhood homogeneity term (default: 1e-4).
+    kl_norm_p : float, optional
+        Norm used to project queries onto probability distributions
+        before the KL divergence (default: 1.0).
+    """
+
+    def __init__(
+        self,
+        lambda_kl: float = 1e-4,
+        lambda_h: float = 1e-4,
+        kl_norm_p: float = 1.0,
+    ):
+        super().__init__()
+        self.lambda_kl = lambda_kl
+        self.lambda_h = lambda_h
+        self.kl_norm_p = kl_norm_p
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(lambda_kl={self.lambda_kl}, "
+            f"lambda_h={self.lambda_h}, kl_norm_p={self.kl_norm_p})"
+        )
+
+    def kl_divergence_matrix(self, queries: torch.Tensor) -> torch.Tensor:
+        r"""Pairwise KL divergence between node query distributions.
+
+        Queries are normalized to probability distributions and
+        :math:`D_{KL}(Q_i \| Q_j) = \sum_d Q_i(d) \log(Q_i(d) / Q_j(d))`
+        is computed for every node pair (Eq. (13)).
+
+        Parameters
+        ----------
+        queries : torch.Tensor
+            Query embeddings of shape [num_nodes, hidden_channels] with
+            positive entries (sigmoid outputs).
+
+        Returns
+        -------
+        torch.Tensor
+            KL divergence matrix of shape [num_nodes, num_nodes].
+        """
+        q = F.normalize(queries, p=self.kl_norm_p, dim=1)
+        log_q = torch.log(q + 1e-10)
+        self_term = (q * log_q).sum(dim=1)
+        cross_term = q @ log_q.T
+        return self_term.unsqueeze(1) - cross_term
+
+    @staticmethod
+    def weighted_homophily(
+        attention: torch.Tensor, y: torch.Tensor, eps: float = 1e-8
+    ) -> torch.Tensor:
+        r"""Attention-weighted neighborhood homogeneity rate per node.
+
+        Implements :math:`h_i = \sum_{j: Y_i = Y_j} \hat{R}_{ij} /
+        \sum_j \hat{R}_{ij}` (Eq. (15)).
+
+        Parameters
+        ----------
+        attention : torch.Tensor
+            Row-normalized attention scores of shape
+            [num_nodes, num_nodes].
+        y : torch.Tensor
+            Node labels of shape [num_nodes].
+        eps : float, optional
+            Small value preventing division by zero for nodes without
+            attention mass (default: 1e-8).
+
+        Returns
+        -------
+        torch.Tensor
+            Homogeneity rates of shape [num_nodes] in [0, 1].
+        """
+        same_label = (y.unsqueeze(0) == y.unsqueeze(1)).to(attention.dtype)
+        return (attention * same_label).sum(dim=1) / attention.sum(
+            dim=1
+        ).clamp_min(eps)
+
+    @staticmethod
+    def _effective_labels(
+        model_out: dict, batch: torch_geometric.data.Data
+    ) -> torch.Tensor | None:
+        """Assemble per-node labels for the homogeneity term.
+
+        Uses ground-truth labels for training nodes and model predictions
+        for the remaining nodes when a training mask is available
+        (transductive setting), otherwise all node labels are known
+        (inductive setting) and used directly. Returns None when the task
+        provides no per-node integer labels.
+
+        Parameters
+        ----------
+        model_out : dict
+            Dictionary containing the model output.
+        batch : torch_geometric.data.Data
+            Batch object containing the batched domain data.
+
+        Returns
+        -------
+        torch.Tensor or None
+            Effective node labels of shape [num_nodes], or None.
+        """
+        y = batch.y
+        num_nodes = batch.x_0.shape[0]
+        if y is None or y.dim() != 1 or y.shape[0] != num_nodes:
+            return None
+        if torch.is_floating_point(y):
+            return None
+
+        train_mask = batch.get("train_mask", None)
+        node_logits = model_out.get("node_logits")
+        if (
+            train_mask is not None
+            and train_mask.dtype == torch.bool
+            and train_mask.shape[0] == num_nodes
+            and not bool(train_mask.all())
+            and node_logits is not None
+            and node_logits.shape[0] == num_nodes
+        ):
+            y = y.clone()
+            y[~train_mask] = node_logits.argmax(dim=1)[~train_mask]
+        return y
+
+    def forward(
+        self, model_out: dict, batch: torch_geometric.data.Data
+    ) -> torch.Tensor:
+        r"""Forward pass of the loss function.
+
+        Parameters
+        ----------
+        model_out : dict
+            Dictionary containing the model output, including the
+            per-layer ``ogformer_queries`` and ``ogformer_attention``
+            auxiliary outputs of the OGFormer backbone.
+        batch : torch_geometric.data.Data
+            Batch object containing the batched domain data.
+
+        Returns
+        -------
+        torch.Tensor
+            The Neighborhood Maximum Homogeneity loss (Eq. (16)), zero outside training.
+        """
+        queries = model_out.get("ogformer_queries")
+        attention_scores = model_out.get("ogformer_attention")
+        if not queries or not attention_scores:  # Validation and test
+            return torch.tensor(0.0, device=batch.x_0.device)
+
+        loss = torch.tensor(0.0, device=batch.x_0.device)
+
+        if self.lambda_kl > 0:
+            for q, attention in zip(queries, attention_scores, strict=True):
+                kl = self.kl_divergence_matrix(q)
+                loss = loss + self.lambda_kl * (kl * attention).sum()
+
+        if self.lambda_h > 0:
+            y = self._effective_labels(model_out, batch)
+            if y is not None:
+                for attention in attention_scores:
+                    h = self.weighted_homophily(attention, y)
+                    loss = loss + self.lambda_h * torch.norm(1.0 - h)
+
+        return loss

--- a/topobench/nn/backbones/graph/ogformer.py
+++ b/topobench/nn/backbones/graph/ogformer.py
@@ -1,0 +1,428 @@
+"""OGFormer: a graph Transformer with optimized attention scores [1].
+
+OGFormer replaces the multi-layer multi-head attention of the vanilla
+Transformer with a simplified Single-head Self-Attention (SSA) mechanism
+built on a symmetric positive-definite kernel. Local structural information
+is injected as an unbiased additive term on the attention scores
+(structural encoding, Eqs. (9)-(11) of [1]) instead of being compressed
+into the node features. Attention scores are further optimized end-to-end
+with the Neighborhood Maximum Homogeneity loss (Eqs. (13)-(16) of [1]),
+implemented in :class:`topobench.loss.model.OGFormerLoss`.
+
+Adapted from the official implementation
+https://github.com/LittleBlackBearLiXin/OGFormer.
+
+[1] Zhang et al. "A graph transformer with optimized attention scores for
+node classification". Scientific Reports (2025).
+https://doi.org/10.1038/s41598-025-15551-2
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def standardize_rows(x: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    r"""Standardize each row of a matrix to zero mean and unit variance.
+
+    Implements :math:`\hat{Q}_i = (Q_i - \mu_i) / (\sigma_i + \epsilon)`
+    used inside the attention score computation (Eq. (7) of the paper).
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor of shape [num_nodes, num_features].
+    eps : float, optional
+        Small value preventing division by zero (default: 1e-8).
+
+    Returns
+    -------
+    torch.Tensor
+        Row-standardized tensor with the same shape as the input.
+    """
+    mean = x.mean(dim=1, keepdim=True)
+    std = x.std(dim=1, keepdim=True)
+    return (x - mean) / (std + eps)
+
+
+def symmetric_normalize(adjacency: torch.Tensor) -> torch.Tensor:
+    r"""Symmetrically normalize a dense adjacency/attention matrix.
+
+    Computes :math:`D^{-1/2} A D^{-1/2}` (GCN-style normalization), one of
+    the normalization options for the attention score matrix in Eq. (7) of
+    the paper. Rows with zero degree are left untouched.
+
+    Parameters
+    ----------
+    adjacency : torch.Tensor
+        Dense matrix of shape [num_nodes, num_nodes] with non-negative
+        entries.
+
+    Returns
+    -------
+    torch.Tensor
+        Symmetrically normalized matrix of shape [num_nodes, num_nodes].
+    """
+    d_inv_sqrt = torch.pow(adjacency.sum(dim=1), -0.5)
+    d_inv_sqrt[torch.isinf(d_inv_sqrt)] = 0.0
+    return d_inv_sqrt.unsqueeze(1) * adjacency * d_inv_sqrt.unsqueeze(0)
+
+
+class OGFormerAttention(nn.Module):
+    r"""Single-head self-attention with structural encoding of OGFormer.
+
+    Queries and keys share the same sigmoid projection, defining a
+    symmetric positive-definite kernel between node pairs (Eq. (6)). The raw attention scores are the squared dot products of the
+    row-standardized queries, row-normalized over all nodes (Eq. (7)).
+    Structural encoding enters as an additive bias term ``alpha * se`` on
+    the attention scores (Eqs. (9)-(10)).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    hidden_channels : int
+        Dimension of the shared query/key latent space.
+    alpha : float
+        Weight of the structural encoding bias. The paper recommends
+        values in [0.7, 1] for homophilous graphs and [0, 0.2] for
+        heterophilous graphs.
+    """
+
+    def __init__(self, in_channels: int, hidden_channels: int, alpha: float):
+        super().__init__()
+        self.lin_q = nn.Linear(in_channels, hidden_channels)
+        self.alpha = alpha
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Reset parameters following the official implementation."""
+        nn.init.xavier_normal_(self.lin_q.weight, gain=1)
+        nn.init.normal_(self.lin_q.bias, mean=0.0, std=0.01)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        se: torch.Tensor,
+        graph_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        r"""Compute queries and structurally-biased attention scores.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        se : torch.Tensor
+            Structural encoding of shape [num_nodes, num_nodes]: the dense
+            adjacency matrix at the first layer, the previous layer's
+            attention score matrix afterwards (Eq. (10) of the paper).
+        graph_mask : torch.Tensor, optional
+            Boolean matrix of shape [num_nodes, num_nodes] that is True
+            for node pairs belonging to the same graph. Restricts global
+            attention to each graph of a batched input (default: None).
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor]
+            Queries ``q`` of shape [num_nodes, hidden_channels] and the
+            attention score matrix ``r = Norm((q_hat q_hat^T)^2) + alpha * se``
+            of shape [num_nodes, num_nodes].
+        """
+        q = torch.sigmoid(self.lin_q(x))
+        q_hat = standardize_rows(q)
+        scores = (q_hat @ q_hat.T).pow(2)
+        if graph_mask is not None:
+            scores = scores * graph_mask
+        scores = F.normalize(scores, p=1, dim=1)
+        r = scores + self.alpha * se
+        return q, r
+
+
+class OGFormerPropagation(nn.Module):
+    r"""Message passing over the optimized attention scores.
+
+    Normalizes the attention score matrix (random-walk or symmetric
+    normalization) and aggregates node features through it,
+    :math:`Z^l = \hat{R} Z^{l-1} W^{l-1}` (Eq. (11)).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    out_channels : int
+        Number of output features per node.
+    sym_norm : bool, optional
+        If True use symmetric (GCN-style) normalization of the attention
+        scores, otherwise random-walk (row L1) normalization
+        (default: False).
+    """
+
+    def __init__(
+        self, in_channels: int, out_channels: int, sym_norm: bool = False
+    ):
+        super().__init__()
+        self.lin = nn.Linear(in_channels, out_channels)
+        self.sym_norm = sym_norm
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Reset parameters following the official implementation."""
+        nn.init.xavier_normal_(self.lin.weight, gain=1)
+        nn.init.zeros_(self.lin.bias)
+
+    def forward(self, r: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        r"""Aggregate node features through normalized attention scores.
+
+        Parameters
+        ----------
+        r : torch.Tensor
+            Attention score matrix of shape [num_nodes, num_nodes].
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+
+        Returns
+        -------
+        torch.Tensor
+            Aggregated node features of shape [num_nodes, out_channels].
+        """
+        if self.sym_norm:
+            r_hat = symmetric_normalize(r)
+        else:
+            r_hat = F.normalize(r, p=1, dim=1)
+        return self.lin(r_hat @ x)
+
+
+class OGFormerLayer(nn.Module):
+    r"""One OGFormer layer: SSA with structural encoding and residual.
+
+    Implements the node update of Eqs. (5) and (11) of the paper,
+    :math:`Z^l = \mathrm{ReLU}(\hat{R} Z^{l-1} W^{l-1}) + f(Z^{l-1})`,
+    where the residual branch ``f`` is the shared query projection of the
+    attention module.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    out_channels : int
+        Number of output features per node (also the query dimension).
+    alpha : float
+        Structural encoding weight for this layer.
+    sym_norm : bool, optional
+        Whether to use symmetric instead of random-walk normalization of
+        the attention scores (default: False).
+    apply_activation : bool, optional
+        Whether to apply ReLU to the aggregated messages; the official
+        implementation omits it in the last layer (default: True).
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        alpha: float,
+        sym_norm: bool = False,
+        apply_activation: bool = True,
+    ):
+        super().__init__()
+        self.attention = OGFormerAttention(in_channels, out_channels, alpha)
+        self.propagation = OGFormerPropagation(
+            in_channels, out_channels, sym_norm
+        )
+        self.apply_activation = apply_activation
+
+    def reset_parameters(self):
+        """Reset parameters of the attention and propagation modules."""
+        self.attention.reset_parameters()
+        self.propagation.reset_parameters()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        se: torch.Tensor,
+        graph_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        r"""Update node embeddings through one OGFormer layer.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        se : torch.Tensor
+            Structural encoding of shape [num_nodes, num_nodes].
+        graph_mask : torch.Tensor, optional
+            Same-graph mask of shape [num_nodes, num_nodes] for batched
+            inputs (default: None).
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            Updated node embeddings of shape [num_nodes, out_channels],
+            the queries ``q`` and the attention score matrix ``r`` (used
+            as the next layer's structural encoding and by the
+            Neighborhood Maximum Homogeneity loss).
+        """
+        q, r = self.attention(x, se, graph_mask)
+        h = self.propagation(r, x)
+        if self.apply_activation:
+            h = F.relu(h)
+        return h + q, q, r
+
+
+class OGFormer(nn.Module):
+    r"""OGFormer backbone for node and graph level tasks.
+
+    Stacks :class:`OGFormerLayer` modules. The structural encoding of the
+    first layer is the dense (block-diagonal for batched inputs)
+    adjacency matrix; deeper layers reuse the previous layer's attention
+    score matrix (Eq. (10)). When the module is in training
+    mode, the per-layer queries and row-normalized attention scores are
+    returned as auxiliary outputs so that
+    :class:`topobench.loss.model.OGFormerLoss` can optimize the attention
+    scores end-to-end (Eq. (16)).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features per node.
+    hidden_channels : int
+        Number of hidden (and output) features per node.
+    n_layers : int, optional
+        Number of OGFormer layers; the paper uses 2 for most datasets
+        (default: 2).
+    alpha : float or list[float], optional
+        Structural encoding weight(s). A single float is broadcast to all
+        layers; a list specifies one value per layer. The paper recommends
+        [0.7, 1] for homophilous and [0, 0.2] for heterophilous graphs
+        (default: 0.8).
+    sym_norm : bool, optional
+        Use symmetric instead of random-walk normalization of the
+        attention scores (default: False).
+    dropout : float, optional
+        Dropout rate applied to node embeddings between layers
+        (default: 0.0).
+    **kwargs : dict
+        Additional arguments.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        n_layers: int = 2,
+        alpha: float | list[float] = 0.8,
+        sym_norm: bool = False,
+        dropout: float = 0.0,
+        **kwargs,
+    ):
+        super().__init__()
+        if isinstance(alpha, (int, float)):
+            alphas = [float(alpha)] * n_layers
+        else:
+            alphas = [float(a) for a in alpha]
+        if len(alphas) != n_layers:
+            raise ValueError(
+                f"Expected {n_layers} alpha values, got {len(alphas)}"
+            )
+
+        self.out_channels = hidden_channels
+        self.dropout = dropout
+        self.layers = nn.ModuleList(
+            OGFormerLayer(
+                in_channels if i == 0 else hidden_channels,
+                hidden_channels,
+                alphas[i],
+                sym_norm=sym_norm,
+                apply_activation=i < n_layers - 1,
+            )
+            for i in range(n_layers)
+        )
+
+    def reset_parameters(self):
+        """Reset parameters of all layers."""
+        for layer in self.layers:
+            layer.reset_parameters()
+
+    @staticmethod
+    def build_dense_adjacency(
+        edge_index: torch.Tensor, num_nodes: int, dtype: torch.dtype
+    ) -> torch.Tensor:
+        """Build a dense symmetric binary adjacency matrix.
+
+        For batched inputs the (globally indexed) edges of different
+        graphs never overlap, so the result is block-diagonal.
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            Edge index tensor of shape [2, num_edges].
+        num_nodes : int
+            Total number of nodes.
+        dtype : torch.dtype
+            Data type of the resulting matrix.
+
+        Returns
+        -------
+        torch.Tensor
+            Dense adjacency matrix of shape [num_nodes, num_nodes].
+        """
+        adjacency = torch.zeros(
+            num_nodes, num_nodes, dtype=dtype, device=edge_index.device
+        )
+        adjacency[edge_index[0], edge_index[1]] = 1.0
+        adjacency[edge_index[1], edge_index[0]] = 1.0
+        return adjacency
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, dict | None]:
+        r"""Forward pass of the OGFormer backbone.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape [num_nodes, in_channels].
+        edge_index : torch.Tensor
+            Edge index tensor of shape [2, num_edges].
+        batch : torch.Tensor, optional
+            Batch vector of shape [num_nodes] assigning each node to a
+            graph. Attention is restricted to nodes of the same graph
+            (default: None).
+        **kwargs : dict
+            Additional arguments (ignored; e.g. ``edge_weight``).
+
+        Returns
+        -------
+        tuple[torch.Tensor, dict | None]
+            Node embeddings of shape [num_nodes, hidden_channels] and, in
+            training mode, a dictionary with the per-layer ``queries`` and
+            row-normalized ``attention_scores`` consumed by
+            :class:`topobench.loss.model.OGFormerLoss` (None otherwise).
+        """
+        num_nodes = x.size(0)
+        se = self.build_dense_adjacency(edge_index, num_nodes, x.dtype)
+
+        graph_mask = None
+        if batch is not None and batch.numel() > 0 and batch.max() > 0:
+            graph_mask = (batch.unsqueeze(0) == batch.unsqueeze(1)).to(x.dtype)
+
+        queries, attention_scores = [], []
+        for i, layer in enumerate(self.layers):
+            if i > 0 and self.dropout > 0:
+                x = F.dropout(x, p=self.dropout, training=self.training)
+            x, q, r = layer(x, se, graph_mask)
+            se = r
+            if self.training:
+                queries.append(q)
+                attention_scores.append(F.normalize(r, p=1, dim=1))
+
+        aux = (
+            {"queries": queries, "attention_scores": attention_scores}
+            if self.training
+            else None
+        )
+        return x, aux

--- a/topobench/nn/readouts/ogformer_readout.py
+++ b/topobench/nn/readouts/ogformer_readout.py
@@ -1,0 +1,53 @@
+"""Readout for OGFormer exposing unmasked node logits."""
+
+import torch_geometric
+
+from topobench.nn.readouts.base import AbstractZeroCellReadOut
+
+
+class OGFormerReadOut(AbstractZeroCellReadOut):
+    r"""Readout layer for OGFormer.
+
+    Behaves like :class:`topobench.nn.readouts.NoReadOut` but additionally
+    keeps a reference to the logits over *all* nodes under the
+    ``node_logits`` key. In transductive node classification the trainer
+    masks ``logits`` down to the current split, while
+    :class:`topobench.loss.model.OGFormerLoss` needs full-graph
+    predictions to build pseudo-labels for unlabeled nodes
+    (:math:`Y_{train} \| Y_{pred}` in Eq. (15)).
+
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        Additional keyword arguments forwarded to the base readout.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def forward(
+        self, model_out: dict, batch: torch_geometric.data.Data
+    ) -> dict:
+        r"""Forward pass of the OGFormer readout layer.
+
+        Parameters
+        ----------
+        model_out : dict
+            Dictionary containing the model output.
+        batch : torch_geometric.data.Data
+            Batch object containing the batched domain data.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the model output with logits and their
+            unmasked ``node_logits`` alias.
+        """
+        model_out["logits"] = self.compute_logits(
+            model_out["x_0"], batch["batch_0"]
+        )
+        model_out["node_logits"] = model_out["logits"]
+        return model_out
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"

--- a/topobench/nn/wrappers/graph/ogformer_wrapper.py
+++ b/topobench/nn/wrappers/graph/ogformer_wrapper.py
@@ -1,0 +1,43 @@
+"""Wrapper for the OGFormer backbone."""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class OGFormerWrapper(AbstractWrapper):
+    r"""Wrapper for the OGFormer backbone.
+
+    Forwards the rank-0 cell features, the edge index and the batch
+    vector to the backbone, and exposes the backbone's auxiliary outputs
+    (per-layer queries and attention scores) to
+    :class:`topobench.loss.model.OGFormerLoss` through the model output
+    dictionary. OGFormer applies its own residual connections internally
+    (Eq. (5)), so the wrapper-level residual connection
+    should be disabled in the model configuration.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the OGFormer wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the updated model output.
+        """
+        x_0, aux = self.backbone(
+            batch.x_0,
+            batch.edge_index,
+            batch=batch.batch_0,
+        )
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+        if aux is not None:  # Training mode
+            model_out["ogformer_queries"] = aux["queries"]
+            model_out["ogformer_attention"] = aux["attention_scores"]
+
+        return model_out


### PR DESCRIPTION
## Checklist

- [X] My pull request has a clear and explanatory title.
- [X] My pull request passes the Linting test.
- [X] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [X] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [X] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [X] I linked to issues and PRs that are relevant to this PR.


## Description

This PR adds **OGFormer** to TopoBench, following the paper:

> Y. Zhang, X. Li, Y. Xu, X. Xu, Z. Wang.
> **"A graph transformer with optimized attention scores for node classification"**, *Scientific Reports* 15 (2025). 
> Paper: <https://doi.org/10.1038/s41598-025-15551-2> · Official code: <https://github.com/LittleBlackBearLiXin/OGFormer>


## Model 

OGFormer is a graph Transformer designed specifically for node-level prediction. Instead of approximating the vanilla Transformer with linear kernels or sparsification (SGFormer, NodeFormer, Exphormer), it keeps the explicit quadratic attention matrix and invests in making the attention scores themselves better. It differs from both standard GTs and MPNNs in four ways:

1. **Single-head Self-Attention (SSA) with a shared Q/K projection**. Queries and keys come from one sigmoid projection ($Q = K = \sigma(ZW + b)$, Eq. 6), defining a symmetric positive-definite kernel between node pairs. Attention scores $R$ are the squared dot products of row-standardized queries (Eq. 7). Multi-head attention and the FFN block are dropped entirely, so every node attends globally to all others at minimal parameter cost.
2. **Structural encoding (SE) as an attention bias, not a feature bias**. Instead of compressing positional information into node features, the dense adjacency matrix is added directly to the attention scores at the first layer, and each deeper layer reuses the previous layer's attention matrix as its SE ($\hat{R} = Norm(R + SE)$, Eqs. 9–10). This keeps the encoding permutation-invariant, unbiased, and free of any preprocessing.
3. **Neighborhood Maximum Homogeneity (NMH) loss**. The attention scores are optimized end-to-end (Eq. 16) by (a) a KL term that penalizes attention mass between nodes with dissimilar query distributions (Eqs. 13–14), and (b) a homogeneity term that pushes each node's attention mass toward same-label nodes, using training labels plus model pseudo-labels to avoid label leakage (Eq. 15).
4. **Residual via the query branch**. Each layer updates $Z^l = \text{SSA}(Z^{l-1}, SE^l) + f(Z^{l-1})$ (Eq. 5),  mitigating feature forgetting without FFN blocks.



## Files added

| File | Description |
|---|---|
| `configs/model/graph/ogformer.yaml` | Full `TBModel` composition (2 layers, hidden 64, `α = 0.8`, random-walk normalization, `λ_KL = λ_h = 1e-4`). `alpha` accepts a per-layer list (e.g. `[0.8, 0.9]` as in the official Cora config), `sym_norm: true` switches to the GCN-style normalization used for Citeseer. |
| `topobench/nn/backbones/graph/ogformer.py` | Backbone: `OGFormer` (layer stack, dense block-diagonal adjacency, SE recursion), `OGFormerAttention` (shared-Q/K SPD kernel + SE bias, Eqs. 6–7, 9–10), `OGFormerPropagation` (random-walk or symmetric normalization + message passing, Eq. 11), `OGFormerLayer` (SSA + query residual, Eq. 5), and helpers `standardize_rows` / `symmetric_normalize`. Auto-discovered by `ModelExportsManager`. |
| `topobench/loss/model/OGFormerLoss.py` | NMH auxiliary loss (Eqs. 13–16): per-layer KL-divergence term and attention-weighted neighborhood homogeneity term; summed with the task loss by `TBLoss` via `modules_losses`. Active only during training, homogeneity term auto-disables for non-node-level labels. |
| `topobench/nn/wrappers/graph/ogformer_wrapper.py` | `OGFormerWrapper`: feeds `x_0` / `edge_index` / `batch_0` to the backbone and exposes the per-layer queries and attention matrices to the loss through `model_out`. |
| `topobench/nn/readouts/ogformer_readout.py` | `OGFormerReadOut`: identical to `NoReadOut` but keeps an unmasked `node_logits` alias so the loss can build `Y_train‖Y_pred` pseudo-labels in transductive splits. |
| `test/nn/backbones/graph/test_ogformer.py` | Backbone unit tests: helpers, attention/propagation/layer modules, train/eval forward, cross-graph attention masking, permutation equivariance, parameter validation and reset, Hydra instantiation. |
| `test/nn/wrappers/graph/test_ogformer_wrapper.py` | Wrapper output dictionary in training and eval modes (plus `__init__.py` for the previously empty `test/nn/wrappers/graph/` package). |
| `test/nn/readouts/test_ogformer_readout.py` | Node-level `node_logits` exposure and graph-level pooling. |
| `test/loss/test_ogformer_loss.py` | Loss behaviour: differentiability, zero outside training, per-term toggles, KL matrix properties, weighted homophily, transductive pseudo-labels, graph-level/regression label skip. |
| `2026_tdl_challenge/outputs/2026-07-14_22-36-06/results.json` | Results file produced by the unmodified `run_evaluation.ipynb` with `MODEL_CONFIG = "graph/ogformer"`. |

## Files modified

| File | Description |
|---|---|
| `test/pipeline/test_pipeline.py` | Filled in per the challenge instructions: `DATASET = "graph/MUTAG"`, `MODELS = ["graph/ogformer"]`. Full training pipeline runs end-to-end. |


## Testing

- **21 unit tests**, mirroring the source structure (`test/nn/backbones/graph/`, `test/nn/wrappers/graph/`, `test/nn/readouts/`, `test/loss/`), all passing.
- **Coverage: 100 %** on all four contributed source files.
- **Pipeline test** (`test/pipeline/test_pipeline.py`) passes on `graph/MUTAG` with `graph/ogformer`.

## Evaluation results (official notebook, `results.json` included)

`2026_tdl_challenge/run_evaluation.ipynb` was run unmodified with `MODEL_CONFIG = "graph/ogformer"`: 12 GraphUniverse settings × 3 seeds = **36 runs per task**.

| Task | Metric | Result | Params | Avg epoch time |
|---|---|---|---|---|
| Community detection (node, inductive) | avg test accuracy | **0.4574** | 19,137 | 1.557 s |
| Triangle counting (graph, inductive) | avg test MSE / total triangles | **0.9509** | 17,902 | 0.974 s |

<img width="3214" height="2171" alt="heatmap_community_detection_accuracy" src="https://github.com/user-attachments/assets/9d67a4a0-b230-41e9-af64-fd5c1a507a48" />

<img width="3134" height="2171" alt="heatmap_triangle_mse_over_triangles" src="https://github.com/user-attachments/assets/adef3869-c973-45d4-99f0-26f59ebefded" />


## Notes

- Quadratic  $O(n^2)$  attention is inherent to the architecture (explicitly acknowledged in the paper).
- Both model variants from the paper are covered by config switches (`sym_norm`, per-layer `alpha`) rather than separate config files, since they change only normalization/scalars, not the architecture.
