### PR TITLE
Track: Track2; Team name: MISN_AY; Model: Bi-SCNN

### DIFF
--- a/2026_tdl_challenge/outputs/biscnn/results.json
+++ b/2026_tdl_challenge/outputs/biscnn/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-07-17_17-17-51",
+    "model_config": "simplicial/biscnn",
+    "generated_at_utc": "2026-07-17T18:13:27.174843+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.3553717136383057,
+      "test_best_rerun_accuracy": 0.2877607047557831,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28352051973342896,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2466192990541458,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24073649942874908,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3106425106525421,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3091145157814026,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28734052181243896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2822217047214508,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33432653546333313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33272212743759155,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3428451418876648,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3251967430114746,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.352750301361084,
+      "test_best_rerun_accuracy": 0.2863091230392456,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2818396985530853,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24776530265808105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2370692938566208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3040721118450165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2997555136680603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2910459041595459,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27973872423171997,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32794713973999023,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3293987214565277,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33978912234306335,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3238215148448944,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.353628635406494,
+      "test_best_rerun_accuracy": 0.28470471501350403,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28650012612342834,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23905569314956665,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24027809500694275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30701351165771484,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30728092789649963,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28283292055130005,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2775613069534302,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3256933391094208,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32565513253211975,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3379555344581604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32729771733283997,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.352019786834717,
+      "test_best_rerun_accuracy": 0.28268012404441833,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2775613069534302,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24379250407218933,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24214988946914673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2996027171611786,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30605852603912354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2845519185066223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2859271168708801,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31927573680877686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32458552718162537,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3366949260234833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3336007297039032,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3429534435272217,
+      "test_best_rerun_accuracy": 0.28607991337776184,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28107571601867676,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2353120893239975,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23496828973293304,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29001450538635254,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29983192682266235,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27034151554107666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27561309933662415,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3062495291233063,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30869433283805847,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3156849145889282,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3148063123226166,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3335742950439453,
+      "test_best_rerun_accuracy": 0.2870731055736542,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2822217047214508,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2437542974948883,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2460463047027588,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2997555136680603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3027733266353607,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2932615280151367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2869967222213745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3209565281867981,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31503552198410034,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3534647524356842,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34253954887390137,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.406782627105713,
+      "test_best_rerun_accuracy": 0.2743525207042694,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27251890301704407,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2662923038005829,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30854153633117676,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29956451058387756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33260753750801086,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32634273171424866,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3382229208946228,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32985714077949524,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38666054606437683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3774161636829376,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.4000916481018066,
+      "test_best_rerun_accuracy": 0.27099090814590454,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2686225175857544,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2631599009037018,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26552829146385193,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30185651779174805,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29520970582962036,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3351287245750427,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3295515179634094,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3367331326007843,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32550233602523804,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3904041647911072,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37989914417266846,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.390052318572998,
+      "test_best_rerun_accuracy": 0.27931851148605347,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2706471085548401,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2622430920600891,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27114370465278625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.304530531167984,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29303231835365295,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3391779363155365,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.330048143863678,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34074413776397705,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32878753542900085,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38941094279289246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38230574131011963,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.475100040435791,
+      "test_best_rerun_accuracy": 0.2677057087421417,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25960731506347656,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25849950313568115,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2554435133934021,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27465811371803284,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2665978968143463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29005271196365356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3042631149291992,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2890213131904602,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28688210248947144,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3114829361438751,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31992512941360474,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.4481863975524902,
+      "test_best_rerun_accuracy": 0.2596454918384552,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2583085000514984,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2533807158470154,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25930169224739075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28734052181243896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28080829977989197,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3168691396713257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3299717307090759,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3205745220184326,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31652534008026123,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36874476075172424,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37837114930152893,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.437802314758301,
+      "test_best_rerun_accuracy": 0.2633126974105835,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2578883171081543,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25781190395355225,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25998929142951965,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2894415259361267,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2821071147918701,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3089999258518219,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.317862331867218,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3162197172641754,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.308350533246994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3527389466762543,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35610052943229675,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.144625425338745,
+      "test_best_rerun_accuracy": 0.3677133619785309,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2373749017715454,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23225609958171844,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20967988669872284,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21449308097362518,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3449079394340515,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37157154083251953,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3685155510902405,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47639238834381104,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46088317036628723,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5117273926734924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.486668199300766,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.142911672592163,
+      "test_best_rerun_accuracy": 0.36916494369506836,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23428069055080414,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2320650964975357,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21361447870731354,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21311788260936737,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34509894251823425,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37688136100769043,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37229734659194946,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47983038425445557,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46638399362564087,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5179157853126526,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49339139461517334,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.1331639289855957,
+      "test_best_rerun_accuracy": 0.36198335886001587,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23580870032310486,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23267629742622375,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2135762870311737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21307969093322754,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34494614601135254,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36561235785484314,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3663763403892517,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4713499844074249,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45656657218933105,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5097792148590088,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.48185500502586365,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1928553581237793,
+      "test_best_rerun_accuracy": 0.3492627441883087,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23569409549236298,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23657269775867462,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20223088562488556,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20937427878379822,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3455955386161804,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32974252104759216,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3475055396556854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.447780579328537,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4485827684402466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45817098021507263,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45179158449172974,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.216552257537842,
+      "test_best_rerun_accuracy": 0.34223392605781555,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23951409757137299,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2366872876882553,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20070287585258484,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20410268008708954,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3458629250526428,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3217969238758087,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3459393382072449,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4362441599369049,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4442279636859894,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44499197602272034,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44327297806739807,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.182368278503418,
+      "test_best_rerun_accuracy": 0.34903353452682495,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2349300980567932,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23771870136260986,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20276568830013275,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20620368421077728,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3451371490955353,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3242417275905609,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34223392605781555,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4445335865020752,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45129498839378357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4603483974933624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45289936661720276,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0219802856445312,
+      "test_best_rerun_accuracy": 0.410841166973114,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22098708152770996,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2145312875509262,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23099549114704132,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22304989397525787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34605392813682556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31327831745147705,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4046909511089325,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4581327736377716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43601498007774353,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5529834032058716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5569944381713867,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0171122550964355,
+      "test_best_rerun_accuracy": 0.40297195315361023,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22259148955345154,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21598288416862488,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22843609750270844,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.222935289144516,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3482695519924164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3212621212005615,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4033539593219757,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4613797962665558,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4410191774368286,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5522958040237427,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5550079941749573,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0552170276641846,
+      "test_best_rerun_accuracy": 0.4007945656776428,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22060509026050568,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21663229167461395,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22855068743228912,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22251509130001068,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3440675437450409,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3152647316455841,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3927725553512573,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.455382376909256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4312017858028412,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5506150126457214,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5481702089309692,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.007368564605713,
+      "test_best_rerun_accuracy": 0.4113759696483612,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21449308097362518,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2142638862133026,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21460768580436707,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2133088856935501,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34765833616256714,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3217587172985077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39770036935806274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46092137694358826,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44571778178215027,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5518755912780762,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5773550271987915,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.996617078781128,
+      "test_best_rerun_accuracy": 0.40736496448516846,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21277408301830292,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21059668064117432,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21155168116092682,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21334709227085114,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3416227400302887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31587591767311096,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3949499726295471,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45805639028549194,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44014057517051697,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5527542233467102,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5802582502365112,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.011931896209717,
+      "test_best_rerun_accuracy": 0.41439375281333923,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22897088527679443,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22618229687213898,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22068148851394653,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22190389037132263,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35079073905944824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32943692803382874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39540836215019226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45698678493499756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4449537694454193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5498892068862915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5774696469306946,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6736421585083008,
+      "test_best_rerun_accuracy": 0.5113071799278259,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1973794847726822,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19420887529850006,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18416227400302887,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1888226717710495,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35640615224838257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3268393278121948,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38299334049224854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39307814836502075,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4898006021976471,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5683780312538147,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5659332275390625,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.6610183715820312,
+      "test_best_rerun_accuracy": 0.5177248120307922,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2009320855140686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19787608087062836,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18836428225040436,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19134387373924255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36125755310058594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33925434947013855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3791733384132385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39812055230140686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5032470226287842,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5727710127830505,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5675376057624817,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.7019634246826172,
+      "test_best_rerun_accuracy": 0.5101230144500732,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20505768060684204,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20089387893676758,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18236687779426575,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1889754682779312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.360493540763855,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3379173278808594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3745511472225189,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38979294896125793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49148139357566833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5631828308105469,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5611582398414612,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.689491629600525,
+      "test_best_rerun_accuracy": 0.5033615827560425,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20012988150119781,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20070287585258484,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1798456758260727,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1865306794643402,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3500649333000183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34074413776397705,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3603789508342743,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38601115345954895,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5071433782577515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5643288493156433,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5809076428413391,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.692757248878479,
+      "test_best_rerun_accuracy": 0.5014898180961609,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19489647448062897,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18973948061466217,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17423026263713837,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18030406534671783,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3485751450061798,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33409732580184937,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3602643311023712,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.385247141122818,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.504584014415741,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5611964464187622,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5861028432846069,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.7078380584716797,
+      "test_best_rerun_accuracy": 0.5032470226287842,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20341508090496063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19883108139038086,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1797310709953308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1844678670167923,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3501795530319214,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.338795930147171,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3590037524700165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3816181421279907,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5071433782577515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5649400353431702,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5832760334014893,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.450138807296753,
+      "test_best_rerun_accuracy": 0.5851860046386719,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19107647240161896,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18332187831401825,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17923447489738464,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17873787879943848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33421194553375244,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3068225085735321,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3829551637172699,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3908625543117523,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4928947985172272,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46825578808784485,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6015738248825073,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.402183175086975,
+      "test_best_rerun_accuracy": 0.5904958248138428,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17938727140426636,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17178547382354736,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17484146356582642,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17147986590862274,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3258843421936035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2976163327693939,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3805485665798187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38207656145095825,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48250439763069153,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4593169689178467,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6110474467277527,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.4604486227035522,
+      "test_best_rerun_accuracy": 0.5828940272331238,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18511727452278137,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17885246872901917,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17885246872901917,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1753762662410736,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3285583257675171,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29887691140174866,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3807395398616791,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.387959361076355,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4796393811702728,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45507678389549255,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6078386306762695,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.28987717628479,
+      "test_best_rerun_accuracy": 0.6244938373565674,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18928107619285583,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18431507050991058,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17403927445411682,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17461226880550385,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33329513669013977,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31411871314048767,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3731759488582611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39689815044403076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49079379439353943,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4813583791255951,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.584613025188446,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.3166024684906006,
+      "test_best_rerun_accuracy": 0.6292688250541687,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18931928277015686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1870654821395874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17526167631149292,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18034227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33894872665405273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32156771421432495,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.375773549079895,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39403316378593445,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4919779896736145,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4838413894176483,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5859118103981018,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.313439965248108,
+      "test_best_rerun_accuracy": 0.6301092505455017,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18928107619285583,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18641607463359833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1727786660194397,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1752234697341919,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33012452721595764,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31942853331565857,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3701581358909607,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3916647434234619,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4879288077354431,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4813583791255951,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5896554589271545,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 13.651357650756836,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 11.562213897705078,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.008330125286531036,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.472421646118164,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0288022191900956
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2256.25634765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.17112296910551764
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.099863052368164,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0077855959057526675
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4182.798828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5588241587341349
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.75728988647461,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03346916225084163
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120247.1875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.792290254040498
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7035.8017578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4933250426176202
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32393.302734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6604286603298477
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1771.2733154296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.31489303385416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 637779.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.214454684795765
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185840.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0925466568485516
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 9.95478630065918,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9.759899139404297,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.007031627622049205,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.806731700897217,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.030561745794195877
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2166.766357421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16433571159817026
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.12974739074707,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.005436382672985194
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4220.607421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5638754070641283
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.782371520996094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.032627263835057076
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120543.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7991659216514955
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7041.0048828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.49368986697605527
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32650.693359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.673622090285253
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1748.1075439453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3107746744791667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 639974.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.239288400846125
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 187983.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.128212728603997
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 7.699129581451416,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8.125726699829102,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.005854269956649208,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.871177911758423,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.015111462693465383
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2189.891357421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16608959859096512
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.821613311767578,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.003647325012392173
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4107.36572265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5487462555318972
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.480113983154297,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02718489981274119
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118469.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.75099887667193
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6869.52978515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4816666516025978
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32132.630859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6470670387705675
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1755.365234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.31206493055555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 634450.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.1767968847211066
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185597.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0885021445925482
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.6997029185295105,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.6783312559127808,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0035701645048041093,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.647499084472656,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.042253241415326125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6763.33740234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5129569512585325
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64.68780517578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02180242843807929
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6188.79345703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8268261131638277
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83.66370391845703,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07224844897966928
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151530.5,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5187279398105145
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10969.798828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7691627280973917
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40519.4296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0769608738274643
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2672.612060546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4751310329861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 708544.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.014935861905139
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 228233.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.797997998934984
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.0380842685699463,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.0757850408554077,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.005662026530817935,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.5591049194336,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04867370671428933
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6918.794921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5247474343477436
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.1437873840332,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02128203147422757
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6272.41357421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.837997805506847
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84.20032501220703,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07271185234214769
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152227.21875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5349066215400335
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11094.7666015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7779250176386552
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40731.94140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0878538831436773
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2721.4111328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4838064236111111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710023.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.031664649389727
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 228928.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.80957562652888
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.6366443037986755,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.6294196844100952,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0033127351811057643,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.09922790527344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.054106071977862706
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7067.05322265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5359919016045696
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59.36683654785156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.020009045011072316
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6392.56201171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8540497009644289
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.14800262451172,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07439378464983741
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153952.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.574965458387516
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11240.4560546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7881402366209157
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41498.3125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1271368342816137
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2813.98974609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.50026484375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 715604.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.094800233023767
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232148.59375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8631553383921586
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 423.84649658203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 390.2040100097656,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.029594540008325038,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119.59980773925781,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08616700845767854
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.53883361816406,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5396780716745477
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87.57935333251953,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.029517813728520234
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2160.828857421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2886878901031229
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.9363021850586,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07939231622198496
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77123.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7909147576862345
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3477.90771484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.24385834489158253
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23748.0390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2172863325900867
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1128.1287841796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2005562282986111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 537288.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.07771865773786
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142203.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.3663896481287336
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 441.2671813964844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 409.9714050292969,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.031093773608592862,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.396583557128906,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.037749699969113044
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.589210510253906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18731163426449424
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73.45933532714844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02475879181905913
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2339.45849609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.31255290528974616
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.84870147705078,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.030957427873100848
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78773.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8292261953139513
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3660.38916015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.2566532856651416
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23537.255859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2064819242080578
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1115.6453857421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.19833695746527777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 538921.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.096192295510333
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143833.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.3935098513970012
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 468.57647705078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 420.78741455078125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.03191410045891401,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69.57853698730469,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05012862895338954
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59.05778121948242,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3108304274709601
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.19332885742188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05500280716461809
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2059.34521484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2751296212216099
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.19626998901367,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05025584627721388
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75317.5703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7489682870262864
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3237.132080078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.22697602580831056
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22670.189453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1620374931121533
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1017.6466674804688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.18091496310763888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 531286.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.0098243272287135
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141027.421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.346819461085318
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 6.7751288414001465,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6.869901657104492,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0023154370263243993,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.23741912841797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.013139350957073465
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.034601211547852,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05281369058709395
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3085.78125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2340372582480091
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4876.5751953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6515130521459586
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.76315689086914,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04556403876586282
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129957.7734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0177822180359466
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7834.982421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5493607083070396
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35165.625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8025334461017992
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2012.5819091796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3577923394097222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 659381.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.458810786964244
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197158.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.280883900787113
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 6.307131290435791,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5.8373894691467285,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.001967438311138095,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.6854133605957,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.025709951988901802
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.700815200805664,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.13526744842529298
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3202.379150390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.24288048163751422
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5009.4501953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6692652231546427
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.6892204284668,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05499932679487633
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130714.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.035361975780234
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7929.00732421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5559533953315628
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35691.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8295127809600698
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2058.260009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.365912890625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 663660.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.507213414703121
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 198606.859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.304991585958431
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 7.25311279296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6.869524002075195,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0023153097411780232,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.69643020629883,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.024276967007419905
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.02668571472168,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09487729323537726
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3277.93701171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.24861107407802427
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5118.322265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6838105899298598
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.76593780517578,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05506557668840741
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132590.78125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0789239562047186
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8149.6240234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.57142224256328
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36622.1484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8771924976933723
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2186.553466796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.38872061631944443
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 671810.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.599404149180458
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203744.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.390481992494966
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1132.018310546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1192.2418212890625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.15928414446079658,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82.72195434570312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.059597949816788995
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.3991813659668,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2652588492945621
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1296.421142578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.09832545639576223
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.72160339355469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.025184227635171787
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53.24882507324219,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0459834413413145
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53595.51953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2445550699249954
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2768.877685546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.19414371655776713
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15522.0986328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7956378406280434
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610.4000244140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10851555989583334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 436030.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.93230398006855
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104811.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.744154763241975
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1057.6177978515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1121.34912109375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1498128418294923,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.49932861328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07384677853982799
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119.99885559082031,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6315729241622122
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1285.008056640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.09745984502393819
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.39881896972656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0672055338623952
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79.92794799804688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06902240759762251
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52663.8671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2229209359906186
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2875.037109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.20158723246213714
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16065.896484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8235120449215747
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 760.0233764648438,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13511526692708334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 432370.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.890905144621789
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111913.0234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.862330445101759
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 874.8043212890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 917.7523193359375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1226122003120825,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61.84993362426758,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.044560470910855604
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.34115982055664,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2754797885292455
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 707.4105834960938,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.05365267982526308
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186.7283477783203,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06293506834456364
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53.61299514770508,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.046297923270902486
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52696.2734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2236734496911574
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2154.714599609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.15108081612742777
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15194.794921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7788607781985237
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 542.678466796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.096476171875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434904.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.919568623236768
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108833.1953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8110794154477228
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 27.83779525756836,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28.674612045288086,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.02476218656760629,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.638837814331055,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.010546713122716898
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.862326622009277,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.036117508536890934
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1613.83984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1223996847743648
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.332565307617188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007189944491950518
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3506.046630859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4684097035216266
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108542.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.520484772663942
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6023.4521484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.42234273933792593
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29565.603515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5154853409003537
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1507.5430908203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.26800766059027775
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610936.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.910814678234901
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173806.21875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8922872672357847
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 38.42306900024414,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 38.874473571777344,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.03357035714315833,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.574846267700195,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.011941531893155761
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.614394187927246,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05586523256803814
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2111.865234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16017180389647326
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.841102600097656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007024301516716433
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3949.654052734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5276758921488811
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116447.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.704051673091213
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6827.5546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4787235091501893
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31594.0390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.619459688477113
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1656.691162109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2945228732638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 630337.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.130276970238566
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184361.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0679376653686785
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 35.23700714111328,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 34.9724235534668,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.030200711186068045,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.637598037719727,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.013427664292305278
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.050510406494141,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0371079495078639
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2225.1513671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16876385037447858
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.884309768676758,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008387027222337971
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3644.811767578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.48694879994363727
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111655.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.592777247236671
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6612.134765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4636190412021456
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30498.236328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.563290600652263
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1651.4063720703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2935833550347222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 620525.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.0192852618123815
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181814.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0255499808629955
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 12545.1640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10617.6787109375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.2465557939563789,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 633.9041137695312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4567032519953395
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 632.3685913085938,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.3282557437294407
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1544.7506103515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.11715969741005404
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3524.273681640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1878239574117375
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2109.58447265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.28184161291332666
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 691.080078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.596787632232297
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1268.50146484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.08894274749991235
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7038.09912109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.36076165467700805
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1533.5751953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2726355902777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218086.546875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.4669586651471103
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40805.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6790342157156407
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 12571.52734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10121.1162109375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.2350249909654816,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 876.9916381835938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6318383560400531
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 836.7518920898438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.403957326788651
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2541.465576171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.19275430991064657
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5846.01806640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.9703465003054432
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1268.502197265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.16947257144497327
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 927.6328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8010646049222798
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2039.4375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.14299800168279345
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5285.38671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.2709204325567687
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1458.3045654296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.25925414496527777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 196665.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.2246526560184607
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37327.22265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6211575833499742
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 9589.9970703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7446.41357421875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.17291504677268135,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1619.9144287109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1670853232787735
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1662.9483642578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.752359811883224
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1546.3839111328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.11728357308553754
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3638.050537109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.2261713977449866
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2120.3408203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.28327866670841684
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1808.1656494140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.5614556557979815
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1391.675537109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.09757926918450252
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6034.31982421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3093095404284561
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2273.05517578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4040986979166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207143.65625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.3431745104804134
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41007.62890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6824027574967134
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1521.5206298828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1503.2359619140625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.10540148379708754,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276.1026306152344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.19892120361328125
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137.48899841308594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.7236263074372944
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2674.3955078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.20283621598881305
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.246482849121094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.01963144012440886
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1795.7979736328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.23991956895561958
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 140.886474609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1216636222878886
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40801.43359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9474603751103009
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14257.6201171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7308227032235122
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 618.926513671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11003138020833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 400547.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.530930794203816
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87371.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4539430029287936
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1373.333984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1408.0791015625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.09872942795978824,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 308.992919921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2226173774653278
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132.7830352783203,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6988580804122122
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2473.978515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.18763583736253317
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.76588439941406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03429925325224606
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1707.4111328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22811103978790914
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202.5835723876953,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1749426359133811
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40029.25390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9295293959281534
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13393.482421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6865283931454713
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 600.4542846679688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10674742838541666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 396784.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.488359770030429
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88447.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4718459824771604
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1233.611328125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1208.664794921875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.08474721602312965,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 294.6664123535156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2122956861336568
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 198.81695556640625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.046405029296875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2397.5556640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.18183964080868412
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.06150817871094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05293613352838252
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1618.9261474609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21628939845837508
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 223.1123504638672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.19267042354392677
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37088.328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8612374169840238
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13187.2529296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6759574006708442
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 564.1278076171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10028938802083333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389097.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.401409949322987
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85016.5703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4147499760787445
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 5256.576171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5454.1123046875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.27956903504472297,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612.2227172851562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.44108264934089064
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 363.89459228515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.9152346962376645
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4099.55859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.31092594567690557
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 683.7042846679688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.23043622671653816
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 715.0221557617188,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0955273421191341
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 441.8421325683594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.38155624574124297
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19911.361328125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4623667408537293
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1724.9434814453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.12094681541476038
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 671.7072143554688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11941461588541667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232818.234375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.633601058504802
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48193.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8019832280798096
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 5047.39697265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5067.35302734375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.25974437579290327,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1024.6331787109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7382083420107619
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1483.5545654296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.8081819233141445
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2053.5634765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.15574997926147136
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10137.8212890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.416859214379002
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1003.9166870117188,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.13412380587998915
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1120.6328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.9677312715889465
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16923.41015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3929827734592699
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2707.5048828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1898404769886762
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 836.1567993164062,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.14865009765625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 237972.046875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.6919001264097373
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44969.47265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.748331297426489
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 6447.50927734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6757.2216796875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.3463643282427341,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1492.273193359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0751247790773595
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1744.00390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.178967927631579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3534.34912109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.26805833303706866
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5071.02392578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.7091418691544489
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1481.79345703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.19796839773296593
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1412.3525390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2196481339054404
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22525.25390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5230645993463218
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1950.3233642578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.13674963990028136
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1389.434326171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.247010546875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255528.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.890498625612253
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54240.37109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9026071438229079
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 489.8822326660156,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 509.20196533203125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.09052479383680556,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88.01008605957031,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06340784298239936
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.0544548034668,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2108129200182463
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 903.2825927734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.06850834985009006
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128.23873901367188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04322168487147687
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1491.9805908203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.19932940425121076
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.87398910522461,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04479619093715424
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62331.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4474227312836707
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2855.5703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.20022229087785726
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16255.9150390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8332520907818186
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 453218.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.126733538454578
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110989.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8469663687950344
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 385.91851806640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 404.4178771972656,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.07189651150173611,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.78033447265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10214721503793678
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.156003952026367,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.13766317869487563
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1452.5126953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.11016402694823663
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108.20169067382812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03646838243135427
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1256.917236328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1679248144726954
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.4125862121582,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.027990143533815372
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56847.625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3200730308378228
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2317.9150390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.16252384231261394
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14163.7998046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7260136247212825
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 435363.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.924763936178636
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104267.390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.73510043807099
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 601.4119262695312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 632.1539306640625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.11238292100694444,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169.5136260986328,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12212797269353949
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119.39408874511719,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6283899407637746
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 841.25048828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.06380360168989382
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 336.5838928222656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11344249842341275
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1742.9056396484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.23285312486953072
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111.55951690673828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0963380975015011
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65350.375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5175175320453278
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2542.169677734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.17824776873751053
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17385.595703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8911577068596546
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 470916.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.326924354942705
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116114.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.9322521445925482
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 129843.4609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 63039.19921875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.713088913484271,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13940.341796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.043473917056916
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20698.029296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 108.9369962993421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49280.69921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.7376336153773226
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163437.6875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 55.085165992585104
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8061.619140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0770366253340014
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14242.35546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 12.299097986830743
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15841.73828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3678649981713264
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61694.4609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.325793082141355
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5927.44775390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.303831449787598
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4844.79296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8612965277777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17332.3203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2884249465411945
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 127757.1484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 64409.8515625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.7285935043211204,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14896.5400390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 10.732377549756844
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18863.849609375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 99.28341899671052
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34574.55859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.6222645880735684
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111109.8359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 37.44854598500169
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9003.1787109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2028294870991985
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15587.10546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 13.460367416882557
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13289.1162109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.308589917586325
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40422.16015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.8342560760236992
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7588.90234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.38899494303911014
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6703.9365234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.1918109375
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15957.81640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.26555200116902133
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 100183.0390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 47763.6796875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.54029478284108,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11908.15234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.579360478206052
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15546.36328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 81.8229646381579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60043.60546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.553932913822526
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170391.0,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 57.42871587462083
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8760.29296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1703798221442885
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15166.43359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 13.097092913428325
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22177.7265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5149945792889653
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77333.1015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.422318157516477
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5265.00537109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.2698757174172818
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7377.71142578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.3115931423611111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11791.349609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.19621835503927246
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 24241.515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 21273.439453125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.35400861087189855,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12708.044921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.155651961005043
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14801.955078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 77.90502672697369
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13430.15234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0185932759764884
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20849.740234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 7.027212751727334
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14141.3251953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.889288603248163
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10670.6376953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 9.214713035675734
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20422.552734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.47423724536445755
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8204.6220703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5752785072438998
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14493.3681640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.742906769391691
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6798.02734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2085381944444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136240.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.54112770494214
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 8819.0029296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8945.685546875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.1488640198837635,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8213.2021484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.917292614148055
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8904.9970703125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 46.86840563322368
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12697.2109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9630042425104285
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15110.8447265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.092970922333165
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11261.0712890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.5044851421593186
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6502.4755859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.6152638911377375
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21871.271484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.5078783086655907
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6504.37548828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4560633493395912
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13750.9970703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7048540196992413
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3917.83544921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6965040798611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 111422.6171875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.2603940724579483
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "biscnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 9094.0703125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8984.19921875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.14950492101825505,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4218.43115234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.03921552762518
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4634.255859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 24.3908203125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13567.82421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0290348288775124
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18262.5859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.1552362445230875
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6504.43798828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8689963912199399
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3280.07080078125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.8325309160459846
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13444.41015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3121960374384637
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7962.2431640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5582837725468027
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6843.642578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3507941246668204
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1604.6036376953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.28526286892361113
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94704.640625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.0712831083221157
+        }
+      },
+      "output_dir": "E:\\PhD_Projects\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-17_17-17-51__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -98,13 +98,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "config_cell",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-    "MODEL_CONFIG = \"graph/gin\""
+    "MODEL_CONFIG = \"simplicial/biscnn\""
    ]
   },
   {

--- a/configs/model/simplicial/biscnn.yaml
+++ b/configs/model/simplicial/biscnn.yaml
@@ -1,0 +1,46 @@
+_target_: topobench.model.TBModel
+model_name: biscNN
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 32
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
+
+backbone:
+  _target_: topobench.nn.backbones.simplicial.biscnn.BiSCNN
+  in_channels_all:
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+  hidden_channels_all:
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+    - ${model.feature_encoder.out_channels}
+  n_layers: 2
+  sc_order: 3
+  bias: false
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.SCCNNWrapper
+  _partial_: true
+  wrapper_name: SCCNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+compile: false

--- a/test/nn/backbones/simplicial/test_biscnn.py
+++ b/test/nn/backbones/simplicial/test_biscnn.py
@@ -1,0 +1,195 @@
+"""Unit tests for the Bi-SCNN simplicial backbone."""
+
+import pytest
+import torch
+
+from topobench.nn.backbones.simplicial.biscnn import (
+    BiSCNN,
+    BiSCNNLayer,
+    _hard_sign,
+    _row_l1_mean,
+)
+
+
+def _sparse_identity(size: int) -> torch.Tensor:
+    """Create a sparse identity matrix."""
+    indices = torch.arange(size)
+    return torch.sparse_coo_tensor(
+        torch.stack((indices, indices)),
+        torch.ones(size),
+        (size, size),
+    ).coalesce()
+
+
+@pytest.fixture
+def simplicial_inputs():
+    """Create node, edge, face features and compatible Laplacians."""
+    x_all = (
+        torch.randn(5, 3),
+        torch.randn(7, 4),
+        torch.randn(2, 5),
+    )
+    laplacian_all = (
+        _sparse_identity(5),
+        _sparse_identity(7),
+        _sparse_identity(7),
+        _sparse_identity(2),
+        _sparse_identity(2),
+    )
+    incidence_all = (
+        torch.sparse_coo_tensor(size=(5, 7)),
+        torch.sparse_coo_tensor(size=(7, 2)),
+    )
+    return x_all, laplacian_all, incidence_all
+
+
+def test_hard_sign_matches_paper_approximation():
+    """Hard tanh must clip values while preserving the linear central region."""
+    values = torch.tensor([-3.0, -0.5, 0.0, 0.5, 3.0])
+    expected = torch.tensor([-1.0, -0.5, 0.0, 0.5, 1.0])
+    torch.testing.assert_close(_hard_sign(values), expected)
+
+
+def test_row_l1_mean():
+    """Equation (23) is the row-wise L1 norm divided by feature count."""
+    features = torch.tensor([[1.0, -3.0], [2.0, 4.0]])
+    expected = torch.tensor([[2.0], [3.0]])
+    torch.testing.assert_close(_row_l1_mean(features), expected)
+
+
+def test_layer_keeps_weights_full_precision():
+    """Bi-SCNN binarizes features, not trainable matrices."""
+    layer = BiSCNNLayer(3, 4, use_lower=True, use_upper=True)
+    assert layer.lower_weight.dtype.is_floating_point
+    assert layer.upper_weight.dtype.is_floating_point
+    assert layer.harmonic_weight.dtype.is_floating_point
+
+
+def test_layer_outputs_magnitude_and_binary():
+    """Each paper layer must return its two propagation paths."""
+    layer = BiSCNNLayer(3, 4, use_lower=True, use_upper=True)
+    features = torch.randn(6, 3)
+    operator = _sparse_identity(6)
+    magnitude, binary = layer(features, operator, operator)
+    assert magnitude.shape == (6, 1)
+    assert binary.shape == (6, 4)
+    assert torch.all(magnitude >= 0)
+    assert torch.all(binary <= 1)
+    assert torch.all(binary >= -1)
+
+
+def test_forward_shapes_and_finiteness(simplicial_inputs):
+    """The backbone returns rank-specific TopoBench-compatible embeddings."""
+    x_all, laplacian_all, incidence_all = simplicial_inputs
+    model = BiSCNN(
+        in_channels_all=(3, 4, 5),
+        hidden_channels_all=(8, 8, 8),
+        n_layers=2,
+        sc_order=3,
+    )
+    outputs = model(x_all, laplacian_all, incidence_all)
+    assert [output.shape for output in outputs] == [(5, 8), (7, 8), (2, 8)]
+    assert all(torch.isfinite(output).all() for output in outputs)
+
+
+def test_dense_and_sparse_operators_agree():
+    """Dense and sparse Hodge multiplication must be numerically identical."""
+    torch.manual_seed(7)
+    layer = BiSCNNLayer(3, 2, use_lower=True, use_upper=True)
+    features = torch.randn(4, 3)
+    dense = torch.eye(4)
+    sparse = dense.to_sparse()
+    dense_outputs = layer(features, dense, dense)
+    sparse_outputs = layer(features, sparse, sparse)
+    for dense_output, sparse_output in zip(
+        dense_outputs, sparse_outputs, strict=True
+    ):
+        torch.testing.assert_close(dense_output, sparse_output)
+
+
+def test_sc_order_two_uses_lower_face_laplacian():
+    """A two-dimensional complex has no rank-two upper Hodge component."""
+    model = BiSCNN(
+        in_channels_all=(2, 2, 2),
+        hidden_channels_all=(3, 3, 3),
+        n_layers=1,
+        sc_order=2,
+    )
+    x_all = (torch.randn(4, 2), torch.randn(5, 2), torch.randn(1, 2))
+    laplacian_all = (
+        _sparse_identity(4),
+        _sparse_identity(5),
+        _sparse_identity(5),
+        _sparse_identity(1),
+    )
+    outputs = model(x_all, laplacian_all)
+    assert [output.shape for output in outputs] == [(4, 3), (5, 3), (1, 3)]
+
+
+def test_gradients_flow_through_hard_tanh(simplicial_inputs):
+    """The hard-tanh proxy permits ordinary gradient-based optimization."""
+    x_all, laplacian_all, incidence_all = simplicial_inputs
+    x_all = tuple(features.requires_grad_() for features in x_all)
+    model = BiSCNN(
+        in_channels_all=(3, 4, 5),
+        hidden_channels_all=(6, 6, 6),
+        n_layers=2,
+        sc_order=3,
+    )
+    loss = sum(
+        output.square().mean()
+        for output in model(x_all, laplacian_all, incidence_all)
+    )
+    loss.backward()
+    assert all(features.grad is not None for features in x_all)
+    assert all(
+        parameter.grad is not None
+        for parameter in model.parameters()
+        if parameter.requires_grad
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {
+                "in_channels_all": (3, 4),
+                "hidden_channels_all": (5, 5, 5),
+            },
+            "node, edge, and face",
+        ),
+        (
+            {
+                "in_channels_all": (3, 4, 5),
+                "hidden_channels_all": (5, 5, 5),
+                "n_layers": 0,
+            },
+            "at least one",
+        ),
+        (
+            {
+                "in_channels_all": (3, 4, 5),
+                "hidden_channels_all": (5, 5, 5),
+                "sc_order": 1,
+            },
+            "at least two",
+        ),
+    ],
+)
+def test_invalid_model_arguments(kwargs, message):
+    """Invalid architecture arguments must fail clearly."""
+    with pytest.raises(ValueError, match=message):
+        BiSCNN(**kwargs)
+
+
+def test_invalid_laplacian_count(simplicial_inputs):
+    """The model rejects malformed TopoBench Laplacian tuples."""
+    x_all, laplacian_all, _ = simplicial_inputs
+    model = BiSCNN(
+        in_channels_all=(3, 4, 5),
+        hidden_channels_all=(5, 5, 5),
+        sc_order=3,
+    )
+    with pytest.raises(ValueError, match="expected 5 Laplacians"):
+        model(x_all, laplacian_all[:-1])

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["simplicial/biscnn"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/simplicial/biscnn.py
+++ b/topobench/nn/backbones/simplicial/biscnn.py
@@ -1,0 +1,421 @@
+"""Binarized Simplicial Convolutional Neural Network.
+
+This module implements Bi-SCNN from:
+
+    Yi Yan and Ercan E. Kuruoglu,
+    "Binarized Simplicial Convolutional Neural Networks",
+    Neural Networks 183 (2025), 106928.
+    arXiv:2405.04098.
+
+The implementation follows equations (21)--(27) of the paper. Features are
+binarized with the hard-tanh approximation specified by the authors, while
+the per-simplex magnitude is retained through row-wise L1 normalization.
+Only features are binarized; trainable weights remain full precision.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+from torch import nn
+
+
+def _matmul(
+    operator: torch.Tensor | None, features: torch.Tensor
+) -> torch.Tensor:
+    """Multiply a dense or sparse operator by a feature matrix.
+
+    Parameters
+    ----------
+    operator : torch.Tensor or None
+        Dense or sparse square simplicial operator. ``None`` represents a
+        missing lower or upper Hodge component.
+    features : torch.Tensor
+        Feature matrix of shape ``[num_simplices, num_features]``.
+
+    Returns
+    -------
+    torch.Tensor
+        Propagated feature matrix.
+    """
+    if operator is None:
+        return torch.zeros_like(features)
+    if operator.layout == torch.strided:
+        return operator @ features
+    return torch.sparse.mm(operator, features)
+
+
+def _hard_sign(features: torch.Tensor) -> torch.Tensor:
+    """Approximate the sign function with hard tanh.
+
+    Parameters
+    ----------
+    features : torch.Tensor
+        Input features.
+
+    Returns
+    -------
+    torch.Tensor
+        Features clipped to the interval ``[-1, 1]``.
+
+    Notes
+    -----
+    Section 4.5 of the paper states that ``Sign`` is approximated by hard
+    tanh so ordinary gradient-based optimization can be used.
+    """
+    return torch.nn.functional.hardtanh(features, min_val=-1.0, max_val=1.0)
+
+
+def _row_l1_mean(features: torch.Tensor) -> torch.Tensor:
+    """Compute the feature-normalization vector from equation (23).
+
+    Parameters
+    ----------
+    features : torch.Tensor
+        Feature matrix of shape ``[num_simplices, num_features]``.
+
+    Returns
+    -------
+    torch.Tensor
+        Nonnegative row-wise mean absolute value with shape
+        ``[num_simplices, 1]``.
+    """
+    if features.shape[-1] == 0:
+        raise ValueError("features must contain at least one channel")
+    return features.abs().mean(dim=-1, keepdim=True)
+
+
+class BiSCNNLayer(nn.Module):
+    """One weighted binary-sign simplicial convolution layer.
+
+    For simplex rank ``k``, this layer computes the length-one simplicial
+    convolution from equation (24), then separates it into the magnitude and
+    binary-sign paths used by equations (25)--(27).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input feature channels.
+    out_channels : int
+        Number of output feature channels.
+    use_lower : bool
+        Whether to include the lower-Hodge term.
+    use_upper : bool
+        Whether to include the upper-Hodge term.
+    bias : bool, optional
+        Whether to add a full-precision bias to the preactivation.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        use_lower: bool,
+        use_upper: bool,
+        bias: bool = False,
+    ) -> None:
+        super().__init__()
+        if in_channels <= 0 or out_channels <= 0:
+            raise ValueError("channel dimensions must be positive")
+        if not use_lower and not use_upper:
+            raise ValueError("at least one Hodge component must be enabled")
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.use_lower = use_lower
+        self.use_upper = use_upper
+
+        self.lower_weight = (
+            nn.Parameter(torch.empty(in_channels, out_channels))
+            if use_lower
+            else None
+        )
+        self.upper_weight = (
+            nn.Parameter(torch.empty(in_channels, out_channels))
+            if use_upper
+            else None
+        )
+        self.harmonic_weight = nn.Parameter(
+            torch.empty(in_channels, out_channels)
+        )
+        self.bias = nn.Parameter(torch.zeros(out_channels)) if bias else None
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Initialize all full-precision trainable matrices."""
+        if self.lower_weight is not None:
+            nn.init.xavier_uniform_(self.lower_weight)
+        if self.upper_weight is not None:
+            nn.init.xavier_uniform_(self.upper_weight)
+        nn.init.xavier_uniform_(self.harmonic_weight)
+        if self.bias is not None:
+            nn.init.zeros_(self.bias)
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        lower_laplacian: torch.Tensor | None,
+        upper_laplacian: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute the magnitude and binary-sign outputs of one layer.
+
+        Parameters
+        ----------
+        features : torch.Tensor
+            Input simplex features of shape
+            ``[num_simplices, in_channels]``.
+        lower_laplacian : torch.Tensor or None
+            Lower Hodge Laplacian for the current simplex rank.
+        upper_laplacian : torch.Tensor or None
+            Upper Hodge Laplacian for the current simplex rank.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Row-wise normalization ``M`` and hard-sign output ``Q``. Their
+            shapes are ``[num_simplices, 1]`` and
+            ``[num_simplices, out_channels]``.
+        """
+        if features.ndim != 2:
+            raise ValueError("features must be a rank-two tensor")
+        if features.shape[-1] != self.in_channels:
+            raise ValueError(
+                f"expected {self.in_channels} input channels, "
+                f"received {features.shape[-1]}"
+            )
+
+        preactivation = features @ self.harmonic_weight
+        if self.lower_weight is not None:
+            preactivation = (
+                preactivation
+                + _matmul(lower_laplacian, features) @ self.lower_weight
+            )
+        if self.upper_weight is not None:
+            preactivation = (
+                preactivation
+                + _matmul(upper_laplacian, features) @ self.upper_weight
+            )
+        if self.bias is not None:
+            preactivation = preactivation + self.bias
+
+        magnitude = _row_l1_mean(preactivation)
+        binary = _hard_sign(preactivation)
+        return magnitude, binary
+
+
+class BiSCNN(nn.Module):
+    """Binarized Simplicial Convolutional Neural Network backbone.
+
+    A separate Bi-SCNN stack is applied to ranks 0, 1, and 2. In accordance
+    with the paper, intermediate layers propagate only the binary-sign output.
+    Per-layer normalization vectors bypass the binary path and are multiplied
+    into the final output.
+
+    Parameters
+    ----------
+    in_channels_all : sequence of int
+        Input dimensions for node, edge, and face features.
+    hidden_channels_all : sequence of int
+        Output dimensions for node, edge, and face features.
+    n_layers : int, optional
+        Number of Bi-SCNN layers. Must be at least one.
+    sc_order : int, optional
+        Maximum simplicial-complex order. Rank-2 upper propagation is enabled
+        when ``sc_order > 2``.
+    bias : bool, optional
+        Whether layers use full-precision biases.
+    **kwargs
+        Additional arguments accepted for TopoBench compatibility.
+
+    Notes
+    -----
+    The paper binarizes features but explicitly does not binarize trainable
+    weights. This implementation preserves that distinction.
+    """
+
+    def __init__(
+        self,
+        in_channels_all: Sequence[int],
+        hidden_channels_all: Sequence[int],
+        n_layers: int = 2,
+        sc_order: int = 3,
+        bias: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        del kwargs
+
+        if len(in_channels_all) != 3 or len(hidden_channels_all) != 3:
+            raise ValueError(
+                "in_channels_all and hidden_channels_all must contain "
+                "node, edge, and face dimensions"
+            )
+        if n_layers < 1:
+            raise ValueError("n_layers must be at least one")
+        if sc_order < 2:
+            raise ValueError("sc_order must be at least two")
+
+        self.in_channels_all = tuple(int(v) for v in in_channels_all)
+        self.hidden_channels_all = tuple(int(v) for v in hidden_channels_all)
+        self.out_channels = self.hidden_channels_all
+        self.n_layers = n_layers
+        self.sc_order = sc_order
+
+        rank_flags = (
+            (False, True),
+            (True, True),
+            (True, sc_order > 2),
+        )
+        self.rank_layers = nn.ModuleList()
+        for rank, (use_lower, use_upper) in enumerate(rank_flags):
+            layers = nn.ModuleList()
+            for layer_index in range(n_layers):
+                input_dim = (
+                    self.in_channels_all[rank]
+                    if layer_index == 0
+                    else self.hidden_channels_all[rank]
+                )
+                layers.append(
+                    BiSCNNLayer(
+                        in_channels=input_dim,
+                        out_channels=self.hidden_channels_all[rank],
+                        use_lower=use_lower,
+                        use_upper=use_upper,
+                        bias=bias,
+                    )
+                )
+            self.rank_layers.append(layers)
+
+    @staticmethod
+    def _split_laplacians(
+        laplacian_all: Sequence[torch.Tensor],
+        sc_order: int,
+    ) -> tuple[
+        tuple[torch.Tensor | None, torch.Tensor | None],
+        tuple[torch.Tensor | None, torch.Tensor | None],
+        tuple[torch.Tensor | None, torch.Tensor | None],
+    ]:
+        """Map TopoBench Laplacian tuples to lower/upper rank pairs.
+
+        Parameters
+        ----------
+        laplacian_all : sequence of torch.Tensor
+            For ``sc_order > 2`` this must contain ``L0, L1_down, L1_up,
+            L2_down, L2_up``. For ``sc_order == 2`` it must contain
+            ``L0, L1_down, L1_up, L2``.
+        sc_order : int
+            Simplicial-complex order.
+
+        Returns
+        -------
+        tuple
+            Lower/upper operator pairs for ranks 0, 1, and 2.
+        """
+        expected = 5 if sc_order > 2 else 4
+        if len(laplacian_all) != expected:
+            raise ValueError(
+                f"expected {expected} Laplacians for sc_order={sc_order}, "
+                f"received {len(laplacian_all)}"
+            )
+
+        if sc_order > 2:
+            lap_0, lap_1_down, lap_1_up, lap_2_down, lap_2_up = laplacian_all
+        else:
+            lap_0, lap_1_down, lap_1_up, lap_2_down = laplacian_all
+            lap_2_up = None
+
+        return (
+            (None, lap_0),
+            (lap_1_down, lap_1_up),
+            (lap_2_down, lap_2_up),
+        )
+
+    @staticmethod
+    def _run_rank(
+        features: torch.Tensor,
+        layers: nn.ModuleList,
+        lower_laplacian: torch.Tensor | None,
+        upper_laplacian: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Run one simplex rank through a Bi-SCNN stack.
+
+        Parameters
+        ----------
+        features : torch.Tensor
+            Input features for one simplex rank.
+        layers : torch.nn.ModuleList
+            Rank-specific Bi-SCNN layers.
+        lower_laplacian : torch.Tensor or None
+            Lower Hodge Laplacian.
+        upper_laplacian : torch.Tensor or None
+            Upper Hodge Laplacian.
+
+        Returns
+        -------
+        torch.Tensor
+            Final weighted binary-sign features.
+        """
+        binary = features
+        accumulated_magnitude: torch.Tensor | None = None
+        for layer in layers:
+            magnitude, binary = layer(
+                binary,
+                lower_laplacian=lower_laplacian,
+                upper_laplacian=upper_laplacian,
+            )
+            accumulated_magnitude = (
+                magnitude
+                if accumulated_magnitude is None
+                else accumulated_magnitude * magnitude
+            )
+
+        if accumulated_magnitude is None:
+            raise RuntimeError("Bi-SCNN stack contains no layers")
+        return accumulated_magnitude * binary
+
+    def forward(
+        self,
+        x_all: Sequence[torch.Tensor],
+        laplacian_all: Sequence[torch.Tensor],
+        incidence_all: Sequence[torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Compute node-, edge-, and face-level representations.
+
+        Parameters
+        ----------
+        x_all : sequence of torch.Tensor
+            Node, edge, and face feature matrices.
+        laplacian_all : sequence of torch.Tensor
+            TopoBench Hodge-Laplacian tuple.
+        incidence_all : sequence of torch.Tensor or None, optional
+            Incidence matrices accepted for wrapper compatibility. Bi-SCNN
+            uses the derived Hodge operators directly.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Output feature matrices for ranks 0, 1, and 2.
+        """
+        del incidence_all
+        if len(x_all) != 3:
+            raise ValueError(
+                "x_all must contain node, edge, and face features"
+            )
+
+        laplacian_pairs = self._split_laplacians(
+            laplacian_all, sc_order=self.sc_order
+        )
+        outputs = []
+        for features, layers, (lower, upper) in zip(
+            x_all, self.rank_layers, laplacian_pairs, strict=True
+        ):
+            outputs.append(
+                self._run_rank(
+                    features,
+                    layers,
+                    lower_laplacian=lower,
+                    upper_laplacian=upper,
+                )
+            )
+        return tuple(outputs)


### PR DESCRIPTION
# Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and made sure the code passes all unit tests.
- [x] My PR follows PEP8 guidelines.
- [x] My code is properly documented using NumPy documentation conventions.
- [x] I linked to papers, issues, and PRs that are relevant to this PR.

# Description

This PR adds **Bi-SCNN** as a Track 2 simplicial neural network submission for the TDL Challenge 2026 using:

```text
model=simplicial/biscnn
```

Bi-SCNN was introduced in:

**Binarized Simplicial Convolutional Neural Networks**  
Yi Yan and Ercan E. Kuruoglu  
https://arxiv.org/abs/2405.04098

## Motivation

Bi-SCNN extends simplicial convolutional neural networks with a weighted binary-sign propagation mechanism.

The model operates on simplicial complexes and processes node-, edge-, and face-level signals through lower, upper, and harmonic Hodge components. Its main objective is to reduce the computational and memory cost of simplicial feature propagation while retaining information from higher-order structures.

The implementation follows the paper's layer equations and preserves the distinction between:

- binary-sign feature propagation;
- full-precision trainable weight matrices; and
- magnitude values obtained through row-wise L1 normalization.

The sign operation is approximated using hard tanh, as described in the paper, so that the model can be trained using ordinary gradient-based optimization.

# What is contributed

Added the Bi-SCNN backbone:

```text
topobench/nn/backbones/simplicial/biscnn.py
```

Added the Hydra configuration:

```text
configs/model/simplicial/biscnn.yaml
```

Added unit tests:

```text
test/nn/backbones/simplicial/test_biscnn.py
```

Added pipeline coverage:

```text
test/pipeline/test_pipeline.py
```

Updated the official challenge evaluation notebook for:

```text
simplicial/biscnn
```

Added the generated challenge results:

```text
2026_tdl_challenge/outputs/biscnn/results.json
```

# TopoBench integration

Bi-SCNN follows the TopoBench simplicial-backbone interface and accepts:

```python
forward(x_all, laplacian_all, incidence_all=None)
```

where `x_all` contains node-, edge-, and face-level features and `laplacian_all` contains the corresponding lower and upper Hodge operators.

It returns a tuple of rank-specific embeddings:

```text
(node_embeddings, edge_embeddings, face_embeddings)
```

with output shapes:

```text
[num_nodes, hidden_channels_0]
[num_edges, hidden_channels_1]
[num_faces, hidden_channels_2]
```

The implementation reuses the existing:

- `AllCellFeatureEncoder`;
- `SCCNNWrapper`; and
- `PropagateSignalDown` readout.

# Implementation details

For each simplicial rank, the backbone applies separate trainable matrices to the available:

- lower-Hodge component;
- upper-Hodge component; and
- harmonic or identity component.

The implementation follows the weighted binary-sign construction described in the paper:

1. Compute the full-precision simplicial convolution preactivation.
2. Compute a row-wise magnitude using the mean absolute feature value.
3. Approximate the sign path using hard tanh.
4. Propagate the binary-sign output through intermediate layers.
5. Accumulate the magnitude terms outside the binary path.
6. Multiply the accumulated magnitude with the final binary-sign representation.

Trainable matrices remain full precision; only feature propagation follows the binary-sign path.

# Testing

The unit tests cover:

- model initialization;
- hard-tanh sign approximation;
- row-wise L1 normalization;
- full-precision trainable weights;
- magnitude and binary output paths;
- node-, edge-, and face-level output shapes;
- dense and sparse Hodge operators;
- two-dimensional and higher-order simplicial complexes;
- invalid architecture arguments;
- malformed Laplacian inputs; and
- gradient flow.

The pipeline test also runs `simplicial/biscnn` end to end on `graph/MUTAG`.

# Evaluation

The official challenge notebook was run across:

- 2 tasks;
- 12 GraphUniverse settings per task;
- 3 seeds: 42, 43, and 44;
- 72 total runs.

Summary of the best in-distribution results:

| Task | Metric | Best result |
|---|---|---:|
| Community detection | Accuracy, higher is better | ~0.6301 |
| Triangle counting | MSE per structural triangle, lower is better | ~0.00197 |

The best community-detection result was obtained for:

```text
h_hi__d_hi__pl_hi, seed=44
```

The best normalized triangle-counting result was obtained for:

```text
h_lo__d_hi__pl_hi, seed=43
```

The complete per-setting, per-seed, and OOD results are stored in:

```text
2026_tdl_challenge/outputs/biscnn/results.json
```

# Reproduction

```bash
pytest test/nn/backbones/simplicial/test_biscnn.py -v
pytest test/pipeline/test_pipeline.py -v
python -m topobench model=simplicial/biscnn dataset=graph/MUTAG
```
<img width="3134" height="2171" alt="heatmap_triangle_mse_over_triangles" src="https://github.com/user-attachments/assets/81036bec-cbef-41e0-8ae9-588715ad5449" />
<img width="3214" height="2171" alt="heatmap_community_detection_accuracy" src="https://github.com/user-attachments/assets/dedcd443-3e9f-4219-9734-d15e6051afbe" />

