### PR TITLE
fix: make notebook hash check more robust and non-blocking

### DIFF
--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "53c1d2fb",
    "metadata": {},
    "outputs": [],
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "config_cell",
    "metadata": {},
    "outputs": [],
@@ -119,26 +119,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "f52c90bd",
    "metadata": {},
    "outputs": [],
    "source": [
     "expected_hash = (\n",
-    "    \"f87b2cfd0c61cabaa50ee2c05d8fa7b5e1d78e14e8c3a50dfdd933a5b389bfde\"\n",
+    "    \"e5f21d292c1408cfe0fc90d67955565adcdebbc1d78aa9848b6cf21316d41740\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e146dba8",
+   "execution_count": 46,
+   "id": "df0a6def",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computed hash: e5f21d292c1408cfe0fc90d67955565adcdebbc1d78aa9848b6cf21316d41740\n",
+      "Notebook content is verified.\n"
+     ]
+    }
+   ],
    "source": [
     "# UNIQUE_HASH_MARKER\n",
     "import hashlib\n",
     "import json\n",
+    "import warnings\n",
+    "\n",
+    "\n",
+    "def _normalize(text: str) -> str:\n",
+    "    \"\"\"Collapse whitespace/formatting differences so black/nbformat\n",
+    "    re-saves don't change the hash. Splits on any run of whitespace\n",
+    "    and rejoins with a single canonical separator, so only the\n",
+    "    sequence of actual tokens affects the hash.\n",
+    "    \"\"\"\n",
+    "    return \" \".join(text.split())\n",
     "\n",
     "\n",
     "def hash_remaining_cells(\n",
@@ -153,7 +172,7 @@
     "                                       Defaults to \"# UNIQUE_HASH_MARKER\".\n",
     "\n",
     "    Returns:\n",
-    "        str: The SHA-256 hash of the content of the target cells.\n",
+    "        str: The SHA-256 hash of the normalized content of the target cells.\n",
     "\n",
     "    Raises:\n",
     "        ValueError: If the marker_string is not found in the notebook data.\n",
@@ -175,11 +194,12 @@
     "            f\"Marker string '{marker_string}' not found in the notebook.\"\n",
     "        )\n",
     "\n",
-    "    content_to_hash = \"\"\n",
-    "    for cell in cells[start_index:]:\n",
-    "        content_to_hash += \"\".join(cell.get(\"source\", []))\n",
+    "    # Join with an explicit separator between cells so a cell boundary is never ambiguous with in-cell content\n",
+    "    cell_sources = [\"\".join(cell.get(\"source\", [])) for cell in cells[start_index:]]\n",
+    "    content_to_hash = \"\\n\".join(cell_sources)\n",
     "\n",
-    "    return hashlib.sha256(content_to_hash.encode(\"utf-8\")).hexdigest()\n",
+    "    normalized = _normalize(content_to_hash)\n",
+    "    return hashlib.sha256(normalized.encode(\"utf-8\")).hexdigest()\n",
     "\n",
     "\n",
     "hash_value = hash_remaining_cells(notebook_path=\"run_evaluation.ipynb\")\n",
@@ -187,11 +207,12 @@
     "print(f\"Computed hash: {hash_value}\")\n",
     "\n",
     "if hash_value != expected_hash:\n",
-    "    raise ValueError(\n",
-    "        \"❌ The content of the notebook has been modified. Please ensure that you are using the original notebook without any changes from this point onward.\"\n",
+    "    warnings.warn(\n",
+    "        \"The content of the notebook below this point looks different from the official version. This won't automatically invalidate the submission but please double check you haven't edited any protected cells before opening your PR.\",\n",
+    "        stacklevel=2,\n",
     "    )\n",
     "else:\n",
-    "    print(\"✅ Notebook content is verified.\")"
+    "    print(\"Notebook content is verified.\")\n"
    ]
   },
   {

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -119,46 +119,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 51,
    "id": "f52c90bd",
    "metadata": {},
    "outputs": [],
    "source": [
     "expected_hash = (\n",
-    "    \"e5f21d292c1408cfe0fc90d67955565adcdebbc1d78aa9848b6cf21316d41740\"\n",
+    "    \"ec61c1d64175acca938ae591af1e959ee4b311f545692e89e8363db4b69185a5\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "df0a6def",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Computed hash: e5f21d292c1408cfe0fc90d67955565adcdebbc1d78aa9848b6cf21316d41740\n",
-      "Notebook content is verified.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# UNIQUE_HASH_MARKER\n",
     "import hashlib\n",
     "import json\n",
     "import warnings\n",
-    "\n",
-    "\n",
-    "def _normalize(text: str) -> str:\n",
-    "    \"\"\"Collapse whitespace/formatting differences so black/nbformat\n",
-    "    re-saves don't change the hash. Splits on any run of whitespace\n",
-    "    and rejoins with a single canonical separator, so only the\n",
-    "    sequence of actual tokens affects the hash.\n",
-    "    \"\"\"\n",
-    "    return \" \".join(text.split())\n",
-    "\n",
     "\n",
     "def hash_remaining_cells(\n",
     "    notebook_path: str, marker_string: str = \"# UNIQUE_HASH_MARKER\"\n",
@@ -198,7 +179,7 @@
     "    cell_sources = [\"\".join(cell.get(\"source\", [])) for cell in cells[start_index:]]\n",
     "    content_to_hash = \"\\n\".join(cell_sources)\n",
     "\n",
-    "    normalized = _normalize(content_to_hash)\n",
+    "    normalized = \" \".join(content_to_hash.split())\n",
     "    return hashlib.sha256(normalized.encode(\"utf-8\")).hexdigest()\n",
     "\n",
     "\n",


### PR DESCRIPTION
Aimed to address issue #330. 

Issue was that hash check for detecting changes in notebook was brittle with harmless changes in formatting/environment affecting the notebook json and wrongly flagging this. 

I propose two minor changes
1) Make the hash check not blocking (not stopping the run), just raising warning. I think it's quite unnecessary either way since it's incredible easy to circumvent this either way if someone really wants to tamper. Reducing effect just to giving a warning seems more appropriate.
2) Make the hash more robust to changes by normalizing whitespace (tokenizing and rejoining cell contents) instead of hashing exact text. Clean clone and notebook env. should now pass. 

This is not a definite fix but just patch up. The approach proposed by dario makes more sense and should be the way to go in future challanges, but to not change current guidelines and/or move to far away from original functionalities this seems like a fine in between solution to me. 