### PR TITLE
Track: Track1;  Team name: SweetLesson;  Model: HOD-GNN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-27_22-10-00-rw/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-27_22-10-00-rw/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-07-27_22-10-00-rw",
+    "model_config": "graph/hod_gnn",
+    "generated_at_utc": "2026-07-28T08:07:20.891378+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2889742851257324,
+      "test_best_rerun_accuracy": 0.29925891757011414,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2945985198020935,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30403393507003784,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3035755157470703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3379555344581604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32947513461112976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3310413360595703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3304683268070221,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3991137742996216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3981969654560089,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41683855652809143,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42612117528915405,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.2906179428100586,
+      "test_best_rerun_accuracy": 0.29276493191719055,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29494231939315796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29983192682266235,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30414852499961853,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32771793007850647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32725954055786133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32183513045310974,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3257315158843994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3881121575832367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3926961421966553,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39930474758148193,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4210405647754669,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.245051622390747,
+      "test_best_rerun_accuracy": 0.3107571303844452,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27630069851875305,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27007409930229187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30892351269721985,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33138513565063477,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31136831641197205,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35419052839279175,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34697073698043823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41416457295417786,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40220797061920166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4570249915122986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4539307951927185,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.248884439468384,
+      "test_best_rerun_accuracy": 0.3059821128845215,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27167850732803345,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2719077169895172,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30143633484840393,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.323554128408432,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3149591386318207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33978912234306335,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34441134333610535,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4135533571243286,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4125601649284363,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4646267890930176,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.490488201379776,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.084500551223755,
+      "test_best_rerun_accuracy": 0.3794025480747223,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24914050102233887,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2418442964553833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24585530161857605,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2448239028453827,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3616395592689514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3650011420249939,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3553747534751892,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5257086157798767,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5077164173126221,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5505768060684204,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5247154235839844,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.1141529083251953,
+      "test_best_rerun_accuracy": 0.3653831481933594,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24031630158424377,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23588509857654572,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23622889816761017,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24218809604644775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38001376390457153,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36450454592704773,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3651539385318756,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5285736322402954,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5247154235839844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5657422542572021,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5544732213020325,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9453413486480713,
+      "test_best_rerun_accuracy": 0.41905418038368225,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21987928450107574,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21327067911624908,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2617083191871643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26373291015625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3584689497947693,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33149972558021545,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4122927784919739,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5072197914123535,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48567500710487366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5923294425010681,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5718160271644592,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.965513825416565,
+      "test_best_rerun_accuracy": 0.43154558539390564,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17827947437763214,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17701886594295502,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21021468937397003,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22515088319778442,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33814653754234314,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3212239146232605,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4026663601398468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5146306157112122,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5002673864364624,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6125372648239136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6494384407997131,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5230416059494019,
+      "test_best_rerun_accuracy": 0.5848422050476074,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17270226776599884,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16192986071109772,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1508900672197342,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1439758539199829,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3606463372707367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.334975928068161,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3204217255115509,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3144625127315521,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5755214095115662,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6409198641777039,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6444724798202515,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4726470708847046,
+      "test_best_rerun_accuracy": 0.5801818370819092,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16200625896453857,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15665826201438904,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1474902629852295,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14393766224384308,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34861335158348083,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3326839208602905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3205745220184326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33531972765922546,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5793032050132751,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6457712650299072,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.682214081287384,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.35369074344635,
+      "test_best_rerun_accuracy": 0.6367942690849304,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14225685596466064,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14072886109352112,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15967606008052826,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15788066387176514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3247765302658081,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2932615280151367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36179235577583313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3761173486709595,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5420200228691101,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5310184359550476,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6733898520469666,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1470643281936646,
+      "test_best_rerun_accuracy": 0.6824050545692444,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1461532562971115,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14538925886154175,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14622965455055237,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15406066179275513,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32729771733283997,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3153793215751648,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3499121367931366,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3844067454338074,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5301398038864136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.535869836807251,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6259072422981262,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.3033947944641113,
+      "test_best_rerun_accuracy": 0.29478952288627625,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29123690724372864,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2993735074996948,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2992207109928131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33463212847709656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32267552614212036,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.329245924949646,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32794713973999023,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39743295311927795,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3964015543460846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41851937770843506,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4292917847633362,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.301285982131958,
+      "test_best_rerun_accuracy": 0.2901291251182556,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2891359031200409,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2979601323604584,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2998701333999634,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3227519392967224,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32305753231048584,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31912294030189514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32741233706474304,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38276416063308716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38765376806259155,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3973565697669983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4183283746242523,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.2432868480682373,
+      "test_best_rerun_accuracy": 0.30945831537246704,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2769501209259033,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27110549807548523,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3043777346611023,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3356635272502899,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31625792384147644,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3578195571899414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35082894563674927,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42138436436653137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.40774697065353394,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47031858563423157,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4686377942562103,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.269503116607666,
+      "test_best_rerun_accuracy": 0.30128350853919983,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2683551013469696,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2652226984500885,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3157613277435303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3074719309806824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3342501223087311,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34127894043922424,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3958667516708374,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39987775683403015,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44579416513442993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.475246399641037,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.034531593322754,
+      "test_best_rerun_accuracy": 0.3869279623031616,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2625105082988739,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25716251134872437,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2702268958091736,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2651081085205078,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3677133619785309,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3729085624217987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3565971553325653,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5298342108726501,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5083276033401489,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5454962253570557,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5002291798591614,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0732901096343994,
+      "test_best_rerun_accuracy": 0.37321415543556213,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2627778947353363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2578883171081543,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25907251238822937,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26419129967689514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3872717618942261,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3733287453651428,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3708839416503906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5332340002059937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5321643948554993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5793796181678772,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5708610415458679,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9970381259918213,
+      "test_best_rerun_accuracy": 0.4085109531879425,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1969974786043167,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19229887425899506,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2370692938566208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24100390076637268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3400183320045471,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3143097162246704,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4088165760040283,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4930475950241089,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4694017767906189,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5801436305046082,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5545114278793335,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9816360473632812,
+      "test_best_rerun_accuracy": 0.4284513592720032,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17499427497386932,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17476506531238556,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20857208967208862,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21835128962993622,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32672473788261414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31140652298927307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3958285450935364,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5040491819381714,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4950721859931946,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6084116697311401,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6399266719818115,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5619395971298218,
+      "test_best_rerun_accuracy": 0.5760180354118347,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.163687065243721,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15459546446800232,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14951485395431519,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.13687065243721008,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35082894563674927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32725954055786133,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3153793215751648,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2990679144859314,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5615020394325256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.627206027507782,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6252196431159973,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.503777027130127,
+      "test_best_rerun_accuracy": 0.5715868473052979,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.15283825993537903,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14997325837612152,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.14252425730228424,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14645886421203613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3333333432674408,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3220643401145935,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3146153390407562,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3296661376953125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5649782419204712,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6362212300300598,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6800748705863953,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.311148762702942,
+      "test_best_rerun_accuracy": 0.6378256678581238,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14787225425243378,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14561845362186432,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1587974578142166,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16372527182102203,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3241271376609802,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2983039319515228,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3601497411727905,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38436853885650635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5407212376594543,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5315914154052734,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6748796701431274,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.13566255569458,
+      "test_best_rerun_accuracy": 0.6840476989746094,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1409580558538437,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1389334499835968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13943006098270416,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14821605384349823,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31706011295318604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3030407130718231,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33272212743759155,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3708839416503906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5239896178245544,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.534265398979187,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6222018599510193,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.344719886779785,
+      "test_best_rerun_accuracy": 0.2845137119293213,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2806173264980316,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29192450642585754,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29016730189323425,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.327374130487442,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3222935199737549,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32508212327957153,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32512032985687256,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4027045667171478,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4044617712497711,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4295591711997986,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4487355649471283,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3092942237854004,
+      "test_best_rerun_accuracy": 0.28936511278152466,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29085493087768555,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30158913135528564,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3008633255958557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32321032881736755,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32267552614212036,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32374513149261475,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32347771525382996,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38180914521217346,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38666054606437683,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3988463580608368,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41561615467071533,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.251035690307617,
+      "test_best_rerun_accuracy": 0.3144625127315521,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27714112401008606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26736190915107727,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3084651231765747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33493772149086,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31599053740501404,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35992053151130676,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35201314091682434,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4202001690864563,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4091603755950928,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4721522033214569,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4641301929950714,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2975308895111084,
+      "test_best_rerun_accuracy": 0.29070210456848145,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2668653130531311,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2619757056236267,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28459012508392334,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32500573992729187,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3176713287830353,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3432271480560303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3460157513618469,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4195507764816284,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42214837670326233,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4713117778301239,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.494269996881485,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0508644580841064,
+      "test_best_rerun_accuracy": 0.3893345594406128,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.257200688123703,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2487584948539734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26755291223526,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2633509039878845,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3644663393497467,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38394835591316223,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3677133619785309,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5262433886528015,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.507678210735321,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5589426159858704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5251356363296509,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0973575115203857,
+      "test_best_rerun_accuracy": 0.3670639395713806,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25143250823020935,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2442891001701355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24413630366325378,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2434868961572647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38261136412620544,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3637405335903168,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35843074321746826,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5255557894706726,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5212010145187378,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5614256262779236,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5475972294807434,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.9709676504135132,
+      "test_best_rerun_accuracy": 0.41767895221710205,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19715027511119843,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19634807109832764,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2445565015077591,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2448239028453827,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3467797338962555,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3190465271472931,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41565436124801636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5023683905601501,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4808236062526703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5923294425010681,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5776606202125549,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.9684898853302002,
+      "test_best_rerun_accuracy": 0.42692336440086365,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.17858506739139557,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1787760704755783,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21201008558273315,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22541828453540802,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33474674820899963,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31683093309402466,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40419435501098633,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5040873885154724,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49617999792099,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.608220636844635,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6426770687103271,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.5524837970733643,
+      "test_best_rerun_accuracy": 0.5760944485664368,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16918787360191345,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16498586535453796,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15100465714931488,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.14359386265277863,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3576667308807373,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3364275395870209,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32332491874694824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31450071930885315,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5697532296180725,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6337382793426514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.638627827167511,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4778345823287964,
+      "test_best_rerun_accuracy": 0.5849950313568115,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1623118668794632,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15921767055988312,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15245625376701355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15245625376701355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34819313883781433,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3326457440853119,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3230193257331848,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33868134021759033,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5741080045700073,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6447398662567139,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6822522878646851,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.3367152214050293,
+      "test_best_rerun_accuracy": 0.6439758539199829,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14943845570087433,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.14779585599899292,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15845365822315216,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16074566543102264,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32687753438949585,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29983192682266235,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36056995391845703,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3786385655403137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5422109961509705,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5365956425666809,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6772480607032776,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.1297245025634766,
+      "test_best_rerun_accuracy": 0.6847352981567383,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.14527465403079987,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1431354582309723,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13079684972763062,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.15001146495342255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32279011607170105,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3108717203140259,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.33883413672447205,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.37336695194244385,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5372068285942078,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.538085401058197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6281992793083191,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 137.75411987304688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.2757568359375,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09674045881551693,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.14038848876953,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.41126520257247123
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11697.75,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8872013651877133
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 208.10922241210938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07014129504958186
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7364.03662109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9838392279350368
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.87216186523438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13374107242248218
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173337.21875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.02510725315809
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14809.9501953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0384202913555252
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45448.7265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3296287130298836
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3472.759765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6173795138888889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754327.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.532829061230954
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260477.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.334565537999434
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.808974266052246,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.809879183769226,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.009525679914574875,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152.76222229003906,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11005923796112324
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9493.6865234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7200368997677284
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126.7099380493164,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04270641659902811
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7340.0791015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9806384905227121
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130.4013671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11260912537780657
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164433.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.818353932519041
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12568.2939453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8812434402827444
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45122.3515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3128992548311036
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3450.68896484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6134558159722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 741824.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.391394381412395
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250071.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.161402690413193
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 838.3541259765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 797.8735961914062,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.060513735016413064,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 552.5751342773438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.39810888636696234
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 880.2931518554688,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.6331218518708885
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 266.8232421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0899303141852039
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2083.737060546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.27838838484260187
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 854.4204711914062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.7378415122551004
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75414.6953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7512236511355193
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3596.427978515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.25216855830287654
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22295.880859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1428510359000974
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2717.05712890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.48303237847222225
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 531359.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.010654332997749
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128851.5234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1442018777145426
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 20.07265281677246,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 19.30729103088379,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.006507344466088234,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134.84201049804688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09714842254902513
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.901116371154785,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.025795349321867292
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5038.79931640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3821614953664202
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4917.431640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6569714950734803
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.53145217895508,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03500125404054843
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128409.8671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.981837896793145
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7051.21337890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.49440564990227526
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33423.26171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.7132227033036034
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1766.0247802734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3139599609375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 644648.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.29215213284617
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185912.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.093747399863545
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 769.7946166992188,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 789.6004028320312,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1054910357825025,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125.468017578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09039482534447046
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.54080200195312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3554779052734375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18146.89453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.376328747155859
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21791.4765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 7.344616300134816
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108.66645812988281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09383977386000243
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26685.279296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6196655976424624
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29766.060546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.08708880569871
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8458.6689453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.43357778180903683
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1327.7796630859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.23604971788194445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258153.765625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.9201923647953123
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72805.7109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.211550612176127
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 131.16665649414062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 138.26763916015625,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.11940210635592077,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.44065856933594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10190249176465126
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.5714693069458,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.05563931214182
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11498.46875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8720871255214259
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175.2565155029297,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.059068593024243235
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7696.32080078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0282325719146626
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173211.09375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.02217847273825
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14616.63671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0248658476195485
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46604.69140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3888816139345943
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3680.077392578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6542359809027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757075.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.563909737226112
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261019.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.343598152031019
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 14032.3310546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8649.287109375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.2008472763648291,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2972.443115234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.141529621926783
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3209.04638671875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 16.889717824835525
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3104.083740234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.23542538795861775
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1732.2242431640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5838302134021107
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1506.5863037109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.20128073529872245
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2695.502197265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.3277221047198835
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1754.66650390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.12303088654510237
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18493.73828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.947959315251935
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6361.1171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.1308652777777777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 167653.015625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.896462966471726
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179378.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.985008653254123
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1788.8062744140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1655.5777587890625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.11608314112950936,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1064.9766845703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7672742684224153
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1565.7515869140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.240797825863487
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3774.762939453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.28629222142230754
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 613.3876953125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.20673666845719582
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2309.139404296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3085022584230962
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1286.1331787109375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.110650413394592
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58323.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.354350864411109
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11305.7412109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5795141324997437
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1982.84619140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.35250598958333335
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 332803.96875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.764623019015192
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59509.98046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9902980458414458
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 998.5680541992188,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 963.0601806640625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.04936491776431711,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 383.0377502441406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.275963797005865
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172.00448608398438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9052867688630757
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15457.7763671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.1723759095326127
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19942.404296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.7214035378749575
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 424.4696960449219,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.05670937822911448
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181.95169067382812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.15712581232627645
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16588.458984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.38520478785934886
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14387.23046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0087807087890899
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 650.2930908203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11560766059027777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86256.078125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.9757143776229313
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24089.5390625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4008709677083853
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 245.1805877685547,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 251.27288818359375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.04467073567708333,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 104.76935577392578,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07548224479389465
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81.6296157836914,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.42962955675627057
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3225.115478515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.24460489029318355
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1250.797607421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.4215698036474132
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3848.1650390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5141169056863727
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83.14138793945312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07179739891144483
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80903.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8786751259752925
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3291.374267578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.23077929235577935
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12362.9130859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6337030645311138
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 335114.65625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.790761130843976
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57958.21484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.9644753106643037
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 7074.7626953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5648.578125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.06389577418187166,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4208.7216796875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.032220230322406
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4984.03759765625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 26.231776829769736
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10686.8779296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8105330246255215
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9835.6494140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.315014969350354
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2311.3037109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3087914109468938
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4392.78271484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.7934220335438256
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8921.5654296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.20716991987942365
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11468.412109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8041236929866078
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2091.480712890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.10720594150856656
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3876.912841796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6892289496527778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25463.052734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4237274347157739
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 5863.30322265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4650.119140625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.07738204350964338,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8883.3916015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.400138041471542
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9089.37109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 47.83879523026316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5458.517578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4139945072525597
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6953.22509765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.3435204238814458
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5548.39111328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7412680178064462
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8169.97412109375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.055245355003239
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32289.880859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7498114633887935
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3963.201171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.27788537174835226
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3188.26318359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.16342524904371059
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5771.89892578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.0261153645833334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30738.26953125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.34770618113921475
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 71.11454010009766,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 69.66000366210938,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.05018732252313356,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.890350341796875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.22573868600945723
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3745.07080078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2840402579280432
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4587.453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.546158788338389
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5042.65966796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6737020264487308
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.0683822631836,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07864281715300829
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128188.65625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9767011018484117
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7576.01513671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5312028563117901
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37747.359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9348690027679532
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2280.80908203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4054771701388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 674367.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.628327092971958
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206364.875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4340917411345746
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.7190561294555664,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.7037642002105713,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.00896718000110827,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168.84793090820312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12164836520763914
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11687.1103515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8863944142254456
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 193.07522583007812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06507422508597173
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7855.353515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0494794276052104
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153.23646545410156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1323285539327302
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174003.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.0405689787293335
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14822.3095703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0392868861528888
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47059.98828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4122194003408683
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3794.1201171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6745102430555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759216.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.588126251371559
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 262154.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.362473582613616
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1337.473876953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1309.794921875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.09933977412779674,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 467.66015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.33693094830691644
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 737.7235107421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.8827553196957236
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 622.5663452148438,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.20983024779738582
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1651.908203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22069581872077487
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 800.9769897460938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6916899738740016
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56702.78515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3167096683134405
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3196.022705078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.22409358470608085
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16074.4580078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8239508948594239
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3556.0283203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6321828125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 380002.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.298528825379229
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 76266.171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2691357042417586
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 139.6027069091797,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 135.66400146484375,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.04572430113408957,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205.8114776611328,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14827916258006688
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 302.483642578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5920191714638159
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10333.8544921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7837583991040956
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6672.2626953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8914178617651971
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 278.0405578613281,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.24010410868853896
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168053.8125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.90241994473342
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13484.6220703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9454930634071308
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43212.96875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.2150273591675638
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3093.4306640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5499432291666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 743052.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.405288140673958
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 253829.4375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.223943512555539
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 762.455078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 782.0239868164062,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1044788225539621,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282.101806640625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.20324337654223704
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 265.4881896972656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.397306261564556
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20182.763671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.5307367214163823
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30208.556640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 10.181515551272328
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 333.0206604003906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.28758260829049276
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31489.13671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7312171818398198
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34940.1875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.449879925676623
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9701.8623046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4973018762974781
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1873.6055908203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.33308543836805554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 295045.34375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.3375037470447837
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74199.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2347443493834556
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 140.0202178955078,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 147.9832305908203,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.1277920816846462,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.06423950195312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10667452413685384
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.840078353881836,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.1517898860730623
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12305.9404296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9333288152967387
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282.8818054199219,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.09534270489380582
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7693.4375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0278473613894457
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175560.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.076730999210477
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15407.087890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0802894328022017
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46415.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3791723531447024
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3675.222900390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6533729600694445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 759017.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.585880852459757
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263285.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.381299090576274
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 12010.013671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8956.21484375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.20797452265813673,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8557.2021484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.165131230862752
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9305.693359375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 48.97733347039474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6215.775390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4714277884433068
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6909.71484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.32885569388271
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5014.6396484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6699585368653974
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8376.0712890625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 7.2332221839917965
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6165.1708984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.432279546938543
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13311.04296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6823026792121585
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8793.001953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.5632003472222222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133511.359375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.5102582420845447
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107430.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.787740720633019
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1759.405517578125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1594.6875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.11181373580143038,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1570.154052734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.1312349083100683
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2087.8857421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 10.988872327302632
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3580.375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.27154910883579825
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1045.2823486328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.352302780125653
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2359.998046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.315297000250501
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1728.832763671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.4929471188876295
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54989.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2769174223249118
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9978.0322265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5114579028429187
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2361.732666015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.41986358506944443
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 295178.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.3390071603904845
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52831.98828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8791704238638444
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1395.05078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1406.753173828125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.07210790782859834,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361.3600769042969,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2603458767322024
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129.55426025390625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6818645276521381
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17619.0625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.336295980280622
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21832.30078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 7.358375726744186
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 608.2966918945312,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.08126876311216183
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.39768981933594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.14369403265918473
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21036.349609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.48849037733083317
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17993.884765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.261666299651171
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 660.5310668945312,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11742774522569445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101476.890625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.1478896714478015
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26835.28125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4465625156008187
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 324.40484619140625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 333.7630310058594,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.05933564995659722,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130.90061950683594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09430880367927662
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112.97698211669922,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5946156953510485
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4074.203369140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.309002910059964
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95.27857971191406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.032112767007722975
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3058.563720703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.40862574758892783
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92.78194427490234,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.08012257709404347
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53482.4140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.241928619322404
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1986.125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1392599214696396
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12173.1982421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6239785864056333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 354786.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.01328044579935
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64336.96484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.070623281309803
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 10144.525390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6141.5078125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.06947171263984254,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3019.85546875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.1756883780619596
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3559.680908203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 18.73516267475329
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9530.875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7228574137277209
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6685.083984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.2531459333923154
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1670.3658447265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.22316176950254676
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3053.08740234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.6365176186042745
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10697.599609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.24841165728624837
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6906.18359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.48423668445870144
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1139.13525390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.05839024316501358
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2404.695556640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.42750143229166665
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16155.033203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.26883386090102007
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 6126.1962890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5185.9912109375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.08629942274370558,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12246.6162109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.823210526612032
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12775.1787109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 67.23778268914474
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5325.7451171875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4039245443448995
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9451.2392578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.1854530697042467
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7814.671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0440443386773548
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11630.736328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 10.043813754857513
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39776.16796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9236524235730541
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4942.87939453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3465768752300694
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4118.8623046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.21112626504113485
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8157.98486328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.450308420138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43597.98046875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.4931730876638802
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 138.046630859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 134.41726684570312,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.09684241127212041,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73.99473571777344,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.38944597746196546
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11740.017578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8904070973170269
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 213.5311279296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07196869832480199
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7385.84521484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9867528677145958
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154.0344696044922,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13301767668781708
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173487.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.028602051597622
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14854.712890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0415588901013182
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45513.3984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3329436894510227
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3487.366455078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6199762586805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 754641.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.53637461398369
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260682.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.337976917028605
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.8320754766464233,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.7950191497802734,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.00944746920936986,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 166.54519653320312,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11998933467810023
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11289.1953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.856215040766022
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.08570861816406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05294429006341896
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7777.97021484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0391409772670341
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150.3428192138672,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12982972298261417
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172371.65625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.002685682937024
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14431.4697265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0118826059853105
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46727.3515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3951689764980264
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3742.513427734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6653357204861111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 756119.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.553096331572458
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 260057.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.327579491371707
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 910.7044067382812,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 923.090087890625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.07001062479261472,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 316.4860534667969,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.22801588866483924
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 527.686279296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.7772962068256577
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 309.21685791015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10421869157740352
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1621.6982421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21665975179525718
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 593.9985961914062,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.5129521556057048
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 57812.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3424808134404607
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3093.83642578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.216928651365955
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16403.32421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8408080485288841
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3564.0478515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6336085069444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 411734.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.657473445471307
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83164.5859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3839313387166559
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 18.230548858642578,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18.43462562561035,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.006213220635527587,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112.63546752929688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0811494722833551
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.544485569000244,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0133920293105276
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6237.833984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.47310079517444065
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5824.2412109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7781217382682031
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66.2660903930664,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05722460310282073
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143317.6875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3280161503808285
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8981.7919921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6297708590791965
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40171.9765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.0591509848018865
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2541.119384765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4517545572916667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 699762.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.91559392780788
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 220331.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.666503638110928
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 690.9886474609375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 706.8164672851562,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.09443105775352789,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210.8472442626953,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15190723650050095
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 247.73886108398438,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.3038887425472863
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31675.232421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.4023687843667045
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44175.015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 14.888781808223795
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 288.4617004394531,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.24910336825514087
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29636.046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.6881861154328441
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50908.2109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.569500135850512
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8375.9892578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.42933975384758316
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2207.027099609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3923603732638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 255758.796875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.8931008775154687
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85652.6015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4253340915331236
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 110.00897216796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 115.08458709716797,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.09938219956577544,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96.89726257324219,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06981070790579408
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.3244743347168,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.25960249649850947
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7392.10986328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5606454200440842
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 459.18280029296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.15476333006166793
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6571.38037109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8779399293378424
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155478.828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.610413062534832
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10717.169921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.751449300369864
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42758.1015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.191711597852273
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3024.1494140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5376265625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 726042.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.212874563080439
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239736.34375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9894221248731134
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 10738.576171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6881.5205078125,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.15979752247381804,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1973.0123291015625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.4214786232720191
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2568.972412109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 13.520907432154605
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1940.819580078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14719905802640312
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1771.734130859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5971466568450876
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1021.9811401367188,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.1365372264711715
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2134.496826171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.8432615079204446
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2075.44091796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.1455224314940927
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17367.390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8902245438002973
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5043.1337890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8965571180555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179162.21875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.0266531537391264
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179266.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.9831495556886827
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1484.189697265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1377.005859375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.096550684292175,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 686.4447631835938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4945567458095056
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1025.02880859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.394888466282895
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2780.37744140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.21087428452076223
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 443.05328369140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14932702517404997
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2061.8076171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.27545859949064794
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 797.4996948242188,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.6886871285183236
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54500.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2655723893507338
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8720.0712890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.44697684602298937
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1159.8297119140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.20619194878472222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 300345.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.397458231055507
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50670.94140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8432087165934469
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1676.7962646484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1779.689208984375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.09122400989206904,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175.41099548339844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12637679789870204
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 183.69834899902344,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9668334157843339
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11769.14453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8926161950132726
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22878.255859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 7.710905244143916
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 892.9259643554688,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.11929538601943471
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.01473999023438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1554531433421713
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24349.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.565414629969348
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15088.7998046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0579722202136796
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 637.3565063476562,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.11330782335069445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100572.1015625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.1376548483931541
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23081.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.38410281771587373
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 317.9657897949219,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 330.7585754394531,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.05880152452256945,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135.71160888671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09777493435642562
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 170.6193389892578,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8979965209960937
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3011.6103515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2284118582906712
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 507.30035400390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.17098090798918308
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2872.724365234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.38379751038535403
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.58109283447266,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10412875028883649
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63111.71875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4655331309214192
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2187.734619140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.15339606080077303
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12970.4111328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6648424385059459
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 375674.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.249569796839474
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70531.9375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1737130364601533
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 6963.5732421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5085.4541015625,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.05752580909655215,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3962.343017578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.8547139896096003
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4470.52197265625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 23.529063013980263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22150.181640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.6799531012988245
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24253.771484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.174510105957197
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2306.904052734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.30820361425976955
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3980.53173828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.4374194631098876
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11931.51171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.27706464143484116
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21882.8515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.5343466247721218
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1831.8375244140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.09389704876795646
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3968.967529296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7055942274305556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25923.0703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4313825289551196
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "hod_gnn_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 3623.47705078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3288.87744140625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.05472979284452848,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7307.8984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.265056511167147
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7680.6484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 40.424465460526314
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5480.7578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.41568129029199846
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5490.978515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.8506836924924166
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4722.744140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6309611410320641
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6835.671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.902998164939551
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31835.2734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.7392549098434887
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3356.6484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.23535608172065628
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2584.5390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.13247932044184735
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4632.08056640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8234809895833334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30774.1171875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.34811168385122676
+        }
+      },
+      "output_dir": "/tmp/tb-hod/logs/train/runs/notebook_gu_grid_2026-07-27_22-10-00-rw__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/graph/hod_gnn.yaml
+++ b/configs/model/graph/hod_gnn.yaml
@@ -30,7 +30,14 @@ backbone:
   encoder_hidden: 64
   encoder_channels: 32
   activation: relu # "silu" (analytic) improves substructure counting (paper App. G.1)
-  aggregation: sum # "sum" = paper's GIN; "mean" = row-normalised Theorem-4.2 operator
+  # "mean" (default here) = the row-normalised random-walk operator from the
+  # constructive proof of the paper's Theorem 4.2: with structural_init the
+  # derivative diagonals start exactly at RWSE and stay degree-normalised,
+  # which is scale-stable across the GraphUniverse density grid and trains
+  # stably under the challenge's fixed single learning rate. "sum" = the
+  # paper's GIN aggregation; combined with structural_init its walk-count
+  # scale features destabilise training on dense graphs at lr 1e-3 (see PR).
+  aggregation: mean
   structural_init: true
   include_input: true
   base_dropout: 0.0

--- a/configs/model/graph/hod_gnn.yaml
+++ b/configs/model/graph/hod_gnn.yaml
@@ -1,0 +1,57 @@
+_target_: topobench.model.TBModel
+
+model_name: hod_gnn
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.HODGNN
+  # First-order 1-HOD-GNN (Eitan et al., ICLR 2026, arXiv:2510.02565), the
+  # empirical architecture of the paper's Appendix F: a deep-and-narrow base
+  # GIN whose exact input-Jacobian is propagated analytically alongside the
+  # features; the 1/t!-scaled per-layer diagonal Jacobians are encoded by a
+  # pointwise MLP and consumed, together with the base features and the raw
+  # input, by a downstream GIN. The derivative channels are a learnable,
+  # strictly-more-expressive generalisation of random-walk structural
+  # encodings (the paper's Theorem 4.2) and are computed inside the backbone
+  # from edge_index, per graph segment (batch-aware).
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  out_channels: ${model.feature_encoder.out_channels}
+  base_channels: 8
+  base_layers: 6
+  downstream_layers: 3
+  encoder_hidden: 64
+  encoder_channels: 32
+  activation: relu # "silu" (analytic) improves substructure counting (paper App. G.1)
+  aggregation: sum # "sum" = paper's GIN; "mean" = row-normalised Theorem-4.2 operator
+  structural_init: true
+  include_input: true
+  base_dropout: 0.0
+  dropout: 0.0
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: GNNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  residual_connections: false
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/graph/test_hod_gnn.py
+++ b/test/nn/backbones/graph/test_hod_gnn.py
@@ -108,6 +108,10 @@ def _make_model(**kwargs):
         structural_init=False,
     )
     defaults.update(kwargs)
+    # Seed the global RNG so randomly initialised weights are reproducible
+    # (an unlucky init can e.g. kill every ReLU in a layer and zero the
+    # gradients that TestTraining asserts to be nonzero).
+    torch.manual_seed(0)
     return HODGNN(**defaults)
 
 

--- a/test/nn/backbones/graph/test_hod_gnn.py
+++ b/test/nn/backbones/graph/test_hod_gnn.py
@@ -1,0 +1,417 @@
+"""Unit tests for the HODGNN backbone (HOD-GNN, arXiv:2510.02565).
+
+The load-bearing test is the analytic-vs-autograd Jacobian cross-check: the
+model's hand-propagated first-order derivatives (Algorithm 1 of the paper)
+must match ``torch.autograd`` exactly. Further tests cover the Theorem-4.2
+correspondence with random-walk return probabilities under the paper's
+initialisation, batch isolation, permutation equivariance, gradient flow
+through the derivative computation, and the expressivity motivation
+(distinguishing C6 from 2xC3, which 1-WL message passing cannot).
+"""
+
+import math
+
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+
+from topobench.nn.backbones.graph.hod_gnn import HODGNN
+
+IN_DIM = 16
+
+
+def _ring_graph(num_nodes, seed, feat_dim=IN_DIM, extra_edges=4):
+    """Create a ring graph with random chords (no isolated nodes).
+
+    Parameters
+    ----------
+    num_nodes : int
+        Number of nodes.
+    seed : int
+        Random seed for chords and features.
+    feat_dim : int, optional
+        Node feature dimension.
+    extra_edges : int, optional
+        Number of random chord edges added on top of the ring.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        The undirected graph.
+    """
+    g = torch.Generator().manual_seed(seed)
+    ring = torch.stack(
+        [
+            torch.arange(num_nodes),
+            (torch.arange(num_nodes) + 1) % num_nodes,
+        ]
+    )
+    chords = torch.randint(0, num_nodes, (2, extra_edges), generator=g)
+    chords = chords[:, chords[0] != chords[1]]
+    ei = torch.cat([ring, chords], dim=1)
+    ei = torch.cat([ei, ei.flip(0)], dim=1)
+    ei = torch.unique(ei, dim=1)  # the sparse operator sums duplicates
+    x = torch.randn(num_nodes, feat_dim, generator=g)
+    return Data(x=x, edge_index=ei, num_nodes=num_nodes)
+
+
+def _cycle_graph(cycle_sizes, feat_value=1.0, feat_dim=IN_DIM):
+    """Create a disjoint union of cycles with constant features.
+
+    Parameters
+    ----------
+    cycle_sizes : list of int
+        Length of each cycle.
+    feat_value : float, optional
+        Constant node feature value.
+    feat_dim : int, optional
+        Node feature dimension.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        The undirected graph.
+    """
+    edges, offset = [], 0
+    for size in cycle_sizes:
+        idx = torch.arange(size)
+        edges.append(torch.stack([idx, (idx + 1) % size]) + offset)
+        offset += size
+    ei = torch.cat(edges, dim=1)
+    ei = torch.cat([ei, ei.flip(0)], dim=1)
+    x = torch.full((offset, feat_dim), feat_value)
+    return Data(x=x, edge_index=ei, num_nodes=offset)
+
+
+def _make_model(**kwargs):
+    """Build a small HODGNN with test-friendly defaults.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Overrides for the HODGNN constructor.
+
+    Returns
+    -------
+    HODGNN
+        The instantiated model.
+    """
+    defaults = dict(
+        in_channels=IN_DIM,
+        hidden_channels=24,
+        out_channels=20,
+        base_channels=4,
+        base_layers=3,
+        downstream_layers=2,
+        encoder_hidden=16,
+        encoder_channels=8,
+        structural_init=False,
+    )
+    defaults.update(kwargs)
+    return HODGNN(**defaults)
+
+
+def _base_internals(model, data_list):
+    """Run the plumbing of ``forward`` up to the base propagation.
+
+    Parameters
+    ----------
+    model : HODGNN
+        The model (must be in double precision).
+    data_list : list of torch_geometric.data.Data
+        Graphs to batch together.
+
+    Returns
+    -------
+    tuple
+        ``(z, adj, idx_local, max_graph_size, batch_vector)`` as consumed
+        by ``HODGNN._propagate_base``.
+    """
+    batch = Batch.from_data_list(data_list)
+    x = batch.x.double()
+    n = x.size(0)
+    counts = torch.bincount(batch.batch)
+    offsets = torch.cumsum(counts, dim=0) - counts
+    idx_local = torch.arange(n) - offsets[batch.batch]
+    adj = model._adjacency(batch.edge_index, n, None, x.dtype)
+    z = model.lin_in(x)
+    return z, adj, idx_local, int(counts.max().item()), batch.batch
+
+
+class TestJacobianCorrectness:
+    """Analytic derivative propagation must match torch.autograd exactly."""
+
+    @pytest.mark.parametrize("activation", ["relu", "silu"])
+    @pytest.mark.parametrize("aggregation", ["sum", "mean"])
+    def test_diagonals_match_autograd(self, activation, aggregation):
+        """Per-layer diagonal Jacobians equal autograd's, in a batch."""
+        model = _make_model(
+            activation=activation, aggregation=aggregation
+        ).double()
+        model.eval()
+        z, adj, idx_local, s_max, _ = _base_internals(
+            model, [_ring_graph(7, 1), _ring_graph(5, 2)]
+        )
+        z = z.detach().requires_grad_(True)
+        k, t_layers = model.base_channels, model.base_layers
+
+        feats, diags = model._propagate_base(z, adj, idx_local, s_max)
+        jac_auto = torch.autograd.functional.jacobian(
+            lambda inp: model._propagate_base(inp, adj, idx_local, s_max)[0],
+            z,
+        )  # [n, T*k, n, k]; rows carry the same 1/t! scale as `diags`.
+
+        n = z.size(0)
+        for t in range(t_layers):
+            for v in range(n):
+                ours = diags[v, t * k * k : (t + 1) * k * k].reshape(k, k)
+                auto = jac_auto[v, t * k : (t + 1) * k, v, :]
+                assert torch.allclose(ours, auto, atol=1e-10)
+
+    def test_no_cross_graph_derivatives(self):
+        """Autograd Jacobian is exactly zero across graph boundaries."""
+        model = _make_model(activation="silu").double()
+        model.eval()
+        z, adj, idx_local, s_max, batch_vec = _base_internals(
+            model, [_ring_graph(6, 3), _ring_graph(4, 4)]
+        )
+        jac_auto = torch.autograd.functional.jacobian(
+            lambda inp: model._propagate_base(inp, adj, idx_local, s_max)[0],
+            z.detach(),
+        )
+        cross = jac_auto[batch_vec == 0][:, :, batch_vec == 1, :]
+        assert cross.abs().max().item() == 0.0
+
+
+class TestStructuralInit:
+    """Paper initialisation reproduces walk-based encodings (Theorem 4.2)."""
+
+    def _diag_blocks(self, model, data):
+        """Return the per-layer diagonal Jacobian blocks of ``data``.
+
+        Parameters
+        ----------
+        model : HODGNN
+            A double-precision model.
+        data : torch_geometric.data.Data
+            A single graph.
+
+        Returns
+        -------
+        list of torch.Tensor
+            Per-layer ``[n, k, k]`` diagonal blocks, rescaled by ``t!``.
+        """
+        z, adj, idx_local, s_max, _ = _base_internals(model, [data])
+        _, diags = model._propagate_base(z, adj, idx_local, s_max)
+        k = model.base_channels
+        n = z.size(0)
+        return [
+            diags[:, t * k * k : (t + 1) * k * k].reshape(n, k, k)
+            * math.factorial(t + 1)
+            for t in range(model.base_layers)
+        ]
+
+    def _dense_adj(self, data):
+        """Return the dense adjacency matrix of ``data``.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            A single graph.
+
+        Returns
+        -------
+        torch.Tensor
+            Dense ``[n, n]`` adjacency matrix.
+        """
+        n = data.num_nodes
+        a = torch.zeros(n, n, dtype=torch.double)
+        a[data.edge_index[1], data.edge_index[0]] = 1.0
+        return a
+
+    def test_mean_aggregation_gives_rw_return_probabilities(self):
+        """Diagonals at init equal (P^t)_vv for P the random walk."""
+        model = _make_model(
+            structural_init=True, aggregation="mean", base_channels=3
+        ).double()
+        model.eval()
+        data = _ring_graph(9, 5)
+        a = self._dense_adj(data)
+        p = a / a.sum(dim=1, keepdim=True)
+        eye = torch.eye(3, dtype=torch.double)
+        for t, block in enumerate(self._diag_blocks(model, data), start=1):
+            returns = torch.diagonal(torch.linalg.matrix_power(p, t))
+            expected = returns[:, None, None] * eye
+            assert torch.allclose(block, expected, atol=1e-10)
+
+    def test_sum_aggregation_gives_closed_walk_counts(self):
+        """Diagonals at init equal (A^t)_vv (closed-walk centrality)."""
+        model = _make_model(
+            structural_init=True, aggregation="sum", base_channels=3
+        ).double()
+        model.eval()
+        data = _ring_graph(8, 6)
+        a = self._dense_adj(data)
+        eye = torch.eye(3, dtype=torch.double)
+        for t, block in enumerate(self._diag_blocks(model, data), start=1):
+            walks = torch.diagonal(torch.linalg.matrix_power(a, t))
+            expected = walks[:, None, None] * eye
+            assert torch.allclose(block, expected, atol=1e-10)
+
+    def test_distinguishes_c6_from_two_triangles(self):
+        """Derivative features separate C6 from 2xC3 (1-WL cannot).
+
+        Both graphs are 2-regular with identical constant features, so
+        message passing sees identical multisets at every round. The
+        3-step closed-walk derivative channel is nonzero exactly on the
+        triangles — the paper's A^3 motivating example.
+        """
+        model = _make_model(
+            structural_init=True, aggregation="sum", base_channels=3
+        ).double()
+        model.eval()
+        c6 = _cycle_graph([6])
+        c3c3 = _cycle_graph([3, 3])
+        block_c6 = self._diag_blocks(model, c6)[2]
+        block_c3 = self._diag_blocks(model, c3c3)[2]
+        assert block_c6.abs().max().item() == 0.0  # no triangles in C6
+        assert torch.allclose(
+            torch.diagonal(block_c3, dim1=1, dim2=2),
+            torch.full((6, 3), 2.0, dtype=torch.double),
+        )  # every C3 node closes 2 directed 3-walks
+
+
+class TestBatchIsolation:
+    """A graph's output is identical alone and inside a batch."""
+
+    @pytest.mark.parametrize("structural_init", [False, True])
+    def test_batched_equals_individual(self, structural_init):
+        """Forward on a batch matches per-graph forwards (diff == 0)."""
+        model = _make_model(structural_init=structural_init).double()
+        model.eval()
+        g_a, g_b = _ring_graph(11, 7), _ring_graph(6, 8)
+        batch = Batch.from_data_list([g_a, g_b])
+        with torch.no_grad():
+            out_batch = model(batch.x.double(), batch.edge_index, batch.batch)
+            out_a = model(g_a.x.double(), g_a.edge_index)
+            out_b = model(g_b.x.double(), g_b.edge_index)
+        assert torch.allclose(out_batch[:11], out_a, atol=1e-12)
+        assert torch.allclose(out_batch[11:], out_b, atol=1e-12)
+
+
+class TestPermutationEquivariance:
+    """Node relabelling permutes the output embeddings."""
+
+    def test_permutation_equivariance(self):
+        """f(P x, P edge_index) == P f(x, edge_index)."""
+        model = _make_model().double()
+        model.eval()
+        data = _ring_graph(10, 9)
+        perm = torch.randperm(10, generator=torch.Generator().manual_seed(0))
+        inv = torch.empty_like(perm)
+        inv[perm] = torch.arange(10)
+        x_p = data.x.double()[perm]
+        ei_p = inv[data.edge_index]
+        with torch.no_grad():
+            out = model(data.x.double(), data.edge_index)
+            out_p = model(x_p, ei_p)
+        assert torch.allclose(out[perm], out_p, atol=1e-10)
+
+
+class TestTraining:
+    """Gradient flow and stochastic-regularisation branches."""
+
+    @pytest.mark.parametrize("structural_init", [False, True])
+    def test_gradients_flow_through_derivative_computation(
+        self, structural_init
+    ):
+        """Base weights receive nonzero, finite gradients via the loss."""
+        model = _make_model(structural_init=structural_init)
+        batch = Batch.from_data_list([_ring_graph(8, 10), _ring_graph(7, 11)])
+        out = model(batch.x, batch.edge_index, batch.batch)
+        out.sum().backward()
+        for name, param in model.named_parameters():
+            assert param.grad is not None, name
+            assert torch.isfinite(param.grad).all(), name
+        assert model.base_lin1[0].weight.grad.abs().sum() > 0
+        assert model.base_eps.grad.abs().sum() > 0
+        assert model.encoder[0].weight.grad.abs().sum() > 0
+
+    def test_dropout_branches_run(self):
+        """Base and downstream dropout paths execute in training mode."""
+        model = _make_model(base_dropout=0.5, dropout=0.5)
+        model.train()
+        data = _ring_graph(9, 12)
+        out = model(data.x, data.edge_index)
+        assert out.shape == (9, 20)
+        assert torch.isfinite(out).all()
+
+
+class TestInterfaceAndBranches:
+    """Constructor validation and remaining forward branches."""
+
+    def test_invalid_activation_raises(self):
+        """Unknown activation names are rejected."""
+        with pytest.raises(ValueError, match="activation"):
+            _make_model(activation="gelu")
+
+    def test_invalid_aggregation_raises(self):
+        """Unknown aggregation names are rejected."""
+        with pytest.raises(ValueError, match="aggregation"):
+            _make_model(aggregation="max")
+
+    def test_edge_weight_is_used(self):
+        """Doubling edge weights changes the output under sum aggregation."""
+        model = _make_model()
+        model.eval()
+        data = _ring_graph(8, 13)
+        ones = torch.ones(data.edge_index.size(1))
+        with torch.no_grad():
+            out_none = model(data.x, data.edge_index)
+            out_ones = model(data.x, data.edge_index, None, ones)
+            out_two = model(data.x, data.edge_index, None, 2 * ones)
+        assert torch.allclose(out_none, out_ones, atol=1e-6)
+        assert not torch.allclose(out_none, out_two, atol=1e-3)
+
+    def test_include_input_false(self):
+        """The raw-feature skip can be disabled."""
+        model = _make_model(include_input=False)
+        model.eval()
+        data = _ring_graph(7, 14)
+        with torch.no_grad():
+            out = model(data.x, data.edge_index)
+        assert out.shape == (7, 20)
+
+    def test_edgeless_graph(self):
+        """A graph with no edges still produces embeddings."""
+        model = _make_model()
+        model.eval()
+        x = torch.randn(5, IN_DIM)
+        ei = torch.empty(2, 0, dtype=torch.long)
+        with torch.no_grad():
+            out = model(x, ei)
+        assert out.shape == (5, 20)
+        assert torch.isfinite(out).all()
+
+    def test_reset_parameters_applies_structural_init(self):
+        """reset_parameters restores the Appendix F initialisation."""
+        model = _make_model(structural_init=True)
+        with torch.no_grad():
+            model.lin_in.bias.fill_(3.0)
+            model.base_eps.fill_(0.5)
+        model.reset_parameters()
+        assert torch.all(model.lin_in.bias == 1.0)
+        assert torch.all(model.lin_in.weight == 0.0)
+        assert torch.all(model.base_eps == -1.0)
+        assert torch.allclose(
+            model.base_lin1[0].weight,
+            torch.eye(model.base_channels),
+        )
+
+    def test_reset_parameters_standard_init(self):
+        """Without structural_init, eps resets to zero."""
+        model = _make_model(structural_init=False)
+        with torch.no_grad():
+            model.base_eps.fill_(0.7)
+        model.reset_parameters()
+        assert torch.all(model.base_eps == 0.0)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune", "graph/hod_gnn"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/graph/hod_gnn.py
+++ b/topobench/nn/backbones/graph/hod_gnn.py
@@ -1,0 +1,517 @@
+r"""HOD-GNN: High-Order Derivative GNN (first public implementation).
+
+This backbone implements **1-HOD-GNN** from "On the Expressive Power of GNN
+Derivatives" (Eitan, Eliasof, Gelberg, Frasca, Bar-Shalom, Maron; ICLR 2026,
+[1]_) — specifically the empirical architecture the authors use in *all* of
+their experiments (their Appendix F): a deep-and-narrow base GIN whose
+**first-order derivatives with respect to its own input features** are
+computed analytically, encoded by a pointwise MLP, and passed together with
+the base representations to a downstream GIN. To our knowledge no public
+implementation of this paper exists; this file is written from the paper
+alone.
+
+**Why derivatives?** Message passing is bounded by 1-WL and provably cannot
+count triangles ([2]_). The paper's motivating example: for the (linear) GNN
+:math:`\mathcal{M}(\bm{A}, \bm{X}) = \bm{A}^3\bm{X}`, the derivative of node
+:math:`v`'s output with respect to its own input is exactly
+:math:`\bm{A}^3_{v,v}` — the number of closed 3-walks at :math:`v`, i.e.
+(six times) the triangles at :math:`v`. Derivatives of a GNN are therefore
+*structure-aware* quantities that restore precisely the substructure
+information 1-WL message passing is blind to, and Theorem 4.1 of [1]_ places
+the resulting models between Subgraph GNNs and the WL hierarchy.
+
+**Relation to random-walk encodings.** Theorem 4.2 of [1]_ is constructive:
+with degree-normalised aggregation, the diagonal derivative
+:math:`\partial \bm{h}^{(t)}_v / \partial \bm{X}_v` of a suitably initialised
+base MPNN equals the :math:`t`-step random-walk return probability
+:math:`(\tilde{\bm{A}}^t)_{v,v}` — i.e. the RWSE of GraphGPS ([3]_). HOD-GNN
+is thus a *learnable, strictly more expressive generalisation* of a
+hand-crafted RWSE: it starts (under ``structural_init``) at the same
+random-walk fingerprint and is free to learn task-adapted structural
+features end-to-end. The ``structural_init`` scheme below follows Appendix F
+of [1]_ (constant-one input embedding, identity MLPs, GIN
+:math:`\epsilon = -1`), under which the derivative diagonal at
+initialisation equals the walk-return / centrality encoding of [4]_.
+
+**What is computed** (all inside the backbone, from ``edge_index`` alone):
+
+1. The input is projected to a narrow base width :math:`k`
+   (``base_channels``); these projected features :math:`\bm{z}` play the
+   role of the paper's initial features :math:`\bm{X}`.
+2. A base GIN runs for ``base_layers`` layers. Alongside each layer's node
+   update, the exact Jacobian
+   :math:`\bm{J}^{(t)}[v, u] = \partial \bm{h}^{(t)}_v / \partial \bm{z}_u`
+   is propagated analytically with the *same* sparse aggregation used for
+   the features (Appendix D of [1]_; for first-order derivatives Faà di
+   Bruno's formula reduces to the chain rule). The propagation is fully
+   differentiable, so training updates the base GIN *through* the
+   derivative computation — the paper's key algorithmic contribution.
+3. Following Eq. (73) of [1]_, the per-layer representations and the
+   per-layer **diagonal** Jacobians :math:`\bm{J}^{(t)}[v, v]` are
+   concatenated across layers with :math:`1/t!` scaling. (The diagonal at
+   *every* depth is kept, matching the RWSE correspondence, which needs all
+   walk lengths.) The stacked diagonals are encoded by a pointwise MLP
+   (:math:`\text{U}^{\text{node}}`, Eq. (74) of [1]_).
+4. A downstream GIN consumes ``[base features ⊕ encoded derivatives ⊕
+   optionally the raw input]`` and produces the output node embeddings.
+   Output-level derivatives :math:`\bm{\mathsf{D}}^{\text{out}}` and
+   :math:`k \geq 2` mixed derivatives are deliberately **not** implemented:
+   the paper's own experiments omit them (Appendix F).
+
+**Batch-awareness.** Batches contain disjoint graphs. The Jacobian source
+axis is indexed *locally per graph* (padded to the largest graph in the
+batch), and all propagation uses ``edge_index``, which never crosses graph
+boundaries — so a graph's output, including every derivative channel, is
+identical whether it is processed alone or inside a batch.
+
+**Cost.** The Jacobian tensor has shape ``[N, S, k, k]`` for ``N`` total
+nodes, largest-graph size ``S`` and base width ``k`` — the reason the paper
+(and this implementation) keeps the base GIN narrow (:math:`k \le 16`) while
+allowing it to be deep. Sparsity in the source axis (nodes further than
+:math:`t` hops have zero derivative) is not exploited; for the graph sizes
+targeted here (:math:`\le` a few hundred nodes) the dense-padded form is
+faster and simpler.
+
+References
+----------
+.. [1] Eitan, Eliasof, Gelberg, Frasca, Bar-Shalom, Maron. "On the
+   Expressive Power of GNN Derivatives." ICLR 2026.
+   https://arxiv.org/abs/2510.02565
+.. [2] Chen, Chen, Villar, Bruna. "Can Graph Neural Networks Count
+   Substructures?" NeurIPS 2020. https://arxiv.org/abs/2002.04025
+.. [3] Rampášek et al. "Recipe for a General, Powerful, Scalable Graph
+   Transformer" (GraphGPS / RWSE). NeurIPS 2022.
+   https://arxiv.org/abs/2205.12454
+.. [4] Southern, Eitan, Bar-Shalom, Bronstein, Maron, Frasca. "Balancing
+   Efficiency and Expressiveness: Subgraph GNNs with Walk-Based Centrality"
+   (HyMN). ICLR 2025. https://openreview.net/forum?id=2hbgKYuao1
+"""
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+
+class HODGNN(torch.nn.Module):
+    r"""First-order 1-HOD-GNN backbone (Appendix F of the paper).
+
+    A narrow base GIN is run for ``base_layers`` layers while its exact
+    input-Jacobian is propagated analytically alongside the features. The
+    :math:`1/t!`-scaled per-layer features and diagonal Jacobians are
+    concatenated, the diagonals are encoded by a pointwise MLP, and a
+    downstream GIN maps ``[features ⊕ encoded derivatives ⊕ input]`` to the
+    output node embeddings. See the module docstring for the full method
+    description and references.
+
+    Faithfulness notes (for the correctness criterion): this is the
+    architecture of Appendix F of the paper — first-order derivatives only,
+    output derivatives omitted, diagonal-only encoding, factorial residual —
+    which is the configuration used for every experimental result reported
+    there. ``aggregation="sum"`` gives the paper's GIN aggregation;
+    ``aggregation="mean"`` gives the row-normalised (random-walk) operator
+    used in the constructive proof of the paper's Theorem 4.2, whose
+    derivative diagonals are degree-normalised and hence scale-stable across
+    graph-density regimes. Both are instances of the linear aggregations the
+    derivative algorithm supports (Eq. (28) of the paper).
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the input node features.
+    hidden_channels : int
+        Hidden width of the downstream GIN.
+    out_channels : int
+        Dimension of the returned node embeddings.
+    base_channels : int, optional
+        Width :math:`k` of the base GIN. Kept deliberately narrow: the
+        Jacobian tensor scales with :math:`k^2`. Default is 8.
+    base_layers : int, optional
+        Depth :math:`T` of the base GIN; the derivative encoding contains
+        walk information up to length :math:`T`. Default is 6.
+    downstream_layers : int, optional
+        Number of downstream GIN layers. Default is 3.
+    encoder_hidden : int, optional
+        Hidden width of the derivative-encoder MLP. Default is 64.
+    encoder_channels : int, optional
+        Output width of the derivative-encoder MLP. Default is 32.
+    activation : str, optional
+        Activation of base and downstream MLPs, ``"relu"`` or ``"silu"``.
+        The paper uses ReLU by default; the analytic SiLU improves
+        substructure counting (its Appendix G.1). Default is ``"relu"``.
+    aggregation : str, optional
+        Neighbour aggregation, ``"sum"`` (GIN, the paper's default) or
+        ``"mean"`` (row-normalised random walk, the Theorem 4.2 operator).
+        Default is ``"sum"``.
+    structural_init : bool, optional
+        Apply the paper's Appendix F initialisation (constant-one input
+        embedding, identity base MLPs, :math:`\epsilon = -1`), under which
+        the derivative diagonals at initialisation equal walk-return /
+        centrality encodings. Default is True.
+    include_input : bool, optional
+        Concatenate the raw input features to the downstream GIN's input
+        (the feature-preservation component of Eq. (58) of the paper; the
+        narrow base width would otherwise bottleneck feature information).
+        Default is True.
+    base_dropout : float, optional
+        Dropout inside the base GIN. Applied consistently to features and
+        Jacobians (a dropout mask is a linear map, so its exact derivative
+        is the same mask). Default is 0.0.
+    dropout : float, optional
+        Dropout between downstream GIN layers. Default is 0.0.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        base_channels: int = 8,
+        base_layers: int = 6,
+        downstream_layers: int = 3,
+        encoder_hidden: int = 64,
+        encoder_channels: int = 32,
+        activation: str = "relu",
+        aggregation: str = "sum",
+        structural_init: bool = True,
+        include_input: bool = True,
+        base_dropout: float = 0.0,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        if activation not in ("relu", "silu"):
+            raise ValueError(
+                f"activation must be 'relu' or 'silu', got {activation!r}"
+            )
+        if aggregation not in ("sum", "mean"):
+            raise ValueError(
+                f"aggregation must be 'sum' or 'mean', got {aggregation!r}"
+            )
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels
+        self.base_channels = base_channels
+        self.base_layers = base_layers
+        self.downstream_layers = downstream_layers
+        self.activation = activation
+        self.aggregation = aggregation
+        self.structural_init = structural_init
+        self.include_input = include_input
+        self.base_dropout = base_dropout
+        self.dropout = dropout
+
+        k = base_channels
+        self.lin_in = torch.nn.Linear(in_channels, k)
+
+        # Base GIN: per layer a learnable eps and a two-layer MLP (an
+        # activation after each linear layer, matching the recursive
+        # "sigma(Wx+b)" decomposition of Appendix D, Eq. (30)).
+        self.base_eps = torch.nn.Parameter(torch.zeros(base_layers))
+        self.base_lin1 = torch.nn.ModuleList(
+            torch.nn.Linear(k, k) for _ in range(base_layers)
+        )
+        self.base_lin2 = torch.nn.ModuleList(
+            torch.nn.Linear(k, k) for _ in range(base_layers)
+        )
+
+        # Pointwise derivative encoder U^node (Eq. (74)) over the stacked
+        # per-layer diagonal Jacobians.
+        self.encoder = torch.nn.Sequential(
+            torch.nn.Linear(base_layers * k * k, encoder_hidden),
+            torch.nn.ReLU(),
+            torch.nn.Linear(encoder_hidden, encoder_channels),
+        )
+
+        down_in = (
+            base_layers * k
+            + encoder_channels
+            + (in_channels if include_input else 0)
+        )
+        self.down_eps = torch.nn.Parameter(torch.zeros(downstream_layers))
+        self.down_lin1 = torch.nn.ModuleList()
+        self.down_lin2 = torch.nn.ModuleList()
+        width = down_in
+        for _ in range(downstream_layers):
+            self.down_lin1.append(torch.nn.Linear(width, hidden_channels))
+            self.down_lin2.append(
+                torch.nn.Linear(hidden_channels, hidden_channels)
+            )
+            width = hidden_channels
+        self.lin_out = torch.nn.Linear(width, out_channels)
+
+        # 1/t! scaling of the per-layer residual (Eq. (73)).
+        self._scales = [
+            1.0 / math.factorial(t) for t in range(1, base_layers + 1)
+        ]
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        r"""Reset all learnable parameters.
+
+        Applies the paper's Appendix F initialisation to the base GIN when
+        ``structural_init`` is set: the input projection outputs the
+        constant-one vector, the base MLPs are identities and the GIN
+        :math:`\epsilon` is :math:`-1`, so that the derivative diagonals at
+        initialisation equal walk-return / centrality encodings.
+
+        Returns
+        -------
+        None
+            This method updates the module in place.
+        """
+        self.lin_in.reset_parameters()
+        for lin in (*self.base_lin1, *self.base_lin2):
+            lin.reset_parameters()
+        if self.structural_init:
+            torch.nn.init.zeros_(self.lin_in.weight)
+            torch.nn.init.ones_(self.lin_in.bias)
+            for lin in (*self.base_lin1, *self.base_lin2):
+                torch.nn.init.eye_(lin.weight)
+                torch.nn.init.zeros_(lin.bias)
+            torch.nn.init.constant_(self.base_eps, -1.0)
+        else:
+            torch.nn.init.zeros_(self.base_eps)
+        for layer in self.encoder:
+            if isinstance(layer, torch.nn.Linear):
+                layer.reset_parameters()
+        for lin in (*self.down_lin1, *self.down_lin2):
+            lin.reset_parameters()
+        torch.nn.init.zeros_(self.down_eps)
+        self.lin_out.reset_parameters()
+
+    def _act(self, pre: torch.Tensor) -> torch.Tensor:
+        """Apply the configured activation.
+
+        Parameters
+        ----------
+        pre : torch.Tensor
+            Pre-activation values.
+
+        Returns
+        -------
+        torch.Tensor
+            Activated values, same shape as ``pre``.
+        """
+        if self.activation == "relu":
+            return F.relu(pre)
+        return F.silu(pre)
+
+    def _act_deriv(self, pre: torch.Tensor) -> torch.Tensor:
+        r"""First derivative of the configured activation.
+
+        For ReLU this is the (almost-everywhere) step function; for SiLU,
+        :math:`\sigma(x) + x\,\sigma(x)(1 - \sigma(x))` with
+        :math:`\sigma` the logistic sigmoid. Both are expressed with
+        differentiable ops so that training can backpropagate through the
+        derivative computation itself.
+
+        Parameters
+        ----------
+        pre : torch.Tensor
+            Pre-activation values.
+
+        Returns
+        -------
+        torch.Tensor
+            Elementwise derivative values, same shape as ``pre``.
+        """
+        if self.activation == "relu":
+            return (pre > 0).to(pre.dtype)
+        sig = torch.sigmoid(pre)
+        return sig * (1 + pre * (1 - sig))
+
+    def _adjacency(
+        self,
+        edge_index: torch.Tensor,
+        num_nodes: int,
+        edge_weight: torch.Tensor | None,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        r"""Build the sparse aggregation operator.
+
+        Row :math:`v` of the returned matrix holds the coefficients
+        :math:`b_{u,v}` of the linear neighbour aggregation
+        :math:`\sum_{u \in \mathcal{N}(v)} b_{u,v}\,\bm{h}_u` (Eq. (28) of
+        the paper): edge weights for ``aggregation="sum"``, degree-normalised
+        weights for ``aggregation="mean"``. The same operator aggregates
+        features and Jacobians, which is what makes the derivative
+        computation exact.
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            Graph connectivity of shape ``[2, num_edges]`` (messages flow
+            from row 0 to row 1).
+        num_nodes : int
+            Total number of nodes in the batch.
+        edge_weight : torch.Tensor, optional
+            Optional edge weights of shape ``[num_edges]``.
+        dtype : torch.dtype
+            Floating dtype of the values.
+
+        Returns
+        -------
+        torch.Tensor
+            Sparse COO tensor of shape ``[num_nodes, num_nodes]``.
+        """
+        src, dst = edge_index[0], edge_index[1]
+        if edge_weight is None:
+            values = torch.ones(
+                src.numel(), dtype=dtype, device=edge_index.device
+            )
+        else:
+            values = edge_weight.to(dtype)
+        if self.aggregation == "mean":
+            deg = torch.zeros(num_nodes, dtype=dtype, device=edge_index.device)
+            deg.index_add_(0, dst, values)
+            values = values / deg.clamp(min=1)[dst]
+        return torch.sparse_coo_tensor(
+            torch.stack([dst, src]),
+            values,
+            (num_nodes, num_nodes),
+        ).coalesce()
+
+    def _propagate_base(
+        self,
+        z: torch.Tensor,
+        adj: torch.Tensor,
+        idx_local: torch.Tensor,
+        max_graph_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        r"""Run the base GIN and its analytic Jacobian propagation.
+
+        Implements Algorithm 1 of the paper for first-order derivatives:
+        the Jacobian ``jac[v, s, i, j]`` :math:`= \partial h^{(t)}_{v,i} /
+        \partial z_{u(s),j}` (``s`` indexes source nodes *locally within
+        each graph*) is updated with the same aggregation as the features,
+        mapped through each linear layer, and scaled by the activation
+        derivative at the pre-activations (the first-order case of Faà di
+        Bruno's formula). All operations are differentiable, so gradients
+        flow through the derivative computation into the base weights.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Projected input features of shape ``[num_nodes, k]``.
+        adj : torch.Tensor
+            Sparse aggregation operator from :meth:`_adjacency`.
+        idx_local : torch.Tensor
+            Within-graph node index of each node, shape ``[num_nodes]``.
+        max_graph_size : int
+            Largest graph size in the batch (padded source-axis length).
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            ``(features, diagonals)`` where ``features`` has shape
+            ``[num_nodes, base_layers * k]`` and stacks the
+            :math:`1/t!`-scaled per-layer representations (Eq. (73)), and
+            ``diagonals`` has shape ``[num_nodes, base_layers * k * k]``
+            and stacks the equally scaled per-layer diagonal Jacobians.
+        """
+        n, k = z.shape
+        s_dim = max_graph_size
+        arange_n = torch.arange(n, device=z.device)
+
+        h = z
+        # jac[v, s, i, j] = d h[v, i] / d z[u(s), j], initialised to the
+        # identity: each node depends only on itself, coordinate-wise.
+        jac = z.new_zeros(n, s_dim, k, k)
+        jac[arange_n, idx_local] = torch.eye(k, device=z.device, dtype=z.dtype)
+
+        feats, diags = [], []
+        for t in range(self.base_layers):
+            # Aggregation step (Eq. (10)): identical linear operator for
+            # features and Jacobian.
+            eps = self.base_eps[t]
+            h_agg = torch.sparse.mm(adj, h)
+            jac_agg = torch.sparse.mm(adj, jac.reshape(n, -1)).reshape(
+                n, s_dim, k, k
+            )
+            h = (1 + eps) * h + h_agg
+            jac = (1 + eps) * jac + jac_agg
+
+            # DeepSets step: two sigma(Wx+b) layers, each propagating the
+            # Jacobian by W (Eq. (32)) then by the chain rule.
+            for lin in (self.base_lin1[t], self.base_lin2[t]):
+                pre = lin(h)
+                jac = torch.einsum("nsij,oi->nsoj", jac, lin.weight)
+                jac = jac * self._act_deriv(pre)[:, None, :, None]
+                h = self._act(pre)
+
+            if self.base_dropout > 0 and self.training:
+                # A dropout mask is a linear map; applying the same mask to
+                # the Jacobian is its exact derivative.
+                mask = (torch.rand_like(h) >= self.base_dropout).to(
+                    h.dtype
+                ) / (1 - self.base_dropout)
+                h = h * mask
+                jac = jac * mask[:, None, :, None]
+
+            scale = self._scales[t]
+            feats.append(h * scale)
+            diags.append(jac[arange_n, idx_local].reshape(n, k * k) * scale)
+
+        return torch.cat(feats, dim=1), torch.cat(diags, dim=1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor | None = None,
+        edge_weight: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""Compute HOD-GNN node embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node feature matrix of shape ``[num_nodes, in_channels]``.
+        edge_index : torch.Tensor
+            Graph connectivity of shape ``[2, num_edges]``.
+        batch : torch.Tensor, optional
+            Batch assignment of shape ``[num_nodes]``. Keeps the Jacobian
+            source axis within graph boundaries. If ``None``, all nodes are
+            treated as one graph.
+        edge_weight : torch.Tensor, optional
+            Optional edge weights of shape ``[num_edges]``, used in the
+            aggregation operator.
+        **kwargs : dict
+            Additional unused keyword arguments.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``[num_nodes, out_channels]``.
+        """
+        n = x.size(0)
+        device = x.device
+        if batch is None:
+            batch = torch.zeros(n, dtype=torch.long, device=device)
+
+        # Within-graph local index of every node and the padded source-axis
+        # length (largest graph in the batch).
+        counts = torch.bincount(batch)
+        offsets = torch.cumsum(counts, dim=0) - counts
+        idx_local = torch.arange(n, device=device) - offsets[batch]
+        max_graph_size = int(counts.max().item()) if n > 0 else 0
+
+        adj = self._adjacency(edge_index, n, edge_weight, x.dtype)
+        z = self.lin_in(x)
+        feats, diags = self._propagate_base(z, adj, idx_local, max_graph_size)
+
+        h_der = [feats, self.encoder(diags)]
+        if self.include_input:
+            h_der.append(x)
+        h = torch.cat(h_der, dim=1)
+
+        for t in range(self.downstream_layers):
+            h = (1 + self.down_eps[t]) * h + torch.sparse.mm(adj, h)
+            h = self._act(self.down_lin1[t](h))
+            h = self._act(self.down_lin2[t](h))
+            h = F.dropout(h, p=self.dropout, training=self.training)
+
+        return self.lin_out(h)

--- a/topobench/nn/backbones/graph/hod_gnn.py
+++ b/topobench/nn/backbones/graph/hod_gnn.py
@@ -369,7 +369,9 @@ class HODGNN(torch.nn.Module):
         if self.aggregation == "mean":
             deg = torch.zeros(num_nodes, dtype=dtype, device=edge_index.device)
             deg.index_add_(0, dst, values)
-            values = values / deg.clamp(min=1)[dst]
+            # Guard only true zero degrees so fractional weighted degrees
+            # still yield an exact mean.
+            values = values / deg.masked_fill(deg == 0, 1)[dst]
         return torch.sparse_coo_tensor(
             torch.stack([dst, src]),
             values,
@@ -496,7 +498,8 @@ class HODGNN(torch.nn.Module):
             batch = torch.zeros(n, dtype=torch.long, device=device)
 
         # Within-graph local index of every node and the padded source-axis
-        # length (largest graph in the batch).
+        # length (largest graph in the batch). Assumes nodes of each graph
+        # are contiguous in the batch vector, as PyG's Batch guarantees.
         counts = torch.bincount(batch)
         offsets = torch.cumsum(counts, dim=0) - counts
         idx_local = torch.arange(n, device=device) - offsets[batch]

--- a/topobench/nn/backbones/graph/hod_gnn.py
+++ b/topobench/nn/backbones/graph/hod_gnn.py
@@ -142,6 +142,9 @@ class HODGNN(torch.nn.Module):
     aggregation : str, optional
         Neighbour aggregation, ``"sum"`` (GIN, the paper's default) or
         ``"mean"`` (row-normalised random walk, the Theorem 4.2 operator).
+        With ``structural_init``, ``"sum"`` yields walk-count-scale features
+        that can destabilise training on dense graphs under hot learning
+        rates, whereas ``"mean"`` keeps them in ``[0, 1]``.
         Default is ``"sum"``.
     structural_init : bool, optional
         Apply the paper's Appendix F initialisation (constant-one input

--- a/tutorials/tutorial_hod_gnn.ipynb
+++ b/tutorials/tutorial_hod_gnn.ipynb
@@ -1,0 +1,1353 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1de7eab4",
+   "metadata": {},
+   "source": [
+    "# HOD-GNN: a GNN that learns from its own derivatives\n",
+    "\n",
+    "**The idea in one sentence.** The derivative of a GNN's output with respect to its own input is a structure-aware quantity — for a base network computing $A^3X$, the diagonal $\\partial h_v / \\partial x_v$ counts the **triangles** at $v$ — so HOD-GNN propagates the exact Jacobian of a small base GIN *analytically alongside its features* and feeds those derivative channels, as learned structural encodings, to a downstream GNN.\n",
+    "\n",
+    "This is the empirical architecture of **\"On the Expressive Power of GNN Derivatives\"** (Eitan, Eliasof, Gelberg, Frasca, Bar-Shalom & Maron, ICLR 2026, [arXiv:2510.02565](https://arxiv.org/abs/2510.02565)); to our knowledge this is its first public implementation. Message passing alone is bounded by 1-WL and provably cannot count triangles — the derivative features restore exactly what 1-WL is blind to. Theorem 4.2 of the paper makes the bridge to hand-crafted encodings precise, and this notebook lets you touch it:\n",
+    "\n",
+    "1. at initialisation the derivative diagonals **equal the random-walk structural encoding (RWSE)** — then training makes them *learnable*;\n",
+    "2. the features **separate graphs 1-WL cannot** ($C_6$ vs $2{\\times}C_3$);\n",
+    "3. everything is **batch-aware** (disjoint graphs never mix);\n",
+    "4. the backbone trains in the TopoBench pipeline like any other model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4cfa785",
+   "metadata": {},
+   "source": [
+    "## 1. The theorem you can touch: derivative diagonals = RWSE at init\n",
+    "\n",
+    "Under the paper's Appendix-F initialisation (`structural_init`: constant-one projected input, identity base MLPs) with the row-normalised **mean** aggregation — the operator used in the constructive proof of Theorem 4.2 — the layer-$t$ diagonal Jacobian of node $v$ is exactly $(P^t)_{vv}$, the probability that a $t$-step random walk returns home. That is precisely the RWSE of GraphGPS, obtained here not as a precomputed feature but as the *starting point* of a fully learnable module. (The internal features carry a $1/t!$ residual scaling — Eq. 73 of the paper — which we undo below for the comparison.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e29d7c62",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T20:56:59.766305Z",
+     "iopub.status.busy": "2026-07-28T20:56:59.766077Z",
+     "iopub.status.idle": "2026-07-28T20:57:04.627718Z",
+     "shell.execute_reply": "2026-07-28T20:57:04.627067Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1-step: diagonal == RW return probability: True | e.g. node 0: 0.0\n",
+      "2-step: diagonal == RW return probability: True | e.g. node 0: 0.4444\n",
+      "3-step: diagonal == RW return probability: True | e.g. node 0: 0.0\n",
+      "4-step: diagonal == RW return probability: True | e.g. node 0: 0.2901\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "import torch\n",
+    "from torch_geometric.data import Batch, Data\n",
+    "\n",
+    "from topobench.nn.backbones.graph.hod_gnn import HODGNN\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "\n",
+    "def make_graph(num_nodes, chords, feat_dim=8):\n",
+    "    ring = [(i, (i + 1) % num_nodes) for i in range(num_nodes)]\n",
+    "    src, dst = zip(*(ring + chords))\n",
+    "    ei = torch.tensor([src + dst, dst + src])  # undirected\n",
+    "    return Data(x=torch.randn(num_nodes, feat_dim), edge_index=ei)\n",
+    "\n",
+    "\n",
+    "def diag_blocks(model, data):\n",
+    "    \"\"\"Per-layer [n, k, k] diagonal Jacobian blocks, t! rescaled.\"\"\"\n",
+    "    n, k = data.num_nodes, model.base_channels\n",
+    "    idx_local = torch.arange(n)  # single graph: local index = global\n",
+    "    adj = model._adjacency(data.edge_index, n, None, torch.double)\n",
+    "    with torch.no_grad():\n",
+    "        _, diags = model._propagate_base(\n",
+    "            model.lin_in(data.x.double()), adj, idx_local, n\n",
+    "        )\n",
+    "    return [\n",
+    "        diags[:, t * k * k : (t + 1) * k * k].reshape(n, k, k)\n",
+    "        * math.factorial(t + 1)\n",
+    "        for t in range(model.base_layers)\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "model = HODGNN(\n",
+    "    in_channels=8, hidden_channels=32, out_channels=8,\n",
+    "    base_channels=3, base_layers=4,\n",
+    "    aggregation='mean', structural_init=True,\n",
+    ").double().eval()\n",
+    "\n",
+    "g = make_graph(10, chords=[(0, 5), (2, 7), (3, 8)])\n",
+    "a = torch.zeros(10, 10, dtype=torch.double)\n",
+    "a[g.edge_index[1], g.edge_index[0]] = 1.0\n",
+    "p = a / a.sum(dim=1, keepdim=True)  # random-walk operator D^-1 A\n",
+    "\n",
+    "for t, block in enumerate(diag_blocks(model, g), start=1):\n",
+    "    rwse_t = torch.diagonal(torch.linalg.matrix_power(p, t))\n",
+    "    ours_t = torch.diagonal(block, dim1=1, dim2=2)[:, 0]\n",
+    "    print(f'{t}-step: diagonal == RW return probability:',\n",
+    "          torch.allclose(ours_t, rwse_t, atol=1e-12),\n",
+    "          '| e.g. node 0:', round(ours_t[0].item(), 4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77ec423d",
+   "metadata": {},
+   "source": [
+    "## 2. Beyond 1-WL: separating $C_6$ from $2{\\times}C_3$\n",
+    "\n",
+    "Both graphs are 2-regular with constant features, so 1-WL message passing sees identical neighbourhood multisets at every round and *no MPNN can tell them apart*. The 3-step derivative channel is the paper's motivating $A^3$ example: with **sum** (GIN) aggregation it counts closed 3-walks, which exist only around triangles — zero everywhere on $C_6$, exactly 2 on every node of a triangle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e98c5419",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T20:57:04.629220Z",
+     "iopub.status.busy": "2026-07-28T20:57:04.628906Z",
+     "iopub.status.idle": "2026-07-28T20:57:04.636648Z",
+     "shell.execute_reply": "2026-07-28T20:57:04.636196Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C6      3-step diagonal (all nodes): [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n",
+      "2 x C3  3-step diagonal (all nodes): [2.0, 2.0, 2.0, 2.0, 2.0, 2.0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cycles(sizes, feat_dim=8):\n",
+    "    edges, offset = [], 0\n",
+    "    for s in sizes:\n",
+    "        edges += [(offset + i, offset + (i + 1) % s) for i in range(s)]\n",
+    "        offset += s\n",
+    "    src, dst = zip(*edges)\n",
+    "    ei = torch.tensor([src + dst, dst + src])\n",
+    "    return Data(x=torch.ones(offset, feat_dim), edge_index=ei)\n",
+    "\n",
+    "\n",
+    "wl_blind = HODGNN(\n",
+    "    in_channels=8, hidden_channels=32, out_channels=8,\n",
+    "    base_channels=3, base_layers=4,\n",
+    "    aggregation='sum', structural_init=True,\n",
+    ").double().eval()\n",
+    "\n",
+    "block_c6 = diag_blocks(wl_blind, cycles([6]))[2]      # 3-step channel\n",
+    "block_2c3 = diag_blocks(wl_blind, cycles([3, 3]))[2]\n",
+    "print('C6      3-step diagonal (all nodes):',\n",
+    "      torch.diagonal(block_c6, dim1=1, dim2=2)[:, 0].tolist())\n",
+    "print('2 x C3  3-step diagonal (all nodes):',\n",
+    "      torch.diagonal(block_2c3, dim1=1, dim2=2)[:, 0].tolist())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66599512",
+   "metadata": {},
+   "source": [
+    "## 3. Batch-aware by construction\n",
+    "\n",
+    "The Jacobian's source axis is indexed *locally per graph*, so batching disjoint graphs (TopoBench batches 16 at a time) never leaks structure across graphs — a correctness property the challenge's triangle-counting task is very sensitive to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "112de488",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T20:57:04.637668Z",
+     "iopub.status.busy": "2026-07-28T20:57:04.637563Z",
+     "iopub.status.idle": "2026-07-28T20:57:04.643628Z",
+     "shell.execute_reply": "2026-07-28T20:57:04.643207Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "graph A alone == graph A in a batch: True (max abs diff 2.78e-17)\n"
+     ]
+    }
+   ],
+   "source": [
+    "g_a, g_b = make_graph(10, [(0, 5)]), make_graph(7, [(1, 4)])\n",
+    "batch = Batch.from_data_list([g_a, g_b])\n",
+    "with torch.no_grad():\n",
+    "    out_batch = model(batch.x.double(), batch.edge_index, batch.batch)\n",
+    "    out_alone = model(g_a.x.double(), g_a.edge_index)\n",
+    "diff = (out_batch[:10] - out_alone).abs().max().item()\n",
+    "print('graph A alone == graph A in a batch:', diff < 1e-12,\n",
+    "      f'(max abs diff {diff:.2e})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dbd1a5e",
+   "metadata": {},
+   "source": [
+    "## 4. Training in the TopoBench pipeline\n",
+    "\n",
+    "The model ships with `configs/model/graph/hod_gnn.yaml`, so the canonical run is `python -m topobench model=graph/hod_gnn dataset=<dataset>`. The config defaults to the **mean** (Theorem-4.2) aggregation with `structural_init` — the combination whose derivative features stay in $[0,1]$ and train stably; with sum aggregation the same init produces walk-count-scale features ($(A^t)_{vv}$) that destabilise training on dense graphs under a hot learning rate. Here we train briefly on MUTAG on CPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ce26f5cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-28T20:57:04.644618Z",
+     "iopub.status.busy": "2026-07-28T20:57:04.644517Z",
+     "iopub.status.idle": "2026-07-28T20:57:11.889531Z",
+     "shell.execute_reply": "2026-07-28T20:57:11.888448Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Seed set to 42\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/aarav/topobench/.venv/lib/python3.11/site-packages/outdated/__init__.py:36: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
+      "  from pkg_resources import parse_version\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Trainer already configured with model summary callbacks: [<class 'lightning.pytorch.callbacks.rich_model_summary.RichModelSummary'>]. Skipping setting a default `ModelSummary` callback.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "GPU available: True (cuda), used: False\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "TPU available: False, using: 0 TPU cores\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "HPU available: False, using: 0 HPUs\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┓\n",
+       "┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">    </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Name                              </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Type                  </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Params </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Mode  </span>┃\n",
+       "┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━┩\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 0  </span>│ feature_encoder                   │ AllCellFeatureEncoder │    533 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 1  </span>│ feature_encoder.encoder_0         │ BaseEncoder           │    533 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 2  </span>│ feature_encoder.encoder_0.BN      │ GraphNorm             │     21 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 3  </span>│ feature_encoder.encoder_0.linear  │ Linear                │    512 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 4  </span>│ feature_encoder.encoder_0.relu    │ ReLU                  │      0 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 5  </span>│ feature_encoder.encoder_0.dropout │ Dropout               │      0 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 6  </span>│ backbone                          │ GNNWrapper            │ 62.5 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 7  </span>│ backbone.backbone                 │ HODGNN                │ 62.4 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 8  </span>│ backbone.backbone.lin_in          │ Linear                │    520 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 9  </span>│ backbone.backbone.base_lin1       │ ModuleList            │    432 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 10 </span>│ backbone.backbone.base_lin1.0     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 11 </span>│ backbone.backbone.base_lin1.1     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 12 </span>│ backbone.backbone.base_lin1.2     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 13 </span>│ backbone.backbone.base_lin1.3     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 14 </span>│ backbone.backbone.base_lin1.4     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 15 </span>│ backbone.backbone.base_lin1.5     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 16 </span>│ backbone.backbone.base_lin2       │ ModuleList            │    432 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 17 </span>│ backbone.backbone.base_lin2.0     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 18 </span>│ backbone.backbone.base_lin2.1     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 19 </span>│ backbone.backbone.base_lin2.2     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 20 </span>│ backbone.backbone.base_lin2.3     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 21 </span>│ backbone.backbone.base_lin2.4     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 22 </span>│ backbone.backbone.base_lin2.5     │ Linear                │     72 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 23 </span>│ backbone.backbone.encoder         │ Sequential            │ 26.7 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 24 </span>│ backbone.backbone.encoder.0       │ Linear                │ 24.6 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 25 </span>│ backbone.backbone.encoder.1       │ ReLU                  │      0 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 26 </span>│ backbone.backbone.encoder.2       │ Linear                │  2.1 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 27 </span>│ backbone.backbone.down_lin1       │ ModuleList            │ 17.6 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 28 </span>│ backbone.backbone.down_lin1.0     │ Linear                │  9.3 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 29 </span>│ backbone.backbone.down_lin1.1     │ Linear                │  4.2 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 30 </span>│ backbone.backbone.down_lin1.2     │ Linear                │  4.2 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 31 </span>│ backbone.backbone.down_lin2       │ ModuleList            │ 12.5 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 32 </span>│ backbone.backbone.down_lin2.0     │ Linear                │  4.2 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 33 </span>│ backbone.backbone.down_lin2.1     │ Linear                │  4.2 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 34 </span>│ backbone.backbone.down_lin2.2     │ Linear                │  4.2 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 35 </span>│ backbone.backbone.lin_out         │ Linear                │  4.2 K │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 36 </span>│ backbone.ln_0                     │ LayerNorm             │    128 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 37 </span>│ readout                           │ NoReadOut             │    130 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 38 </span>│ readout.linear                    │ Linear                │    130 │ train │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> 39 </span>│ val_acc_best                      │ MeanMetric            │      0 │ train │\n",
+       "└────┴───────────────────────────────────┴───────────────────────┴────────┴───────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┓\n",
+       "┃\u001b[1;35m \u001b[0m\u001b[1;35m  \u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mName                             \u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mType                 \u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mParams\u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mMode \u001b[0m\u001b[1;35m \u001b[0m┃\n",
+       "┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━┩\n",
+       "│\u001b[2m \u001b[0m\u001b[2m0 \u001b[0m\u001b[2m \u001b[0m│ feature_encoder                   │ AllCellFeatureEncoder │    533 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m1 \u001b[0m\u001b[2m \u001b[0m│ feature_encoder.encoder_0         │ BaseEncoder           │    533 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m2 \u001b[0m\u001b[2m \u001b[0m│ feature_encoder.encoder_0.BN      │ GraphNorm             │     21 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m3 \u001b[0m\u001b[2m \u001b[0m│ feature_encoder.encoder_0.linear  │ Linear                │    512 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m4 \u001b[0m\u001b[2m \u001b[0m│ feature_encoder.encoder_0.relu    │ ReLU                  │      0 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m5 \u001b[0m\u001b[2m \u001b[0m│ feature_encoder.encoder_0.dropout │ Dropout               │      0 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m6 \u001b[0m\u001b[2m \u001b[0m│ backbone                          │ GNNWrapper            │ 62.5 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m7 \u001b[0m\u001b[2m \u001b[0m│ backbone.backbone                 │ HODGNN                │ 62.4 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m8 \u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.lin_in          │ Linear                │    520 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m9 \u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin1       │ ModuleList            │    432 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m10\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin1.0     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m11\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin1.1     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m12\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin1.2     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m13\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin1.3     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m14\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin1.4     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m15\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin1.5     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m16\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin2       │ ModuleList            │    432 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m17\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin2.0     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m18\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin2.1     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m19\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin2.2     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m20\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin2.3     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m21\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin2.4     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m22\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.base_lin2.5     │ Linear                │     72 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m23\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.encoder         │ Sequential            │ 26.7 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m24\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.encoder.0       │ Linear                │ 24.6 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m25\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.encoder.1       │ ReLU                  │      0 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m26\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.encoder.2       │ Linear                │  2.1 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m27\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin1       │ ModuleList            │ 17.6 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m28\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin1.0     │ Linear                │  9.3 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m29\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin1.1     │ Linear                │  4.2 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m30\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin1.2     │ Linear                │  4.2 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m31\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin2       │ ModuleList            │ 12.5 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m32\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin2.0     │ Linear                │  4.2 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m33\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin2.1     │ Linear                │  4.2 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m34\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.down_lin2.2     │ Linear                │  4.2 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m35\u001b[0m\u001b[2m \u001b[0m│ backbone.backbone.lin_out         │ Linear                │  4.2 K │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m36\u001b[0m\u001b[2m \u001b[0m│ backbone.ln_0                     │ LayerNorm             │    128 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m37\u001b[0m\u001b[2m \u001b[0m│ readout                           │ NoReadOut             │    130 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m38\u001b[0m\u001b[2m \u001b[0m│ readout.linear                    │ Linear                │    130 │ train │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m39\u001b[0m\u001b[2m \u001b[0m│ val_acc_best                      │ MeanMetric            │      0 │ train │\n",
+       "└────┴───────────────────────────────────┴───────────────────────┴────────┴───────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Trainable params</span>: 63.1 K                                                                                           \n",
+       "<span style=\"font-weight: bold\">Non-trainable params</span>: 0                                                                                            \n",
+       "<span style=\"font-weight: bold\">Total params</span>: 63.1 K                                                                                               \n",
+       "<span style=\"font-weight: bold\">Total estimated model params size (MB)</span>: 0                                                                          \n",
+       "<span style=\"font-weight: bold\">Modules in train mode</span>: 40                                                                                          \n",
+       "<span style=\"font-weight: bold\">Modules in eval mode</span>: 0                                                                                            \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mTrainable params\u001b[0m: 63.1 K                                                                                           \n",
+       "\u001b[1mNon-trainable params\u001b[0m: 0                                                                                            \n",
+       "\u001b[1mTotal params\u001b[0m: 63.1 K                                                                                               \n",
+       "\u001b[1mTotal estimated model params size (MB)\u001b[0m: 0                                                                          \n",
+       "\u001b[1mModules in train mode\u001b[0m: 40                                                                                          \n",
+       "\u001b[1mModules in eval mode\u001b[0m: 0                                                                                            \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Metric val/accuracy improved. New best score: 0.681\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "`Trainer.fit` stopped: `max_epochs=10` reached.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "GPU available: True (cuda), used: False\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "TPU available: False, using: 0 TPU cores\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "HPU available: False, using: 0 HPUs\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "535a3c2d60e7484fbd060a428d408320",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validation: |          | 0/? [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\">      Validate metric      </span>┃<span style=\"font-weight: bold\">       DataLoader 0        </span>┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">       val/accuracy        </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.6808510422706604     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">         val/auroc         </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.7937500476837158     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">          val/f1           </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.40506330132484436    </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">         val/loss          </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.5873425602912903     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">       val/precision       </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.3404255211353302     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">        val/recall         </span>│<span style=\"color: #800080; text-decoration-color: #800080\">            0.5            </span>│\n",
+       "└───────────────────────────┴───────────────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1m     Validate metric     \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      DataLoader 0       \u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+       "│\u001b[36m \u001b[0m\u001b[36m      val/accuracy       \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.6808510422706604    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m        val/auroc        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.7937500476837158    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m         val/f1          \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.40506330132484436   \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m        val/loss         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.5873425602912903    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m      val/precision      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.3404255211353302    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m       val/recall        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m           0.5           \u001b[0m\u001b[35m \u001b[0m│\n",
+       "└───────────────────────────┴───────────────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1d9c857c92ff472a89e0c538d8f5fe4d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Testing: |          | 0/? [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\">        Test metric        </span>┃<span style=\"font-weight: bold\">       DataLoader 0        </span>┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">       test/accuracy       </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.6382978558540344     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">        test/auroc         </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.9666666984558105     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">          test/f1          </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.3896103799343109     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">         test/loss         </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.5789005160331726     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">      test/precision       </span>│<span style=\"color: #800080; text-decoration-color: #800080\">    0.3191489279270172     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">        test/recall        </span>│<span style=\"color: #800080; text-decoration-color: #800080\">            0.5            </span>│\n",
+       "└───────────────────────────┴───────────────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1m       Test metric       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      DataLoader 0       \u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+       "│\u001b[36m \u001b[0m\u001b[36m      test/accuracy      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.6382978558540344    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m       test/auroc        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.9666666984558105    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m         test/f1         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.3896103799343109    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m        test/loss        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.5789005160331726    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m     test/precision      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m   0.3191489279270172    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36m       test/recall       \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m           0.5           \u001b[0m\u001b[35m \u001b[0m│\n",
+       "└───────────────────────────┴───────────────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Metrics:\n",
+      "lr-Adam              0.0010\n",
+      "train/accuracy       0.6702\n",
+      "train/auroc          0.8725\n",
+      "train/f1             0.4013\n",
+      "train/precision      0.3351\n",
+      "train/recall         0.5000\n",
+      "val/loss             0.5623\n",
+      "best_epoch           1.0000\n",
+      "best_epoch/val/loss  0.5825\n",
+      "val/accuracy         0.6809\n",
+      "val/auroc            0.8125\n",
+      "val/f1               0.4051\n",
+      "val/precision        0.3404\n",
+      "val/recall           0.5000\n",
+      "train/loss           0.5672\n",
+      "best_epoch/train/accuracy 0.6702\n",
+      "best_epoch/train/auroc 0.7066\n",
+      "best_epoch/train/f1  0.4013\n",
+      "best_epoch/train/precision 0.3351\n",
+      "best_epoch/train/recall 0.5000\n",
+      "best_epoch/train/loss 0.6083\n",
+      "best_epoch/val/accuracy 0.6809\n",
+      "best_epoch/val/auroc 0.7938\n",
+      "best_epoch/val/f1    0.4051\n",
+      "best_epoch/val/precision 0.3404\n",
+      "best_epoch/val/recall 0.5000\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from hydra import compose, initialize_config_dir\n",
+    "from hydra.core.global_hydra import GlobalHydra\n",
+    "\n",
+    "from topobench.run import run\n",
+    "from topobench.utils.config_resolvers import register_all_resolvers\n",
+    "\n",
+    "root = Path.cwd().resolve()\n",
+    "while not (root / 'configs' / 'run.yaml').exists():\n",
+    "    root = root.parent\n",
+    "os.environ['PROJECT_ROOT'] = str(root)\n",
+    "out_dir = root / 'logs' / 'tutorial_hod_gnn'\n",
+    "out_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "register_all_resolvers()\n",
+    "GlobalHydra.instance().clear()\n",
+    "with initialize_config_dir(version_base='1.3', config_dir=str(root / 'configs')):\n",
+    "    cfg = compose(\n",
+    "        config_name='run.yaml',\n",
+    "        overrides=[\n",
+    "            'model=graph/hod_gnn',\n",
+    "            'dataset=graph/MUTAG',\n",
+    "            'logger=csv',\n",
+    "            'trainer.max_epochs=10',\n",
+    "            'trainer.accelerator=cpu',\n",
+    "            'trainer.devices=1',\n",
+    "            '+trainer.enable_progress_bar=False',\n",
+    "            f'paths.output_dir={out_dir.as_posix()}',\n",
+    "            f'paths.work_dir={root.as_posix()}',\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "metric_dict, _ = run(cfg)\n",
+    "print('\\nMetrics:')\n",
+    "for key, value in metric_dict.items():\n",
+    "    print(f'{key:<20s} {float(value):.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8490e0a5",
+   "metadata": {},
+   "source": [
+    "We let a GNN differentiate itself: the exact Jacobian of a small base GIN, propagated analytically and end-to-end differentiably, supplies each node with learnable structural features that *start* at the classical random-walk encoding and go strictly beyond 1-WL. On the challenge's GraphUniverse grid this cuts the triangle-counting error by roughly an order of magnitude versus a strong graph-transformer baseline while improving out-of-distribution community detection — see `2026_tdl_challenge/outputs/` and the accompanying PR for the full 72-run results. To benchmark it yourself, set `MODEL_CONFIG = \"graph/hod_gnn\"` in the challenge evaluation pipeline."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "071eb561435e4e81868e82da79916649": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": "inline-flex",
+       "flex": null,
+       "flex_flow": "row wrap",
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": "100%"
+      }
+     },
+     "11f3fe38eb2d43169995716d4a20f6ee": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "1d9c857c92ff472a89e0c538d8f5fe4d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_e5b11e84b3e6419bb65d6593c0518085",
+        "IPY_MODEL_aba22b85e1b248f6916e5e2955eb6e50",
+        "IPY_MODEL_f628c5f844d1404ab13a3ec235d932cf"
+       ],
+       "layout": "IPY_MODEL_071eb561435e4e81868e82da79916649",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "2131c54a0de846d697951e24ddd8a134": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "3db80ab6d8c142db8c18a40fe79784f9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "3f95efca0f8d4e658eaee952c0e8f8d0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "451cb9eb47484a8ca5f52ad3d1ae7e2d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_65533915763142548ed51cf62cafa6e6",
+       "placeholder": "​",
+       "style": "IPY_MODEL_3f95efca0f8d4e658eaee952c0e8f8d0",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Validation DataLoader 0: 100%"
+      }
+     },
+     "535a3c2d60e7484fbd060a428d408320": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_451cb9eb47484a8ca5f52ad3d1ae7e2d",
+        "IPY_MODEL_8fe2eea914da434eb3d7ce3d3c2dbf30",
+        "IPY_MODEL_ec4313de1e2145249e74989d662bfab3"
+       ],
+       "layout": "IPY_MODEL_6df9164e239e47d693acd64b6ca2ccb0",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "65533915763142548ed51cf62cafa6e6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "6df9164e239e47d693acd64b6ca2ccb0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": "inline-flex",
+       "flex": null,
+       "flex_flow": "row wrap",
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": "100%"
+      }
+     },
+     "79d7700000be40e18f668260afb66b4c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": "2",
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "8b715412348648e6a00884dc1cebc493": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "8fe2eea914da434eb3d7ce3d3c2dbf30": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_933bce6c05994ec5b7158a06c54b602b",
+       "max": 5.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_3db80ab6d8c142db8c18a40fe79784f9",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 5.0
+      }
+     },
+     "933bce6c05994ec5b7158a06c54b602b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": "2",
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "941a04b65ddc4e8183b8bc771fce52f7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "9808a052c8db4e4ca441570ebb618683": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "aba22b85e1b248f6916e5e2955eb6e50": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_79d7700000be40e18f668260afb66b4c",
+       "max": 5.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_11f3fe38eb2d43169995716d4a20f6ee",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 5.0
+      }
+     },
+     "da7f98cdc4aa400ab0114cbaa90412e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "e5b11e84b3e6419bb65d6593c0518085": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_8b715412348648e6a00884dc1cebc493",
+       "placeholder": "​",
+       "style": "IPY_MODEL_9808a052c8db4e4ca441570ebb618683",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Testing DataLoader 0: 100%"
+      }
+     },
+     "ec4313de1e2145249e74989d662bfab3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_941a04b65ddc4e8183b8bc771fce52f7",
+       "placeholder": "​",
+       "style": "IPY_MODEL_da7f98cdc4aa400ab0114cbaa90412e1",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 5/5 [00:00&lt;00:00, 66.46it/s]"
+      }
+     },
+     "f314eaa05d444b46b86e1f3c08d63d22": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "f628c5f844d1404ab13a3ec235d932cf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_f314eaa05d444b46b86e1f3c08d63d22",
+       "placeholder": "​",
+       "style": "IPY_MODEL_2131c54a0de846d697951e24ddd8a134",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 5/5 [00:00&lt;00:00, 64.77it/s]"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## HOD-GNN — first public implementation of "On the Expressive Power of GNN Derivatives" (ICLR 2026)

**Paper:** Eitan, Eliasof, Gelberg, Frasca, Bar-Shalom, Maron — [arXiv:2510.02565](https://arxiv.org/abs/2510.02565) / [OpenReview Tvat33IDmK](https://openreview.net/forum?id=Tvat33IDmK).
To our knowledge **no public implementation exists** (checked the authors' pages, GitHub code search, and the paper's citations as of 2026-07-28); this backbone was written from the paper alone.

### Why this model for this challenge

Message passing is bounded by 1-WL and provably cannot count triangles (Chen et al., NeurIPS 2020). HOD-GNN's motivating example is exactly the triangle-counting task: for a base GNN computing `A³X`, the derivative of node *v*'s output w.r.t. its own input is `(A³)_vv` — six times the triangles at *v*. HOD-GNN turns the derivatives of a base MPNN into learnable, structure-aware node features that restore what 1-WL is blind to, with expressivity between encoding-augmented MPNNs and Subgraph GNNs (paper §4). It is also a direct conceptual extension of our TopoPolynormer submission (#353): Theorem 4.2 of the paper proves the derivative diagonal of a suitably initialised base MPNN **equals the random-walk structural encoding** — so the hand-crafted RWSE we injected there is here *learned end-to-end*, strictly more expressively.

### What is implemented

The paper's own empirical architecture (its Appendix F — used for every reported experiment):

- **1-HOD-GNN with first-order derivatives**: a deep-and-narrow base GIN (width 8, depth 6 here) whose exact input-Jacobian is propagated **analytically** alongside the features (the message-passing derivative algorithm of the paper's §3.2.1 / Appendix D; for first order, Faà di Bruno's formula reduces to the chain rule). The propagation uses the same sparse operator as feature aggregation and is fully differentiable, so the base GIN is trained *through* the derivative computation — the paper's key algorithmic contribution.
- **Factorial residual** (Eq. 73): per-layer features and per-layer *diagonal* Jacobians concatenated with 1/t! scaling (keeping every depth's diagonal matches the RWSE correspondence, which needs all walk lengths).
- **Pointwise encoder** U^node on the diagonal (Eq. 74), then a **downstream GIN**.
- Deliberately omitted, matching the paper's experiments: output-level derivatives D^out, k≥2 mixed derivatives, IGN encoders.
- **Batch-aware by construction**: the Jacobian source axis is indexed locally per graph; a graph's outputs (including all derivative channels) are bit-identical alone vs. inside a batch (tested).

### Documented deviations and an insight for reusers

1. **Default aggregation is the row-normalised (random-walk) operator** from the constructive proof of Theorem 4.2 — a member of the linear-aggregation family the derivative algorithm supports (Eq. 28) — rather than GIN sum. Reason, discovered empirically and reproducible: the challenge harness fixes a single Adam lr=1e-3, while the paper uses a separate base-MPNN lr of 1e-4 with warmup+cosine on small molecular graphs. With sum aggregation, the paper's Appendix-F initialisation produces *walk-count-scale* derivative features (`(A^t)_vv`) that explode on the denser GraphUniverse regimes (initial loss ~2×10⁷, oscillatory training that patience-10 early stopping freezes at a bad checkpoint). The mean operator keeps the derivative diagonals in [0,1] — at initialisation they are **exactly the k-step RW return probabilities** — and trains stably. Both variants are implemented and both were run on the full grid (table below).
2. Derivatives are taken w.r.t. the projected (64→8) input features; the paper's "initial features X" are likewise an embedding of the raw input.

### Tests (100% line coverage of the backbone)

- **Analytic vs autograd**: the hand-propagated per-layer diagonal Jacobians match `torch.autograd.functional.jacobian` exactly (atol 1e-10, float64), for every activation × aggregation combination, inside a batch.
- **Theorem-4.2 equivalence**: under the paper's initialisation, derivative diagonals equal dense-matrix-power RW return probabilities (mean) / closed-walk counts (sum) exactly.
- **Beyond-1-WL fixture**: the derivative features separate C₆ from 2×C₃ (identical 1-WL colourings).
- Batch isolation (batched == individual, diff 0), permutation equivariance, gradient flow through the derivative computation into the base weights, dropout/validation branches.

### Results — full 72-run GraphUniverse grid + OOD evaluation

Generated with `run_challenge_grid()` + `save_challenge_artifacts()` from `2026_tdl_challenge/utils.py` (unmodified). Note: the evaluation notebook's integrity-hash cell currently rejects the *unmodified* upstream notebook (stored hash mismatch), same as noted in #345/#353, so the backend was called directly — identical pipeline. Committed `results.json` is the default config (study `2026-07-27_22-10-00-rw`).

| Config | CD accuracy (in-dist / OOD ↑) | Triangle MSE/total-tri (in-dist / OOD ↓) |
|---|---|---|
| **HOD-GNN default** (mean, RWSE init) | **0.439 / 0.358** | **0.080 / 2.40** |
| HOD-GNN ablation (sum, standard init) | 0.432 / 0.355 | 0.174 / 10.6 |
| Polynormer baseline (#345) | 0.455 / 0.350 | 0.872 / 35.1 |

- **~11× (in-dist) / ~15× (OOD) lower triangle-counting error** than our faithful Polynormer baseline — direct empirical confirmation of the derivative mechanism restoring sub-structure counting.
- **Best OOD community-detection accuracy** among our submissions (0.358) — consistent with the degree-normalised derivative features being invariant across the density/degree grid (~92% of all evaluations are OOD).
- Backbone parameters: 62,353 (Polynormer baseline: 76,160). Worst-case grid setting: 160 ms/iteration, 7.3 GiB peak (batch of 16 × 300-node graphs).

### Files

- `topobench/nn/backbones/graph/hod_gnn.py` — backbone (module docstring contains the full method description, faithfulness notes, and references)
- `configs/model/graph/hod_gnn.yaml` — model config (both tasks)
- `test/nn/backbones/graph/test_hod_gnn.py` — test suite
- `test/pipeline/test_pipeline.py` — pipeline registration
- `2026_tdl_challenge/outputs/2026-07-27_22-10-00-rw/results.json` — grid results (default config)

Team **SweetLesson** · Track 1 (GNNs) · companion submissions: #345 (Polynormer, faithful baseline), #353 (TopoPolynormer, hand-crafted RWSE) — together the three PRs progress from a faithful transformer baseline (#345), to a hand-crafted structural encoding (#353), to this PR, where that encoding is generalised and learned end-to-end.