### PR TITLE
Track: Track1; Team name: LangDiff; Model: MTGCN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-26_11-39-05/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-26_11-39-05/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-26_11-39-05",
+    "model_config": "graph/mtgcn",
+    "generated_at_utc": "2026-07-26T12:33:51.937395+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1754870414733887,
+      "test_best_rerun_accuracy": 0.32309573888778687,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3215295374393463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3355107307434082,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3346703350543976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36523035168647766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3611811399459839,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36400794982910156,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36316755414009094,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4234471619129181,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4290243685245514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4448391795158386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46145617961883545,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4526205408400383,
+        "AvgTime/train_epoch_std": 0.044190527303118676,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.179767370223999,
+      "test_best_rerun_accuracy": 0.32187333703041077,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31870272755622864,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3383375406265259,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33600732684135437,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36736953258514404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3614867329597473,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3712659478187561,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.370005339384079,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42554816603660583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.43074336647987366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45614638924598694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47421500086784363,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4546029949188233,
+        "AvgTime/train_epoch_std": 0.03898669528541541,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1688363552093506,
+      "test_best_rerun_accuracy": 0.3253495395183563,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3224845230579376,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33707693219184875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3373825252056122,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.368095338344574,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36347314715385437,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3664909601211548,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3667965531349182,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4266177713871002,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4341813623905182,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4513331949710846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46852317452430725,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5051738540810276,
+        "AvgTime/train_epoch_std": 0.10495726384495907,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.177615165710449,
+      "test_best_rerun_accuracy": 0.3232867419719696,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3214913308620453,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3331805467605591,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.333065927028656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36076095700263977,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3577813506126404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.356749951839447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35843074321746826,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.414661169052124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.41874855756759644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43143096566200256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4464435875415802,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.208458967208862,
+        "AvgTime/train_epoch_std": 0.4175827695619722,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.17659330368042,
+      "test_best_rerun_accuracy": 0.3224845230579376,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32359233498573303,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3339827358722687,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3355107307434082,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3625945448875427,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3594621419906616,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3621361553668976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3648865520954132,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42069676518440247,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42570096254348755,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44430437684059143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46229657530784607,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.1536375747364795,
+        "AvgTime/train_epoch_std": 0.1446402490284289,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.180591106414795,
+      "test_best_rerun_accuracy": 0.32072731852531433,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32187333703041077,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3318435251712799,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3344411253929138,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36152493953704834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.358621746301651,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3623271584510803,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3648865520954132,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4180227816104889,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4257773756980896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4436167776584625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4627549946308136,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.130243175466296,
+        "AvgTime/train_epoch_std": 0.11457156923059097,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1088829040527344,
+      "test_best_rerun_accuracy": 0.34372374415397644,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.310184121131897,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33910152316093445,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38287875056266785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3734433352947235,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3893345594406128,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3875391483306885,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4695545732975006,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48265719413757324,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5085949897766113,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5373595952987671,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.4764783146145106,
+        "AvgTime/train_epoch_std": 0.6627974689692894,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.0979392528533936,
+      "test_best_rerun_accuracy": 0.3446023464202881,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30785393714904785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33875772356987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38096874952316284,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3712659478187561,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3980441689491272,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39456796646118164,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4765069782733917,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4808236062526703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5279623866081238,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5480937957763672,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.399298854340288,
+        "AvgTime/train_epoch_std": 0.15328216606309383,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1255886554718018,
+      "test_best_rerun_accuracy": 0.3385285437107086,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30922913551330566,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30334633588790894,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33283674716949463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3788295388221741,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36591795086860657,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3925051689147949,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38780656456947327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.46745359897613525,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.47669798135757446,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5197494029998779,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5439299941062927,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.437307036441305,
+        "AvgTime/train_epoch_std": 0.13985956034417277,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.13550066947937,
+      "test_best_rerun_accuracy": 0.3354725241661072,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3128963112831116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.306440532207489,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33463212847709656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3800901472568512,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3741309642791748,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3862021565437317,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38666054606437683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47635418176651,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49071741104125977,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5204370021820068,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5506150126457214,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.458552425557917,
+        "AvgTime/train_epoch_std": 0.15065969860546677,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.14278244972229,
+      "test_best_rerun_accuracy": 0.3344029486179352,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30838871002197266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30361372232437134,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33554893732070923,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38505616784095764,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3749331533908844,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3926961421966553,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3938421607017517,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49327680468559265,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5052334070205688,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.542669415473938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5720070004463196,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.392218524759466,
+        "AvgTime/train_epoch_std": 0.14745192737543775,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1296401023864746,
+      "test_best_rerun_accuracy": 0.33623653650283813,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31178852915763855,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.306402325630188,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3378027379512787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38734814524650574,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37856215238571167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3962487578392029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39796775579452515,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.490526407957077,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5036671757698059,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5376270413398743,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5704790353775024,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.6179474998922907,
+        "AvgTime/train_epoch_std": 0.3832066504167789,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9355218410491943,
+      "test_best_rerun_accuracy": 0.4064863622188568,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3062495291233063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2981511056423187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33405911922454834,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32916954159736633,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3946061432361603,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4095041751861572,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4135533571243286,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.545687198638916,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5597830414772034,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6086408495903015,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6455038785934448,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.508525573477453,
+        "AvgTime/train_epoch_std": 0.11309708220959379,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9341739416122437,
+      "test_best_rerun_accuracy": 0.4086255729198456,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30376651883125305,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2962411046028137,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33165252208709717,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.328138142824173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3952173590660095,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4113759696483612,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4173351526260376,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5518374443054199,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5639850497245789,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6152876615524292,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6566200852394104,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0334987269507514,
+        "AvgTime/train_epoch_std": 0.07843954673395695,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9534012079238892,
+      "test_best_rerun_accuracy": 0.403201162815094,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3011307120323181,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29070210456848145,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32821452617645264,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3274887204170227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3930399715900421,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4120253622531891,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4154633581638336,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5519902110099792,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5634502172470093,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6137596368789673,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6552830338478088,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9610212392974318,
+        "AvgTime/train_epoch_std": 0.06892495011582475,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.980303406715393,
+      "test_best_rerun_accuracy": 0.3920467495918274,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30365192890167236,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2965849041938782,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.327374130487442,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3293605446815491,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4010619521141052,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4023607671260834,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40965697169303894,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5390785932540894,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5525250434875488,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6008480191230774,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6363740563392639,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0316735870308347,
+        "AvgTime/train_epoch_std": 0.06451513512048684,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9736783504486084,
+      "test_best_rerun_accuracy": 0.3918939530849457,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3027733266353607,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2940637171268463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32943692803382874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3299717307090759,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40423256158828735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40789976716041565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41263657808303833,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5457636117935181,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5580640435218811,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.607418417930603,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6475284695625305,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9123199114928375,
+        "AvgTime/train_epoch_std": 0.449722398490689,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9721609354019165,
+      "test_best_rerun_accuracy": 0.39323094487190247,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3065551221370697,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2985331118106842,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3306211233139038,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32947513461112976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40194055438041687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4075941741466522,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41019177436828613,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5433952212333679,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5558866262435913,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6035220623016357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6423332691192627,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.784409792283002,
+        "AvgTime/train_epoch_std": 0.04888056843800599,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8696489334106445,
+      "test_best_rerun_accuracy": 0.4251279830932617,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2937581241130829,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2801971137523651,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3361601233482361,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32645732164382935,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4068683683872223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3918939530849457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4297501742839813,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5611200332641602,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5757124423980713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6344640254974365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6766368746757507,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.767256139119466,
+        "AvgTime/train_epoch_std": 0.05803696008060936,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8385534286499023,
+      "test_best_rerun_accuracy": 0.43548017740249634,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28638550639152527,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27305370569229126,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3333333432674408,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3276415169239044,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4035831689834595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3888379633426666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43372297286987305,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5593246221542358,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5702880024909973,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6381694674491882,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6755672693252563,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7509558689899933,
+        "AvgTime/train_epoch_std": 0.0527940729993332,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8609981536865234,
+      "test_best_rerun_accuracy": 0.4284895658493042,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28978532552719116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2765299081802368,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33394452929496765,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3280235230922699,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4075941741466522,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39365115761756897,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43345558643341064,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5634884238243103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.577737033367157,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6373672485351562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6831308603286743,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7717172083307484,
+        "AvgTime/train_epoch_std": 0.05256717623405473,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8286495208740234,
+      "test_best_rerun_accuracy": 0.4404461681842804,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28256550431251526,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27099090814590454,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32703033089637756,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3241271376609802,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40602797269821167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39105355739593506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42829856276512146,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5712430477142334,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5850714445114136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6493620872497559,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6943234801292419,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7538174788157146,
+        "AvgTime/train_epoch_std": 0.05018792031965205,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.813865065574646,
+      "test_best_rerun_accuracy": 0.44380778074264526,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27710291743278503,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26556649804115295,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32187333703041077,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32416534423828125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4037741720676422,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39319276809692383,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4294445812702179,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5718160271644592,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5850714445114136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6493620872497559,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6934830546379089,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7646245816174675,
+        "AvgTime/train_epoch_std": 0.05821618789343956,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8309545516967773,
+      "test_best_rerun_accuracy": 0.4408281743526459,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2804645001888275,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2654901146888733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3248911201953888,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3243563175201416,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4037741720676422,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39170295000076294,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4287951588630676,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5705172419548035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5866758227348328,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6492092609405518,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6954694986343384,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7563611567020416,
+        "AvgTime/train_epoch_std": 0.053669805600346364,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.428397297859192,
+      "test_best_rerun_accuracy": 0.5955000519752502,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26663610339164734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2551378905773163,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2979601323604584,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.294178307056427,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4064481556415558,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3942623436450958,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41699135303497314,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4265795648097992,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6114676594734192,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6757200956344604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.720299482345581,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7570289583767162,
+        "AvgTime/train_epoch_std": 0.05052087671645164,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4059381484985352,
+      "test_best_rerun_accuracy": 0.6035602688789368,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26858431100845337,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25536710023880005,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2985331118106842,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2956681251525879,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41168156266212463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39663076400756836,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41752615571022034,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43208035826683044,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6143326163291931,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6812973022460938,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7231644988059998,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7606457596394554,
+        "AvgTime/train_epoch_std": 0.0487583200084317,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.41053307056427,
+      "test_best_rerun_accuracy": 0.600542426109314,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2654901146888733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25509971380233765,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3009397089481354,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2957827150821686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40725037455558777,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3969745635986328,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4200855791568756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.429864764213562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6140652298927307,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6812208890914917,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7233936786651611,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7565114868098293,
+        "AvgTime/train_epoch_std": 0.05349067389495263,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3524106740951538,
+      "test_best_rerun_accuracy": 0.6146764755249023,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2645350992679596,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2520054876804352,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29196271300315857,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28810450434684753,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40896937251091003,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3957139551639557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4173351526260376,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4275345802307129,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.599816620349884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6823287010192871,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7264496684074402,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7612696704217943,
+        "AvgTime/train_epoch_std": 0.051460922022345305,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3336989879608154,
+      "test_best_rerun_accuracy": 0.6197188496589661,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26610130071640015,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.256131112575531,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2918481230735779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2898235023021698,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41103217005729675,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39659255743026733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4154633581638336,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42638856172561646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6078004240989685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.686721682548523,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7269845008850098,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.763400588372741,
+        "AvgTime/train_epoch_std": 0.05206754108336607,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3486062288284302,
+      "test_best_rerun_accuracy": 0.6188784241676331,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2587287127971649,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2479563057422638,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29123690724372864,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28692030906677246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40640994906425476,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3935365676879883,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4166475534439087,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4278401732444763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.604362428188324,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6842768788337708,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7274810671806335,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.778537781733387,
+        "AvgTime/train_epoch_std": 0.06781481617318452,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1577736139297485,
+      "test_best_rerun_accuracy": 0.6861104965209961,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2525402903556824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23974329233169556,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2891359031200409,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2833295166492462,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40465277433395386,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38929635286331177,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4185957610607147,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4350217878818512,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6022996306419373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6175032258033752,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7314538955688477,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.788935476419877,
+        "AvgTime/train_epoch_std": 0.07669502030463919,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1385753154754639,
+      "test_best_rerun_accuracy": 0.6910001039505005,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25548169016838074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24172969162464142,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29028192162513733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28852471709251404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4072885513305664,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3941095471382141,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42421117424964905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4392237663269043,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6065780520439148,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6199098229408264,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.733249306678772,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7911084267630506,
+        "AvgTime/train_epoch_std": 0.05994636175291289,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1346710920333862,
+      "test_best_rerun_accuracy": 0.6919932961463928,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25616928935050964,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2434868961572647,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2924211025238037,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28665292263031006,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4067537486553192,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39388036727905273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4253953695297241,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4361295700073242,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.608182430267334,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6225074529647827,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7335548996925354,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.811838099161784,
+        "AvgTime/train_epoch_std": 0.05270089271425046,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.994775116443634,
+      "test_best_rerun_accuracy": 0.7338986992835999,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24814729392528534,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23550309240818024,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2867293059825897,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28485751152038574,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40365955233573914,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3881121575832367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4251279830932617,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4409809708595276,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6030636429786682,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6175414323806763,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6881350874900818,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7708234898746014,
+        "AvgTime/train_epoch_std": 0.04898330489969298,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9837177991867065,
+      "test_best_rerun_accuracy": 0.7380625009536743,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2478034943342209,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23324929177761078,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28734052181243896,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2838643193244934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4037741720676422,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39116814732551575,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.427916556596756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4441515803337097,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6075330376625061,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6179616451263428,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6933302879333496,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7863209701719738,
+        "AvgTime/train_epoch_std": 0.05794035152549205,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9844422340393066,
+      "test_best_rerun_accuracy": 0.7348536849021912,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24940790235996246,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23538848757743835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2894033193588257,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28355872631073,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4030483663082123,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3920849561691284,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4257773756980896,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4411719739437103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6063106656074524,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6198334693908691,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6903125047683716,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.776132092547061,
+        "AvgTime/train_epoch_std": 0.06051171161224665,
+        "model/params/total": 27715,
+        "model/params/trainable": 27715,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 140.3067169189453,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 136.23158264160156,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0981495552172922,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83.16361999511719,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4377032631321957
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11707.78515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8879624691884718
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215.46408081054688,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0726201822752096
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7350.9716796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9820937447812291
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.00819396972656,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13644921759043743
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173257.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.023251367151217
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14813.3779296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0386606317267915
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45407.8125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3275315239120404
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3461.02294921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.61529296875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754228.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.531708482743799
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260434.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.333850500474265
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0315433343251545,
+        "AvgTime/train_epoch_std": 0.04802777971903245,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 85.26374816894531,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 84.92440032958984,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.06118472646224052,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.70867156982422,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.17215090299907485
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9939.51953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.753850552237391
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 280.2850341796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09446748708449192
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6986.50927734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9334013730586173
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152.0661163330078,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13131788975216563
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166472.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.865692269064648
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14639.8818359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0264957113965432
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45355.02734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3248258415987495
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3581.19384765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6366566840277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 749541.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.478687799056592
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259600.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.319976952390461
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0123672627691012,
+        "AvgTime/train_epoch_std": 0.05241102835797057,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 82.92391204833984,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 79.78240966796875,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.05748012223917057,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.579999923706055,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1662105259142424
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9107.48828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6907461722601441
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 277.4223327636719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09350263996079268
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6828.68603515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9123161035612892
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159.3241424560547,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13758561524702478
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163008.3125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7852571173137655
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14299.919921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0026588081527836
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45393.57421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3268016924880826
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3631.71533203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.64563828125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 747267.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.45297034602898
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258609.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.303484806882665
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0075162982081507,
+        "AvgTime/train_epoch_std": 0.05833430548876904,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 4.093451023101807,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.9842448234558105,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.020969709597135844,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209.0672149658203,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15062479464396275
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13197.8857421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0009773031617368
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 426.4574890136719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14373356555904007
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8205.2216796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0962220012942552
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181.6635284423828,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15687696756682454
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178683.40625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.149252420815531
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16271.23046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1408799936018792
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47813.02734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.450818972974012
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4002.12255859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7114884548611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765517.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.659406354987953
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267205.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.446539634400013
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.039377727508545,
+        "AvgTime/train_epoch_std": 0.07244530496101433,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 3.3419907093048096,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.166435718536377,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.016665451150191458,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206.85409545898438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14903032814047865
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13184.7744140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9999828907138794
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 430.0285339355469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14493715333183244
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8185.265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0935558617234469
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.37010192871094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15576001893671065
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178643.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.148319579579231
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16280.294921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.14151556036145
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47794.8671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.449888112537803
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3996.639892578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7105137586805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765574.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.660046180559483
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267244.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.447175107749655
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.012105649776673,
+        "AvgTime/train_epoch_std": 0.05373923821837533,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 4.87912130355835,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.697303295135498,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.024722648921765778,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206.80917358398438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14899796367722218
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13087.6611328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9926174541382252
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 431.0325927734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14527556210766346
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8165.82763671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0909589361013694
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.740234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15780676543609673
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 178302.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.140399681288315
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16247.5546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1392199332141355
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47779.81640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.449116633669076
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4001.222412109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7113284288194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765240.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.656271563182244
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267081.71875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.444473045945451
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.021510884875343,
+        "AvgTime/train_epoch_std": 0.0508304663237027,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3692.65283203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3712.3720703125,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.2815602632015548,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2416.38525390625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.7409115662148775
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1417.00830078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.457938425164474
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2138.100830078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.7206271756245787
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5382.68017578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.719128948000167
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1483.815673828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2813606855165156
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124277.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.885875528283485
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9119.34375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6394154922170804
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36205.9609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.85585939502281
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3461.767822265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.615425390625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 676202.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.649092790968632
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221124.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6797076510575275
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0314852396647136,
+        "AvgTime/train_epoch_std": 0.05496278680881203,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3036.314453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3021.123046875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.22913333688850968,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2160.898193359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.5568430787891752
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 823.040283203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.331790964226974
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 784.9622192382812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.26456428016120026
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4564.8984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.609872870741483
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 984.0316772460938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8497682877772831
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 117194.7734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7214093776123907
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9163.1416015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6424864395991096
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36611.19140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8766308578732893
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3189.436767578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5670109809027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 679960.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.691601953553612
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 227902.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.792490129882016
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0155148429255332,
+        "AvgTime/train_epoch_std": 0.05663789476574398,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 3194.35498046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3146.66748046875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.238655099011661,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1765.22412109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.2717753033816643
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 655.9869384765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.4525628340871712
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 762.6971435546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2570600416429685
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4445.57275390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5939308956454575
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 795.65869140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6870973155494386
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 118216.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.7451427671605053
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9666.8515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6778047652853737
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37692.5078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9320573997898405
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3220.366943359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5725096788194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 685569.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.755045077655736
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230640.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8380661017090176
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0204394359093207,
+        "AvgTime/train_epoch_std": 0.05102474273835351,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 140.24075317382812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 138.32064819335938,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04661969942479251,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233.14187622070312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16796965145583798
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 364.7471618652344,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.9197219045538652
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10086.0009765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7649602560912021
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6521.3515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8712560537742151
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 313.7001647949219,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.27089824248266137
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166958.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.8769886825422626
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13223.177734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9271615295452952
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42709.953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1892435862935056
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3003.441162109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5339450954861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 740784.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.379632195739964
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252468.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.201289303662656
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.01322802901268,
+        "AvgTime/train_epoch_std": 0.03762514282491939,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 149.6920928955078,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.6769256591797,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04943610571593518,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230.74879455566406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16624552921877814
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 337.6466064453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.77708740234375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10314.2666015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7822727797923777
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6700.93310546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8952482438836006
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312.4867858886719,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2698504195929809
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167977.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9006562180707784
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13473.15625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.944689121441593
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43214.41015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.215101243336409
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3126.489501953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5558203559027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742663.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.400888544506408
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253645.734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.220886532125206
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 0.995684689283371,
+        "AvgTime/train_epoch_std": 0.06447149601107112,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 159.26614379882812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 158.16322326660156,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.05330745644307434,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 238.34890747070312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1717211148924374
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 333.560791015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7555831106085527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10260.8720703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.778223137680129
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6707.65966796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8961469162282899
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312.6834411621094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.270020242799749
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167659.03125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.893252629806799
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13476.5439453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9449266544182092
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43259.30078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2174022646599005
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3147.751708984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5596003038194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 742388.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.397769306471499
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253614.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.220368584943338
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.013493669444117,
+        "AvgTime/train_epoch_std": 0.04365498169787078,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5268.42919921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5429.55224609375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.7253910816424516,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1304.1827392578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9396129245373289
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1840.6041259765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.68739013671875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7184.39404296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5448914708357034
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 817.5023193359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.27553162094234496
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1505.18017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.299810169068437
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153014.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.553184649591306
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10307.861328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7227500580651381
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37323.703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9131530639704752
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2765.7294921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.49168524305555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 710218.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.033870456884948
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 234594.109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.903850854092823
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0305685620558889,
+        "AvgTime/train_epoch_std": 0.06114410544934,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 5058.5439453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5225.9375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.6981880427521711,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1410.80419921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.016429538342039
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1824.3717041015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.601956337376645
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6439.44140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4883914604664391
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 861.987060546875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.29052479290423827
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1538.4259033203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.3285197783422387
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148798.125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4552787711313395
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9952.158203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6978094378856402
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36909.1015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8919012539084525
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2801.6767578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.49807586805555554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 705490.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.980391643948734
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232498.640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.868980424092656
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0198675841093063,
+        "AvgTime/train_epoch_std": 0.050171555740919194,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 4638.53125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4828.140625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.6450421676686707,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1451.5145263671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.0457597452213165
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 900.6218872070312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.740115195826481
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4130.79541015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.31329506334139173
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 773.0305786132812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.26054283067518746
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 992.9357299804688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8574574524874514
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130182.109375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.022991579393461
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9880.7041015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6927993340038213
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38069.296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.951371001845302
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3123.40087890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5552712673611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 695353.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.8657228827076
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232864.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.87506552343867
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0309569165947732,
+        "AvgTime/train_epoch_std": 0.06265696129530125,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 138.69070434570312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 146.29090881347656,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.12633066391491932,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150.71612548828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10858510481864643
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39.13807678222656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.20598987780119243
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12263.900390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.930140340585893
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 285.2770690917969,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09615000643471415
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7621.47607421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0182332764487307
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175139.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.0669490467676015
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15284.1416015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.071668882454249
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46197.80078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.368025054141678
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3613.260498046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.642357421875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758067.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.57513673178512
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262685.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.371310926397418
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0050545632839203,
+        "AvgTime/train_epoch_std": 0.0435173478609399,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 147.8424530029297,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 154.6232452392578,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.13352611851403956,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.46926879882812,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10696633198762834
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.65719223022461,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.21398522226434005
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12042.8359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9133739808494501
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 289.4400939941406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09755311560301336
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7576.9384765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0122830296008685
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174176.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.044601494287572
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15213.65625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.066726703828355
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46171.02734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.366652690745297
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3643.100830078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6476623697916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757075.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.563916100132348
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262410.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.366737286372789
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.042858211361632,
+        "AvgTime/train_epoch_std": 0.07208181713342678,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 149.22732543945312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 156.6578826904297,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.1352831456739462,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.25450134277344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11401621134205579
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.23221206665039,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18543269508763363
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12237.26171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9281199635001897
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 299.8835144042969,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10107297418412432
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7719.556640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.03133689253507
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175141.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.067015445035296
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15372.634765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0778737039422943
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46523.64453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3847272813188787
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3695.262939453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6569356336805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 758659.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.58182414623938
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263071.375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.377737423659994
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0255412213942583,
+        "AvgTime/train_epoch_std": 0.044696439936255716,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 113235.828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 79240.25,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8400578209177039,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68454.2734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 49.31864080511527
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73356.7109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 386.0879523026316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36064.375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.735257868790292
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64354.30078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 21.690023856167848
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52340.61328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 6.9927339053106214
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70238.1171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 60.65467805483593
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40584.3515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.8456283524400505
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43522.49609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2308932335716847
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58082.078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.325702777777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 478880.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.417019218804792
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124269.0234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0679450757575757
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0475505249840873,
+        "AvgTime/train_epoch_std": 0.08948740420899738,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 112353.421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 78766.5234375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.8290572969882035,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69417.2265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 50.01241106808357
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73241.328125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 385.48067434210526
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38028.6015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.8842322004171406
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64705.97265625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 21.808551619902257
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53418.23828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 7.136705181195725
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70399.6015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 60.79412915587219
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41260.35546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.893027308144019
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44292.5703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2703660009482802
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58623.61328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 10.421975694444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 477589.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.402411046570818
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124331.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.068990460619373
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0153056621551513,
+        "AvgTime/train_epoch_std": 0.04713676125444658,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 109078.609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 77245.25,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.793731422998328,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58382.921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 42.06262382925072
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56919.859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 299.5782072368421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36392.77734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.760165137940842
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51519.51171875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 17.364176514577014
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44675.29296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 5.968643015197061
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55164.3515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 47.637609294041454
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32895.75390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.306531615919927
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38795.76171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.988608422715157
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46631.74609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 8.290088194444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 490774.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.55155509428413
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130009.3203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.163468628833641
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.012589630873307,
+        "AvgTime/train_epoch_std": 0.06692595094132521,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8533.4189453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8076.46240234375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5662924135705897,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4868.21826171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.5073618600279177
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6023.4091796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 31.70215357730263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4978.63623046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.37759850060438
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3783.385498046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.2751552066217982
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5880.4296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7856285487641951
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5262.8466796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.5447726076748705
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134844.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1312686495680846
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31459.423828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6125595278140858
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4443.1015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7898847222222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 667638.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.5522189575014425
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210297.78125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4995387357928545
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0432402938604355,
+        "AvgTime/train_epoch_std": 0.07868889724276378,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8638.1572265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8221.0712890625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5764318671338171,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4929.5703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.551563625720461
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6126.798828125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 32.24630962171052
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5020.80322265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.38079660391780434
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3875.041259765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.3060469362202982
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6072.16259765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.811244168023547
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5370.30322265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.637567549789508
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135091.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1369999448495265
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31814.08984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6307391380260392
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4617.5908203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8209050347222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 667946.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.55570300216056
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210603.296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.504622782603631
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0485145543750964,
+        "AvgTime/train_epoch_std": 0.07547554434693188,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 8411.3076171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8035.2568359375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.5634032278738956,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4598.48388671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.3130287368290707
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5555.12841796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 29.23751798930921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5077.03955078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.38506177859546836
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3507.513671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1821751506150995
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5932.59814453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.792598282502505
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4857.529296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.194757596610535
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135107.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1373620512493035
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32213.74609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6512248753780308
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4290.806640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7628100694444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 670279.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.58209068131172
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211425.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.5182982002895513
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0284185028076172,
+        "AvgTime/train_epoch_std": 0.06612643056621267,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27303.005859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27730.935546875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4214432081026707,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12521.015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.020904628962535
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14435.6279296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 75.97698910361842
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5494.81103515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.41674713956437237
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10743.029296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.6208389945652173
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9759.4833984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.30387219752004
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13183.1796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.384438417530225
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116213.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.69861753727011
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8952.095703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6276886623983312
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9896.01171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.7592909722222223
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 619755.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.010575857154169
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185303.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0836084277702893
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0438836812973022,
+        "AvgTime/train_epoch_std": 0.06674608939943988,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27613.71484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28058.74609375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4382462501281459,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12276.3271484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.844616101179755
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14196.9833984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 74.72096525493421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5488.33935546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.41625630303138034
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10627.0869140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.58176168320273
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9695.150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2952772732965931
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12957.3671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.18943625863558
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116761.0390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.711337522350455
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9000.744140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6310997153712663
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9817.15625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.7452722222222221
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 621346.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.028572983948509
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 186205.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.098619015525935
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0577833652496338,
+        "AvgTime/train_epoch_std": 0.07530169132306896,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 27621.931640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28129.900390625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 1.4418935050809882,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12749.7529296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 9.185700957988113
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14749.162109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 77.62716899671052
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5562.90478515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4219116257228859
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11032.2724609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.718325736750084
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10057.3212890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.3436634988727454
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13463.875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.62683506044905
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116537.6796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.706150837996935
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9174.82421875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6433055825795821
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10183.373046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8103774305555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 619822.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.011333042996278
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185409.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.085367940109497
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0256760567426682,
+        "AvgTime/train_epoch_std": 0.04594039702154777,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2596.20751953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2750.086181640625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.48890421006944446,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 481.53411865234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.34692659845269724
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 763.7465209960938,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.0197185315583885
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8901.625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6751327265832385
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 246.379638671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08303998607073644
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5956.82666015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7958352251377756
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 604.3439331054688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5218859525953962
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161720.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7553546755991083
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11988.28125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8405750420698359
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40543.2890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.078183867061356
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 729454.5625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.251468417361401
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245624.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.08740722713128
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0107243061065674,
+        "AvgTime/train_epoch_std": 0.03777321652257041,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2673.864013671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2831.934326171875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5034549913194445,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 489.8705749511719,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.35293269088701146
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 765.8148193359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.0306043122944075
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8958.9990234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6794841883532423
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260.2016296386719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08769856071407882
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6073.65478515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8114435250709753
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 622.67236328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5377136125053973
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161916.53125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7599045896804757
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12066.0380859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8460270709534077
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40803.01171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0914968331923727
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 729762.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.254955996968429
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245886.078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.091759075516283
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.016712750707354,
+        "AvgTime/train_epoch_std": 0.07932453236106299,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 2663.03857421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2821.220703125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.5015503472222222,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 615.605224609375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.443519614271884
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 926.6074829101562,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.876881489000822
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8484.2099609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6434743997677285
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 320.6261901855469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10806410184885301
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5956.7783203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7958287669088177
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752.6151123046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6499266945636334
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160047.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.7165047951885564
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11732.9951171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8226752991997967
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40253.5703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0633333493515815
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 726179.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.214415800368766
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243851.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.0578995785698835
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0030732949574788,
+        "AvgTime/train_epoch_std": 0.0349254655445875,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 502751.40625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 324443.90625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6700553855638383,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 388332.5,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 279.7784582132565
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 405511.3125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2134.270065789474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 287655.09375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 21.816844425483502
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 381825.0625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 128.69061762723288
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 338822.46875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 45.26686289245157
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 396326.96875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 342.2512683506045
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170521.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.959732534715772
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 302617.375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.21843885850512
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266719.5625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.671616305294991
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361103.65625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 64.19620555555555
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162094.359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.69739169911637
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0158306902105159,
+        "AvgTime/train_epoch_std": 0.03443800172968323,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 503848.5625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 325458.46875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6815319474452224,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 395432.75,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 284.8939121037464
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415042.4375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2184.4338815789474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291300.59375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 22.09333285930982
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 392171.6875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 132.17785220761712
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 344473.0625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 46.021785237140946
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 405037.53125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 349.77334304835927
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173159.390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.020977861438789
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 310336.40625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 21.759669488851493
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 271568.40625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.920160246552873
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 368063.1875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 65.43345555555555
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 165270.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.75024181269033
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0452040354410808,
+        "AvgTime/train_epoch_std": 0.06464987040391867,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 506491.0625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 326420.1875,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 3.6924107496351932,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 378139.1875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 272.4345731268011
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 397328.25,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2091.2013157894735
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276446.78125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 20.96676384148654
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 373864.46875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 126.0075728850691
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 328830.625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 43.93194722778891
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 387570.21875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 334.68930807426597
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164925.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.829780965539662
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 294479.21875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 20.647820694853458
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258468.90625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 13.248700920088165
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 351704.125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 62.52517777777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158621.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.6395995061820843
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0150679179600306,
+        "AvgTime/train_epoch_std": 0.033538447973709126,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111629.453125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107628.0546875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7910248229827102,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120191.5703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 86.5933503692363
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127066.8125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 668.7726973684211
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73790.4765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.5965473312476295
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 115303.8671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 38.86210555695989
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96868.5390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 12.941688585504343
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 122662.4375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 105.92611183074266
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 79458.6171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8451285804268067
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78320.3359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.491539471147104
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73436.53125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.7642386206366294
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105332.8046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 18.725831944444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 421209.78125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.7646548335463725
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0320720958709717,
+        "AvgTime/train_epoch_std": 0.0474394906639223,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 111123.875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 107572.25,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7900961842477494,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133127.125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 95.91291426512969
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142357.203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 749.2484375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85056.796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.451027445961319
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134772.53125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 45.423839315807214
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107407.15625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 14.349653473613895
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136157.3125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 117.57971718480138
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83106.890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9298460576119265
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92146.640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.46099008729491
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81186.1171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.161469946563125
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116099.0,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 20.63982222222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 415264.15625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.697398914629594
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.053637135413385,
+        "AvgTime/train_epoch_std": 0.06754514733552039,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "mtgcn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 108103.9765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 104878.75,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.7452739919790992,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129495.7578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 93.29665548451008
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136602.4375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 718.9601973684211
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87831.75,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.661490329920364
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133602.234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 45.029401541961576
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103742.75,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 13.860086840347362
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129791.2265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 112.08223364637306
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84371.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9592231184980493
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90335.1171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.333972597637078
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77835.375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.9897162847916348
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109821.8828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 19.523890277777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 420124.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.752382554890671
+        }
+      },
+      "output_dir": "C:\\tmp\\TopoBench\\logs\\train\\runs\\notebook_gu_grid_2026-07-26_11-39-05__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0234572951858107,
+        "AvgTime/train_epoch_std": 0.0447974285445236,
+        "model/params/total": 26480,
+        "model/params/trainable": 26480,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/graph/mtgcn.yaml
+++ b/configs/model/graph/mtgcn.yaml
@@ -1,0 +1,50 @@
+_target_: topobench.model.TBModel
+
+model_name: mtgcn
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.MTGCNEncoder
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_layers: 4
+  num_tracks: 2
+  num_heads: 1
+  dropout: 0.1
+  propagation_weight: 0.8
+  use_residual: true
+  use_output_residual: true
+  normalization: symmetric
+  add_self_loops: true
+  make_undirected: true
+  temperature: 1.0
+  affiliation_source: hybrid
+  use_entropy_sharpening: false
+  sharpening_power: 2.0
+  output_norm: layer
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.GNNWrapper
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.NoReadOut
+  readout_name: NoReadOut
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+compile: false

--- a/test/nn/backbones/graph/test_mtgcn.py
+++ b/test/nn/backbones/graph/test_mtgcn.py
@@ -1,0 +1,241 @@
+"""Tests for the Multi-Track Graph Convolutional Network backbone."""
+
+import torch
+from torch.nn import functional as F
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.mtgcn import MTGCNEncoder, _prepare_graph
+
+
+def _graph() -> Data:
+    """Create a small bidirectional graph with non-uniform features."""
+    x = torch.tensor(
+        [
+            [1.0, 0.0, -1.0],
+            [0.0, 2.0, 1.0],
+            [-1.0, 1.0, 0.5],
+            [2.0, -1.0, 0.0],
+        ]
+    )
+    edge_index = torch.tensor(
+        [[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]], dtype=torch.long
+    )
+    return Data(x=x, edge_index=edge_index)
+
+
+def _model(**kwargs) -> MTGCNEncoder:
+    """Create a deterministic compact MTGCN encoder."""
+    torch.manual_seed(7)
+    return MTGCNEncoder(
+        in_channels=3,
+        hidden_channels=5,
+        num_layers=2,
+        num_tracks=3,
+        num_heads=2,
+        dropout=0.0,
+        output_norm="none",
+        **kwargs,
+    )
+
+
+def _prepared_for(model: MTGCNEncoder, data: Data):
+    """Prepare the graph exactly as the model forward does."""
+    return _prepare_graph(
+        data.edge_index,
+        None,
+        data.num_nodes,
+        data.x.dtype,
+        data.x.device,
+        model.normalization,
+        model.add_self_loops,
+        model.make_undirected,
+    )
+
+
+def test_forward_shape():
+    """Return node embeddings with the configured hidden size."""
+    data = _graph()
+    output = _model()(data.x, data.edge_index)
+    assert output.shape == (data.num_nodes, 5)
+    assert torch.isfinite(output).all()
+
+
+def test_wrapper_kwargs():
+    """Accept wrapper arguments, batches, and scalar edge attributes."""
+    data = _graph()
+    edge_attr = torch.linspace(0.5, 1.5, data.num_edges)
+    output = _model()(
+        data.x,
+        data.edge_index,
+        edge_attr=edge_attr,
+        batch=torch.zeros(data.num_nodes, dtype=torch.long),
+        model_state="train",
+    )
+    assert output.shape == (data.num_nodes, 5)
+
+
+def test_edge_weight_support():
+    """Use supplied edge weights during every sparse propagation."""
+    data = _graph()
+    model = _model().eval()
+    unweighted = model(data.x, data.edge_index)
+    edge_weight = torch.tensor([0.1, 0.1, 1.0, 1.0, 3.0, 3.0])
+    weighted = model(data.x, data.edge_index, edge_weight=edge_weight)
+    assert torch.isfinite(weighted).all()
+    assert not torch.allclose(unweighted, weighted)
+
+
+def test_batched_graphs():
+    """Keep propagation local to each graph in a disjoint PyG batch."""
+    first = _graph()
+    second = _graph()
+    second.x = second.x.flip(0)
+    model = _model().eval()
+
+    expected = torch.cat(
+        (model(first.x, first.edge_index), model(second.x, second.edge_index))
+    )
+    batched = Batch.from_data_list([first, second])
+    actual = model(batched.x, batched.edge_index, batch=batched.batch)
+    assert torch.allclose(actual, expected, atol=1e-6)
+
+
+def test_affiliations_sum_to_one():
+    """Produce finite normalized head-specific affiliations."""
+    data = _graph()
+    model = _model()
+    graph = _prepared_for(model, data)
+    affiliations = model._compute_affiliations(
+        model._affiliation_embeddings(data.x, graph)
+    )
+    diagnostics = model.affiliation_diagnostics(data.x, data.edge_index)
+
+    assert affiliations.shape == (data.num_nodes, 2, 3)
+    assert torch.allclose(affiliations.sum(-1), torch.ones(data.num_nodes, 2))
+    assert all(torch.isfinite(value) for value in diagnostics.values())
+
+
+def test_affiliation_sources():
+    """Support raw-feature, auxiliary-GCN, and hybrid affiliation inputs."""
+    data = _graph()
+    outputs = []
+    for source in ("features", "auxiliary", "hybrid"):
+        model = _model(affiliation_source=source).eval()
+        outputs.append(model(data.x, data.edge_index))
+    assert all(output.shape == (data.num_nodes, 5) for output in outputs)
+    assert not torch.allclose(outputs[0], outputs[1])
+
+
+def test_head_specific_acquiring():
+    """Acquire tracks with each head's own affiliation weights before fusion."""
+    torch.manual_seed(3)
+    model = _model().eval()
+    tracks = torch.randn(4, 3, 2, 5)
+    affiliations = F.softmax(torch.randn(4, 2, 3), dim=-1)
+
+    acquired = model._acquire_messages(tracks, affiliations)
+    mean_affiliation = affiliations.mean(dim=1)
+    averaged = (mean_affiliation[..., None, None] * tracks).sum(dim=1)
+    averaged = model.head_fusion(averaged.transpose(1, 2)).squeeze(-1)
+    assert acquired.shape == (4, 5)
+    assert not torch.allclose(acquired, averaged)
+
+
+def test_entropy_sharpening_modes():
+    """Keep direct affiliations by default and normalized sharpened weights on request."""
+    affiliations = torch.tensor([[[0.25, 0.25, 0.50], [0.20, 0.30, 0.50]]])
+    direct = _model(use_entropy_sharpening=False)._track_weights(affiliations)
+    sharpened = _model(
+        use_entropy_sharpening=True, sharpening_power=2.0
+    )._track_weights(affiliations)
+
+    assert torch.allclose(direct, affiliations)
+    assert torch.allclose(sharpened.sum(-1), torch.ones(1, 2))
+    assert sharpened[..., -1].gt(affiliations[..., -1]).all()
+
+
+def test_output_residual():
+    """Add the projected input once after acquisition when enabled."""
+    data = _graph()
+    model = MTGCNEncoder(
+        in_channels=3,
+        hidden_channels=3,
+        num_layers=1,
+        num_tracks=2,
+        num_heads=1,
+        dropout=0.0,
+        use_output_residual=True,
+        output_norm="none",
+    )
+    for name, parameter in model.named_parameters():
+        if not name.startswith("output_residual"):
+            parameter.data.zero_()
+    assert torch.allclose(model(data.x, data.edge_index), data.x)
+
+
+def test_make_undirected():
+    """Match graph preparation for directed and already-bidirectional inputs."""
+    x = torch.randn(3, 4)
+    one_way = torch.tensor([[0, 1], [1, 2]], dtype=torch.long)
+    two_way = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long)
+    left = _prepare_graph(
+        one_way, None, 3, x.dtype, x.device, "symmetric", True, True
+    )
+    right = _prepare_graph(
+        two_way, None, 3, x.dtype, x.device, "symmetric", True, True
+    )
+    assert torch.allclose(left.matmul(x), right.matmul(x), atol=1e-6)
+
+
+def test_multiple_tracks_active():
+    """Assign nonzero probability and gradients to multiple tracks."""
+    data = _graph()
+    model = _model()
+    graph = _prepared_for(model, data)
+    affiliations = model._compute_affiliations(
+        model._affiliation_embeddings(data.x, graph)
+    )
+
+    assert (affiliations.sum(dim=(0, 1)) > 0).sum() == model.num_tracks
+    model(data.x, data.edge_index).square().sum().backward()
+    prototype_grad = model.track_prototypes.grad.abs().sum(dim=1)
+    assert (prototype_grad > 0).sum() > 1
+
+
+def test_finite_backward_gradients():
+    """Backpropagate finite gradients through loading and propagation."""
+    data = _graph()
+    data.x.requires_grad_(True)
+    model = _model()
+    model(data.x, data.edge_index).mean().backward()
+
+    assert data.x.grad is not None
+    assert torch.isfinite(data.x.grad).all()
+    gradients = [
+        parameter.grad
+        for parameter in model.parameters()
+        if parameter.requires_grad
+    ]
+    assert all(gradient is not None for gradient in gradients)
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+
+def test_not_equivalent_to_single_mean_aggregation():
+    """Produce behavior beyond one ordinary mean-aggregation layer."""
+    data = _graph()
+    model = _model().eval()
+    output = model(data.x, data.edge_index)
+
+    mean_graph = _prepare_graph(
+        data.edge_index,
+        None,
+        data.num_nodes,
+        data.x.dtype,
+        data.x.device,
+        "row",
+        True,
+        False,
+    )
+    ordinary_mean = mean_graph.matmul(data.x)
+    projected_mean = F.pad(ordinary_mean, (0, 2))
+    assert not torch.allclose(output, projected_mean)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,11 +1,11 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
+
 from test._utils.simplified_pipeline import run
 
-
-DATASET = "graph/MUTAG"                                                 # ADD YOUR DATASET HERE
-MODELS   = ["graph/gcn", "cell/topotune", "simplicial/topotune"]        # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
+DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
+MODELS = ["graph/mtgcn"]  # ADD ONE OR SEVERAL MODELS OF YOUR CHOICE HERE
 
 
 class TestPipeline:
@@ -23,13 +23,13 @@ class TestPipeline:
                     config_name="run.yaml",
                     overrides=[
                         f"model={MODEL}",
-                        f"dataset={DATASET}", # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
+                        f"dataset={DATASET}",  # IF YOU IMPLEMENT A LARGE DATASET WITH AN OPTION TO USE A SLICE OF IT, ADD BELOW THE CORRESPONDING OPTION
                         "trainer.max_epochs=2",
                         "trainer.min_epochs=1",
                         "trainer.check_val_every_n_epoch=1",
                         "paths=test",
                         "callbacks=model_checkpoint",
                     ],
-                    return_hydra_config=True
+                    return_hydra_config=True,
                 )
                 run(cfg)

--- a/topobench/nn/backbones/graph/mtgcn.py
+++ b/topobench/nn/backbones/graph/mtgcn.py
@@ -1,0 +1,418 @@
+"""Multi-Track Graph Convolutional Network backbone.
+
+This module implements a TopoBench-compatible adaptation of Pei et al.,
+"Multi-Track Message Passing: Tackling Oversmoothing and Oversquashing in
+Graph Learning via Preventing Heterophily Mixing" (ICML 2024), roughly following the
+official https://github.com/XJTU-Graph-Intelligence-Lab/Multi-Track-Message-Passing. 
+Unlike their full pipeline, this only implements the multi track encoder and is not specific to any application.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torch_geometric.utils import add_remaining_self_loops, coalesce
+
+
+class _PreparedGraph:
+    """Sparse normalized graph, this is reused by all layers of the encoder."""
+
+    __slots__ = ("dst", "norm_weight", "src")
+
+    def __init__(self, src, dst, norm_weight) -> None:
+        self.src = src
+        self.dst = dst
+        self.norm_weight = norm_weight
+
+    def matmul(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the normalized adjacency to arbitrary dimensions."""
+        if self.src.numel() == 0:
+            return torch.zeros_like(x)
+        weight_shape = (-1,) + (1,) * (x.dim() - 1)
+        messages = x.index_select(0, self.src) * self.norm_weight.view(
+            weight_shape
+        )
+        return torch.zeros_like(x).index_add(0, self.dst, messages)
+
+
+def _as_undirected(
+    edge_index: torch.Tensor, edge_weight: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Symmetrize an edge list while preserving scalar edge weights."""
+    reverse = edge_index.flip(0)
+    edge_index = torch.cat((edge_index, reverse), dim=1)
+    edge_weight = torch.cat((edge_weight, edge_weight), dim=0)
+    return coalesce(edge_index, edge_weight, reduce="mean")
+
+
+def _prepare_graph(
+    edge_index: torch.Tensor,
+    edge_weight: torch.Tensor | None,
+    num_nodes: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    normalization: str,
+    add_self_loops: bool,
+    make_undirected: bool,
+) -> _PreparedGraph:
+    """Build the sparse normalized adjacency used by all propagation layers."""
+    edge_index = edge_index.to(device=device)
+    if edge_weight is None:
+        edge_weight = torch.ones(
+            edge_index.shape[1], dtype=dtype, device=device
+        )
+    else:
+        edge_weight = edge_weight.to(dtype=dtype, device=device)
+
+    if make_undirected and edge_index.numel() > 0:
+        edge_index, edge_weight = _as_undirected(edge_index, edge_weight)
+    if add_self_loops:
+        edge_index, edge_weight = add_remaining_self_loops(
+            edge_index, edge_weight, fill_value=1.0, num_nodes=num_nodes
+        )
+    if edge_index.numel() == 0:
+        empty = edge_index.new_empty(0)
+        return _PreparedGraph(empty, empty, edge_weight)
+
+    src, dst = edge_index
+    degree = torch.zeros(num_nodes, dtype=dtype, device=device)
+    degree.index_add_(0, dst, edge_weight)
+    inverse_degree = torch.zeros_like(degree)
+    positive = degree > 0
+    if normalization == "symmetric":
+        inverse_degree[positive] = degree[positive].pow(-0.5)
+        norm_weight = inverse_degree[src] * edge_weight * inverse_degree[dst]
+    else:
+        inverse_degree[positive] = degree[positive].reciprocal()
+        norm_weight = inverse_degree[dst] * edge_weight
+    return _PreparedGraph(src, dst, norm_weight)
+
+
+class MTGCNEncoder(nn.Module):
+    """Multi-Track Message Passing graph encoder.
+
+    The encoder implements MTGCN's loading, independent multi-track message
+    passing, and acquiring stages. Track prototypes are learnable because a
+    reusable TopoBench backbone cannot access labels or pseudo-label stages.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input node features.
+    hidden_channels : int
+        Number of output features per node.
+    num_layers : int, optional
+        Number of multi-track propagation layers.
+    num_tracks : int, optional
+        Number of semantic propagation tracks.
+    num_heads : int, optional
+        Number of track-assignment heads.
+    dropout : float, optional
+        Dropout probability used by the reference architecture.
+    propagation_weight : float, optional
+        Weight of propagated messages in each initial-residual update.
+    use_residual : bool, optional
+        Whether to retain the initial-message residual.
+    normalization : str, optional
+        Sparse adjacency normalization, ``"symmetric"`` or ``"row"``.
+    add_self_loops : bool, optional
+        Whether to add the self-loops used by the reference model.
+    make_undirected : bool, optional
+        Whether to symmetrize the observed graph before propagation.
+    temperature : float, optional
+        Soft track-assignment temperature.
+    affiliation_source : str, optional
+        Source for track affiliations: ``"features"``, ``"auxiliary"``, or
+        ``"hybrid"``.
+    use_entropy_sharpening : bool, optional
+        Whether to sharpen affiliations before loading messages onto tracks.
+    sharpening_power : float, optional
+        Power used by normalized affiliation sharpening.
+    use_output_residual : bool, optional
+        Whether to add a projected input residual after acquiring messages.
+    output_norm : str, optional
+        Output normalization, either ``"none"`` or ``"layer"``.
+    **kwargs : dict
+        Additional wrapper arguments, ignored.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_layers: int = 4,
+        num_tracks: int = 2,
+        num_heads: int = 1,
+        dropout: float = 0.1,
+        propagation_weight: float = 0.8,
+        use_residual: bool = True,
+        normalization: str = "symmetric",
+        add_self_loops: bool = True,
+        make_undirected: bool = False,
+        temperature: float = 1.0,
+        affiliation_source: str = "hybrid",
+        use_entropy_sharpening: bool = False,
+        sharpening_power: float = 2.0,
+        use_output_residual: bool = True,
+        output_norm: str = "layer",
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError("num_layers must be at least 1.")
+        if num_tracks < 2:
+            raise ValueError("num_tracks must be at least 2.")
+        if num_heads < 1:
+            raise ValueError("num_heads must be at least 1.")
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError("dropout must be in [0, 1).")
+        if not 0.0 <= propagation_weight <= 1.0:
+            raise ValueError("propagation_weight must be in [0, 1].")
+        if normalization not in {"symmetric", "row"}:
+            raise ValueError("normalization must be 'symmetric' or 'row'.")
+        if temperature <= 0.0:
+            raise ValueError("temperature must be positive.")
+        if affiliation_source not in {"features", "auxiliary", "hybrid"}:
+            raise ValueError(
+                "affiliation_source must be 'features', 'auxiliary', or 'hybrid'."
+            )
+        if sharpening_power <= 0.0:
+            raise ValueError("sharpening_power must be positive.")
+        if output_norm not in {"none", "layer"}:
+            raise ValueError("output_norm must be 'none' or 'layer'.")
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = hidden_channels
+        self.num_layers = num_layers
+        self.num_tracks = num_tracks
+        self.num_heads = num_heads
+        self.dropout = dropout
+        self.propagation_weight = propagation_weight
+        self.use_residual = use_residual
+        self.normalization = normalization
+        self.add_self_loops = add_self_loops
+        self.make_undirected = make_undirected
+        self.temperature = temperature
+        self.affiliation_source = affiliation_source
+        self.use_entropy_sharpening = use_entropy_sharpening
+        self.sharpening_power = sharpening_power
+        self.use_output_residual = use_output_residual
+        self.output_norm = output_norm
+
+        projected_channels = num_heads * hidden_channels
+        self.value_projection = nn.Linear(in_channels, projected_channels)
+        self.affiliation_input = nn.Linear(in_channels, hidden_channels)
+        self.output_residual = (
+            nn.Identity()
+            if in_channels == hidden_channels
+            else nn.Linear(in_channels, hidden_channels)
+        )
+        self.auxiliary_input = nn.Linear(in_channels, hidden_channels)
+        self.auxiliary_output = nn.Linear(hidden_channels, hidden_channels)
+        self.query_projection = nn.Linear(hidden_channels, projected_channels)
+        self.key_projection = nn.Linear(hidden_channels, projected_channels)
+        self.track_prototypes = nn.Parameter(
+            torch.empty(num_tracks, hidden_channels)
+        )
+        self.head_fusion = nn.Linear(num_heads, 1)
+        self.norm = (
+            nn.LayerNorm(hidden_channels)
+            if output_norm == "layer"
+            else nn.Identity()
+        )
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reset learnable parameters."""
+        for module in (
+            self.value_projection,
+            self.affiliation_input,
+            self.auxiliary_input,
+            self.auxiliary_output,
+            self.query_projection,
+            self.key_projection,
+            self.head_fusion,
+        ):
+            module.reset_parameters()
+        if isinstance(self.output_residual, nn.Linear):
+            self.output_residual.reset_parameters()
+        if isinstance(self.norm, nn.LayerNorm):
+            self.norm.reset_parameters()
+        nn.init.xavier_uniform_(self.track_prototypes)
+
+    def _auxiliary_embeddings(
+        self, x: torch.Tensor, graph: _PreparedGraph
+    ) -> torch.Tensor:
+        """Compute the two-layer GCN representation used for affiliation."""
+        hidden = graph.matmul(self.auxiliary_input(x))
+        hidden = F.relu(hidden)
+        hidden = F.dropout(hidden, self.dropout, training=self.training)
+        return graph.matmul(self.auxiliary_output(hidden))
+
+    def _affiliation_embeddings(
+        self, x: torch.Tensor, graph: _PreparedGraph
+    ) -> torch.Tensor:
+        """Select the representation used for semantic track assignment."""
+        feature_affiliation = self.affiliation_input(x)
+        if self.affiliation_source == "features":
+            return feature_affiliation
+
+        auxiliary = self._auxiliary_embeddings(x, graph)
+        if self.affiliation_source == "auxiliary":
+            return auxiliary
+        return feature_affiliation + auxiliary
+
+    def _compute_affiliations(
+        self, affiliation_input: torch.Tensor
+    ) -> torch.Tensor:
+        """Compute soft node-to-track affiliations for every head."""
+        query = self.query_projection(affiliation_input).view(
+            -1, self.num_heads, self.hidden_channels
+        )
+        keys = self.key_projection(self.track_prototypes).view(
+            self.num_tracks, self.num_heads, self.hidden_channels
+        )
+        scores = torch.einsum("nhd,thd->nht", query, keys)
+        return F.softmax(scores / self.temperature, dim=-1)
+
+    def _track_weights(self, affiliations: torch.Tensor) -> torch.Tensor:
+        """Return normalized node-to-track loading weights."""
+        if not self.use_entropy_sharpening:
+            return affiliations
+        sharpened = affiliations.pow(self.sharpening_power)
+        return sharpened / sharpened.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    def _load_tracks(
+        self, x: torch.Tensor, affiliations: torch.Tensor
+    ) -> torch.Tensor:
+        """Load node values onto semantic tracks."""
+        values = self.value_projection(x).view(
+            -1, self.num_heads, self.hidden_channels
+        )
+        values = F.dropout(values, self.dropout, training=self.training)
+        track_weights = self._track_weights(affiliations).permute(0, 2, 1)
+        return track_weights.unsqueeze(-1) * values.unsqueeze(1)
+
+    def _propagate_tracks(
+        self, initial_tracks: torch.Tensor, graph: _PreparedGraph
+    ) -> torch.Tensor:
+        """Run the released model's sparse two-hop residual track layers."""
+        tracks = initial_tracks
+        for _ in range(self.num_layers):
+            tracks = F.dropout(tracks, self.dropout, training=self.training)
+            tracks = graph.matmul(tracks)
+            tracks = self.propagation_weight * graph.matmul(tracks)
+            if self.use_residual:
+                tracks = (
+                    tracks + (1.0 - self.propagation_weight) * initial_tracks
+                )
+        return tracks
+
+    def _acquire_messages(
+        self, tracks: torch.Tensor, affiliations: torch.Tensor
+    ) -> torch.Tensor:
+        """Acquire head-specific track messages and fuse heads."""
+        # tracks: [N, T, H, C], affiliations: [N, H, T], per_head: [N, H, C].
+        track_weights = self._track_weights(affiliations).permute(0, 2, 1)
+        per_head = (track_weights.unsqueeze(-1) * tracks).sum(dim=1)
+        per_head = F.dropout(per_head, self.dropout, training=self.training)
+        return self.head_fusion(per_head.transpose(1, 2)).squeeze(-1)
+
+    def affiliation_diagnostics(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+        edge_attr: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Return affiliation entropy and track-usage diagnostics."""
+        if (
+            edge_weight is None
+            and edge_attr is not None
+            and edge_attr.dim() == 1
+        ):
+            edge_weight = edge_attr
+        graph = _prepare_graph(
+            edge_index,
+            edge_weight,
+            x.shape[0],
+            x.dtype,
+            x.device,
+            self.normalization,
+            self.add_self_loops,
+            self.make_undirected,
+        )
+        affiliations = self._compute_affiliations(
+            self._affiliation_embeddings(x, graph)
+        )
+        usage = affiliations.mean(dim=(0, 1))
+        entropy = -(affiliations * affiliations.clamp_min(1e-12).log()).sum(
+            dim=-1
+        )
+        return {
+            "mean_entropy": entropy.mean(),
+            "mean_track_usage": usage.mean(),
+            "max_track_usage": usage.max(),
+            "min_track_usage": usage.min(),
+        }
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+        edge_attr: torch.Tensor | None = None,
+        batch: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Encode node features with graph-local multi-track propagation.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            Sparse edge indices of shape ``[2, num_edges]``.
+        edge_weight : torch.Tensor, optional
+            Scalar edge weights.
+        edge_attr : torch.Tensor, optional
+            Used as edge weights when one-dimensional and ``edge_weight`` is
+            not supplied.
+        batch : torch.Tensor, optional
+            Accepted for wrapper compatibility. Disjoint ``edge_index`` keeps
+            propagation graph-local.
+        **kwargs : dict
+            Additional wrapper arguments, ignored.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``[num_nodes, hidden_channels]``.
+        """
+        if (
+            edge_weight is None
+            and edge_attr is not None
+            and edge_attr.dim() == 1
+        ):
+            edge_weight = edge_attr
+        graph = _prepare_graph(
+            edge_index,
+            edge_weight,
+            x.shape[0],
+            x.dtype,
+            x.device,
+            self.normalization,
+            self.add_self_loops,
+            self.make_undirected,
+        )
+        affiliations = self._compute_affiliations(
+            self._affiliation_embeddings(x, graph)
+        )
+        initial_tracks = self._load_tracks(x, affiliations)
+        tracks = self._propagate_tracks(initial_tracks, graph)
+        output = self._acquire_messages(tracks, affiliations)
+        if self.use_output_residual:
+            output = output + self.output_residual(x)
+        return self.norm(output)


### PR DESCRIPTION
## Checklist

* [x] My pull request has a clear and explanatory title.
* [x] My pull request passes the Linting test.
* [x] I added appropriate unit tests and made sure the code passes all unit tests.
* [x] My PR follows [PEP 8](https://peps.python.org/pep-0008/) guidelines.
* [x] My code is properly documented using numpy documentation conventions, and I made sure the documentation renders properly.

## Description

This PR adds MTGCN, based on the Multi-Track Message Passing framework from , Hongbin Pei et al. ICML (2024) https://proceedings.mlr.press/v235/pei24a.html as a graph backbone. It is partially based on the official implemenation
https://github.com/XJTU-Graph-Intelligence-Lab/Multi-Track-Message-Passing.

The original MTGCN code obtains semantic relations through task specific training. Since the TopoBench backbone cannot depend on the task and or labels, this implementation learns track affiliations from the node features. In particular, the implemenation supports: 

- configurable propagation depth
- multiple semantic tracks and assignment heads
- feature-based, graph-based, or hybrid track affiliations
- optional affiliation sharpening
- initial-track and output residual connections
- row or symmetric graph normalization
- optional graph symmetrization and self-loops
- scalar edge weights
- sparse propagation over disjoint PyG graph batches (this is similar to our other submission #399) 

## Tests

The unit tests cover:

- TopoBench wrapper and configuration compatibility, expected output shapes etc.
- support for scalar weights supplied through either `edge_weight` or one-dimensional `edge_attr`
- equivalent propagation for undirected graphs represented as one-way or bidirectional edge lists
- no cross-graph message passing when processing disjoint PyG batches
- head-specific track probabilities that sum to one for every node
- affiliation inputs from raw features, graph-derived features, or their combination
- use of each head’s own weights before combining attention heads
- unchanged affiliations in direct mode, sharp mode tracks preferences that still sum to 1
- correct addition of the optional projected input residual

The testing was run locally using:
uv run --no-sync ruff check topobench/nn/backbones/graph/mtgcn.py test/nn/backbones/graph/test_mtgcn.py test/pipeline/test_pipeline.py

uv run --no-sync pytest test/nn/backbones/graph/test_mtgcn.py -q

uv run --no-sync pytest test/pipeline/test_pipeline.py -q


## Benchmarking

We ran the benchmarking from the challenge notebook, without tuning the hyperparameters, we have
<img width="3205" height="2158" alt="grafik" src="https://github.com/user-attachments/assets/e6bdbc5b-65fb-4cad-80f5-5c308e2eb8ff" />
