### PR TITLE
Track: Track1; Team name: LangDiff; Model: AdvDIFFormer

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-13_00-06-05/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-13_00-06-05/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-13_00-06-05",
+    "model_config": "graph/advdifformer",
+    "generated_at_utc": "2026-07-13T05:42:28.498395+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.156095504760742,
+      "test_best_rerun_accuracy": 0.33394452929496765,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33325693011283875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3335625231266022,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33638933300971985,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3181297183036804,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3173275291919708,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3193139135837555,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32019251585006714,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31094813346862793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3142715394496918,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31599053740501404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31518831849098206,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.417654644648234,
+        "AvgTime/train_epoch_std": 1.251593842164193,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1674551963806152,
+      "test_best_rerun_accuracy": 0.33138513565063477,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3303155303001404,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3299335241317749,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33379173278808594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3152265250682831,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3145771324634552,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3191611170768738,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3188173174858093,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31140652298927307,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3109099268913269,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3149591386318207,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3154939115047455,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.791412110598582,
+        "AvgTime/train_epoch_std": 0.09501094864302591,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.165889024734497,
+      "test_best_rerun_accuracy": 0.33058294653892517,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32852011919021606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33134692907333374,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33218732476234436,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3148445188999176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31683093309402466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3157613277435303,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30800673365592957,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3073955178260803,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3107953369617462,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3119795322418213,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.555958526235231,
+        "AvgTime/train_epoch_std": 0.3699730152082544,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.160416841506958,
+      "test_best_rerun_accuracy": 0.3327985405921936,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3327603340148926,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3345557451248169,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3348231315612793,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3190847337245941,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31774774193763733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3190847337245941,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31965771317481995,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3141569197177887,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31438612937927246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3132019340991974,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31503552198410034,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.1747554540634155,
+        "AvgTime/train_epoch_std": 0.3169794732120617,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1558356285095215,
+      "test_best_rerun_accuracy": 0.3341355323791504,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3313087224960327,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3321109414100647,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33573994040489197,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3160287141799927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31736573576927185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3188173174858093,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3202689290046692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3122851252555847,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3107953369617462,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3149591386318207,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.205720327902531,
+        "AvgTime/train_epoch_std": 0.49220556653045283,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1716177463531494,
+      "test_best_rerun_accuracy": 0.32985714077949524,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3299335241317749,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.328138142824173,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3308503329753876,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3125525116920471,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3123997151851654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3163343369960785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3166399300098419,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30800673365592957,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30796852707862854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3105279207229614,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3107953369617462,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.763863779604435,
+        "AvgTime/train_epoch_std": 0.12810785806706793,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.153271436691284,
+      "test_best_rerun_accuracy": 0.33501413464546204,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33245474100112915,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3322637379169464,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33627474308013916,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3059821128845215,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3067079186439514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3106425106525421,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31056612730026245,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2976927161216736,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29899153113365173,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.830840395718086,
+        "AvgTime/train_epoch_std": 0.17170200686886142,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.159456253051758,
+      "test_best_rerun_accuracy": 0.33528152108192444,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3329131305217743,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33394452929496765,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.336885929107666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30487433075904846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30686071515083313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3093819320201874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31205591559410095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29562991857528687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2955153286457062,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29803651571273804,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.92096671417578,
+        "AvgTime/train_epoch_std": 0.24706509126049422,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1608874797821045,
+      "test_best_rerun_accuracy": 0.3319963216781616,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.329284131526947,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33069753646850586,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3344411253929138,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3020475208759308,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.304492324590683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3073573112487793,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3084269165992737,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2926885187625885,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2925739288330078,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29440751671791077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2963557243347168,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.284745290245809,
+        "AvgTime/train_epoch_std": 1.3525370623865056,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1725101470947266,
+      "test_best_rerun_accuracy": 0.3298953175544739,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32550233602523804,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3240507245063782,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3268393278121948,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.299908310174942,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3020475208759308,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30487433075904846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3054473102092743,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2905111014842987,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29261210560798645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2923829257488251,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2952861189842224,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.5636065621529855,
+        "AvgTime/train_epoch_std": 0.14651971748336812,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.148571491241455,
+      "test_best_rerun_accuracy": 0.33787912130355835,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33069753646850586,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3351287245750427,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33379173278808594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3015509247779846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3018947243690491,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046451210975647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3072427213191986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28638550639152527,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28569790720939636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28718772530555725,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2879135012626648,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.407103316203968,
+        "AvgTime/train_epoch_std": 0.09621072037402968,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1518571376800537,
+      "test_best_rerun_accuracy": 0.33829933404922485,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3312705457210541,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33340972661972046,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.333027720451355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.300672322511673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30090153217315674,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046451210975647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30567651987075806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2850867211818695,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2858507037162781,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28692030906677246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.286576509475708,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.43275021052942,
+        "AvgTime/train_epoch_std": 0.12192046148143648,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.086832284927368,
+      "test_best_rerun_accuracy": 0.35583314299583435,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29501873254776,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29807472229003906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3024677336215973,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3057147264480591,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3542669415473938,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35770493745803833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3632439374923706,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4020169675350189,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39999234676361084,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.410802960395813,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41905418038368225,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.333337461739256,
+        "AvgTime/train_epoch_std": 0.08937050553076584,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0773415565490723,
+      "test_best_rerun_accuracy": 0.3598823547363281,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2995263338088989,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3011307120323181,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3036901354789734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30972573161125183,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35770493745803833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3617159426212311,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36427533626556396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40610435605049133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40365955233573914,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41550156474113464,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4234853684902191,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.347547911025665,
+        "AvgTime/train_epoch_std": 0.1032938725729843,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.145477771759033,
+      "test_best_rerun_accuracy": 0.3383375406265259,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28539231419563293,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2856215238571167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28760790824890137,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.293070524930954,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33654212951660156,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3381083309650421,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34253954887390137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3804721534252167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3803957402706146,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38967835903167725,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39750936627388,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.3425406118234,
+        "AvgTime/train_epoch_std": 0.09115187126130493,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1043789386749268,
+      "test_best_rerun_accuracy": 0.35365575551986694,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29287952184677124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2970433235168457,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2993353307247162,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30212393403053284,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35335013270378113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35403773188591003,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36060813069343567,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40094736218452454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3979295492172241,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4090457558631897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41863396763801575,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.392657891186801,
+        "AvgTime/train_epoch_std": 0.09740799524133797,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.095609188079834,
+      "test_best_rerun_accuracy": 0.3526243269443512,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29902970790863037,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30212393403053284,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30445411801338196,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30827412009239197,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35717013478279114,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3564443290233612,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3625181317329407,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3984643518924713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39701277017593384,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40816715359687805,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41729697585105896,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.350013781476904,
+        "AvgTime/train_epoch_std": 0.10490231474836674,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.104325771331787,
+      "test_best_rerun_accuracy": 0.349148154258728,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2918481230735779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2954007089138031,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2979601323604584,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30132171511650085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35079073905944824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.350981742143631,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35705554485321045,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3954847455024719,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39537015557289124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4068683683872223,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4142027795314789,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.3327222288700575,
+        "AvgTime/train_epoch_std": 0.12813923068020086,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0867812633514404,
+      "test_best_rerun_accuracy": 0.35923293232917786,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2838261127471924,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28802812099456787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2908167243003845,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29654672741889954,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35663533210754395,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35377034544944763,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36698755621910095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4121781587600708,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.410841166973114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4248223602771759,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4341049790382385,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.3658411923576805,
+        "AvgTime/train_epoch_std": 0.09906462639815525,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.0884153842926025,
+      "test_best_rerun_accuracy": 0.35839253664016724,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2855069041252136,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2879517078399658,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2933379113674164,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3016273081302643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3546871542930603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35434335470199585,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3655741512775421,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4083963632583618,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4083963632583618,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42256855964660645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43307358026504517,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.345327921633451,
+        "AvgTime/train_epoch_std": 0.10416953226214401,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 2.1252846717834473,
+      "test_best_rerun_accuracy": 0.3441821336746216,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2785544991493225,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28145772218704224,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2838643193244934,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2910459041595459,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34467872977256775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34139353036880493,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3518603444099426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39051875472068787,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3894491493701935,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40438535809516907,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4134387671947479,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.371546166283744,
+        "AvgTime/train_epoch_std": 0.09395368048658216,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.0452489852905273,
+      "test_best_rerun_accuracy": 0.3741309642791748,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26598671078681946,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2720223069190979,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2784399092197418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2870731055736542,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3545343279838562,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35312095284461975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36114293336868286,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.420314759016037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42394375801086426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4415157735347748,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4536633789539337,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.366637748584413,
+        "AvgTime/train_epoch_std": 0.0951824942161886,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.048643112182617,
+      "test_best_rerun_accuracy": 0.3724883496761322,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26678889989852905,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2702651023864746,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27851632237434387,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2871113121509552,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3536939322948456,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3531973361968994,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3592711389064789,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.420314759016037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.420314759016037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43941476941108704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45247918367385864,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.400084627085719,
+        "AvgTime/train_epoch_std": 0.1558814069667103,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2.0592567920684814,
+      "test_best_rerun_accuracy": 0.36519214510917664,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2619374990463257,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2667125165462494,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2729773223400116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28256550431251526,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3459393382072449,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34452593326568604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35377034544944763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4113377630710602,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4125983715057373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4303613603115082,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4433111846446991,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.369171667098999,
+        "AvgTime/train_epoch_std": 0.12341034687285245,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.8014341592788696,
+      "test_best_rerun_accuracy": 0.4620673954486847,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25456491112709045,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2588433027267456,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2566659152507782,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2707999050617218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3597295582294464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35892733931541443,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3684391379356384,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38520896434783936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4651997983455658,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5055772066116333,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5324318408966064,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.700239944876286,
+        "AvgTime/train_epoch_std": 0.17558072905540287,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.8118566274642944,
+      "test_best_rerun_accuracy": 0.45832377672195435,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25456491112709045,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25823211669921875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2552907168865204,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27034151554107666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3584689497947693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35843074321746826,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3690885603427887,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38604936003685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45996639132499695,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.49614179134368896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5259377956390381,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.5696155600028465,
+        "AvgTime/train_epoch_std": 0.1609586716549917,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.8132774829864502,
+      "test_best_rerun_accuracy": 0.4598899781703949,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24860569834709167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2524639070034027,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25047749280929565,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2635801136493683,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35312095284461975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35105815529823303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3658415377140045,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38627853989601135,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.45916417241096497,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.49885401129722595,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5278478264808655,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.4969883922837735,
+        "AvgTime/train_epoch_std": 0.1471261369298798,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.8573884963989258,
+      "test_best_rerun_accuracy": 0.44266176223754883,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2402016967535019,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24845290184020996,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2508212924003601,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2640385031700134,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3485751450061798,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34807854890823364,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35518375039100647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3724501430988312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4392619729042053,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47478798031806946,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4974023997783661,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.531315713632302,
+        "AvgTime/train_epoch_std": 0.15210619971430636,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.7755553722381592,
+      "test_best_rerun_accuracy": 0.47421500086784363,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2498663067817688,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2557491064071655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2493315041065216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26529911160469055,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3591565489768982,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35839253664016724,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3682481348514557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38994574546813965,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4680265784263611,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5175719857215881,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5471388101577759,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.4642315977936855,
+        "AvgTime/train_epoch_std": 0.1357401723392347,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.797690749168396,
+      "test_best_rerun_accuracy": 0.4658491909503937,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.243334099650383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24799449741840363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24451829493045807,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25834670662879944,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35514554381370544,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.351019948720932,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.364351749420166,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38478875160217285,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46283137798309326,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5099319815635681,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5344182252883911,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.444513075333789,
+        "AvgTime/train_epoch_std": 0.1512608349836468,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.5960756540298462,
+      "test_best_rerun_accuracy": 0.5520284175872803,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22736649215221405,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22889448702335358,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22889448702335358,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2501336932182312,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3473145365715027,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34876614809036255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37134236097335815,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3941095471382141,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4821988046169281,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48620977997779846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5948506593704224,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.405713081359863,
+        "AvgTime/train_epoch_std": 0.12156611513771406,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.5972814559936523,
+      "test_best_rerun_accuracy": 0.5505003929138184,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.230575293302536,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23309649527072906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2296202927827835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24925510585308075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3475055396556854,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34697073698043823,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.373825341463089,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39632517099380493,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4818931818008423,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.487775981426239,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5928642153739929,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.455756524649773,
+        "AvgTime/train_epoch_std": 0.12026041947946652,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.665271520614624,
+      "test_best_rerun_accuracy": 0.5204752087593079,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2198028862476349,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22515088319778442,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22576208412647247,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.243334099650383,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34154632687568665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34005653858184814,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36438995599746704,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3875773549079895,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4607303738594055,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4671097993850708,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.553327202796936,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.4564028487486,
+        "AvgTime/train_epoch_std": 0.14635708210629178,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.453223466873169,
+      "test_best_rerun_accuracy": 0.6000840663909912,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21082589030265808,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21449308097362518,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21678508818149567,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23978149890899658,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3363511264324188,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3310413360595703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3648865520954132,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.391817569732666,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4778439998626709,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48200780153274536,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5529070496559143,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.462016499868714,
+        "AvgTime/train_epoch_std": 0.14626222444102888,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.4396892786026,
+      "test_best_rerun_accuracy": 0.608182430267334,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2130032777786255,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21785469353199005,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2181984931230545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23863549530506134,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3348613381385803,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33489954471588135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36672013998031616,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39349836111068726,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4754374027252197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48659178614616394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5561922192573547,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.418091967954474,
+        "AvgTime/train_epoch_std": 0.12543708167049966,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.4590564966201782,
+      "test_best_rerun_accuracy": 0.6031782627105713,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21132248640060425,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21571548283100128,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21674688160419464,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23485369980335236,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33329513669013977,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3302009403705597,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3651157319545746,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3930399715900421,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47073879837989807,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4826189875602722,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5545114278793335,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.434328361719596,
+        "AvgTime/train_epoch_std": 0.13171931265160294,
+        "model/params/total": 43793,
+        "model/params/trainable": 43793,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 138.28482055664062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.6267852783203,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0969933611515276,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69.49140930175781,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3657442594829359
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11785.0634765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8938235477104665
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.26736450195312,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07289092163867648
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7410.29150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.990018904997495
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.90023803710938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13117464424620845
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173666.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.032763009706484
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14890.03125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0440352860748843
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45588.1328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3367744534573784
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3498.85498046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6220186631944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755023.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.540695027318078
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260866.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.341042477909241
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.268417879939079,
+        "AvgTime/train_epoch_std": 0.14511461177610926,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 138.8935089111328,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 135.11976623535156,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09734853475169421,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73.98576354980469,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.38939875552528785
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11749.759765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8911459814656807
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214.7635040283203,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07238405932872272
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7393.79931640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9878155399340347
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.0762939453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1339173522843804
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173513.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.02919092803734
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14868.0986328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0424974500639812
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45529.7890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3337838465579988
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3495.02197265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6213372395833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754629.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.536244527900637
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260710.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.338453522040837
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.359836459159851,
+        "AvgTime/train_epoch_std": 0.07089817523956299,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 139.75375366210938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 136.50439453125,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09834610557006485,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.63302612304688,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4507001374897204
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11622.48828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8814932333143723
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201.23892211914062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06782572366671406
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7337.93603515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9803521757055779
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.17315673828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13745523034393892
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173032.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.018035656232584
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14748.5537109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0341153913152084
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45365.765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3253762686452406
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3465.8515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6161513888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753714.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.5258927864439
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260216.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.3302329306242
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.309587536187007,
+        "AvgTime/train_epoch_std": 0.1450649458739958,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.305305004119873,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.2769269943237305,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.011983826285914372,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.59457397460938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15028427519784537
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13184.1787109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9999377103479332
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 423.6396484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14278383836788
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8186.4833984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0937185569054777
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178.33065795898438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1539988410699347
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178671.515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.148976305614899
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16256.11328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1398200309388584
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47785.3046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.449397954149367
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3989.7275390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7092848958333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765538.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.65964814542493
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267147.71875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.4455713435841115
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.249963465858908,
+        "AvgTime/train_epoch_std": 0.11626272640717536,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2916438579559326,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.258782386779785,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.011888328351472554,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.35154724121094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15010918389136235
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13181.7802734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9997558038253698
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 423.0313415527344,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1425788141397824
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8187.943359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0939136084669339
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177.93399047851562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1536562957500135
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178672.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.1490024295235
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16252.0830078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.13953744270176
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47787.171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4494936631810957
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3987.74169921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7089318576388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765553.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.659814994966235
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267133.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.4453347311666915
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.477190363925437,
+        "AvgTime/train_epoch_std": 0.9717132451752488,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.4408187866210938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.420287609100342,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.01273835583737022,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207.26028442382812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14932297148690787
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13171.4931640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9989755907518013
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 423.2091064453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14263872815817746
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8183.7275390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0933503726202405
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.0043487548828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15458061205084872
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178631.390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.148044552874791
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16254.9345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1397373839792806
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47777.45703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4489956958967656
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3991.447998046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7095907552083334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765460.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.658762287478933
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267139.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.445434056379279
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.22784457887922,
+        "AvgTime/train_epoch_std": 0.1418712080492484,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5027.52099609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4718.89599609375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3578988241254266,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6978.7001953125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.027881985095461
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8396.044921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 44.18971011513158
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5661.77294921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.9082483819409337
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6864.05859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9170418962925851
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7494.66064453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.4720730954501295
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128675.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9880073117917516
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8173.6484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5731067478263918
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30100.5703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.542906879517146
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5966.47998046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.0607075520833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 652114.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.376615471194416
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202557.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3707347361589535
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.117604851722717,
+        "AvgTime/train_epoch_std": 0.013383030891418457,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5012.4580078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4718.72021484375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3578854922141638,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7287.3291015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.250237104872118
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8735.4580078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 45.976094777960526
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5942.458984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.0028510227081227
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7008.8974609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9363924463510354
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7813.62646484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.747518536134499
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127821.28125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.96817019436188
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8194.7890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5745890522016548
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29919.359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5336182979650417
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6182.255859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.0990677083333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 649923.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.351829830435618
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201440.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.352147140681943
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.306735813617706,
+        "AvgTime/train_epoch_std": 0.16344160241965222,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 5014.0400390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4726.421875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.3584696150929086,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7439.69677734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.360012087423451
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8902.3525390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 46.85448704769737
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6075.07763671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.047548916993175
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7083.12841796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9463097418795925
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7969.6650390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 6.882266873110967
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127424.6171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9589591581715586
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8197.0458984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5747472933976652
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29829.603515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5290175568007074
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6287.3662109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.1177539930555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 648890.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.340146120606767
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200900.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3431628891884246
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.226155849603506,
+        "AvgTime/train_epoch_std": 0.1306485516844697,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 136.6849365234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 133.241943359375,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04490796877633131,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 216.0084686279297,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15562569785873898
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 323.4962463378906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7026118228310032
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10234.46875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7762206105422829
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6633.20263671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8861994170632933
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.0959777832031,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2513782191564794
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167693.21875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8940465063626233
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13387.6298828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9386923210498177
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43070.18359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.207708421433697
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3071.766357421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.546091796875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742363.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.397491459565853
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253366.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.216232807897758
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.240706443786621,
+        "AvgTime/train_epoch_std": 0.12294953874811582,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 141.12974548339844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 138.28273010253906,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04660691948181296,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229.38223266601562,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16526097454323893
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349.05029296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.8371068050986843
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10144.572265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7694025229901403
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6586.97607421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8800235236097195
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 310.2322998046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2679035404185557
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167281.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.884486969974921
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13304.90625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9328920382835507
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42903.23828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.19915107290225
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3053.943603515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5429233072916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741368.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.386239720371481
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252855.5,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.207736342003228
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.326046705245972,
+        "AvgTime/train_epoch_std": 0.1049676306756158,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 140.34732055664062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 138.11074829101562,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04654895459757857,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236.7230224609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.17054972799779358
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 360.78826904296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.8988856265419407
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10097.8662109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.765860160101441
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6571.79296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8779950526052104
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 318.5950012207031,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.27512521694361236
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167111.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8805281093256547
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13260.74609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.92979568740359
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42840.58203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1959394141806348
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3047.488037109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5417756510416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741024.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.382350570681991
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252656.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.2044240281729985
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.336410143796136,
+        "AvgTime/train_epoch_std": 0.1340844082396658,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5265.8369140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5442.552734375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7271279538243153,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1513.25341796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.090240214674892
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2117.637451171875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 11.145460269325659
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6857.2431640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5200791174867273
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 959.688720703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3234542368396107
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1755.0877685546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.515619834675896
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151545.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5190679134543936
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10125.279296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7099480645684336
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36852.9765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8890243765697883
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2894.938720703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5146557725694444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706675.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.993800408357182
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232745.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.873096180087531
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.424551963806152,
+        "AvgTime/train_epoch_std": 0.16746187210083008,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5258.91357421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5436.6669921875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.726341615522712,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1527.5382080078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1005318501497208
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2136.016357421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 11.242191354851974
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6841.19189453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5188617288229996
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 973.4678955078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3280983806901963
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1771.9749755859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.530202915013763
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151429.703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.516387310166264
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10117.2421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7093845314472024
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36807.3828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8866873141883234
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2901.63427734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.51584609375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706360.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.990232938927412
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232611.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.870862922886193
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.3176248371601105,
+        "AvgTime/train_epoch_std": 0.08790525305965473,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5279.79296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5453.94921875,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7286505302271209,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1447.68359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0429997073126802
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2036.318359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 10.717465049342104
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6945.369140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.526762923065984
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 910.4976806640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.3068748502406682
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1684.8153076171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.4549354988058614
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152036.671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5304818845207135
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10211.486328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.715992590669261
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37020.875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.897630580757599
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2878.110107421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5116640190972223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 707726.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.005687024196012
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233375.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8835690097016293
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.311642567316691,
+        "AvgTime/train_epoch_std": 0.09559917759566809,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 137.66275024414062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 145.57125854492188,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12570920427022614,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146.82992553710938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10578524894604421
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.769065856933594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.15667929398386102
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12285.52734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9317806100682594
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276.768798828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09328237237213516
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7678.97265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0259148505344022
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175491.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.075140706274382
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15365.5380859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0773761103588206
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46377.375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3772297401199447
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3659.049072265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6504976128472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758905.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.584610392181261
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263127.53125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.378671912701979
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.340016029775143,
+        "AvgTime/train_epoch_std": 0.1802404661199669,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 138.82066345214844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.65664672851562,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12664649976555753,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145.29156494140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10467691998660393
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.574806213378906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17144634849146792
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12246.5146484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9288217404958286
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 275.3939514160156,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09281899272531703
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7655.72412109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0228088338134602
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175331.890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.071426031604124
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15341.89453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0757183095814051
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46303.16796875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3734260069070685
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3649.978271484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6488850260416666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758519.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.580245438503217
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262961.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.37591680811409
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.275163197517395,
+        "AvgTime/train_epoch_std": 0.15569464549484746,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 141.69595336914062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 149.8002166748047,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12936115429603168,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150.33206176757812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10830840184984014
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.19223976135254,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.13785389348080285
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12355.181640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.937063453972317
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 289.0630187988281,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09742602588433709
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7724.15087890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0319506852246159
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175758.453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.081331346948727
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15462.96484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0842073232190437
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46505.921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.383818846429853
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3698.247802734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6574662760416666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759416.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.590388618033325
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263535.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.385453068577039
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.36911416053772,
+        "AvgTime/train_epoch_std": 0.12206625938415527,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 106555.453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 76846.2265625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.784465599166357,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104344.6796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 75.17628219560518
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110014.7421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 579.024958881579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62060.7734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.706922520857034
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98996.703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 33.36592623019885
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82959.359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 11.083414746158985
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106285.0703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 91.78330769645942
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66520.4765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.664175891354649
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63196.97265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.2393752963375877
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90737.9375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 16.13118888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 433450.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.903125106048437
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112413.6640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8706615423177408
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.4046056270599365,
+        "AvgTime/train_epoch_std": 0.16591972782241143,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 106923.421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 76696.7890625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.7809954733071707,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99212.1796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 71.478515625
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104749.3828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 551.3125411184211
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58264.5390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.419001824990519
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94010.6953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 31.685438258341758
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78532.2265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 10.491947436539746
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101111.734375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 87.31583279360967
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62708.7265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.396909729526013
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60210.953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.0863167320211184
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86032.015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 15.294580555555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 438870.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.964433828603101
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113565.1328125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8898229879104056
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.262659788131714,
+        "AvgTime/train_epoch_std": 0.011743545532226562,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 106169.109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 77469.296875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.7989340719626603,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114945.71875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 82.81391840778097
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120907.1875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 636.3536184210526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69985.09375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.30793278346606
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109332.65625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 36.84956395348837
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92142.5625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 12.310295591182365
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116993.5859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 101.03073051597582
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74522.34375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.225237957509465
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69498.484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.5623806640524887
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100503.9375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 17.867366666666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 422873.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.783473128739975
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110487.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8386014698051354
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.407734473546346,
+        "AvgTime/train_epoch_std": 0.12892502481820872,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8571.4658203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8205.8056640625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.575361496568679,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5811.22607421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.186762301310338
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7096.9384765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 37.35230777138158
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4785.53125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3629526924535457
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4616.75244140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5560338528501012
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6351.5302734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8485678388026052
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6282.25634765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.425091837354275
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132108.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.067726233048486
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30912.619140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.584531197940694
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5185.693359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9219010416666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 660675.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.473449006255444
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207159.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.447316815186461
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.316304087638855,
+        "AvgTime/train_epoch_std": 0.011477351188659668,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8580.4599609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8217.134765625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5761558523085822,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5777.8232421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.162696860365634
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7057.208984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 37.14320518092105
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4784.7158203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.36289084719852105
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4589.28173828125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5467751055885575
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6334.810546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8463340743987976
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6246.861328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.394526190090674
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132183.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.0694747207644437
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30933.27734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.585590104246758
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5165.20947265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9182594618055555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 660845.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.475369896949198
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207301.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4496696786647365
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.298000710351126,
+        "AvgTime/train_epoch_std": 0.1257877079236586,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8510.8681640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8162.09765625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5722968487063526,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5692.3330078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.101104472487392
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6952.822265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 36.593801398026315
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4863.57958984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.36887217215348883
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4520.79248046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5236914325813111
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6275.533203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8384145895958584
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6105.23583984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.27222438673899
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132441.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.075447299368382
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31045.763671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5913559727241273
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5059.91455078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8995403645833333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 661668.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.4846823637206885
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 207665.734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.455739177192019
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.335139820652623,
+        "AvgTime/train_epoch_std": 0.1404972641026707,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27456.66796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27932.201171875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4317597607194115,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12843.4287109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.253190713931916
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14791.0478515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 77.84762027138157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5578.103515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.423064354616989
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11022.4501953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.7150152326634647
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10070.85546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.34547167251169
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13535.3896484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.688592097096286
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115879.0390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.690856378007152
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9157.015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6420569082176413
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10252.3896484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.822647048611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 618456.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.995878250738097
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184974.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.078140600818731
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.255720615386963,
+        "AvgTime/train_epoch_std": 0,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27605.125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28060.533203125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.438337854483828,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12232.8662109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.813304186554396
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14131.5380859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 74.37651624177632
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5429.7880859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.41181555448900264
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10461.8564453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.5260722768158073
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9701.3193359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2961014476870407
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12909.810546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.148368347905873
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116985.5078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7165499677805127
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9009.8271484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6317365831186019
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9791.333984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.7406815972222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 621460.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.029858997997805
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186538.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.1041630264756295
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.374573349952698,
+        "AvgTime/train_epoch_std": 0.028071045875549316,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 26860.13671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27499.26953125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4095683802988364,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17142.34375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 12.350391750720462
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19401.29296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 102.11206825657895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6935.61474609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5260231130901593
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15023.966796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 5.063689516978429
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12803.74609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.7105873204742819
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17939.654296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 15.491929444624352
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109198.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.5357291618289057
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10596.048828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7429567261341327
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13631.373046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.423355208333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 599446.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.78083393663111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175502.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.920517208743115
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.337285995483398,
+        "AvgTime/train_epoch_std": 0.12272738810836939,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2635.065673828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2792.455322265625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.4964365017361111,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 634.3590698242188,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.45703103013272245
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 976.581787109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.139904142680921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8443.8896484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6404163555887372
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 328.80157470703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11081953984059024
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5874.75244140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7848700656521376
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 787.9013671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6803984172603627
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159862.078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7121976157579417
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11650.5048828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8168913814901486
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39937.1484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0471140723512224
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 725305.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.204535620963089
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243428.984375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.050870889704291
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.398106336593628,
+        "AvgTime/train_epoch_std": 0.13382935523986816,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2628.90185546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2782.90283203125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.49473828125,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 706.5061645507812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5090102050077675
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1077.682373046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.6720124897203945
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8252.9287109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6259331597222222
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 377.38897705078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12719547591869945
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5802.8701171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7752665487224449
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 871.2583618164062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.7523820050228033
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158933.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.690624346902285
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11471.6416015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8043501333307039
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39573.578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.028478042185658
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 723162.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.180294362182279
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 242241.328125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.031107252508612
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.258647918701172,
+        "AvgTime/train_epoch_std": 0.13018931062367659,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2661.189208984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2822.00048828125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5016889756944445,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 515.9715576171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.37173743344177773
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 807.7249755859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.25118408203125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8801.068359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6675061326791809
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258.4731140136719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08711598045624262
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6004.78369140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8022423101411156
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 652.7913818359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5637231276648855
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161496.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7501425930011147
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11992.953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8409026170943766
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40568.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0794645259880054
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 728806.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.244140470346029
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245488.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.085145368428935
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.168858784895677,
+        "AvgTime/train_epoch_std": 0.10006242078394209,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 488078.65625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 334236.4375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.780826866735292,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 598387.375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 431.1148234870317
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 612043.5,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3221.2815789473684
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 480966.65625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 36.47832053469852
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 585468.5625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 197.3267821031345
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 537062.625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 71.75185370741482
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 603003.75,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 520.7286269430052
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 290832.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 6.75348536480587
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 487305.0625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 34.168073376805495
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 436574.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 22.37808191091291
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 561123.5,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 99.75528888888888
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254434.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.234008900787114
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.307737986246745,
+        "AvgTime/train_epoch_std": 0.11613642610144304,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 487894.5,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 333889.25,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.7768995396083844,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 596412.5,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 429.69200288184436
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 610064.9375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3210.8680921052633
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 479191.15625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 36.343659935532806
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 583524.6875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 196.67161695315133
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 535215.125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 71.50502672010688
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 601043.375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 519.0357297063904
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 289625.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 6.725456587869218
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 485559.09375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 34.04565234539335
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434953.0,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 22.294992054949
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 559240.3125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 99.4205
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253490.03125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.218295496147638
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.359648555517197,
+        "AvgTime/train_epoch_std": 0.1791364631254888,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 486056.59375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 326089.34375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.688668300283927,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 533233.5,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 384.17399135446686
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 546138.0,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2874.4105263157894
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 423031.15625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 32.08427427000379
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 521059.78125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 175.61839610717897
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 475766.875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 63.562708750835
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 537623.0625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 464.26862046632124
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252597.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 5.865638207087126
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 429221.71875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 30.095478807320152
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 383037.8125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 19.633902942231792
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 498279.3125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 88.58298888888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 223145.9375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.713343276255138
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.676163673400879,
+        "AvgTime/train_epoch_std": 0,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111007.7265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108571.125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8067183365783037,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175083.4375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 126.14080511527378
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182443.9375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 960.23125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116883.1171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.864855304323095
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168126.953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 56.66563974553421
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145239.28125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 19.404045591182363
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 177594.625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 153.36323402417963
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88264.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0496154705786735
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121736.296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 8.535710059949515
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108376.046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 5.555182063406633
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156462.96875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 27.815638888888888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 378514.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.28169363596258
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.318302949269612,
+        "AvgTime/train_epoch_std": 0.13172960089434993,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 110812.984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108179.6015625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8002030446557835,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167333.265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 120.55710779899135
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174546.015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 918.663240131579
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110690.015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 8.395147184300342
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160550.25,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 54.111981799797775
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138325.5,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 18.480360721442885
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 169805.546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 146.63691439982728
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86320.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.004463197218094
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115534.53125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 8.100864622773804
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103140.7109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 5.28682715349326
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149226.5625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 26.529166666666665
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 383043.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.33292634299741
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.283232480287552,
+        "AvgTime/train_epoch_std": 0.11458055214351538,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "advdifformer_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111167.4375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 108808.5078125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.8106685938878073,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178075.28125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 128.29631213976944
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185510.84375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 976.3728618421053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119274.7890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.046248696435343
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171068.515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 57.657066270643746
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147919.234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 19.762088760855043
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180618.796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 155.9747814119171
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89029.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.067383356748096
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124168.4140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 8.706241345007713
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110414.671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 5.659678705981855
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159289.8125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 28.31818888888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376780.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.262083512437361
+        }
+      },
+      "output_dir": "C:\\Users\\JoCraft\\Desktop\\topobench\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-13_00-06-05__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.364881197611491,
+        "AvgTime/train_epoch_std": 0.18756220651018357,
+        "model/params/total": 43470,
+        "model/params/trainable": 43470,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -104,7 +104,7 @@
       "outputs": [],
       "source": [
         "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-        "MODEL_CONFIG = \"graph/gin\""
+        "MODEL_CONFIG = \"graph/advdifformer\""
       ]
     },
     {

--- a/configs/model/graph/advdifformer.yaml
+++ b/configs/model/graph/advdifformer.yaml
@@ -1,0 +1,52 @@
+_target_: topobench.model.TBModel
+
+model_name: advdifformer
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.AdvDIFFormerEncoder
+  input_dim: ${model.feature_encoder.out_channels}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  num_layers: 2
+  heads: 1
+  variant: series
+  propagation_steps: 2
+  beta: 0.25
+  theta: 0.0
+  dropout: 0.1
+  input_dropout: 0.0
+  residual: true
+  layer_norm: true
+  head_aggregation: mean
+  make_undirected: true
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: MLPReadout
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_layers: [16]
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+  dropout: 0.1
+  act: "relu"
+  norm: null
+  final_act: null
+
+compile: false

--- a/test/nn/backbones/graph/test_advdifformer.py
+++ b/test/nn/backbones/graph/test_advdifformer.py
@@ -1,0 +1,275 @@
+"""Unit tests for AdvDIFFormer."""
+
+from copy import deepcopy
+
+import pytest
+import torch
+from torch_geometric.data import Batch
+
+from topobench.nn.backbones.graph.advdifformer import (
+    AdvDIFFormerEncoder,
+    AdvDIFFormerLayer,
+    _normalized_adjacency_matmul,
+)
+
+
+def _reference_series(layer, x, edge_index, batch, edge_weight=None):
+    """Direct implementation of the original series equations."""
+    _, canonical = torch.unique(batch, sorted=True, return_inverse=True)
+    num_graphs = canonical.max().item() + 1
+    outputs = []
+    for query, key, output in zip(
+        layer.query, layer.key, layer.output, strict=True
+    ):
+        q = torch.nn.functional.normalize(query(x), dim=-1, eps=1e-12)
+        k = torch.nn.functional.normalize(key(x), dim=-1, eps=1e-12)
+        states = [x]
+        current = x
+        for _ in range(layer.propagation_steps):
+            attentive = torch.zeros_like(current)
+            for graph_id in range(num_graphs):
+                idx = torch.nonzero(canonical == graph_id, as_tuple=True)[0]
+                q_graph = q[idx]
+                k_graph = k[idx]
+                values = current[idx]
+                similarity = 1 + q_graph @ k_graph.T
+                attentive[idx] = (
+                    similarity @ values
+                    / similarity.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+                )
+            current = attentive + layer.beta * _normalized_adjacency_matmul(
+                current,
+                edge_index,
+                edge_weight=edge_weight,
+                make_undirected=layer.make_undirected,
+            )
+            states.append(current)
+        outputs.append(output(torch.cat(states, dim=-1)))
+    result = torch.stack(outputs).sum(dim=0)
+    return result / layer.heads if layer.head_aggregation == "mean" else result
+
+
+class TestAdvDIFFormerEncoder:
+    """Test AdvDIFFormerEncoder."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.input_dim = 8
+        self.hidden_dim = 16
+
+    def _features(self, num_nodes, feat_dim=None):
+        """Create random node features."""
+        return torch.randn(num_nodes, feat_dim or self.input_dim)
+
+    def test_initialization_default(self):
+        """Test default initialization."""
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+        )
+
+        assert model.input_dim == self.input_dim
+        assert model.hidden_dim == self.hidden_dim
+        assert model.out_channels == self.hidden_dim
+        assert model.num_layers == 2
+        assert model.variant == "series"
+        assert len(model.layers) == 2
+
+    def test_invalid_variant(self):
+        """Test that invalid variants fail clearly."""
+        with pytest.raises(ValueError, match="variant"):
+            AdvDIFFormerEncoder(
+                input_dim=self.input_dim,
+                hidden_dim=self.hidden_dim,
+                variant="bad",
+            )
+
+    def test_variant_aliases(self):
+        """Test short variant aliases."""
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            variant="i",
+        )
+
+        assert model.variant == "inverse"
+
+    def test_row_normalized_advection(self):
+        """Test D^{-1} A aggregation used by the official implementation."""
+        edge_index = torch.tensor([[0, 1, 2], [1, 2, 2]])
+        x = torch.tensor([[1.0], [2.0], [4.0]])
+
+        out = _normalized_adjacency_matmul(
+            x,
+            edge_index,
+            make_undirected=False,
+        )
+
+        expected = torch.tensor([[0.0], [1.0], [3.0]])
+        assert torch.allclose(out, expected)
+
+    def test_forward_scalable(self, simple_graph_0):
+        """Test AdvDIFFormer-S forward pass."""
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            num_layers=2,
+            heads=2,
+            variant="s",
+            propagation_steps=2,
+        )
+
+        x = self._features(simple_graph_0.num_nodes)
+        out = model(x=x, edge_index=simple_graph_0.edge_index)
+
+        assert out.shape == (simple_graph_0.num_nodes, self.hidden_dim)
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+
+    def test_forward_inverse(self, simple_graph_0):
+        """Test AdvDIFFormer-I forward pass."""
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            num_layers=1,
+            heads=1,
+            variant="i",
+            theta=1.0,
+        )
+
+        x = self._features(simple_graph_0.num_nodes)
+        out = model(x=x, edge_index=simple_graph_0.edge_index)
+
+        assert out.shape == (simple_graph_0.num_nodes, self.hidden_dim)
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+
+    def test_forward_batched_graphs(self, simple_graph_0, simple_graph_1):
+        """Test that batched graphs preserve graph boundaries."""
+        batch_data = Batch.from_data_list([simple_graph_0, simple_graph_1])
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            num_layers=1,
+            heads=2,
+            variant="s",
+        )
+
+        x = self._features(batch_data.num_nodes)
+        out = model(
+            x=x,
+            edge_index=batch_data.edge_index,
+            batch=batch_data.batch,
+        )
+
+        assert out.shape == (batch_data.num_nodes, self.hidden_dim)
+
+    def test_forward_with_edge_weight(self, simple_graph_0):
+        """Test optional edge weights."""
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            num_layers=1,
+        )
+        edge_weight = torch.ones(simple_graph_0.edge_index.shape[1])
+
+        out = model(
+            x=self._features(simple_graph_0.num_nodes),
+            edge_index=simple_graph_0.edge_index,
+            edge_weight=edge_weight,
+        )
+
+        assert out.shape == (simple_graph_0.num_nodes, self.hidden_dim)
+
+    def test_backward_pass(self, simple_graph_0):
+        """Test gradient flow."""
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            num_layers=1,
+        )
+        x = self._features(simple_graph_0.num_nodes).requires_grad_(True)
+
+        out = model(x=x, edge_index=simple_graph_0.edge_index)
+        loss = out.mean()
+        loss.backward()
+
+        assert x.grad is not None
+        assert any(
+            param.grad is not None
+            for param in model.parameters()
+            if param.requires_grad
+        )
+
+    def test_series_matches_reference_outputs_and_gradients(self):
+        """Optimized series propagation must preserve values and gradients."""
+        torch.manual_seed(7)
+        layer = AdvDIFFormerLayer(
+            hidden_dim=5,
+            heads=2,
+            propagation_steps=2,
+            beta=0.3,
+            dropout=0.0,
+            head_aggregation="mean",
+            make_undirected=True,
+        )
+        reference_layer = deepcopy(layer)
+        edge_index = torch.tensor([[0, 1, 2, 3, 4], [1, 0, 3, 4, 2]])
+        edge_weight = torch.tensor([0.5, 1.5, 2.0, 0.75, 1.25])
+        batch = torch.tensor([10, 10, 3, 3, 3])
+        x = torch.randn(5, 5, requires_grad=True)
+        x_reference = x.detach().clone().requires_grad_(True)
+
+        actual = layer(x, edge_index, batch, edge_weight)
+        expected = _reference_series(
+            reference_layer,
+            x_reference,
+            edge_index,
+            batch,
+            edge_weight,
+        )
+        actual.square().sum().backward()
+        expected.square().sum().backward()
+
+        assert torch.allclose(actual, expected, atol=2e-6, rtol=2e-5)
+        assert torch.allclose(x.grad, x_reference.grad, atol=2e-6, rtol=2e-5)
+        for parameter, reference_parameter in zip(
+            layer.parameters(), reference_layer.parameters(), strict=True
+        ):
+            assert torch.allclose(
+                parameter.grad,
+                reference_parameter.grad,
+                atol=2e-6,
+                rtol=2e-5,
+            )
+
+    def test_interleaved_non_contiguous_batch_ids(self):
+        """Graph-local attention supports unusual batch IDs and node ordering."""
+        torch.manual_seed(11)
+        layer = AdvDIFFormerLayer(hidden_dim=4, propagation_steps=1)
+        x = torch.randn(6, 4)
+        batch = torch.tensor([9, 2, 9, 2, 9, 2])
+        edge_index = torch.empty((2, 0), dtype=torch.long)
+
+        actual = layer(x, edge_index, batch)
+        expected = _reference_series(layer, x, edge_index, batch)
+
+        assert torch.allclose(actual, expected, atol=1e-6, rtol=1e-5)
+
+    @pytest.mark.parametrize("heads", [1, 2, 4])
+    def test_different_heads(self, simple_graph_0, heads):
+        """Test different numbers of heads."""
+        model = AdvDIFFormerEncoder(
+            input_dim=self.input_dim,
+            hidden_dim=self.hidden_dim,
+            num_layers=1,
+            heads=heads,
+            head_aggregation="mean",
+        )
+
+        out = model(
+            x=self._features(simple_graph_0.num_nodes),
+            edge_index=simple_graph_0.edge_index,
+        )
+
+        assert out.shape == (simple_graph_0.num_nodes, self.hidden_dim)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,11 +1,11 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
+
 from test._utils.simplified_pipeline import run
 
-
 DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+MODELS   = ["graph/advdifformer"]                                       # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/advdifformer.py
+++ b/topobench/nn/backbones/graph/advdifformer.py
@@ -1,0 +1,761 @@
+"""Advective Diffusion Transformer graph backbone.
+
+This module implements a TopoBench-compatible AdvDIFFormer encoder following
+Wu et al., "Supercharging Graph Transformers with Advective Diffusion"
+(ICML 2025) and the official ``qitianwu/AdvDIFFormer`` implementation.
+The propagation layer corresponds to the model's global attentive diffusion
+plus observed-graph advection operator.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torch_geometric.utils import coalesce
+
+
+class _PreparedGraph:
+    """Row-normalized graph data reused throughout one encoder forward."""
+
+    __slots__ = ("dst", "norm_weight", "num_nodes", "src")
+
+    def __init__(self, src, dst, norm_weight, num_nodes) -> None:
+        self.src = src
+        self.dst = dst
+        self.norm_weight = norm_weight
+        self.num_nodes = num_nodes
+
+    def matmul(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the prepared row-normalized adjacency to node features."""
+        if self.src.numel() == 0:
+            return torch.zeros_like(x)
+        messages = x.index_select(0, self.src) * self.norm_weight.unsqueeze(-1)
+        out = torch.zeros_like(x)
+        out.index_add_(0, self.dst, messages)
+        return out
+
+
+class _PreparedBatch:
+    """Canonical graph assignments and contiguous graph segments."""
+
+    __slots__ = (
+        "batch",
+        "counts",
+        "counts_list",
+        "num_graphs",
+        "ptr",
+        "restore_indices",
+        "sorted_batch",
+        "sorted_indices",
+    )
+
+    def __init__(
+        self,
+        batch,
+        sorted_batch,
+        ptr,
+        counts,
+        counts_list,
+        sorted_indices,
+        restore_indices,
+    ) -> None:
+        self.batch = batch
+        self.sorted_batch = sorted_batch
+        self.ptr = ptr
+        self.counts = counts
+        self.counts_list = counts_list
+        self.num_graphs = counts.numel()
+        self.sorted_indices = sorted_indices
+        self.restore_indices = restore_indices
+
+
+def _prepare_batch(batch: torch.Tensor | None, num_nodes: int, device) -> _PreparedBatch:
+    """Canonicalize graph IDs and build contiguous segments once."""
+    identity = torch.arange(num_nodes, device=device)
+    if batch is None or num_nodes == 0:
+        canonical = torch.zeros(num_nodes, dtype=torch.long, device=device)
+        counts = torch.tensor([num_nodes], dtype=torch.long, device=device)
+        ptr = torch.tensor([0, num_nodes], dtype=torch.long, device=device)
+        return _PreparedBatch(
+            canonical,
+            canonical,
+            ptr,
+            counts,
+            [num_nodes],
+            identity,
+            identity,
+        )
+
+    _, canonical = torch.unique(batch, sorted=True, return_inverse=True)
+    counts = torch.bincount(canonical)
+    ptr = torch.cat([counts.new_zeros(1), counts.cumsum(0)])
+
+    is_contiguous = bool(
+        num_nodes < 2 or torch.all(canonical[1:] >= canonical[:-1]).item()
+    )
+    if is_contiguous:
+        sorted_indices = identity
+        restore_indices = identity
+        sorted_batch = canonical
+    else:
+        sorted_indices = torch.argsort(canonical, stable=True)
+        restore_indices = torch.empty_like(sorted_indices)
+        restore_indices[sorted_indices] = identity
+        sorted_batch = canonical.index_select(0, sorted_indices)
+
+    return _PreparedBatch(
+        canonical,
+        sorted_batch,
+        ptr,
+        counts,
+        counts.tolist(),
+        sorted_indices,
+        restore_indices,
+    )
+
+
+def _prepare_graph(
+    edge_index: torch.Tensor,
+    edge_weight: torch.Tensor | None,
+    num_nodes: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    make_undirected: bool,
+) -> _PreparedGraph:
+    """Prepare receiving-node row normalization once per encoder forward."""
+    if edge_index.numel() == 0:
+        empty = edge_index.new_empty(0)
+        return _PreparedGraph(empty, empty, torch.empty(0, dtype=dtype, device=device), num_nodes)
+
+    edge_index = edge_index.to(device=device)
+    if edge_weight is None:
+        edge_weight = torch.ones(edge_index.shape[1], dtype=dtype, device=device)
+    else:
+        edge_weight = edge_weight.to(dtype=dtype, device=device)
+    if make_undirected:
+        edge_index, edge_weight = _as_undirected(edge_index, edge_weight)
+
+    src, dst = edge_index
+    degree = torch.zeros(num_nodes, dtype=dtype, device=device)
+    degree.index_add_(0, dst, edge_weight)
+    inverse_degree = torch.zeros_like(degree)
+    positive = degree > 0
+    inverse_degree[positive] = degree[positive].reciprocal()
+    return _PreparedGraph(src, dst, inverse_degree[dst] * edge_weight, num_nodes)
+
+
+def _as_undirected(
+    edge_index: torch.Tensor,
+    edge_weight: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Return an undirected version of an edge list."""
+    if edge_index.numel() == 0:
+        return edge_index, edge_weight
+
+    rev_edge_index = edge_index.flip(0)
+    edge_index = torch.cat([edge_index, rev_edge_index], dim=1)
+
+    if edge_weight is not None:
+        edge_weight = torch.cat([edge_weight, edge_weight], dim=0)
+
+    return coalesce(edge_index, edge_weight, reduce="mean")
+
+
+def _normalized_adjacency_matmul(
+    x: torch.Tensor,
+    edge_index: torch.Tensor,
+    edge_weight: torch.Tensor | None = None,
+    make_undirected: bool = False,
+) -> torch.Tensor:
+    """Compute D^{-1} A X with sparse edge indices.
+
+    The official implementation constructs a transposed sparse adjacency and
+    left-normalizes it by the receiving-node degree before multiplying node
+    features, which is equivalent to row-normalized message aggregation.
+    """
+    prepared = _prepare_graph(
+        edge_index,
+        edge_weight,
+        x.shape[0],
+        x.dtype,
+        x.device,
+        make_undirected,
+    )
+    return prepared.matmul(x)
+
+
+def _dense_normalized_adjacency(
+    num_nodes: int,
+    edge_index: torch.Tensor,
+    edge_weight: torch.Tensor | None,
+    device: torch.device,
+    dtype: torch.dtype,
+    make_undirected: bool = False,
+) -> torch.Tensor:
+    """Build a dense row-normalized adjacency matrix."""
+    if edge_index.numel() == 0:
+        return torch.zeros(num_nodes, num_nodes, device=device, dtype=dtype)
+
+    if edge_weight is None:
+        edge_weight = torch.ones(edge_index.shape[1], device=device, dtype=dtype)
+    else:
+        edge_weight = edge_weight.to(dtype=dtype, device=device)
+
+    if make_undirected:
+        edge_index, edge_weight = _as_undirected(edge_index, edge_weight)
+
+    row, col = edge_index
+    deg = torch.zeros(num_nodes, device=device, dtype=dtype)
+    deg.index_add_(0, col, edge_weight)
+    deg_inv = torch.zeros_like(deg)
+    nonzero = deg > 0
+    deg_inv[nonzero] = deg[nonzero].reciprocal()
+    norm = deg_inv[col] * edge_weight
+
+    adj = torch.zeros(num_nodes, num_nodes, device=device, dtype=dtype)
+    adj[col, row] = norm
+    return adj
+
+
+class AdvDIFFormerLayer(nn.Module):
+    """One AdvDIFFormer propagation layer.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Dimension of node embeddings.
+    heads : int
+        Number of propagation heads.
+    variant : str
+        Propagation variant. ``"series"`` uses the scalable polynomial
+        propagation, while ``"inverse"`` uses a dense linear solve. The
+        aliases ``"s"`` and ``"i"`` are accepted for compatibility.
+    propagation_steps : int
+        Number of propagation powers, called ``K_order`` in the official
+        implementation, for the scalable variant.
+    beta : float
+        Weight of observed-graph advection.
+    theta : float
+        Identity coefficient for the inverse variant.
+    dropout : float
+        Dropout rate applied inside the layer.
+    head_aggregation : str
+        Either ``"sum"`` or ``"mean"`` for combining heads.
+    make_undirected : bool
+        Whether to symmetrize the input edge list before local propagation.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        heads: int = 1,
+        variant: str = "series",
+        propagation_steps: int = 2,
+        beta: float = 0.5,
+        theta: float = 0.0,
+        dropout: float = 0.0,
+        head_aggregation: str = "sum",
+        make_undirected: bool = False,
+    ) -> None:
+        super().__init__()
+        variant_aliases = {"s": "series", "i": "inverse"}
+        variant = variant_aliases.get(variant, variant)
+        if variant not in {"series", "inverse"}:
+            raise ValueError("variant must be 'series'/'s' or 'inverse'/'i'.")
+        if propagation_steps < 1:
+            raise ValueError("propagation_steps must be at least 1.")
+        if head_aggregation not in {"sum", "mean"}:
+            raise ValueError("head_aggregation must be either 'sum' or 'mean'.")
+
+        self.hidden_dim = hidden_dim
+        self.heads = heads
+        self.variant = variant
+        self.propagation_steps = propagation_steps
+        self.beta = beta
+        self.theta = theta
+        self.head_aggregation = head_aggregation
+        self.make_undirected = make_undirected
+
+        self.query = nn.ModuleList(
+            nn.Linear(hidden_dim, hidden_dim, bias=False)
+            for _ in range(heads)
+        )
+        self.key = nn.ModuleList(
+            nn.Linear(hidden_dim, hidden_dim, bias=False)
+            for _ in range(heads)
+        )
+
+        output_input_dim = (
+            hidden_dim * (propagation_steps + 1)
+            if variant == "series"
+            else hidden_dim
+        )
+        self.output = nn.ModuleList(
+            nn.Linear(output_input_dim, hidden_dim, bias=False)
+            for _ in range(heads)
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        prepared_graph: _PreparedGraph | None = None,
+        prepared_batch: _PreparedBatch | None = None,
+    ) -> torch.Tensor:
+        """Forward pass."""
+        if prepared_batch is None:
+            prepared_batch = _prepare_batch(batch, x.shape[0], x.device)
+        batch = prepared_batch.batch
+        if prepared_graph is None:
+            prepared_graph = _prepare_graph(
+                edge_index,
+                edge_weight,
+                x.shape[0],
+                x.dtype,
+                x.device,
+                self.make_undirected,
+            )
+
+        if self.variant == "series":
+            return self._forward_series_all_heads(x, prepared_graph, prepared_batch)
+
+        head_outputs = []
+        for head in range(self.heads):
+            q = F.normalize(self.query[head](x), p=2, dim=-1, eps=1e-12)
+            k = F.normalize(self.key[head](x), p=2, dim=-1, eps=1e-12)
+
+            out = self._forward_inverse(
+                x, q, k, edge_index, batch, edge_weight
+            )
+            projected = self.output[head](out)
+            head_outputs.append(projected)
+
+        out = torch.stack(head_outputs, dim=0).sum(dim=0)
+        if self.head_aggregation == "mean":
+            out = out / self.heads
+        return self.dropout(out)
+
+    def _forward_series_all_heads(
+        self,
+        x: torch.Tensor,
+        graph: _PreparedGraph,
+        batch: _PreparedBatch,
+    ) -> torch.Tensor:
+        """Apply AdvDIFFormer-S while batching heads in the hot path."""
+        q = torch.stack(
+            [
+                F.normalize(query(x), p=2, dim=-1, eps=1e-12)
+                for query in self.query
+            ],
+            dim=0,
+        )
+        k = torch.stack(
+            [
+                F.normalize(key(x), p=2, dim=-1, eps=1e-12)
+                for key in self.key
+            ],
+            dim=0,
+        )
+        context = self._prepare_multihead_attention_context(q, k, batch)
+        weights = torch.stack([output.weight for output in self.output], dim=0)
+        weight_blocks = weights.split(self.hidden_dim, dim=2)
+
+        current = x.unsqueeze(0).expand(self.heads, -1, -1)
+        projected = torch.einsum("hni,hoi->hno", current, weight_blocks[0])
+        for step in range(self.propagation_steps):
+            attentive = self._linear_multihead_attention_prepared(current, context)
+            advective = self._multihead_graph_matmul(graph, current)
+            current = attentive + self.beta * advective
+            projected = projected + torch.einsum(
+                "hni,hoi->hno",
+                current,
+                weight_blocks[step + 1],
+            )
+
+        out = projected.sum(dim=0)
+        if self.head_aggregation == "mean":
+            out = out / self.heads
+        return self.dropout(out)
+
+    def _multihead_graph_matmul(
+        self,
+        graph: _PreparedGraph,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply local propagation to all heads with one graph aggregation."""
+        flat = x.permute(1, 0, 2).reshape(x.shape[1], self.heads * self.hidden_dim)
+        out = graph.matmul(flat)
+        return out.view(x.shape[1], self.heads, self.hidden_dim).permute(1, 0, 2)
+
+    def _forward_scalable_projected(
+        self,
+        x: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        graph: _PreparedGraph,
+        batch: _PreparedBatch,
+        output: nn.Linear,
+    ) -> torch.Tensor:
+        """Propagate while applying output weight blocks incrementally."""
+        context = self._prepare_attention_context(q, k, batch)
+        weights = output.weight.split(self.hidden_dim, dim=1)
+        projected = F.linear(x, weights[0])
+        current = x
+        for step in range(self.propagation_steps):
+            attentive = self._linear_attention_prepared(q, k, current, context)
+            current = attentive + self.beta * graph.matmul(current)
+            projected = projected + F.linear(current, weights[step + 1])
+        return projected
+
+    def _forward_scalable(
+        self,
+        x: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor,
+        edge_weight: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Apply the linear-complexity AdvDIFFormer-S propagation."""
+        states = [x]
+        current = x
+        for _ in range(self.propagation_steps):
+            attentive = self._linear_attention_matmul(q, k, current, batch)
+
+            advective = _normalized_adjacency_matmul(
+                current,
+                edge_index,
+                edge_weight=edge_weight,
+                make_undirected=self.make_undirected,
+            )
+            current = attentive + self.beta * advective
+            states.append(current)
+
+        return torch.cat(states, dim=-1)
+
+    def _forward_inverse(
+        self,
+        x: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor,
+        edge_weight: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Apply the dense AdvDIFFormer-I linear solve."""
+        num_nodes = x.shape[0]
+        attention = torch.zeros(
+            num_nodes, num_nodes, device=x.device, dtype=x.dtype
+        )
+        for graph_id in batch.unique(sorted=True):
+            mask = batch == graph_id
+            idx = mask.nonzero(as_tuple=True)[0]
+            attention[idx[:, None], idx[None, :]] = self._dense_attention(
+                q[mask], k[mask]
+            )
+
+        adj = _dense_normalized_adjacency(
+            num_nodes,
+            edge_index,
+            edge_weight,
+            device=x.device,
+            dtype=x.dtype,
+            make_undirected=self.make_undirected,
+        )
+        identity = torch.eye(num_nodes, device=x.device, dtype=x.dtype)
+        operator = (1 + self.theta) * identity - attention - self.beta * adj
+
+        jitter = 1e-6 * identity
+        return torch.linalg.solve(operator + jitter, x)
+
+    @staticmethod
+    def _linear_attention_matmul(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        values: torch.Tensor,
+        batch: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute C values for eta(q, k) = 1 + cosine(q, k).
+
+        This vectorized form is algebraically the same as applying the
+        operation independently to each graph in a batch, but avoids an inner
+        Python loop over graphs for every layer, head, and propagation step.
+        """
+        prepared = _prepare_batch(batch, values.shape[0], values.device)
+        context = AdvDIFFormerLayer._prepare_attention_context(q, k, prepared)
+        return AdvDIFFormerLayer._linear_attention_prepared(q, k, values, context)
+
+    @staticmethod
+    def _prepare_attention_context(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        batch: _PreparedBatch,
+    ) -> tuple[
+        _PreparedBatch,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        """Compute graph-local denominators once for all propagation steps."""
+        q_sorted = q.index_select(0, batch.sorted_indices)
+        k_sorted = k.index_select(0, batch.sorted_indices)
+        key_sums = k.new_zeros(batch.num_graphs, k.shape[-1])
+        key_sums.index_add_(0, batch.sorted_batch, k_sorted)
+
+        counts = batch.counts.to(dtype=q.dtype).unsqueeze(-1)
+        denominator = counts.index_select(0, batch.sorted_batch)
+        denominator = denominator + (q_sorted * key_sums.index_select(0, batch.sorted_batch)).sum(dim=-1, keepdim=True)
+        return batch, q_sorted, k_sorted, denominator.clamp_min(1e-12)
+
+    @staticmethod
+    def _linear_attention_prepared(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        values: torch.Tensor,
+        context: tuple[
+            _PreparedBatch,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ],
+    ) -> torch.Tensor:
+        """Graphwise linear attention without a node-wise outer-product tensor."""
+        batch, q_sorted, k_sorted, denominator = context
+        values_sorted = values.index_select(0, batch.sorted_indices)
+        parts = []
+        q_parts = q_sorted.split(batch.counts_list, dim=0)
+        k_parts = k_sorted.split(batch.counts_list, dim=0)
+        value_parts = values_sorted.split(batch.counts_list, dim=0)
+        denominator_parts = denominator.split(batch.counts_list, dim=0)
+        for q_graph, k_graph, value_graph, denominator_graph in zip(
+            q_parts,
+            k_parts,
+            value_parts,
+            denominator_parts,
+            strict=True,
+        ):
+            numerator = value_graph.sum(dim=0, keepdim=True) + q_graph @ (
+                k_graph.T @ value_graph
+            )
+            parts.append(numerator / denominator_graph)
+
+        out_sorted = parts[0] if len(parts) == 1 else torch.cat(parts, dim=0)
+        return out_sorted.index_select(0, batch.restore_indices)
+
+    @staticmethod
+    def _prepare_multihead_attention_context(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        batch: _PreparedBatch,
+    ) -> tuple[_PreparedBatch, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Compute graph-local denominators for all heads at once."""
+        q_sorted = q.index_select(1, batch.sorted_indices)
+        k_sorted = k.index_select(1, batch.sorted_indices)
+        heads, _, hidden_dim = k_sorted.shape
+        graph_ids = batch.sorted_batch.unsqueeze(0) + torch.arange(heads, device=k.device).unsqueeze(-1) * batch.num_graphs
+
+        key_sums = k.new_zeros(heads * batch.num_graphs, hidden_dim)
+        key_sums.index_add_(0, graph_ids.reshape(-1), k_sorted.reshape(-1, hidden_dim))
+        key_sums = key_sums.view(heads, batch.num_graphs, hidden_dim)
+
+        counts = batch.counts.to(dtype=q.dtype).view(1, batch.num_graphs, 1)
+        denominator = counts.index_select(1, batch.sorted_batch)
+        denominator = denominator + (q_sorted * key_sums.index_select(1, batch.sorted_batch)).sum(dim=-1, keepdim=True)
+        return batch, q_sorted, k_sorted, denominator.clamp_min(1e-12)
+
+    @staticmethod
+    def _linear_multihead_attention_prepared(
+        values: torch.Tensor,
+        context: tuple[_PreparedBatch, torch.Tensor, torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        """Graphwise linear attention for values shaped [heads, nodes, dim]."""
+        batch, q_sorted, k_sorted, denominator = context
+        values_sorted = values.index_select(1, batch.sorted_indices)
+        parts = []
+        q_parts = q_sorted.split(batch.counts_list, dim=1)
+        k_parts = k_sorted.split(batch.counts_list, dim=1)
+        value_parts = values_sorted.split(batch.counts_list, dim=1)
+        denominator_parts = denominator.split(batch.counts_list, dim=1)
+        for q_graph, k_graph, value_graph, denominator_graph in zip(
+            q_parts,
+            k_parts,
+            value_parts,
+            denominator_parts,
+            strict=True,
+        ):
+            key_value = k_graph.transpose(-1, -2) @ value_graph
+            numerator = value_graph.sum(dim=1, keepdim=True) + q_graph @ key_value
+            parts.append(numerator / denominator_graph)
+
+        out_sorted = parts[0] if len(parts) == 1 else torch.cat(parts, dim=1)
+        return out_sorted.index_select(1, batch.restore_indices)
+
+    @staticmethod
+    def _dense_attention(q: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
+        """Build the dense row-normalized positive similarity matrix."""
+        sim = 1 + q @ k.T
+        return sim / sim.sum(dim=-1, keepdim=True).clamp(min=1e-12)
+
+
+class AdvDIFFormerEncoder(nn.Module):
+    """Advective Diffusion Transformer encoder for graph node embeddings.
+
+    Parameters
+    ----------
+    input_dim : int
+        Dimension of input node features.
+    hidden_dim : int
+        Dimension of hidden node embeddings.
+    num_layers : int, optional
+        Number of stacked AdvDIFFormer propagation layers.
+    heads : int, optional
+        Number of heads in each propagation layer.
+    variant : str, optional
+        ``"series"``/``"s"`` for AdvDIFFormer-S or ``"inverse"``/``"i"``
+        for AdvDIFFormer-I.
+    propagation_steps : int, optional
+        Number of propagation powers for AdvDIFFormer-S.
+    beta : float, optional
+        Weight of observed-graph advection.
+    theta : float, optional
+        Identity coefficient for AdvDIFFormer-I.
+    dropout : float, optional
+        Dropout rate.
+    input_dropout : float, optional
+        Dropout applied after the input projection.
+    residual : bool, optional
+        Whether to use residual connections around propagation layers.
+    layer_norm : bool, optional
+        Whether to apply layer normalization after each layer.
+    head_aggregation : str, optional
+        Either ``"sum"`` or ``"mean"``.
+    make_undirected : bool, optional
+        Whether to symmetrize the input edge list before local propagation.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int,
+        num_layers: int = 2,
+        heads: int = 1,
+        variant: str = "series",
+        propagation_steps: int = 2,
+        beta: float = 0.5,
+        theta: float = 0.0,
+        dropout: float = 0.0,
+        input_dropout: float = 0.0,
+        residual: bool = True,
+        layer_norm: bool = True,
+        head_aggregation: str = "sum",
+        make_undirected: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError("num_layers must be at least 1.")
+
+        self.input_dim = input_dim
+        self.hidden_dim = hidden_dim
+        self.out_channels = hidden_dim
+        self.num_layers = num_layers
+        self.heads = heads
+        variant_aliases = {"s": "series", "i": "inverse"}
+        self.variant = variant_aliases.get(variant, variant)
+        self.propagation_steps = propagation_steps
+        self.beta = beta
+        self.theta = theta
+        self.residual = residual
+        self.layer_norm = layer_norm
+        self.make_undirected = make_undirected
+
+        self.input_proj = (
+            nn.Identity()
+            if input_dim == hidden_dim
+            else nn.Linear(input_dim, hidden_dim)
+        )
+        self.input_dropout = nn.Dropout(input_dropout)
+        self.layers = nn.ModuleList(
+            AdvDIFFormerLayer(
+                hidden_dim=hidden_dim,
+                heads=heads,
+                variant=self.variant,
+                propagation_steps=propagation_steps,
+                beta=beta,
+                theta=theta,
+                dropout=dropout,
+                head_aggregation=head_aggregation,
+                make_undirected=make_undirected,
+            )
+            for _ in range(num_layers)
+        )
+        self.norms = nn.ModuleList(
+            nn.LayerNorm(hidden_dim) if layer_norm else nn.Identity()
+            for _ in range(num_layers)
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        edge_attr: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node feature matrix of shape ``[num_nodes, input_dim]``.
+        edge_index : torch.Tensor
+            Edge indices of shape ``[2, num_edges]``.
+        batch : torch.Tensor, optional
+            Batch assignment for each node.
+        edge_weight : torch.Tensor, optional
+            Optional scalar edge weights.
+        edge_attr : torch.Tensor, optional
+            Ignored unless it is one-dimensional and ``edge_weight`` is unset.
+        **kwargs : dict
+            Additional arguments ignored for wrapper compatibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``[num_nodes, hidden_dim]``.
+        """
+        if edge_weight is None and edge_attr is not None and edge_attr.dim() == 1:
+            edge_weight = edge_attr
+
+        x = self.input_dropout(self.input_proj(x))
+        prepared_batch = _prepare_batch(batch, x.shape[0], x.device)
+        prepared_graph = _prepare_graph(
+            edge_index,
+            edge_weight,
+            x.shape[0],
+            x.dtype,
+            x.device,
+            self.make_undirected,
+        )
+        for layer, norm in zip(self.layers, self.norms, strict=False):
+            propagated = layer(
+                x,
+                edge_index,
+                batch=prepared_batch.batch,
+                edge_weight=edge_weight,
+                prepared_graph=prepared_graph,
+                prepared_batch=prepared_batch,
+            )
+            if self.residual:
+                x = x + self.dropout(propagated)
+            else:
+                x = self.dropout(propagated)
+            x = norm(x)
+
+        return x


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.

## Description
This PR adds an implementation of AdvDIFFormer (Advective Diffusion Transformer) from Wu et al., “Supercharging Graph Transformers with Advective Diffusion” https://arxiv.org/abs/2310.06417.

AdvDIFFormer is a PDE inspired graph Transformer derived from the advective diffusion equations. It combines graph-structured propagation with learned non-local interactions.

This PR also adds, as per challenge a example config: 

configs/model/graph/advdifformer.yaml

And some unit tests in: 

test/nn/backbones/graph/test_advdifformer.py

Testing was run locally:

uv run --no-sync ruff check topobench/nn/backbones/graph/advdifformer.py test/nn/backbones/graph/test_advdifformer.py test/pipeline/test_pipeline.py

uv run --no-sync pytest test/nn/backbones/graph/test_advdifformer.py -q

uv run --no-sync pytest test/pipeline/test_pipeline.py -q


## Additional context

The implementation supports both AdvDIFFormer variants: the more scalable **AdvDIFFormer-S** formulation and the **AdvDIFFormer-I** (inverse) formulation. For more details, we refer to the original paper.

For AdvDIFFormer-S, the implementation supports batched PyG graphs while keeping global attention graph-local and avoiding building of dense node-to-node attention matrices. Propagation across multiple heads is batched. The normalized graph structure and batch segmentation are prepared once forward and reused across layers. This improved speed in local testing.

Propagation-order projections are accumulated incrementally rather than by materializing a concatenation of all intermediate propagation states. In line with the original implementation, this implemementation supports weighted edges and multi-head propagation. Additionally, it supports optional graph symmetrization, arbitrary PyG batch assignments and layer normalization. These can be configured through the yaml as in the example.