### PR TITLE
Track: Track1; Team name: TripleA; Model: HeroFilter

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-17_03-01-10/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-17_03-01-10/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-17_03-01-10",
+    "model_config": "graph/herofilter",
+    "generated_at_utc": "2026-07-17T01:42:19.258173+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.265012264251709,
+      "test_best_rerun_accuracy": 0.3022003173828125,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3000229299068451,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3030025064945221,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3042249083518982,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35338833928108215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3473527431488037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3693941533565521,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3789059519767761,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45820918679237366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4642829895019531,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.491595983505249,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49896860122680664,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9356113433837892,
+        "AvgTime/train_epoch_std": 0.021194398194686395,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.255096912384033,
+      "test_best_rerun_accuracy": 0.30078691244125366,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3023149073123932,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30441591143608093,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30319350957870483,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35365575551986694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34658873081207275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3663381338119507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37202996015548706,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4558025896549225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.461112380027771,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4898006021976471,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5044311881065369,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.950083770535209,
+        "AvgTime/train_epoch_std": 0.028300519010963986,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.266331195831299,
+      "test_best_rerun_accuracy": 0.3016655147075653,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2979601323604584,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3020475208759308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30376651883125305,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35296812653541565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34425854682922363,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3704255521297455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.377607136964798,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.459202378988266,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4627167880535126,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.49503400921821594,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5074490308761597,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9731726381513808,
+        "AvgTime/train_epoch_std": 0.028121822574098523,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2550430297851562,
+      "test_best_rerun_accuracy": 0.3005959093570709,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3050653338432312,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30961111187934875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30563831329345703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3556039333343506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34639772772789,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3660707473754883,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3761937618255615,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44460996985435486,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44854459166526794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47154098749160767,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47952479124069214,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9763063777576793,
+        "AvgTime/train_epoch_std": 0.05900944570299396,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2503819465637207,
+      "test_best_rerun_accuracy": 0.3042249083518982,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3071281313896179,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3071281313896179,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30567651987075806,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3530827462673187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3470471501350403,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3674459457397461,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3747803568840027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4582473933696747,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45820918679237366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48620977997779846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4978226125240326,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9356634418169658,
+        "AvgTime/train_epoch_std": 0.025828805217092618,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2652814388275146,
+      "test_best_rerun_accuracy": 0.3008251190185547,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30510351061820984,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3072045147418976,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3041103184223175,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.354801744222641,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34876614809036255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36985254287719727,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38150355219841003,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.459240585565567,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4636717736721039,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4872412085533142,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5006111860275269,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.990178178857874,
+        "AvgTime/train_epoch_std": 0.037173677994310136,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2447900772094727,
+      "test_best_rerun_accuracy": 0.30945831537246704,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3041103184223175,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3022003173828125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3062495291233063,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35335013270378113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3443731367588043,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37054014205932617,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37974634766578674,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4669569730758667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46756818890571594,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5012987852096558,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5108488202095032,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9842550567552155,
+        "AvgTime/train_epoch_std": 0.058687849434551964,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2356486320495605,
+      "test_best_rerun_accuracy": 0.30540913343429565,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30265870690345764,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30319350957870483,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3061349093914032,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35434335470199585,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3450225293636322,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37145695090293884,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3784857392311096,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46921077370643616,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.47589579224586487,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5036290287971497,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5175337791442871,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9950664675965601,
+        "AvgTime/train_epoch_std": 0.04909053293276771,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2356204986572266,
+      "test_best_rerun_accuracy": 0.3130491375923157,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.306402325630188,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3015127182006836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31056612730026245,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36087554693222046,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35518375039100647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3780273497104645,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3878447413444519,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48227518796920776,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48716479539871216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.51528000831604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5295286178588867,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0046322579477347,
+        "AvgTime/train_epoch_std": 0.10663267722274002,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.222862720489502,
+      "test_best_rerun_accuracy": 0.31205591559410095,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3059821128845215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3021621108055115,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3093819320201874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3488425314426422,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3405149281024933,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3644663393497467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3720681369304657,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45603176951408386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45939338207244873,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48876920342445374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5021010041236877,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9519379875876688,
+        "AvgTime/train_epoch_std": 0.024292980233898472,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2269821166992188,
+      "test_best_rerun_accuracy": 0.3096875250339508,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3077775239944458,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3049125075340271,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3110245168209076,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3507143259048462,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34280693531036377,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3723737597465515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37921154499053955,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46489417552948,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4691725969314575,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4989303946495056,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5072197914123535,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0306935548782348,
+        "AvgTime/train_epoch_std": 0.06607379687408327,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2259068489074707,
+      "test_best_rerun_accuracy": 0.3136221170425415,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30647870898246765,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30487433075904846,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3137749135494232,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3524715304374695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34605392813682556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3695087432861328,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37825655937194824,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47016578912734985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4721522033214569,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.50382000207901,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5112690329551697,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2242830500883213,
+        "AvgTime/train_epoch_std": 0.044702704882260864,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9962772130966187,
+      "test_best_rerun_accuracy": 0.3950645625591278,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2737795114517212,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2721368968486786,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2721751034259796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26747649908065796,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.389067143201828,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41699135303497314,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43192756175994873,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5856062173843384,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5945832133293152,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.635724663734436,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6537932753562927,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.214204466342926,
+        "AvgTime/train_epoch_std": 0.040789464492107165,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.000194787979126,
+      "test_best_rerun_accuracy": 0.3965543508529663,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2801971137523651,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27454352378845215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2804263234138489,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2731301188468933,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3870425522327423,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4229505658149719,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43047598004341125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5922912359237671,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5971808433532715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6390480399131775,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6574986577033997,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.215800717819569,
+        "AvgTime/train_epoch_std": 0.04689784881026753,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9965412616729736,
+      "test_best_rerun_accuracy": 0.40003055334091187,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27358850836753845,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2657957077026367,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2716020941734314,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2679349184036255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3911299705505371,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4229505658149719,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4371991753578186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6038658618927002,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.608144223690033,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6533730626106262,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.675338089466095,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.217570571672349,
+        "AvgTime/train_epoch_std": 0.04366461483262087,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.01631760597229,
+      "test_best_rerun_accuracy": 0.389067143201828,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2745817005634308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27194592356681824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2746199071407318,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2660630941390991,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39567574858665466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4201619625091553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4332645833492279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5865994095802307,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5954618453979492,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6359538435935974,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6523798704147339,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.218499912155999,
+        "AvgTime/train_epoch_std": 0.04105641077629516,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0110907554626465,
+      "test_best_rerun_accuracy": 0.3931163549423218,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2820689082145691,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27358850836753845,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2790893018245697,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2740468978881836,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3998013734817505,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4219573736190796,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43643516302108765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5895408391952515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5957674384117126,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.636450469493866,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6536022424697876,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2147984504699707,
+        "AvgTime/train_epoch_std": 0.04277125800973094,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.020836353302002,
+      "test_best_rerun_accuracy": 0.3927343487739563,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27970051765441895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2728627026081085,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27416151762008667,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27018871903419495,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4026663601398468,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4212697744369507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43429598212242126,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5890824198722839,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5989380478858948,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6373290419578552,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6558178663253784,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9115060637978947,
+        "AvgTime/train_epoch_std": 0.03741555248995789,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.918617844581604,
+      "test_best_rerun_accuracy": 0.4278019666671753,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2706853151321411,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26201391220092773,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2659102976322174,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26243409514427185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39728015661239624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39063334465026855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44269996881484985,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6057758331298828,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6130720376968384,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6576514840126038,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6796928644180298,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9275316993395488,
+        "AvgTime/train_epoch_std": 0.03131583944424085,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9091602563858032,
+      "test_best_rerun_accuracy": 0.4290625751018524,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27492550015449524,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2676675021648407,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2754220962524414,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2672854959964752,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39632517099380493,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38986936211586,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44121018052101135,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6064634323120117,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6150202751159668,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6573458909988403,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6785086989402771,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8750426304049608,
+        "AvgTime/train_epoch_std": 0.03143580491939397,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9190845489501953,
+      "test_best_rerun_accuracy": 0.42489877343177795,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2759951055049896,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2677821218967438,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27400872111320496,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2717167139053345,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3981587588787079,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3885323405265808,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4384597837924957,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6016502380371094,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6088318228721619,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6493620872497559,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6724348664283752,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9300210866061125,
+        "AvgTime/train_epoch_std": 0.045846054748038594,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8474286794662476,
+      "test_best_rerun_accuracy": 0.4485063850879669,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2691573202610016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2643059194087982,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2695775032043457,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2623959183692932,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3979295492172241,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3911299705505371,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4292917847633362,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6153640747070312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6193750500679016,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6694934964179993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.685919463634491,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.159472836388482,
+        "AvgTime/train_epoch_std": 0.03693625342865451,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8612480163574219,
+      "test_best_rerun_accuracy": 0.4465963840484619,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.273244708776474,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2646878957748413,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.271334707736969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26461151242256165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3935747444629669,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38788294792175293,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4249751567840576,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6075712442398071,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6182672381401062,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6602108478546143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6825578808784485,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1399965867763613,
+        "AvgTime/train_epoch_std": 0.03985191938459975,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8506132364273071,
+      "test_best_rerun_accuracy": 0.44418978691101074,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2682023048400879,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2643823027610779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2685078978538513,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26445871591567993,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39487355947494507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39009854197502136,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4284513592720032,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6124608516693115,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6170448660850525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6647948622703552,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6844678521156311,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.15684344291687,
+        "AvgTime/train_epoch_std": 0.04469047092297958,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.40757417678833,
+      "test_best_rerun_accuracy": 0.6064634323120117,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2253800928592682,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2142638862133026,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22423408925533295,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.217243492603302,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3642371594905853,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3499121367931366,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3984643518924713,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4133623540401459,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6152494549751282,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6649858951568604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.690579891204834,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.196696564555168,
+        "AvgTime/train_epoch_std": 0.09369062102299602,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.375098705291748,
+      "test_best_rerun_accuracy": 0.6167392730712891,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22411948442459106,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2167086899280548,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2296202927827835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21770188212394714,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3680189549922943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3557949364185333,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40194055438041687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4150049686431885,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6183818578720093,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6700282692909241,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6956222653388977,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1713661327958107,
+        "AvgTime/train_epoch_std": 0.04043793284375376,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3813400268554688,
+      "test_best_rerun_accuracy": 0.6170448660850525,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22965848445892334,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2226678878068924,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23130109906196594,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22667889297008514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37229734659194946,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3661089539527893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4025135636329651,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42287418246269226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6178852319717407,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6693788766860962,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6918786764144897,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1856878743027197,
+        "AvgTime/train_epoch_std": 0.03580368887125645,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.361252784729004,
+      "test_best_rerun_accuracy": 0.6175796389579773,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2298876941204071,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22446328401565552,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22725188732147217,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22045229375362396,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3693177402019501,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36114293336868286,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4035831689834595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42039117217063904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6117350459098816,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6668576598167419,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6921842694282532,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1765549818674725,
+        "AvgTime/train_epoch_std": 0.042440359767999904,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3398727178573608,
+      "test_best_rerun_accuracy": 0.6231950521469116,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22740468382835388,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21919168531894684,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22828328609466553,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2195354849100113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3754679560661316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3641989529132843,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4079761505126953,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4240201711654663,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6194514632225037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.678317666053772,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6997096538543701,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1814877135413036,
+        "AvgTime/train_epoch_std": 0.04831169830053664,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.343250036239624,
+      "test_best_rerun_accuracy": 0.6203300356864929,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2266024947166443,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.219688281416893,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2272900938987732,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22167469561100006,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3727557361125946,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36412253975868225,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4025135636329651,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41687676310539246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6149438619613647,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6705248951911926,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6945144534111023,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1904926607685704,
+        "AvgTime/train_epoch_std": 0.050122958444433735,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1962887048721313,
+      "test_best_rerun_accuracy": 0.6696844696998596,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22156009078025818,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21059668064117432,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22041408717632294,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21032927930355072,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3669111430644989,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3561387360095978,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40045076608657837,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4137825667858124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6133394241333008,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6182672381401062,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.692757248878479,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.160926826298237,
+        "AvgTime/train_epoch_std": 0.05264055199289193,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1934914588928223,
+      "test_best_rerun_accuracy": 0.6675834655761719,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2157536894083023,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2050194889307022,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.215868279337883,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20639468729496002,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35770493745803833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3481549322605133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.391817569732666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41317135095596313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.612881064414978,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6171976327896118,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.697455883026123,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.145118759228633,
+        "AvgTime/train_epoch_std": 0.08366585044573693,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1916882991790771,
+      "test_best_rerun_accuracy": 0.6723202466964722,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22220948338508606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2149132788181305,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22270609438419342,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2150660902261734,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36767515540122986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3594621419906616,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40285736322402954,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.416532963514328,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6134158372879028,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6179616451263428,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6959660649299622,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1353786425157026,
+        "AvgTime/train_epoch_std": 0.045108570854168854,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1019963026046753,
+      "test_best_rerun_accuracy": 0.6967682838439941,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20788449048995972,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19948047399520874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20563067495822906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19734127819538116,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3596913516521454,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34796392917633057,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39365115761756897,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41076475381851196,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6087936162948608,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.616624653339386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6694552898406982,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1576670748846873,
+        "AvgTime/train_epoch_std": 0.11674693545458772,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0941736698150635,
+      "test_best_rerun_accuracy": 0.7001298666000366,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21663229167461395,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2075788825750351,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21563908457756042,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20945067703723907,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3614867329597473,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3526625335216522,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39796775579452515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41508135199546814,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6156314611434937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6205974221229553,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6748414635658264,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1876818793160573,
+        "AvgTime/train_epoch_std": 0.05162363636241445,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1147520542144775,
+      "test_best_rerun_accuracy": 0.6984490752220154,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.213423490524292,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20639468729496002,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21189548075199127,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2013140767812729,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36125755310058594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3488425314426422,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3953319489955902,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41141417622566223,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6122698187828064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6182290315628052,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6716326475143433,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.187073255840101,
+        "AvgTime/train_epoch_std": 0.03925637048840428,
+        "model/params/total": 37217,
+        "model/params/trainable": 37217,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 140.3174285888672,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.80177307128906,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09711943304847916,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57.72344970703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.30380763003700656
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11901.4853515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9026534206721654
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 235.639892578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07942025364951971
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7469.52685546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9979327796217435
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.17770385742188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13055069417739368
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173994.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.040375226407208
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15044.81640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0548882629540037
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45776.53515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.346431654941309
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3550.7763671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6312491319444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755701.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.548373641166023
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261555.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.352517140099512
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6128414392471313,
+        "AvgTime/train_epoch_std": 0.045211362946601025,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 145.0008087158203,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 141.06190490722656,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.10162961448647446,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69.34246063232422,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3649603191174959
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11795.4951171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8946147225777399
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 220.37075805664062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07427393261093382
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7419.619140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9912650822478289
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.80670166015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13368454374797603
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173635.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.032029000441204
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14920.240234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0461534311018792
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45593.18359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3370333483904866
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3496.415771484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6215850260416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755240.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.54314898815651
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260985.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3430222218062005
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5845051765441895,
+        "AvgTime/train_epoch_std": 0.017685038151636218,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 149.57203674316406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.04112243652344,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.10521694700037712,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.47272491455078,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3972248679713199
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11781.4384765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8935486140737581
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215.93348693847656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07277839128361192
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7404.27001953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9892144314671009
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167.1345977783203,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1443303953180659
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173412.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.026847395736578
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14886.294921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0437733082229
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45570.203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.335855406479061
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3508.406982421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.623716796875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754472.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.53447139802948
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260494.9375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.33486325362355
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.645917364529201,
+        "AvgTime/train_epoch_std": 0.12260866602021077,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.6894760131835938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.51285719871521,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.018488722098501106,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210.9871368408203,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15200802366053337
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13210.5380859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0019369045079636
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 433.4189147949219,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14607984994773235
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8199.6318359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0954751951820307
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183.62680053710938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15857236661235696
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178654.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.148587349642392
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16302.5,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.143072500350582
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47819.4921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4511503504792658
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4015.5517578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7138758680555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765592.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.660250500548624
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267405.71875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.449864688898874
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6319849491119385,
+        "AvgTime/train_epoch_std": 0.03688571095065773,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.539424419403076,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.5706095695495605,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.018792681944997686,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 213.73715209960938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15398930266542463
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13192.951171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0006030467861207
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 428.2782897949219,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14434724967809973
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8188.64892578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.094007872515865
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181.24966430664062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15651957194010416
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178660.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.148731756803826
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16284.9052734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1418388215844553
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47810.69921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4506996370265006
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3992.686767578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7098109809027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765822.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.66285505016798
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267300.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.448117917228296
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6251748353242874,
+        "AvgTime/train_epoch_std": 0.030671225477847106,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 4.0399370193481445,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.023129940032959,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.021174368105436627,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.49880981445312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1502152808461478
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13143.3369140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9968401148321957
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415.3780822753906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1399993536485981
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8155.166015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0895345378256514
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.49118041992188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15759169293602926
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178466.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.144214134776147
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16223.58984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1375396048064788
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47749.81640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4475788818622175
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3981.18115234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7077655381944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 764762.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.650862385891882
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266911.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.44164097731849
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.628899146528805,
+        "AvgTime/train_epoch_std": 0.04273050618504721,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 4982.6064453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4641.927734375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.35206126161357604,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6402.31787109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.612620944592039
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7712.66162109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 40.59295590049342
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5160.3759765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7392571542172228
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6633.94970703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8862992260562792
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6956.75390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.0075595045336785
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130398.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0280095468372656
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8371.828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5870023927219183
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30469.080078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5617960981149726
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5574.71630859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9910606770833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 654772.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.40667384025429
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204961.421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4107370554806717
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.63297738134861,
+        "AvgTime/train_epoch_std": 0.02880012777127848,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5072.30078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4737.8974609375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3593399666998483,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6384.30322265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.5996420912509
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7724.03271484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 40.65280376233552
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5116.2900390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7243983953699022
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6614.79296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8837398755845023
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6877.390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.9390247193436965
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130228.2109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0240621153980123
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8209.4345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5756159423862361
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30454.716796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5610598593918192
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5525.103515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.982240625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 656470.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.425879212243928
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 204948.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4105225442231206
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6246695518493652,
+        "AvgTime/train_epoch_std": 0.016533613204956055,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5486.2763671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5072.86376953125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.38474507163680316,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5493.322265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.9577249752341497
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6857.3701171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 36.09142166940789
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4347.1640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.4651715748230536
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6327.1923828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8453162836088844
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5901.107421875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.09594768728411
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133203.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.09314878727011
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8229.43359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5770182017774506
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31460.119140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6125951684158593
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5057.62939453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8991341145833334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 662138.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.4900045812924905
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208050.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.462140193117335
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6774964597490098,
+        "AvgTime/train_epoch_std": 0.051635560582268564,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 142.25900268554688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 138.0082244873047,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04651439989460893,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212.02178955078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1527534506850009
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 314.7450866699219,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.656553087736431
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10269.2841796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7788611437002275
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6633.39697265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8862253804483968
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 286.8306579589844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.24769486870378615
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167670.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8935113290683634
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13443.5458984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9426129503882695
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43106.3984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2095647361474193
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3087.388427734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5488690538194444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742314.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.396939300702465
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253607.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.220244038407135
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6328631180983324,
+        "AvgTime/train_epoch_std": 0.02591582673594869,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 139.02114868164062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 136.0260009765625,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04584630973257921,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 227.3340606689453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1637853463032747
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 333.52484130859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7553939016241775
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10192.779296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7730587255877892
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6608.2392578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8828642963009352
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 301.50115966796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2603636957409057
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167428.421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.887897591375627
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13373.5205078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9377030225643318
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42966.546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.202396169716541
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3052.33544921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5426374131944445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741992.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.393297597366605
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253188.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.213284513171251
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.634903907775879,
+        "AvgTime/train_epoch_std": 0.00622248649597168,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 144.56558227539062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 140.4101104736328,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.047323933425558753,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 223.73095703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16118945031069884
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 343.0712890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.805638363486842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10227.76953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7757125165908229
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6613.466796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8835626983132933
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 307.9035339355469,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.26589251635194033
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167310.578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8851611119496563
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13348.9921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9359831852124527
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43034.05078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.205856311510072
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3067.971923828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5454172309027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741208.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.384425585104578
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252822.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.207179392774533
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6778639157613118,
+        "AvgTime/train_epoch_std": 0.05607736233642893,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5305.390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5471.265625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7309640113560454,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1302.1793212890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9381695398336185
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1858.4466552734375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.781298185649671
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7134.3681640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5410973199895714
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 800.8736572265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2699270836624747
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1521.2152099609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.313657348843642
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153054.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5541283757895226
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10401.6396484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.729325455646999
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37408.21484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9174849989107592
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2837.04541015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5043636284722223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710283.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.034607140029184
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234858.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.908254705206929
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.619637906551361,
+        "AvgTime/train_epoch_std": 0.03156780205353527,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5326.1845703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5496.8720703125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7343850461339345,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1285.1441650390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9258963725065292
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1819.613525390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.576913291529605
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7155.05078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5426659674819871
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 779.283935546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.26265046698580213
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1503.8358154296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2986492361223554
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153192.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.557324200608397
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10445.0498046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7323692192320502
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37470.91015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9206986599133733
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2817.698974609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5009242621527777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710932.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.041946398877867
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 235153.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.913162982793337
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5720707178115845,
+        "AvgTime/train_epoch_std": 0.0071173906326293945,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5376.21923828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5533.3544921875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7392591171927188,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1268.63671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9140033996757925
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1830.3004150390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.63316007915296
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7251.3515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5499697810011377
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 785.7142944335938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.26481776017310205
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1495.14697265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2911459176651554
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153343.515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.56082843268159
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10452.7080078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7329061848136657
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37575.37109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9260531597595982
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2848.244873046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5063546440972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710437.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.03635199031707
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 235054.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9115095560215
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6119128465652466,
+        "AvgTime/train_epoch_std": 0.040367869532493356,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 140.12094116210938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 147.7478790283203,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12758884199336815,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144.88015747070312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10438051690972848
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.72801399230957,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1669895473279451
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12265.2763671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9302446998246113
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279.6940612792969,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09426830511604209
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7659.5439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0233191643704074
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175228.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.069020455020435
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15366.83984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0774673849214695
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46342.2265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.375428087677482
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3663.142578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6512253472222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758352.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.578359897288554
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263133.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.378764477559782
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5722428349887623,
+        "AvgTime/train_epoch_std": 0.026508626165812847,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 143.40234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 151.73681640625,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13103352021265113,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.5366668701172,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11493996172198645
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.333267211914062,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.12806982743112663
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12399.931640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9404574623151308
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.09326171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10046958601912706
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7744.1435546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0346217173931196
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175829.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.08298549832807
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15519.6279296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0881803344332843
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46554.59765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3863138887821007
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3701.070068359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6579680121527778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759877.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.595609736094929
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263784.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3895987261411475
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5718411922454834,
+        "AvgTime/train_epoch_std": 0.01688230660644102,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 147.05006408691406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 155.4310302734375,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13422368762818437,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152.78631591796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11007659648268642
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.49967575073242,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18684039868806537
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12287.6513671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9319417039960182
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 273.8774108886719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09230785672014556
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7662.6943359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.023740058241483
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175176.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.067818392392718
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15348.751953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0761991272700182
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46377.29296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3772255353298477
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3663.324951171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6512577690972222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757956.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.573878997319095
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262763.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.372605794352087
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5909343787602015,
+        "AvgTime/train_epoch_std": 0.027503602051006135,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 111008.7734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78085.8828125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.813251969452443,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74280.5703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 53.51626103206052
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79109.4921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 416.3657483552632
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40541.15234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.074793503507774
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69946.84375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 23.574938911358274
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57464.921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.677344271877088
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75855.6328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 65.50572781735751
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44758.2734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.138288699866779
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46776.8046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3977038642421444
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63293.87890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 11.252245138888888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 469244.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.308010616155561
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121663.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0245785698833476
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.566774559020996,
+        "AvgTime/train_epoch_std": 0.02220942632477401,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112464.796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78870.2734375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.831466501892532,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72566.4375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 52.28129502881844
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77651.4296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 408.6917351973684
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39321.19140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.982267076697004
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67548.90625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.76673618132794
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55959.4140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.476207623580494
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73892.78125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 63.81069192573403
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44135.2890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.09460728246389
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45993.125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.357533702393767
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60871.75390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.821645138888888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 467530.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.288625315317353
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122294.7890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.035092091632969
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.513131049963144,
+        "AvgTime/train_epoch_std": 0.07741478889091528,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 146576.46875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 100386.0,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 2.3310886122979753,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74018.4921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 53.32744393912104
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83933.6171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 441.75587993421055
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46593.01953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.5337898772279104
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67292.15625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 22.68020096056623
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63579.78515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 8.494293274048097
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77957.8203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 67.32108835276338
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48602.69140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.4078454218377505
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61042.1484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.128922468476088
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84708.4921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 15.0592875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 470774.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.325326911982625
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117929.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9624509094237266
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6230132138287579,
+        "AvgTime/train_epoch_std": 0.028803985628375724,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8852.822265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8420.470703125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.590413034856612,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4904.22021484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.533299866602125
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6051.611328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 31.8505859375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5076.552734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.38502485660788777
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3891.217529296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.311498998751896
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5956.71923828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7958208735178691
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5414.2919921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.675554397398532
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134680.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.127460001393275
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31781.232421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6290549193641397
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4562.20263671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8110582465277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668582.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.562891672228318
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210146.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.497025703908941
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6112384796142578,
+        "AvgTime/train_epoch_std": 0.024252813983778317,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8659.861328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8291.2587890625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5813531614824359,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5176.47021484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.729445399743336
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6352.111328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 33.43216488486842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4884.123046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.37043026521615474
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4040.135498046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.3616904273835102
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6128.68994140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8187962513568804
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5622.89111328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.855691807669473
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134119.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1144205426806613
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31467.61328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.612979306025424
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4741.87353515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8429997395833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 666207.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.536025361130278
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209814.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4914887133276755
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6230068640275435,
+        "AvgTime/train_epoch_std": 0.014329491078584309,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8520.4697265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8170.8935546875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5729135853798556,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6348.4287109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.573795901251801
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7454.005859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 39.23160978618421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4888.7900390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.370784227460182
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5083.431640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7133237750674082
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6647.95361328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8881701554149967
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6776.89404296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.852240106190631
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130105.8828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0212215031697007
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31255.99609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6021321489440772
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5449.87548828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9688667534722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 656521.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.426465306607242
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205203.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.414772987286373
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6329662084579468,
+        "AvgTime/train_epoch_std": 0.036092486339976346,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27546.369140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28006.640625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4355754075042289,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12377.587890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.917570526386887
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14293.5068359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 75.22898334703947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5457.6611328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.41392955121824043
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10595.4296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.5710919068082236
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9785.78125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.3073856045424181
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13058.71484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.276955823618307
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116668.4296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.709187016707691
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9030.6748046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6331983455817908
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9889.953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.758213888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 620649.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.020685101184349
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186173.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.098092487893765
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5979884231791777,
+        "AvgTime/train_epoch_std": 0.024067118360866,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27195.60546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27741.642578125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4219920333243632,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14262.83984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.27582121307637
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16280.1630859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 85.68506887335526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5992.7705078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4545142592197573
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12328.2490234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.155122690744018
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10973.0927734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.4660110585754842
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14949.974609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 12.910168056455095
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113570.75,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6372550157904513
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9612.1982421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.673972671587961
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11317.236328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.011953125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 611932.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.922079143241745
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181835.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0258957990115323
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.584177361594306,
+        "AvgTime/train_epoch_std": 0.01658389496739658,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 28045.287109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28585.603515625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.465252115209647,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14871.1669921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.714097256619237
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16709.1328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 87.94280427631578
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6416.5322265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.48665394209802804
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12292.904296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.1432100764661275
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11009.1240234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.4708248528306613
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14874.0751953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 12.84462452099525
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114486.2421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.6585138906627344
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9886.40625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6931991480858225
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12003.8037109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.134009548611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610555.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.906497799848421
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181228.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.015808049606443
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5982882976531982,
+        "AvgTime/train_epoch_std": 0.04199819254316404,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2637.96923828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2795.281982421875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4969390190972222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 593.3170776367188,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4274618714961951
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 919.9760131835938,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.841979016755756
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8543.119140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6479422935627607
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 310.1416931152344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10453039875808372
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5889.56396484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7868488930986974
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 738.4462280273438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6376910432015058
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160224.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.720618947961174
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11765.3369140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8249429893466905
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40107.04296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0558225930980574
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 726114.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.213683359162019
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244066.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.061485946782487
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5902047157287598,
+        "AvgTime/train_epoch_std": 0.024179707527907515,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2611.0361328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2766.94580078125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4919014756944444,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 705.6046752929688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5083607170698622
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1066.78662109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.614666426809211
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8260.1220703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6264787311575654
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 369.1062316894531,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12440385294555212
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5806.603515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.775765332748831
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 866.3908081054688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.7481785907646535
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158893.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6896958596507523
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11501.181640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8064213743251297
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39563.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0279678609872365
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 723496.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.184075342465754
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 242366.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.0331863216181585
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5683796405792236,
+        "AvgTime/train_epoch_std": 0,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2639.10302734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2796.769287109375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.49720342881944446,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 596.5711669921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.42980631627679217
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 944.3041381835938,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.970021779913651
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8562.041015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6493773997440273
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 317.246337890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10692495378854903
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5918.7099609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.790742813752505
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 762.0697631835938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6580913326283193
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160023.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7159507506269738
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11719.2138671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8217090076558337
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40121.37890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0565574302245118
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 726032.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.212755081841115
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243564.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.0531220878471705
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6334942749568395,
+        "AvgTime/train_epoch_std": 0.022130750907575256,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 499401.40625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 322722.65625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6505848924810245,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 378633.6875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 272.7908411383285
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389484.9375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2049.9207236842103
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 287581.40625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.811255688282138
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368321.1875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 124.1392610380856
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 331257.875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 44.2562291249165
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 382223.53125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 330.0721340673575
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169351.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.932564032602638
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 293177.28125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 20.556533533165055
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259021.546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.277028390742734
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349499.0,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 62.133155555555554
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158177.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.632219278867755
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.604849406651088,
+        "AvgTime/train_epoch_std": 0.03049613031845465,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 498241.1875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 322391.78125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.646842089634967,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 386973.3125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 278.7992164985591
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 397937.90625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2094.410032894737
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 294781.96875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 22.357373435722412
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376544.0,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 126.91068419278733
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 339029.8125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 45.29456412825651
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 390572.21875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 337.2817087651123
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173579.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.0307394952860855
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 300445.34375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.066143861309776
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 265590.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.613716746117177
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 357447.6875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 63.546255555555554
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161298.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.684140363686286
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.601348352432251,
+        "AvgTime/train_epoch_std": 0.02359800626589841,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 501289.0,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 323507.71875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6594653886180333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368618.6875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 265.5754232708934
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 379355.375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1996.6072368421053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 278964.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.15767918088737
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 358433.6875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 120.80677030670711
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 321972.5625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 43.01570641282565
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 372200.3125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 321.4165047495682
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164387.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.817291197403864
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 284528.28125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 19.950096848268124
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 251263.40625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 12.879358565277565
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 339949.46875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 60.43546111111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154672.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.5738919778509977
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6171483993530273,
+        "AvgTime/train_epoch_std": 0.004738330841064453,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 112128.4765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108476.1015625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8051370635930974,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131231.546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 94.54722397334294
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137641.5625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 724.4292763157895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82397.7578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.2493559205536595
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125286.7890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 42.226757351702055
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106386.9609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.213354834669339
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133243.828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 115.06375485751295
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79265.6953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.840648692933773
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86963.8828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.097593802587295
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79437.9296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.07186066366805
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115322.09375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.501705555555557
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 408833.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.6246556960736624
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6360252698262532,
+        "AvgTime/train_epoch_std": 0.03694126423810597,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 112120.359375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108457.3515625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.804825047218478,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132677.125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 95.58870677233429
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139094.875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 732.0782894736842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83515.640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.334140358361775
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126600.3984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 42.669497282608695
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107636.703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.380321058784235
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134817.1875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 116.42244170984456
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79574.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8478249669097158
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88101.828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.177382423573132
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80462.2109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.124363675098673
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116823.4765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.768618055555557
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 407618.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.6109107581190685
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6172643502553303,
+        "AvgTime/train_epoch_std": 0.015971714530664382,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "herofilter_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111647.9375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108273.2265625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.801761046419716,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133437.703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 96.13667372118155
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140209.5,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 737.9447368421053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84354.546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.3977661642017445
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127575.9765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 42.998306896697
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108609.03125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.510224615898464
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135548.0,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 117.05354058721935
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80233.3671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8631192454834664
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88710.6484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.22007070800028
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80809.5078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.142165555000256
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117377.7578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.867156944444446
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 406365.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.596744100878929
+        }
+      },
+      "output_dir": "/scratch/work/akbaria1/topobench_amirreza/topobench/logs/train/runs/notebook_gu_grid_2026-07-17_03-01-10__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6177254290807814,
+        "AvgTime/train_epoch_std": 0.039092787705524976,
+        "model/params/total": 35982,
+        "model/params/trainable": 35982,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/graph/herofilter.yaml
+++ b/configs/model/graph/herofilter.yaml
@@ -1,0 +1,47 @@
+# HeroFilter (arXiv:2510.10864, NeurIPS 2025) — default variant.
+# Fast-HeroFilter patcher (Eq. 12–15): truncated-Neumann personalized-PageRank
+# relevance, no per-node spectral weights, hence inductive-native.
+_target_: topobench.model.TBModel
+
+model_name: herofilter
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.HeroFilter
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  patcher: fast
+  patch_size: 16
+  order: 10          # Neumann truncation K (Eq. 14)
+  c: 0.5             # teleport factor (Eq. 12–14); reference alpha
+  num_layers: 2
+  expansion_factor: 1
+  dropout: 0.0
+  aggregation: sum   # §4.2 / Appendix pseudocode: aggregate via summation
+  residual: true
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/graph/herofilter_reference.yaml
+++ b/configs/model/graph/herofilter_reference.yaml
@@ -1,0 +1,51 @@
+# HeroFilter (arXiv:2510.10864, NeurIPS 2025) — reference-faithful variant.
+# Reproduces the released implementation (zshuai8/HeroFilter @ f0749d6)
+# verbatim: g(Λ) = Σ_k w_k^k ⊙ Λ^k with identity activation, where the filter
+# bank w is a frozen uniform-random tensor. In the released code the filter
+# bank is not registered as a Parameter and is not passed to the optimizer;
+# this config documents that paper/code gap as a runnable artifact.
+_target_: topobench.model.TBModel
+
+model_name: herofilter_reference
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.HeroFilter
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  patcher: reference
+  patch_size: 16
+  order: 20          # reference default --order
+  sigma: identity    # the released code applies no activation
+  num_layers: 2
+  expansion_factor: 1
+  dropout: 0.0
+  aggregation: sum
+  residual: true
+  seed: 0            # determinism of the frozen filter bank
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/graph/herofilter_spectral.yaml
+++ b/configs/model/graph/herofilter_spectral.yaml
@@ -1,0 +1,54 @@
+# HeroFilter (arXiv:2510.10864, NeurIPS 2025) — spectral variant.
+# Spectral patcher (Eq. 6–9): relevance R = U g(Λ) Uᵀ with the learnable
+# adaptive polynomial filter of Eq. 6. w_k is parameterized on num_bins fixed
+# frequency bins and interpolated onto each graph's spectrum, making the
+# paper's transductive w_k ∈ ℝⁿ usable on the inductive evaluation grid
+# (cf. Fig. 2 of the paper, which analyses filters over eigenvalue segments).
+_target_: topobench.model.TBModel
+
+model_name: herofilter_spectral
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.HeroFilter
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  patcher: spectral
+  patch_size: 16
+  order: 10          # polynomial order K (Eq. 6)
+  num_bins: 16       # frequency bins carrying the learnable w_k
+  sigma: identity    # released code applies no activation; satisfies σ(0)=0 (Prop. 2)
+  num_layers: 2
+  expansion_factor: 1
+  dropout: 0.0
+  aggregation: sum   # §4.2 / Appendix pseudocode: aggregate via summation
+  residual: true
+  # Eq. 8–9 select indices (non-differentiable); softmax relevance weighting
+  # of the patches restores the gradient path that makes w_k learnable.
+  weight_patches: true
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/graph/test_herofilter.py
+++ b/test/nn/backbones/graph/test_herofilter.py
@@ -1,0 +1,494 @@
+"""Unit tests for the HeroFilter backbone (arXiv:2510.10864).
+
+The parity tests transcribe the relevant lines of the authors' released
+implementation (`zshuai8/HeroFilter` @ f0749d6, ``src/HeroFilter.py``)
+verbatim into plain loops and assert numerical agreement with this
+implementation, following the plan of testing the patcher math with fixed
+weights (there is no trained reference model to match end-to-end).
+"""
+
+import pytest
+import torch
+
+from topobench.nn.backbones.graph.herofilter import (
+    AdaptivePolynomialFilter,
+    FastPatcher,
+    FeatureMixer,
+    HeroFilter,
+    HeroFilterMLP,
+    MixerLayer,
+    PatchMixer,
+    SpectralPatcher,
+    _top_p_col,
+)
+
+
+def _random_graph(num_nodes, num_edges, seed):
+    """Create a random undirected test graph.
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes.
+    num_edges : int
+        Number of directed edges to draw before symmetrization.
+    seed : int
+        Random seed.
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        Node features ``(n, 12)`` and edge index ``(2, e)``.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    x = torch.randn(num_nodes, 12, generator=generator)
+    edge_index = torch.randint(
+        0, num_nodes, (2, num_edges), generator=generator
+    )
+    edge_index = torch.cat([edge_index, edge_index.flip(0)], dim=1)
+    return x, edge_index
+
+
+def _reference_filter_response(weights, eigvals):
+    """Verbatim loop transcription of the reference filter.
+
+    Reference: ``src/HeroFilter.py`` lines 118-128 (default mode):
+    ``filtered += torch.mul(p**(i+1), eigV**(i+1))``.
+
+    Parameters
+    ----------
+    weights : torch.Tensor
+        Filter bank of shape ``(order, n)``.
+    eigvals : torch.Tensor
+        Eigenvalues of shape ``(n,)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Filter response of shape ``(n,)``.
+    """
+    filtered = torch.zeros(eigvals.shape[0])
+    for i, p in enumerate(weights):
+        filtered = filtered + torch.mul(p ** (i + 1), eigvals ** (i + 1))
+    return filtered
+
+
+def _reference_patcher(x, filtered, eigvecs, k):
+    """Verbatim loop transcription of the reference spectral patcher.
+
+    Reference: ``src/HeroFilter.py`` lines 133-151: build
+    ``atts = U diag(filtered) U^T``, take ``topk(atts.T, k - 1)`` and prepend
+    each node to its own patch.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Node features ``(n, d)``.
+    filtered : torch.Tensor
+        Filter response ``g(Lambda)`` of shape ``(n,)``.
+    eigvecs : torch.Tensor
+        Eigenvector matrix ``U`` of shape ``(n, n)``.
+    k : int
+        Patch size.
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        Patch tensor ``(n, k, d)`` and patch indices ``(n, k)``.
+    """
+    eigv_diag = torch.diag(filtered)
+    atts = eigvecs.matmul(eigv_diag)
+    atts = atts.matmul(eigvecs.T)
+    _, selected_k_ind = torch.topk(atts.T, k - 1)
+    returned = []
+    indices_all = []
+    for step, indices in enumerate(selected_k_ind):
+        full = torch.cat(
+            (torch.tensor([step], device=indices.device), indices)
+        )
+        returned.append(torch.index_select(x, 0, full))
+        indices_all.append(full)
+    return torch.stack(returned), torch.stack(indices_all)
+
+
+class TestAdaptivePolynomialFilter:
+    """Tests for AdaptivePolynomialFilter (Eq. 6)."""
+
+    def test_reference_mode_parity(self):
+        """Reference mode reproduces the released filter loop exactly."""
+        torch.manual_seed(0)
+        n, order = 20, 6
+        filt = AdaptivePolynomialFilter(order, mode="reference", seed=3)
+        eigvals = torch.linspace(-1, 1, n)
+        weights = filt._reference_weights(n, eigvals.device)
+        expected = _reference_filter_response(weights, eigvals)
+        torch.testing.assert_close(filt(eigvals), expected)
+
+    def test_reference_weights_frozen_and_deterministic(self):
+        """Frozen weights are identical across calls and never trainable."""
+        filt = AdaptivePolynomialFilter(4, mode="reference", seed=1)
+        w1 = filt._reference_weights(15, torch.device("cpu"))
+        w2 = filt._reference_weights(15, torch.device("cpu"))
+        torch.testing.assert_close(w1, w2)
+        assert not w1.requires_grad
+        assert len(list(filt.parameters())) == 0
+
+    def test_binned_mode_matches_bruteforce(self):
+        """Binned Eq. 6 agrees with an explicit loop over k."""
+        torch.manual_seed(0)
+        order, num_bins, n = 5, 8, 30
+        filt = AdaptivePolynomialFilter(order, num_bins=num_bins)
+        eigvals = torch.rand(n) * 2 - 1
+        weights = filt.interpolate_weights(eigvals)
+        expected = torch.zeros(n)
+        for k in range(1, order + 1):
+            expected = expected + weights[k - 1] * eigvals**k
+        torch.testing.assert_close(filt(eigvals), expected)
+
+    def test_binned_weights_trainable(self):
+        """Binned w_k is a Parameter of shape (order, num_bins)."""
+        filt = AdaptivePolynomialFilter(3, num_bins=7)
+        params = list(filt.parameters())
+        assert len(params) == 1
+        assert params[0].shape == (3, 7)
+        assert params[0].requires_grad
+
+    def test_interpolation_at_bin_centers(self):
+        """Eigenvalues exactly on bin centers pick the bin weights."""
+        num_bins = 5
+        filt = AdaptivePolynomialFilter(2, num_bins=num_bins)
+        centers = torch.linspace(-1, 1, num_bins)
+        torch.testing.assert_close(
+            filt.interpolate_weights(centers), filt.weight
+        )
+
+    def test_sigma_applied_per_term(self):
+        """Nonlinear sigma wraps each term of the sum, per Eq. 6."""
+        torch.manual_seed(0)
+        filt = AdaptivePolynomialFilter(3, num_bins=4, sigma="tanh")
+        eigvals = torch.rand(10) * 2 - 1
+        weights = filt.interpolate_weights(eigvals)
+        expected = torch.zeros(10)
+        for k in range(1, 4):
+            expected = expected + torch.tanh(weights[k - 1] * eigvals**k)
+        torch.testing.assert_close(filt(eigvals), expected)
+
+    def test_invalid_arguments_raise(self):
+        """Unknown sigma or mode raises ValueError."""
+        with pytest.raises(ValueError):
+            AdaptivePolynomialFilter(3, sigma="nope")
+        with pytest.raises(ValueError):
+            AdaptivePolynomialFilter(3, mode="nope")
+
+
+class TestSpectralPatcher:
+    """Tests for SpectralPatcher (Eq. 7-9)."""
+
+    def test_relevance_matches_dense_construction(self):
+        """Eq. 7: relevance equals explicit U diag(g) U^T."""
+        torch.manual_seed(0)
+        n = 12
+        patcher = SpectralPatcher(4, num_bins=6)
+        eigvals = torch.rand(n) * 2 - 1
+        eigvecs, _ = torch.linalg.qr(torch.randn(n, n))
+        expected = eigvecs @ torch.diag(patcher.filter(eigvals)) @ eigvecs.T
+        torch.testing.assert_close(
+            patcher.relevance(eigvals, eigvecs), expected
+        )
+
+    def test_patcher_parity_with_reference(self):
+        """R, patch indices and gathered patches match the released code.
+
+        Both implementations receive identical eigenpairs and identical
+        frozen filter weights, isolating the patcher math from the
+        normalization choice documented in the module docstring.
+        """
+        torch.manual_seed(0)
+        n, order, p = 18, 5, 6
+        x = torch.randn(n, 4)
+        eigvals = torch.rand(n) * 2 - 1
+        eigvecs, _ = torch.linalg.qr(torch.randn(n, n))
+
+        patcher = SpectralPatcher(order, filter_mode="reference", seed=7)
+        weights = patcher.filter._reference_weights(n, eigvals.device)
+
+        filtered = _reference_filter_response(weights, eigvals)
+        expected_patches, expected_idx = _reference_patcher(
+            x, filtered, eigvecs, p
+        )
+
+        relevance = patcher.relevance(eigvals, eigvecs)
+        idx, _ = _top_p_col(relevance, p, mask_self=False)
+        torch.testing.assert_close(idx, expected_idx)
+        torch.testing.assert_close(x[idx], expected_patches)
+
+    def test_forward_shape_and_self_first(self):
+        """Forward returns (n, p) indices with each node first in its patch."""
+        _, edge_index = _random_graph(10, 30, seed=0)
+        adj = HeroFilter.normalized_adjacency(edge_index, 10)
+        patcher = SpectralPatcher(3)
+        idx, scores = patcher(adj, 4)
+        assert scores.shape == (10, 4)
+        assert idx.shape == (10, 4)
+        torch.testing.assert_close(idx[:, 0], torch.arange(10))
+
+
+class TestFastPatcher:
+    """Tests for FastPatcher (Eq. 12-15)."""
+
+    def test_neumann_series_converges_to_closed_form(self):
+        """Eq. 14 -> Eq. 13: truncated series approaches (1-c)(I-cA)^-1."""
+        _, edge_index = _random_graph(15, 40, seed=1)
+        adj = HeroFilter.normalized_adjacency(edge_index, 15)
+        c = 0.5
+        closed_form = (1 - c) * torch.linalg.inv(torch.eye(15) - c * adj)
+        errors = []
+        for order in (2, 8, 32):
+            relevance = FastPatcher(c=c, order=order).relevance(adj)
+            errors.append((relevance - closed_form).abs().max().item())
+        assert errors[1] < errors[0]
+        assert errors[2] < 1e-6
+
+    def test_invalid_c_raises(self):
+        """Teleport factor outside (0, 1) raises ValueError."""
+        with pytest.raises(ValueError):
+            FastPatcher(c=1.0)
+        with pytest.raises(ValueError):
+            FastPatcher(c=0.0)
+
+    def test_self_first_and_no_duplicates(self):
+        """Each patch starts with the node itself and has no duplicates."""
+        _, edge_index = _random_graph(12, 40, seed=2)
+        adj = HeroFilter.normalized_adjacency(edge_index, 12)
+        idx, _ = FastPatcher(order=6)(adj, 5)
+        assert idx.shape == (12, 5)
+        torch.testing.assert_close(idx[:, 0], torch.arange(12))
+        for row in idx:
+            assert len(set(row.tolist())) == len(row)
+
+    def test_padding_when_p_exceeds_n(self):
+        """Graphs with n < p are padded by repeating the node itself."""
+        _, edge_index = _random_graph(3, 6, seed=3)
+        adj = HeroFilter.normalized_adjacency(edge_index, 3)
+        idx, _ = FastPatcher(order=4)(adj, 8)
+        assert idx.shape == (3, 8)
+        torch.testing.assert_close(idx[:, 0], torch.arange(3))
+        for v, row in enumerate(idx):
+            assert set(row.tolist()) <= set(range(3))
+            assert (row == v).sum() >= 8 - 3 + 1
+
+
+def test_top_p_col_selects_largest():
+    """top-p_col picks the genuinely largest entries per column (Eq. 8)."""
+    relevance = torch.tensor(
+        [
+            [0.9, 0.1, 5.0],
+            [0.5, 0.2, 4.0],
+            [0.1, 0.3, 3.0],
+        ]
+    )
+    idx, scores = _top_p_col(relevance, 3, mask_self=False)
+    # Column 0 sorted desc: rows 0, 1, 2 -> patch of node 0 = [0, 0, 1].
+    torch.testing.assert_close(idx[0], torch.tensor([0, 0, 1]))
+    # Column 2 sorted desc: rows 0, 1, 2 -> patch of node 2 = [2, 0, 1].
+    torch.testing.assert_close(idx[2], torch.tensor([2, 0, 1]))
+    # With self masked, node 0's top entries exclude row 0 of column 0.
+    # Scores are read from the (unmasked) relevance columns.
+    torch.testing.assert_close(scores[0], torch.tensor([0.9, 0.9, 0.5]))
+    idx_masked, _ = _top_p_col(relevance, 3, mask_self=True)
+    torch.testing.assert_close(idx_masked[0], torch.tensor([0, 1, 2]))
+
+
+class TestMixer:
+    """Tests for HeroFilterMLP, PatchMixer, FeatureMixer, MixerLayer (Eq. 10-11)."""
+
+    def test_mlp_shapes(self):
+        """MLP maps (..., in) -> (..., out) with expansion hidden width."""
+        mlp = HeroFilterMLP(6, 2, 0.0, out_features=4)
+        assert mlp.fc1.out_features == 12
+        assert mlp(torch.randn(5, 3, 6)).shape == (5, 3, 4)
+
+    def test_patch_mixer_mixes_patch_dimension(self):
+        """Eq. 10 output shape is preserved and depends on the patch axis."""
+        torch.manual_seed(0)
+        mixer = PatchMixer(6, 4, 1, 0.0)
+        x = torch.randn(3, 4, 6)
+        out = mixer(x)
+        assert out.shape == x.shape
+        permuted = mixer(x[:, [1, 0, 2, 3], :])
+        assert not torch.allclose(out, permuted[:, [1, 0, 2, 3], :])
+
+    def test_feature_mixer_is_patchwise(self):
+        """Eq. 11 acts identically on every patch slot."""
+        torch.manual_seed(0)
+        mixer = FeatureMixer(6, 1, 0.0)
+        x = torch.randn(3, 4, 6)
+        out = mixer(x)
+        assert out.shape == x.shape
+        permutation = [2, 0, 1, 3]
+        torch.testing.assert_close(
+            mixer(x[:, permutation, :]), out[:, permutation, :]
+        )
+
+    def test_ablation_flags(self):
+        """Table 6 ablations: disabled mixers are absent; both off = identity."""
+        layer = MixerLayer(6, 4, 1, 0.0, use_patch_mixing=False)
+        assert layer.patch_mixer is None
+        layer = MixerLayer(6, 4, 1, 0.0, use_feature_mixing=False)
+        assert layer.feature_mixer is None
+        layer = MixerLayer(
+            6, 4, 1, 0.0, use_patch_mixing=False, use_feature_mixing=False
+        )
+        x = torch.randn(3, 4, 6)
+        torch.testing.assert_close(layer(x), x)
+
+
+class TestHeroFilter:
+    """Tests for the HeroFilter backbone module."""
+
+    def test_normalized_adjacency(self):
+        """Symmetric normalization matches manual D^-1/2 A D^-1/2."""
+        edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+        adj = HeroFilter.normalized_adjacency(edge_index, 4)
+        expected = torch.tensor(
+            [
+                [0.0, 1 / (2**0.5), 0.0, 0.0],
+                [1 / (2**0.5), 0.0, 1 / (2**0.5), 0.0],
+                [0.0, 1 / (2**0.5), 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        torch.testing.assert_close(adj, expected)
+        # Directed input is symmetrized.
+        directed = torch.tensor([[0], [1]])
+        adj = HeroFilter.normalized_adjacency(directed, 2)
+        torch.testing.assert_close(adj, adj.T)
+
+    @pytest.mark.parametrize("patcher", ["fast", "spectral", "reference"])
+    def test_forward_shapes_and_gradients(self, patcher):
+        """Forward yields (n, hidden) embeddings and gradients flow."""
+        x, edge_index = _random_graph(14, 40, seed=4)
+        model = HeroFilter(12, 16, patcher=patcher, patch_size=6, order=4)
+        out = model(x, edge_index)
+        assert out.shape == (14, 16)
+        out.sum().backward()
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        assert len(grads) > 0
+
+    def test_spectral_filter_weights_receive_gradients(self):
+        """The binned w_k of Eq. 6 is trained through R (unlike the release)."""
+        x, edge_index = _random_graph(10, 30, seed=5)
+        model = HeroFilter(12, 8, patcher="spectral", patch_size=4, order=3)
+        model(x, edge_index).sum().backward()
+        assert model.patcher.filter.weight.grad is not None
+
+    def test_batch_safety(self):
+        """Two disjoint graphs in one batch equal each graph run alone."""
+        x1, ei1 = _random_graph(9, 24, seed=6)
+        x2, ei2 = _random_graph(13, 40, seed=7)
+        for patcher in ("fast", "spectral", "reference"):
+            model = HeroFilter(12, 8, patcher=patcher, patch_size=5, order=3)
+            model.eval()
+            x = torch.cat([x1, x2])
+            edge_index = torch.cat([ei1, ei2 + 9], dim=1)
+            batch = torch.cat(
+                [
+                    torch.zeros(9, dtype=torch.long),
+                    torch.ones(13, dtype=torch.long),
+                ]
+            )
+            with torch.no_grad():
+                joint = model(x, edge_index, batch=batch)
+                alone1 = model(x1, ei1)
+                alone2 = model(x2, ei2)
+            torch.testing.assert_close(joint[:9], alone1)
+            torch.testing.assert_close(joint[9:], alone2)
+
+    def test_small_graph_padding_in_forward(self):
+        """Forward works when a graph has fewer nodes than patch_size."""
+        x, edge_index = _random_graph(5, 12, seed=8)
+        model = HeroFilter(12, 8, patcher="fast", patch_size=16, order=3)
+        assert model(x, edge_index).shape == (5, 8)
+
+    def test_edge_weight_used(self):
+        """Edge weights alter the normalized adjacency and the output."""
+        x, edge_index = _random_graph(8, 20, seed=9)
+        model = HeroFilter(12, 8, patcher="fast", patch_size=4, order=3)
+        model.eval()
+        weight = torch.rand(edge_index.shape[1]) + 0.5
+        with torch.no_grad():
+            out_unweighted = model(x, edge_index)
+            out_weighted = model(x, edge_index, edge_weight=weight)
+        assert not torch.allclose(out_unweighted, out_weighted)
+
+    def test_aggregation_mean(self):
+        """Mean aggregation equals sum divided by patch size."""
+        x, edge_index = _random_graph(8, 20, seed=10)
+        kwargs = dict(patcher="fast", patch_size=4, order=3, residual=False)
+        torch.manual_seed(0)
+        model_sum = HeroFilter(12, 8, aggregation="sum", **kwargs)
+        torch.manual_seed(0)
+        model_mean = HeroFilter(12, 8, aggregation="mean", **kwargs)
+        model_sum.eval()
+        model_mean.eval()
+        with torch.no_grad():
+            # LayerNorm is scale-invariant up to its affine params, so
+            # compare pre-norm sums via the internal pipeline instead.
+            patches, _ = model_sum.build_patches(
+                x, edge_index, torch.zeros(8, dtype=torch.long)
+            )
+            patches_sum = model_sum.mixers(model_sum.dim_red(patches)).sum(
+                dim=1
+            )
+            out_sum = model_sum(x, edge_index)
+            out_mean = model_mean(x, edge_index)
+        assert patches_sum.shape == (8, 8)
+        assert out_sum.shape == out_mean.shape
+
+    def test_invalid_arguments_raise(self):
+        """Unknown patcher or aggregation raises ValueError."""
+        with pytest.raises(ValueError):
+            HeroFilter(4, 4, patcher="nope")
+        with pytest.raises(ValueError):
+            HeroFilter(4, 4, aggregation="nope")
+
+    def test_out_channels_attribute(self):
+        """The backbone exposes out_channels for the TopoBench composition."""
+        model = HeroFilter(12, 24)
+        assert model.out_channels == 24
+
+    def test_empty_graph_segment_skipped(self):
+        """A batch index with no nodes (empty segment) is skipped safely."""
+        x, edge_index = _random_graph(6, 16, seed=12)
+        model = HeroFilter(12, 8, patcher="fast", patch_size=4, order=3)
+        # Graph ids 0 and 2 are populated; id 1 is empty.
+        batch = torch.tensor([0, 0, 0, 2, 2, 2])
+        mask = (edge_index < 3).all(dim=0) | (edge_index >= 3).all(dim=0)
+        assert model(x, edge_index[:, mask], batch=batch).shape == (6, 8)
+
+    def test_weight_patches_default_and_override(self):
+        """Relevance weighting defaults on for spectral, off otherwise."""
+        assert HeroFilter(4, 4, patcher="spectral").weight_patches
+        assert not HeroFilter(4, 4, patcher="fast").weight_patches
+        assert not HeroFilter(4, 4, patcher="reference").weight_patches
+        assert HeroFilter(
+            4, 4, patcher="fast", weight_patches=True
+        ).weight_patches
+
+    def test_weight_patches_changes_output(self):
+        """Softmax relevance weighting of patches affects the embedding."""
+        x, edge_index = _random_graph(10, 30, seed=11)
+        torch.manual_seed(0)
+        weighted = HeroFilter(
+            12, 8, patcher="fast", patch_size=4, order=3, weight_patches=True
+        )
+        torch.manual_seed(0)
+        unweighted = HeroFilter(
+            12, 8, patcher="fast", patch_size=4, order=3, weight_patches=False
+        )
+        weighted.eval()
+        unweighted.eval()
+        with torch.no_grad():
+            assert not torch.allclose(
+                weighted(x, edge_index), unweighted(x, edge_index)
+            )

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -6,8 +6,17 @@ import pytest
 from test._utils.simplified_pipeline import run
 
 
-DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+# MUTAG keeps all three HeroFilter configs CI-fast: its ~18-node graphs make
+# the spectral eigendecomposition trivial, and it exercises the graph-level
+# readout and multi-graph batch segmentation. The paper-native transductive
+# node-classification setting is covered by the unit tests and the
+# GraphUniverse evaluation notebook.
+DATASET = "graph/MUTAG"
+MODELS = [
+    "graph/herofilter",
+    "graph/herofilter_spectral",
+    "graph/herofilter_reference",
+]
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/herofilter.py
+++ b/topobench/nn/backbones/graph/herofilter.py
@@ -1,0 +1,825 @@
+"""HeroFilter backbone.
+
+Implementation of *HeroFilter: Adaptive Spectral Graph Filter for Varying
+Heterophilic Relations* (NeurIPS 2025, arXiv:2510.10864), reference code
+`zshuai8/HeroFilter` @ f0749d6.
+
+The model builds, for every node, a *patch* of the p most spectrally relevant
+nodes (Eq. 8-9 / Eq. 15), mixes the patches with an MLP-Mixer (Eq. 10-11) and
+aggregates them into node representations (Section 4.2). Two patchers are
+provided:
+
+- :class:`FastPatcher` (default) - Fast-HeroFilter, Eq. 12-15. Relevance is a
+  truncated Neumann series of the personalized-PageRank closed form; only two
+  hyperparameters (``c``, ``K``), hence usable inductively on graphs of any
+  size.
+- :class:`SpectralPatcher` - Eq. 6-9. Relevance is ``R = U g(Lambda) U^T``
+  built from an eigendecomposition of the normalized adjacency and the
+  learnable filter of :class:`AdaptivePolynomialFilter`.
+
+Known divergences from the released reference code, stated here once:
+
+- The reference eigendecomposes the row-normalized adjacency ``D^-1 A`` with
+  ``np.linalg.eig`` (non-symmetric, so ``U U^T != I``). We use the symmetric
+  normalization ``D^-1/2 A D^-1/2`` with ``torch.linalg.eigh``, which is
+  similar to ``D^-1 A`` (identical eigenvalues) and makes Eq. 7 exact.
+- In the released code the spectral filter bank is a plain tensor - it is not
+  registered as a Parameter and is not passed to the optimizer. The
+  ``"reference"`` filter mode reproduces that behaviour verbatim (frozen
+  weights, ``w_k^k * lambda^k``, identity activation); the ``"binned"`` mode
+  implements the paper's learnable ``w_k`` (Eq. 6) in a size-agnostic way.
+- The reference weights each patch slot by a softmax of a fixed random,
+  non-trainable vector before summing. Section 4.2 and the Appendix
+  pseudocode specify a plain aggregation ("mean, sum, or flatten" /
+  "summation"), which is what ``aggregation`` implements.
+- The patching rule of Eq. 8-9 selects *indices*, which is
+  non-differentiable: as written (and as released - the reference softmax
+  patch weighting is commented out), the classification loss provides no
+  gradient to the filter weights :math:`w_k` of Eq. 6. ``weight_patches``
+  multiplies each patch by the softmax of its selected relevance scores,
+  restoring a gradient path so the Eq. 6 filter is genuinely learnable. It
+  defaults to on for the ``"spectral"`` patcher and off for ``"fast"`` /
+  ``"reference"``.
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+_SIGMAS = {
+    "identity": lambda t: t,
+    "relu": F.relu,
+    "tanh": torch.tanh,
+}
+
+
+class AdaptivePolynomialFilter(nn.Module):
+    r"""Adaptive polynomial spectral filter, Eq. 6 of arXiv:2510.10864.
+
+    Implements :math:`g(\Lambda) = \sum_{k=1}^{K} \sigma(w_k \odot \Lambda^k)`
+    where :math:`w_k` are learnable frequency-specific weights.
+
+    The paper defines :math:`w_k \in \mathbb{R}^n` (one weight per frequency
+    of one fixed graph), which is transductive. For inductive use, ``mode
+    ="binned"`` parameterizes :math:`w_k` on ``num_bins`` fixed frequency bins
+    spanning the eigenvalue range ``[-1, 1]`` of the symmetric normalized
+    adjacency and linearly interpolates onto each graph's actual spectrum.
+    This follows the paper's own Fig. 2, which analyses learned filters over
+    fixed eigenvalue segments (0-0.4, ..., 1.6-2.0 of the Laplacian spectrum).
+
+    ``mode="reference"`` instead reproduces the released reference code
+    (`zshuai8/HeroFilter` @ f0749d6, ``src/HeroFilter.py::Patcher``):
+    :math:`g(\Lambda) = \sum_k w_k^k \odot \Lambda^k` with identity
+    activation, where ``w`` is a uniform random tensor that is *not*
+    registered as a Parameter and receives no gradient updates. Weights are
+    drawn deterministically per graph size so repeated forward passes agree.
+
+    Parameters
+    ----------
+    order : int
+        Polynomial order :math:`K` (Eq. 6).
+    num_bins : int, optional
+        Number of frequency bins for ``mode="binned"`` (default: 16).
+    sigma : str, optional
+        Activation applied to each term. One of ``"identity"``, ``"relu"``,
+        ``"tanh"`` (default: ``"identity"``). The released code applies no
+        activation; identity also satisfies the :math:`\sigma(0)=0` condition
+        of Prop. 2.
+    mode : str, optional
+        ``"binned"`` (paper's Eq. 6, inductive) or ``"reference"`` (released
+        code, frozen) (default: ``"binned"``).
+    seed : int, optional
+        Seed for the frozen ``"reference"`` weights (default: 0).
+    """
+
+    def __init__(
+        self, order, num_bins=16, sigma="identity", mode="binned", seed=0
+    ):
+        super().__init__()
+        if sigma not in _SIGMAS:
+            raise ValueError(f"Unknown sigma '{sigma}'")
+        if mode not in ("binned", "reference"):
+            raise ValueError(f"Unknown filter mode '{mode}'")
+        self.order = order
+        self.num_bins = num_bins
+        self.sigma = sigma
+        self.mode = mode
+        self.seed = seed
+        if mode == "binned":
+            # Uniform init in [0, 1), matching the reference filter bank.
+            self.weight = nn.Parameter(torch.rand(order, num_bins))
+        else:
+            self.weight = None
+            self._frozen_weights: dict[int, torch.Tensor] = {}
+
+    def _reference_weights(self, n, device):
+        """Frozen uniform random weights of the reference code, per graph size.
+
+        Parameters
+        ----------
+        n : int
+            Number of eigenvalues (graph size).
+        device : torch.device
+            Device to place the weights on.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(order, n)``, deterministic in ``(seed, n)``.
+        """
+        if n not in self._frozen_weights:
+            generator = torch.Generator().manual_seed(self.seed + n)
+            self._frozen_weights[n] = torch.rand(
+                self.order, n, generator=generator
+            )
+        return self._frozen_weights[n].to(device)
+
+    def interpolate_weights(self, eigvals):
+        r"""Interpolate the binned weights onto a graph's eigenvalues.
+
+        Bin centers are spread uniformly over ``[-1, 1]`` (the spectrum of
+        the symmetric normalized adjacency); each eigenvalue receives the
+        linear interpolation of the two enclosing bins.
+
+        Parameters
+        ----------
+        eigvals : torch.Tensor
+            Eigenvalues :math:`\Lambda` of shape ``(n,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Weights :math:`w_k(\lambda)` of shape ``(order, n)``.
+        """
+        pos = (eigvals.clamp(-1.0, 1.0) + 1.0) / 2.0 * (self.num_bins - 1)
+        lo = pos.floor().long().clamp(max=self.num_bins - 1)
+        hi = (lo + 1).clamp(max=self.num_bins - 1)
+        frac = pos - lo.to(pos.dtype)
+        return self.weight[:, lo] * (1.0 - frac) + self.weight[:, hi] * frac
+
+    def forward(self, eigvals):
+        r"""Evaluate the filter response :math:`g(\Lambda)` (Eq. 6).
+
+        Parameters
+        ----------
+        eigvals : torch.Tensor
+            Eigenvalues of the normalized adjacency, shape ``(n,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Filter response of shape ``(n,)``.
+        """
+        sigma = _SIGMAS[self.sigma]
+        if self.mode == "binned":
+            weights = self.interpolate_weights(eigvals)
+        else:
+            weights = self._reference_weights(eigvals.shape[0], eigvals.device)
+        response = eigvals.new_zeros(eigvals.shape)
+        for k in range(1, self.order + 1):
+            w_k = weights[k - 1]
+            if self.mode == "reference":
+                # Released code raises the weight itself to the power k:
+                # `filtered += torch.mul(p**(i+1), eigV**(i+1))`.
+                w_k = w_k**k
+            response = response + sigma(w_k * eigvals**k)
+        return response
+
+
+class SpectralPatcher(nn.Module):
+    r"""Spectral patcher, Eq. 6-9 of arXiv:2510.10864.
+
+    Builds the relevance matrix :math:`R = U g(\Lambda) U^\top` (Eq. 7) from
+    an eigendecomposition of the normalized adjacency and the filter of
+    :class:`AdaptivePolynomialFilter`, then selects for each node ``v`` the
+    top-``p-1`` entries of column ``v`` of ``R`` and prepends ``v`` itself
+    (Eq. 8), yielding patch indices for the patch tensor
+    :math:`P \in \mathbb{R}^{n \times p \times d}` (Eq. 9).
+
+    Self-inclusion follows the reference code exactly: the node is prepended
+    and *not* masked out of the top-k, so it may appear twice in its own
+    patch. When a graph has fewer than ``p`` nodes, remaining slots are
+    filled with the node itself - the reference's own padding rule
+    (``train.py:622`` pads with ``neighbor[0]``).
+
+    Parameters
+    ----------
+    order : int
+        Polynomial order :math:`K` of the filter (Eq. 6).
+    num_bins : int, optional
+        Frequency bins of the ``"binned"`` filter (default: 16).
+    sigma : str, optional
+        Filter activation (default: ``"identity"``).
+    filter_mode : str, optional
+        ``"binned"`` or ``"reference"``, see
+        :class:`AdaptivePolynomialFilter` (default: ``"binned"``).
+    seed : int, optional
+        Seed for ``"reference"`` weights (default: 0).
+    """
+
+    def __init__(
+        self,
+        order,
+        num_bins=16,
+        sigma="identity",
+        filter_mode="binned",
+        seed=0,
+    ):
+        super().__init__()
+        self.filter = AdaptivePolynomialFilter(
+            order, num_bins=num_bins, sigma=sigma, mode=filter_mode, seed=seed
+        )
+
+    def relevance(self, eigvals, eigvecs):
+        r"""Relevance matrix :math:`R = U\,\mathrm{diag}(g(\Lambda))\,U^\top` (Eq. 7).
+
+        Parameters
+        ----------
+        eigvals : torch.Tensor
+            Eigenvalues, shape ``(n,)``.
+        eigvecs : torch.Tensor
+            Eigenvectors ``U`` (columns), shape ``(n, n)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Relevance matrix of shape ``(n, n)``.
+        """
+        return (eigvecs * self.filter(eigvals)) @ eigvecs.T
+
+    def forward(self, adj_norm, patch_size):
+        r"""Patch indices via ``top-p_col(R)`` (Eq. 8).
+
+        Parameters
+        ----------
+        adj_norm : torch.Tensor
+            Dense symmetric normalized adjacency of one graph, ``(n, n)``.
+        patch_size : int
+            Patch size ``p``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Patch indices of shape ``(n, p)`` (row ``v`` starts with ``v``)
+            and their relevance scores of shape ``(n, p)``.
+        """
+        eigvals, eigvecs = torch.linalg.eigh(adj_norm)
+        relevance = self.relevance(eigvals, eigvecs)
+        return _top_p_col(relevance, patch_size, mask_self=False)
+
+
+class FastPatcher(nn.Module):
+    r"""Fast-HeroFilter patcher, Eq. 12-15 of arXiv:2510.10864.
+
+    The personalized-PageRank objective (Eq. 12) has the closed-form solution
+    :math:`r_v = (1-c)(I - c\tilde A)^{-1} e_v` (Eq. 13), approximated by the
+    truncated Neumann series
+    :math:`r_v \approx (1-c)\sum_{k=0}^{K} c^k \tilde A^k e_v` (Eq. 14).
+    Stacking all :math:`r_v` columnwise gives the relevance matrix, and
+    patches are :math:`\phi_{fast}(\tilde A) = \mathrm{top\text{-}p_{col}}`
+    of it (Eq. 15).
+
+    The reference computes these scores offline with power-iteration
+    PageRank (``arxiv_year_ppr.py``, alpha=0.5); here the truncated series is
+    evaluated in-model per graph, which is exact w.r.t. Eq. 14 and needs no
+    preprocessing. There are no learnable parameters - only ``c`` and ``K``
+    (Section 4.4) - so the patcher is inductive by construction. The node
+    itself is guaranteed first in its own patch (the reference's PPR ranking
+    places the personalization node first).
+
+    Parameters
+    ----------
+    c : float, optional
+        Teleport/attenuation factor of Eq. 12-14, in ``(0, 1)``
+        (default: 0.5, the reference's alpha).
+    order : int, optional
+        Truncation order ``K`` of the Neumann series (default: 10).
+    """
+
+    def __init__(self, c=0.5, order=10):
+        super().__init__()
+        if not 0.0 < c < 1.0:
+            raise ValueError(f"c must be in (0, 1), got {c}")
+        self.c = c
+        self.order = order
+
+    def relevance(self, adj_norm):
+        r"""Truncated Neumann-series relevance (Eq. 14), all nodes at once.
+
+        Parameters
+        ----------
+        adj_norm : torch.Tensor
+            Dense normalized adjacency of one graph, ``(n, n)``.
+
+        Returns
+        -------
+        torch.Tensor
+            :math:`(1-c)\sum_{k=0}^{K} c^k \tilde A^k`, shape ``(n, n)``;
+            column ``v`` is :math:`r_v`.
+        """
+        n = adj_norm.shape[0]
+        term = torch.eye(n, device=adj_norm.device, dtype=adj_norm.dtype)
+        result = term.clone()
+        for k in range(1, self.order + 1):
+            term = adj_norm @ term
+            result = result + self.c**k * term
+        return (1.0 - self.c) * result
+
+    def forward(self, adj_norm, patch_size):
+        r"""Patch indices via :math:`\phi_{fast}` (Eq. 15).
+
+        Parameters
+        ----------
+        adj_norm : torch.Tensor
+            Dense symmetric normalized adjacency of one graph, ``(n, n)``.
+        patch_size : int
+            Patch size ``p``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Patch indices of shape ``(n, p)`` (row ``v`` starts with ``v``,
+            no duplicates unless padded for ``n < p``) and their relevance
+            scores of shape ``(n, p)``.
+        """
+        return _top_p_col(self.relevance(adj_norm), patch_size, mask_self=True)
+
+
+def _top_p_col(relevance, patch_size, mask_self):
+    """Select top-``p`` patch indices per column of a relevance matrix.
+
+    Row ``v`` of the result indexes node ``v``'s patch: ``v`` itself first,
+    then the highest-scoring entries of column ``v``. Graphs with fewer than
+    ``patch_size`` nodes are padded by repeating ``v``.
+
+    Parameters
+    ----------
+    relevance : torch.Tensor
+        Relevance matrix ``R`` of shape ``(n, n)``.
+    patch_size : int
+        Patch size ``p``.
+    mask_self : bool
+        If True, exclude ``v`` from the top-k of its own column so patches
+        contain no duplicates (Fast-HeroFilter ranking semantics). If False,
+        keep the reference spectral behaviour where ``v`` may also appear
+        inside the top-k.
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        Patch indices of shape ``(n, p)`` and their relevance scores of
+        shape ``(n, p)``; ``scores[v, j] = R[patch[v, j], v]``.
+    """
+    n = relevance.shape[0]
+    self_idx = torch.arange(n, device=relevance.device)
+    columns = relevance.T
+    if mask_self:
+        masked = columns.clone()
+        masked[self_idx, self_idx] = float("-inf")
+    else:
+        masked = columns
+    k = min(patch_size - 1, n)
+    _, top_idx = torch.topk(masked, k, dim=1)
+    patch = torch.cat([self_idx.unsqueeze(1), top_idx], dim=1)
+    if patch.shape[1] < patch_size:
+        pad = self_idx.unsqueeze(1).expand(n, patch_size - patch.shape[1])
+        patch = torch.cat([patch, pad], dim=1)
+    scores = columns.gather(1, patch)
+    return patch, scores
+
+
+class HeroFilterMLP(nn.Module):
+    """Two-layer MLP used inside the mixer (Eq. 10-11 / reference ``MLP``).
+
+    ``Linear -> ReLU -> Dropout -> Linear(bias=False) -> Dropout``, hidden
+    width ``num_features * expansion_factor``, mirroring the reference
+    implementation.
+
+    Parameters
+    ----------
+    num_features : int
+        Input width.
+    expansion_factor : int
+        Hidden width multiplier.
+    dropout : float
+        Dropout probability.
+    out_features : int, optional
+        Output width; defaults to ``num_features``.
+    """
+
+    def __init__(
+        self, num_features, expansion_factor, dropout, out_features=None
+    ):
+        super().__init__()
+        num_hidden = num_features * expansion_factor
+        self.fc1 = nn.Linear(num_features, num_hidden)
+        self.dropout1 = nn.Dropout(dropout)
+        self.fc2 = nn.Linear(
+            num_hidden, out_features or num_features, bias=False
+        )
+        self.dropout2 = nn.Dropout(dropout)
+
+    def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor ``(..., num_features)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor ``(..., out_features)``.
+        """
+        x = self.dropout1(F.relu(self.fc1(x)))
+        return self.dropout2(self.fc2(x))
+
+
+class PatchMixer(nn.Module):
+    r"""Patch-mixing layer, Eq. 10: :math:`\hat P_v = \mathrm{MLP}(\mathrm{LayerNorm}(P_v^\top))^\top`.
+
+    Mixes information *across the patch dimension*, independently per
+    feature, with a residual connection as in the reference implementation.
+
+    Parameters
+    ----------
+    num_features : int
+        Feature width ``d``.
+    num_patches : int
+        Patch size ``p``.
+    expansion_factor : int
+        MLP hidden width multiplier.
+    dropout : float
+        Dropout probability.
+    """
+
+    def __init__(self, num_features, num_patches, expansion_factor, dropout):
+        super().__init__()
+        self.norm = nn.LayerNorm(num_features)
+        self.mlp = HeroFilterMLP(num_patches, expansion_factor, dropout)
+
+    def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Patch tensor of shape ``(n, p, d)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Mixed tensor of shape ``(n, p, d)``.
+        """
+        residual = x
+        x = self.norm(x).transpose(1, 2)
+        x = self.mlp(x).transpose(1, 2)
+        return x + residual
+
+
+class FeatureMixer(nn.Module):
+    r"""Feature-mixing layer, Eq. 11: :math:`\tilde P_v = \mathrm{MLP}(\mathrm{LayerNorm}(\hat P_v))`.
+
+    Mixes information *across the feature dimension*, independently per
+    patch slot, with a residual connection as in the reference
+    implementation.
+
+    Parameters
+    ----------
+    num_features : int
+        Feature width ``d``.
+    expansion_factor : int
+        MLP hidden width multiplier.
+    dropout : float
+        Dropout probability.
+    """
+
+    def __init__(self, num_features, expansion_factor, dropout):
+        super().__init__()
+        self.norm = nn.LayerNorm(num_features)
+        self.mlp = HeroFilterMLP(num_features, expansion_factor, dropout)
+
+    def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Patch tensor of shape ``(n, p, d)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Mixed tensor of shape ``(n, p, d)``.
+        """
+        return self.mlp(self.norm(x)) + x
+
+
+class MixerLayer(nn.Module):
+    """One HeroFilter mixer block: patch-mixing (Eq. 10) + feature-mixing (Eq. 11).
+
+    The ``use_patch_mixing`` / ``use_feature_mixing`` flags enable the
+    Table 6 ablations (+PatchMixer / +FeatureMixer / NoMixer).
+
+    Parameters
+    ----------
+    num_features : int
+        Feature width ``d``.
+    num_patches : int
+        Patch size ``p``.
+    expansion_factor : int
+        MLP hidden width multiplier.
+    dropout : float
+        Dropout probability.
+    use_patch_mixing : bool, optional
+        Apply Eq. 10 (default: True).
+    use_feature_mixing : bool, optional
+        Apply Eq. 11 (default: True).
+    """
+
+    def __init__(
+        self,
+        num_features,
+        num_patches,
+        expansion_factor,
+        dropout,
+        use_patch_mixing=True,
+        use_feature_mixing=True,
+    ):
+        super().__init__()
+        self.patch_mixer = (
+            PatchMixer(num_features, num_patches, expansion_factor, dropout)
+            if use_patch_mixing
+            else None
+        )
+        self.feature_mixer = (
+            FeatureMixer(num_features, expansion_factor, dropout)
+            if use_feature_mixing
+            else None
+        )
+
+    def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Patch tensor of shape ``(n, p, d)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Mixed tensor of shape ``(n, p, d)``.
+        """
+        if self.patch_mixer is not None:
+            x = self.patch_mixer(x)
+        if self.feature_mixer is not None:
+            x = self.feature_mixer(x)
+        return x
+
+
+class HeroFilter(nn.Module):
+    r"""HeroFilter backbone (arXiv:2510.10864), Track 1 / TDL Challenge 2026.
+
+    Pipeline per forward pass: segment the (possibly block-diagonal) batch by
+    the ``batch`` vector; per graph, build the dense symmetric normalized
+    adjacency and run the selected patcher to get patch indices (Eq. 8 /
+    Eq. 15); gather the patch tensor :math:`P \in \mathbb{R}^{n \times p
+    \times d}` (Eq. 9); embed patches; apply ``num_layers`` mixer blocks
+    (Eq. 10-11); aggregate over the patch dimension (Section 4.2) with an
+    optional residual on the embedded input features (reference forward);
+    LayerNorm and return node embeddings.
+
+    Patch selection is segmented per graph, so nodes never select
+    "neighbors" from other graphs in a block-diagonal batch, and graphs
+    smaller than ``patch_size`` are padded with the node itself.
+
+    Parameters
+    ----------
+    in_channels : int
+        Input feature width (output width of the feature encoder).
+    hidden_channels : int
+        Node embedding width.
+    patcher : str, optional
+        ``"fast"`` (Eq. 12-15, default), ``"spectral"`` (Eq. 6-9 with binned
+        learnable :math:`w_k`) or ``"reference"`` (Eq. 6-9 with the released
+        code's frozen :math:`w_k^k` filter).
+    patch_size : int, optional
+        Patch size ``p`` (default: 16).
+    order : int, optional
+        Polynomial order ``K``: filter order in Eq. 6 for the spectral
+        patchers, Neumann truncation in Eq. 14 for the fast patcher
+        (default: 10).
+    c : float, optional
+        Teleport factor of Eq. 12-14, fast patcher only (default: 0.5).
+    num_bins : int, optional
+        Frequency bins of the binned filter (default: 16).
+    sigma : str, optional
+        Filter activation in Eq. 6 (default: ``"identity"``, matching the
+        released code; satisfies Prop. 2's sigma(0)=0).
+    num_layers : int, optional
+        Number of mixer blocks (default: 2).
+    expansion_factor : int, optional
+        Mixer MLP width multiplier (default: 1).
+    dropout : float, optional
+        Dropout probability (default: 0.0).
+    aggregation : str, optional
+        Aggregation over the patch dimension, ``"sum"`` or ``"mean"``
+        (Section 4.2; default: ``"sum"``, the pseudocode's summation).
+    residual : bool, optional
+        Add the embedded input features to the aggregated patches, as in the
+        reference spectral forward (default: True).
+    weight_patches : bool, optional
+        Multiply each patch by the softmax of its selected relevance scores.
+        Eq. 8-9 select indices, which is non-differentiable, so without this
+        the loss provides no gradient to the filter weights of Eq. 6 (true
+        of the released code as well). Defaults to True for the
+        ``"spectral"`` patcher and False otherwise.
+    use_patch_mixing : bool, optional
+        Enable Eq. 10 (default: True). Table 6 ablation flag.
+    use_feature_mixing : bool, optional
+        Enable Eq. 11 (default: True). Table 6 ablation flag.
+    seed : int, optional
+        Seed for the frozen ``"reference"`` filter weights (default: 0).
+    **kwargs
+        Additional arguments (ignored).
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels,
+        patcher="fast",
+        patch_size=16,
+        order=10,
+        c=0.5,
+        num_bins=16,
+        sigma="identity",
+        num_layers=2,
+        expansion_factor=1,
+        dropout=0.0,
+        aggregation="sum",
+        residual=True,
+        weight_patches=None,
+        use_patch_mixing=True,
+        use_feature_mixing=True,
+        seed=0,
+        **kwargs,
+    ):
+        super().__init__()
+        if aggregation not in ("sum", "mean"):
+            raise ValueError(f"Unknown aggregation '{aggregation}'")
+        if weight_patches is None:
+            weight_patches = patcher == "spectral"
+        self.weight_patches = weight_patches
+        if patcher == "fast":
+            self.patcher = FastPatcher(c=c, order=order)
+        elif patcher in ("spectral", "reference"):
+            self.patcher = SpectralPatcher(
+                order,
+                num_bins=num_bins,
+                sigma=sigma,
+                filter_mode="binned" if patcher == "spectral" else "reference",
+                seed=seed,
+            )
+        else:
+            raise ValueError(f"Unknown patcher '{patcher}'")
+        self.out_channels = hidden_channels
+        self.patch_size = patch_size
+        self.aggregation = aggregation
+        self.residual = residual
+        # Patch embedding: the reference's `dim_red` MLP (expansion 2),
+        # applied both to patches and to the residual input features.
+        self.dim_red = HeroFilterMLP(
+            in_channels, 2, dropout, out_features=hidden_channels
+        )
+        self.mixers = nn.Sequential(
+            *[
+                MixerLayer(
+                    hidden_channels,
+                    patch_size,
+                    expansion_factor,
+                    dropout,
+                    use_patch_mixing=use_patch_mixing,
+                    use_feature_mixing=use_feature_mixing,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.norm = nn.LayerNorm(hidden_channels)
+
+    @staticmethod
+    def normalized_adjacency(edge_index, num_nodes, edge_weight=None):
+        r"""Dense symmetric normalized adjacency :math:`D^{-1/2} A D^{-1/2}`.
+
+        The adjacency is symmetrized with an elementwise maximum so
+        ``torch.linalg.eigh`` is applicable; rows/columns of isolated nodes
+        stay zero.
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            Edge indices of one graph (local numbering), shape ``(2, e)``.
+        num_nodes : int
+            Number of nodes ``n``.
+        edge_weight : torch.Tensor, optional
+            Edge weights of shape ``(e,)``; defaults to ones.
+
+        Returns
+        -------
+        torch.Tensor
+            Dense normalized adjacency of shape ``(n, n)``.
+        """
+        adj = torch.zeros(num_nodes, num_nodes, device=edge_index.device)
+        weight = (
+            edge_weight
+            if edge_weight is not None
+            else torch.ones(edge_index.shape[1], device=edge_index.device)
+        )
+        adj[edge_index[0], edge_index[1]] = weight
+        adj = torch.maximum(adj, adj.T)
+        deg = adj.sum(dim=1)
+        deg_inv_sqrt = deg.pow(-0.5)
+        deg_inv_sqrt[deg == 0] = 0.0
+        return deg_inv_sqrt.unsqueeze(1) * adj * deg_inv_sqrt.unsqueeze(0)
+
+    def build_patches(self, x, edge_index, batch, edge_weight=None):
+        r"""Patch tensor :math:`P \in \mathbb{R}^{n \times p \times d}` (Eq. 9).
+
+        Runs the patcher independently on every graph segment of the batch
+        (block-diagonal batching) and maps local patch indices back to batch
+        coordinates.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``(n, d)``.
+        edge_index : torch.Tensor
+            Batched edge indices of shape ``(2, e)``.
+        batch : torch.Tensor
+            Graph assignment vector of shape ``(n,)``.
+        edge_weight : torch.Tensor, optional
+            Edge weights of shape ``(e,)``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Patch tensor of shape ``(n, patch_size, d)`` and relevance
+            scores of shape ``(n, patch_size)``.
+        """
+        counts = torch.bincount(batch)
+        edge_graph = batch[edge_index[0]]
+        indices = []
+        scores = []
+        offset = 0
+        for graph, count in enumerate(counts.tolist()):
+            if count == 0:
+                continue
+            mask = edge_graph == graph
+            local_edges = edge_index[:, mask] - offset
+            local_weight = (
+                edge_weight[mask] if edge_weight is not None else None
+            )
+            adj_norm = self.normalized_adjacency(
+                local_edges, count, local_weight
+            )
+            local_idx, local_scores = self.patcher(adj_norm, self.patch_size)
+            indices.append(local_idx + offset)
+            scores.append(local_scores)
+            offset += count
+        return x[torch.cat(indices, dim=0)], torch.cat(scores, dim=0)
+
+    def forward(self, x, edge_index, batch=None, edge_weight=None):
+        """Forward pass; returns node embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``(n, in_channels)``.
+        edge_index : torch.Tensor
+            Edge indices of shape ``(2, e)``.
+        batch : torch.Tensor, optional
+            Graph assignment vector of shape ``(n,)``; ``None`` means a
+            single graph (transductive setting).
+        edge_weight : torch.Tensor, optional
+            Edge weights of shape ``(e,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``(n, hidden_channels)``.
+        """
+        if batch is None:
+            batch = torch.zeros(x.shape[0], dtype=torch.long, device=x.device)
+        patches, scores = self.build_patches(x, edge_index, batch, edge_weight)
+        if self.weight_patches:
+            patches = patches * F.softmax(scores, dim=1).unsqueeze(-1)
+        patches = self.dim_red(patches)
+        patches = self.mixers(patches)
+        embedding = patches.sum(dim=1)
+        if self.aggregation == "mean":
+            embedding = embedding / patches.shape[1]
+        if self.residual:
+            embedding = embedding + self.dim_red(x)
+        return self.norm(embedding)


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.


## Description

This PR implements **HeroFilter** -- *"Adaptive Spectral Graph Filter for Varying Heterophilic Relations"* (NeurIPS 2025, [arXiv:2510.10864](https://arxiv.org/abs/2510.10864)) -- as a Track 1 (GNN) submission for the TDL Challenge 2026.

HeroFilter's thesis is directly on the challenge's question: the optimal spectral filter response is **non-monotonic** in the heterophily degree (Prop. 1), so fixed low-/high-pass designs fail across a homophily sweep -- exactly the axis GraphUniverse varies. The model scores node pairs with an adaptive spectral filter, gathers each node's top-p most relevant nodes into a *patch* (Eq. 8–9 / Eq. 15), mixes patches with an MLP-Mixer (Eq. 10–11), and aggregates them into node representations (§4.2).

**Provenance.** Reference implementation: [`zshuai8/HeroFilter`](https://github.com/zshuai8/HeroFilter) @ `f0749d6` (pinned; audited before implementation). Every docstring cites the specific equation it implements:

- `AdaptivePolynomialFilter` -- adaptive polynomial filter `g(Λ) = Σ_{k=1..K} σ(w_k ⊙ Λ^k)` -- Eq. 6, Prop. 2
- `SpectralPatcher` -- relevance matrix `R = U g(Λ) Uᵀ` (Eq. 7), columnwise top-p patching rule (Eq. 8), patch tensor `P ∈ ℝ^{n×p×d}` (Eq. 9)
- `FastPatcher` -- PPR objective / recurrence / closed form (Eq. 12–13), truncated Neumann series `r_v ≈ (1−c) Σ_{k=0..K} c^k Ã^k e_v` (Eq. 14), fast patching rule `φ_fast(Ã) = top-p_col` (Eq. 15)
- `PatchMixer` / `FeatureMixer` / `MixerLayer` -- patch-mixing `P̂_v = MLP(LayerNorm(P_vᵀ))ᵀ` (Eq. 10) and feature-mixing `P̃_v = MLP(LayerNorm(P̂_v))` (Eq. 11), with residuals as in the reference; `use_patch_mixing` / `use_feature_mixing` flags reproduce the Table 6 ablations
- Aggregation over the patch dimension via summation -- §4.2 / Appendix pseudocode

**Numerical parity with the reference implementation** is asserted at the patcher level: with identical eigenpairs and identical fixed filter weights, the relevance matrix `R`, the top-p patch indices, and the gathered patches match a verbatim loop transcription of the released `Patcher` (there is no trained reference checkpoint to match end-to-end -- see the observations below).

## Model variants (one config per variant, per challenge rules)

| Config | Patcher | Equations | Notes |
|---|---|---|---|
| `graph/herofilter` (default) | Fast | Eq. 12–15 | inductive-native: no per-node weights, only `c` and `K`; the paper proposes it precisely to avoid the eigendecomposition cost |
| `graph/herofilter_spectral` | Spectral | Eq. 6–9 | learnable `w_k` on frequency bins, softmax relevance patch weighting |
| `graph/herofilter_reference` | Spectral (frozen) | Eq. 6–9 | reference-faithful released-code behaviour: `w_k^k ⊙ Λ^k`, σ = identity, frozen filter bank |

All variants share the same backbone class; only the `patcher` hyperparameter (and its associated options) differs.

## What is contributed

### New modules

- **Backbone** -- `topobench/nn/backbones/graph/herofilter.py`
  `HeroFilter(torch.nn.Module)`; auto-discovered by `ModelExportsManager`. Signature `forward(x, edge_index, batch=None, edge_weight=None)` -- exactly what the stock `GNNWrapper` passes. Patch selection is segmented per graph by the `batch` vector, so top-p never crosses graph boundaries in block-diagonal batches; graphs with `n < p` are padded by repeating the node itself (the reference's own padding rule, `train.py:622`).

### Reused TopoBench components (no modification needed)

- `AllCellFeatureEncoder` feature encoder
- `GNNWrapper` backbone wrapper
- `NoReadOut` readout (handles both node-level and graph-level tasks)
- Standard task losses -- no custom loss

### Configs

- `configs/model/graph/herofilter{,_spectral,_reference}.yaml` -- full `TBModel` composition (feature_encoder / backbone / backbone_wrapper / readout), templated from `configs/model/graph/gcn.yaml`

## Faithfulness notes (allowed modifications)

1. **Inductive `w_k`.** The paper's filter weights `w_k ∈ ℝⁿ` are transductive (one weight per frequency of one fixed graph); the challenge evaluation is inductive over 50–300-node graphs. We parameterize `w_k` on `num_bins` fixed frequency bins spanning the eigenvalue range and linearly interpolate onto each graph's spectrum -- following the paper's own Fig. 2, which analyses learned filters over fixed eigenvalue segments.
2. **Fast variant is the default.** The truncated Neumann series (Eq. 14) is evaluated in-model per graph rather than via the reference's offline power-iteration PageRank preprocessing; the two agree by construction (Eq. 13/14 convergence is unit-tested).
3. **Symmetric normalization.** The reference eigendecomposes the row-normalized `D⁻¹A` with `np.linalg.eig` (non-symmetric, `U Uᵀ ≠ I`); we use `D^{-1/2}AD^{-1/2}` with `eigh`, which is similar to `D⁻¹A` (identical eigenvalues) and makes Eq. 7 exact. The parity tests feed identical eigenpairs to both implementations, isolating the patcher math from this choice.
4. **Patch aggregation.** The released code weights patch slots by a softmax of a fixed random, non-trainable vector before summing; §4.2 and the Appendix pseudocode specify a plain aggregation ("mean, sum, or flatten" / summation), which is what the `aggregation` hyperparameter implements (default: sum).

### Observations about the released reference implementation

Stated as neutral notes on the released artifact:

- The spectral filter bank is a plain tensor -- it is not registered as an `nn.Parameter` and is not passed to the optimizer (which is built from `model.parameters()` only). The `herofilter_reference` config reproduces that behaviour verbatim (frozen filter, `w_k^k ⊙ Λ^k`, no activation) as a runnable artifact of the paper/code gap.
- Eq. 6 wraps each term in an activation σ; the released code applies none. We default to identity (which satisfies Prop. 2's σ(0)=0 condition) and expose σ as a hyperparameter.
- The patching rule (Eq. 8–9) selects indices, which is non-differentiable -- as written, the loss provides no gradient to `w_k` (also true of the released code, whose softmax patch weighting is commented out). The `weight_patches` option (on in `herofilter_spectral`) multiplies patches by the softmax of their selected relevance scores, restoring the gradient path so the Eq. 6 filter is genuinely learnable.

## Testing

- `test/nn/backbones/graph/test_herofilter.py` -- 33 tests, one-to-one with contributed classes/methods:
  - **patcher-level numerical parity** with a verbatim transcription of the released `Patcher` (identical eigenpairs and weights → identical `R`, patch indices, gathered patches);
  - filter correctness against brute-force loops over k (Eq. 6, binned and reference modes, σ per term);
  - relevance matrix against explicit `U diag(g(Λ)) Uᵀ` (Eq. 7); top-p_col selects the genuine largest entries per column (Eq. 8);
  - Neumann series → closed-form convergence as K grows (Eq. 14 → Eq. 13);
  - **batch safety**: two disjoint graphs in one block-diagonal batch produce embeddings identical to each graph alone (all three patchers);
  - `p > n` padding, empty batch segments, edge weights, gradient flow to the binned `w_k`, Table 6 ablation flags, argument validation.
- **Coverage: 100 % on the contributed source file** (187 statements).
- `test/pipeline/test_pipeline.py` filled in with `graph/MUTAG` × all three variants -- full training pipeline passes end-to-end (MUTAG's ~18-node graphs keep the spectral eigendecomposition trivial in CI, and it exercises the graph-level readout and multi-graph batch segmentation; the paper-native transductive node-classification setting was additionally validated on `graph/cocitation_cora`).
- `ruff` check and format pass on all new files.

## Evaluation

- `2026_tdl_challenge/run_evaluation.ipynb` run on `graph/herofilter` (V100, 1h44m, all 72 grid fits: 2 tasks × 12 settings × 3 seeds); the generated `results.json` is included in this PR.

<img width="3214" height="2171" alt="heatmap_community_detection_accuracy" src="https://github.com/user-attachments/assets/726a762b-9387-448b-afe7-91e2cea62c86" />
<img width="3134" height="2171" alt="heatmap_triangle_mse_over_triangles" src="https://github.com/user-attachments/assets/f88cf407-31b2-42ae-af84-19776cedf13c" />


## Reproducing

```bash
# unit tests
pytest test/nn/backbones/graph/test_herofilter.py

# pipeline test
pytest test/pipeline/test_pipeline.py

# single runs
python -m topobench model=graph/herofilter dataset=graph/cocitation_cora
python -m topobench model=graph/herofilter_spectral dataset=graph/cocitation_cora
python -m topobench model=graph/herofilter_reference dataset=graph/cocitation_cora
```

---