### PR TITLE
Track: Track1; Team name: Oversmooth operators; Model: r-ℓMPNN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-28_15-11-41/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-28_15-11-41/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-28_15-11-41",
+    "model_config": "graph/loopy",
+    "generated_at_utc": "2026-07-29T10:35:09.854166+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.217348337173462,
+      "test_best_rerun_accuracy": 0.32072731852531433,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.310260534286499,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2574681043624878,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3172511160373688,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33749714493751526,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34101152420043945,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25590190291404724,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36045533418655396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4129803776741028,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.424936980009079,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37989914417266846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4038887619972229,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7928619028916999,
+        "AvgTime/train_epoch_std": 0.09361168579185303,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2195334434509277,
+      "test_best_rerun_accuracy": 0.32279011607170105,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3100695312023163,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25632211565971375,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3213385343551636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33665674924850464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34131714701652527,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2619374990463257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36714035272598267,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4163801670074463,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4237145781517029,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3806631565093994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4158835709095001,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7814945204783295,
+        "AvgTime/train_epoch_std": 0.0829619220787986,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.211289644241333,
+      "test_best_rerun_accuracy": 0.31656351685523987,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30540913343429565,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2660249173641205,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31885552406311035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3378409445285797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33650392293930054,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26594850420951843,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3721063435077667,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40285736322402954,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.42107877135276794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3779127597808838,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4218045771121979,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8237821861189238,
+        "AvgTime/train_epoch_std": 0.09504394069567679,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.354747772216797,
+      "test_best_rerun_accuracy": 0.2924211025238037,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25578731298446655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11643365025520325,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19436167180538177,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25643670558929443,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.297998309135437,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13587746024131775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22003208100795746,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3077775239944458,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3434945344924927,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22411948442459106,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20425547659397125,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6531338923507266,
+        "AvgTime/train_epoch_std": 0.09463093363378969,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.334430456161499,
+      "test_best_rerun_accuracy": 0.29314690828323364,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2556726932525635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12258385121822357,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21013829112052917,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25998929142951965,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2992207109928131,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1400030553340912,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23431889712810516,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31507372856140137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3545343279838562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2346244901418686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2204904854297638,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6928744554519652,
+        "AvgTime/train_epoch_std": 0.09509097988882816,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3433666229248047,
+      "test_best_rerun_accuracy": 0.2932233214378357,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2518908977508545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11131484806537628,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18981587886810303,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2646878957748413,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3060203194618225,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13305065035820007,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22354649007320404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3195813298225403,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35762855410575867,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24199709296226501,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2277102917432785,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.642066489905119,
+        "AvgTime/train_epoch_std": 0.07371829370933891,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.091182231903076,
+      "test_best_rerun_accuracy": 0.35583314299583435,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3062495291233063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28905951976776123,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3413553237915039,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3317289352416992,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3107571303844452,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3656505346298218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38872334361076355,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39319276809692383,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3800901472568512,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4711589813232422,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5002291798591614,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 11.937276924357695,
+        "AvgTime/train_epoch_std": 5.311417562411801,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.0982909202575684,
+      "test_best_rerun_accuracy": 0.3579723536968231,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31274351477622986,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2934907078742981,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3461303412914276,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3365803360939026,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3169073164463043,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36523035168647766,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3946061432361603,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39999234676361084,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3919321596622467,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4698219895362854,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5111544132232666,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 12.96921746354354,
+        "AvgTime/train_epoch_std": 5.739531964115577,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.094237804412842,
+      "test_best_rerun_accuracy": 0.35843074321746826,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30961111187934875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29261210560798645,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3482695519924164,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3356253206729889,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3144243359565735,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3621743321418762,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39647796750068665,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4030865728855133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39009854197502136,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4626021981239319,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5069906115531921,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 13.31454087920108,
+        "AvgTime/train_epoch_std": 6.041529107513015,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.208852767944336,
+      "test_best_rerun_accuracy": 0.3322255313396454,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2907785177230835,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2898235023021698,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23065169155597687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29345253109931946,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3085797131061554,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2252654880285263,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3587745428085327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3606463372707367,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3867751657962799,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32634273171424866,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3939949572086334,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.717066330068252,
+        "AvgTime/train_epoch_std": 0.9325013690304513,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.173198938369751,
+      "test_best_rerun_accuracy": 0.33188173174858093,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29478952288627625,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2826419174671173,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24451829493045807,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3020857274532318,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30514171719551086,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24459469318389893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3825349509716034,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.383337140083313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3983115553855896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3755061626434326,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44457176327705383,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.3649201721980653,
+        "AvgTime/train_epoch_std": 0.9332293490636983,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1948156356811523,
+      "test_best_rerun_accuracy": 0.3282909393310547,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29001450538635254,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28512492775917053,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22698448598384857,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28974711894989014,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3036901354789734,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23080448806285858,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3610283434391022,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3534647524356842,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38983115553855896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3463595509529114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4171059727668762,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8855345888835626,
+        "AvgTime/train_epoch_std": 0.955357029501688,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.8910653591156006,
+      "test_best_rerun_accuracy": 0.42214837670326233,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3022003173828125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28256550431251526,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2834441065788269,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29192450642585754,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39537015557289124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3942623436450958,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4427763819694519,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5602796077728271,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5373595952987671,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.593017041683197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5797998309135437,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.0684487113246215,
+        "AvgTime/train_epoch_std": 2.2217251131488207,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9011627435684204,
+      "test_best_rerun_accuracy": 0.4205057621002197,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29994651675224304,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28172510862350464,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27523112297058105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29177170991897583,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3962487578392029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3938039541244507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4467109739780426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5509970188140869,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5356405973434448,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5847276449203491,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5826648473739624,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.326570904917187,
+        "AvgTime/train_epoch_std": 2.2693072586250724,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9030323028564453,
+      "test_best_rerun_accuracy": 0.42134615778923035,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2978073060512543,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2775613069534302,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27141112089157104,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2891359031200409,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39242875576019287,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4007945656776428,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44816258549690247,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5550462007522583,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5372450351715088,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6048972606658936,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5935518145561218,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 12.954958703066852,
+        "AvgTime/train_epoch_std": 0.7189814410617406,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9759337902069092,
+      "test_best_rerun_accuracy": 0.39307814836502075,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27901291847229004,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2761097252368927,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20394988358020782,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2681259214878082,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3830697536468506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28245091438293457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43357017636299133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5137519836425781,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5422874093055725,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48590418696403503,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5328902006149292,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5666638229574477,
+        "AvgTime/train_epoch_std": 0.2555570234071369,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9892644882202148,
+      "test_best_rerun_accuracy": 0.38952556252479553,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2750019133090973,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2717549204826355,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1846206784248352,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24894949793815613,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3754679560661316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2538008987903595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4140881597995758,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5092443823814392,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5424402356147766,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4614179730415344,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5085185766220093,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9048742522364077,
+        "AvgTime/train_epoch_std": 0.22573597611748525,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 1.9859867095947266,
+      "test_best_rerun_accuracy": 0.38971656560897827,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2730919122695923,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2718695104122162,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19187867641448975,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25647491216659546,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3793261647224426,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28268012404441833,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41550156474113464,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5162349939346313,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5431278347969055,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.48594239354133606,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5182977914810181,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7899816477740254,
+        "AvgTime/train_epoch_std": 0.06507954635770409,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8479152917861938,
+      "test_best_rerun_accuracy": 0.44281458854675293,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27561309933662415,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2608678936958313,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3002903163433075,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2809993028640747,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37107494473457336,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32607534527778625,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42176637053489685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.459202378988266,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4205057621002197,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5721980333328247,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5850714445114136,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 46.74814103389608,
+        "AvgTime/train_epoch_std": 13.94032160327769,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8342889547348022,
+      "test_best_rerun_accuracy": 0.45056918263435364,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2709144949913025,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25551989674568176,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3004049062728882,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28054091334342957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3835281431674957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33627474308013916,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4424707889556885,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48785239458084106,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44579416513442993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5971044301986694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6184582710266113,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 40.2662533192799,
+        "AvgTime/train_epoch_std": 11.523623148685008,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8778564929962158,
+      "test_best_rerun_accuracy": 0.44010236859321594,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2759568989276886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26273971796035767,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29708153009414673,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2821834981441498,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3845977485179901,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3378027379512787,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4381541609764099,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4797540009021759,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.44407516717910767,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5850332379341125,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6034456491470337,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 38.27625814951383,
+        "AvgTime/train_epoch_std": 10.35247228872684,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.6593458652496338,
+      "test_best_rerun_accuracy": 0.49992358684539795,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2755367159843445,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2614409029483795,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26281610131263733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28172510862350464,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3923141658306122,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37500953674316406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38723355531692505,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5224233865737915,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5205516219139099,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5902666449546814,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.658491849899292,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.180258972602978,
+        "AvgTime/train_epoch_std": 1.7060550145381754,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7052723169326782,
+      "test_best_rerun_accuracy": 0.48441439867019653,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2689281105995178,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25609290599823,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27102911472320557,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2859271168708801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3817327618598938,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35354113578796387,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38291695713996887,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4971731901168823,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4940407872200012,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5796852111816406,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6399648785591125,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.117986261844635,
+        "AvgTime/train_epoch_std": 1.65023575024054,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.6834428310394287,
+      "test_best_rerun_accuracy": 0.4910230040550232,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27370309829711914,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2558254897594452,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27507829666137695,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2829093039035797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38708075881004333,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36114293336868286,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40094736218452454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5058827996253967,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5005729794502258,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5909542441368103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.656314492225647,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.565750515460968,
+        "AvgTime/train_epoch_std": 1.9271517080676983,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3933252096176147,
+      "test_best_rerun_accuracy": 0.5837726593017578,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2701123058795929,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25196731090545654,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2617083191871643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2592253088951111,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40969517827033997,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3799373507499695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38872334361076355,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44961416721343994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5640614032745361,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6215906739234924,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6511956453323364,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.573725208640099,
+        "AvgTime/train_epoch_std": 3.4389935388082042,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.380583643913269,
+      "test_best_rerun_accuracy": 0.5834288597106934,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2689281105995178,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25047749280929565,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2470013052225113,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2538391053676605,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41183435916900635,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3859347403049469,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37730154395103455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45182979106903076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5675758123397827,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6237680315971375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6493620872497559,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.55848575592041,
+        "AvgTime/train_epoch_std": 3.3758054319499116,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3940296173095703,
+      "test_best_rerun_accuracy": 0.578539252281189,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26273971796035767,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24803270399570465,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26866069436073303,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2581939101219177,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4137825667858124,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38287875056266785,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39854076504707336,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4514477849006653,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5608526468276978,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6378256678581238,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6612804532051086,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 7.5731190222280995,
+        "AvgTime/train_epoch_std": 3.4466084944350888,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.4002397060394287,
+      "test_best_rerun_accuracy": 0.5782336592674255,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2614409029483795,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24929329752922058,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2388646900653839,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2569333016872406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39391854405403137,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.391817569732666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32867294549942017,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4556879699230194,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5708610415458679,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5751776099205017,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6475666761398315,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9418287682083417,
+        "AvgTime/train_epoch_std": 0.05576543384024496,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.392986536026001,
+      "test_best_rerun_accuracy": 0.5803728103637695,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2617083191871643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24535870552062988,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2331346869468689,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25360989570617676,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3912063539028168,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3864695429801941,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31438612937927246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4490029811859131,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5678050518035889,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5551226139068604,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6374436616897583,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.961867176402699,
+        "AvgTime/train_epoch_std": 0.05505193184127734,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.394295334815979,
+      "test_best_rerun_accuracy": 0.5767438411712646,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2600657045841217,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2484910935163498,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2247306853532791,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24505309760570526,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3831079602241516,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38559094071388245,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3138895332813263,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44678738713264465,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.560967206954956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5601650476455688,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6293070316314697,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.9816553214239696,
+        "AvgTime/train_epoch_std": 0.07646203623098795,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1091458797454834,
+      "test_best_rerun_accuracy": 0.6639544367790222,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25620749592781067,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24195890128612518,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25521430373191833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24826189875602722,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4029337465763092,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35934755206108093,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43796318769454956,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45939338207244873,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5598212480545044,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5311329960823059,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6996333003044128,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 48.51294758972848,
+        "AvgTime/train_epoch_std": 9.882743481636009,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1450673341751099,
+      "test_best_rerun_accuracy": 0.653907835483551,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2478417009115219,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23225609958171844,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2487584948539734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23798608779907227,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39078617095947266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3441057503223419,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42772558331489563,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4487355649471283,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5407975912094116,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5126060247421265,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6871801018714905,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 45.352495641367774,
+        "AvgTime/train_epoch_std": 8.804396222592153,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1362031698226929,
+      "test_best_rerun_accuracy": 0.6596760749816895,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25452670454978943,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23508289456367493,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2520436942577362,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23878829181194305,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3939567506313324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34769654273986816,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4313545823097229,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45098936557769775,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5461838245391846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5164260268211365,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6904270648956299,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 43.885943576693535,
+        "AvgTime/train_epoch_std": 8.765526657316967,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9357903599739075,
+      "test_best_rerun_accuracy": 0.7148751020431519,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2623577117919922,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2535335123538971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25865229964256287,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2482236921787262,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3970891535282135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3755061626434326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4091603755950928,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47325998544692993,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5610818266868591,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5481320023536682,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6537550687789917,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 20.32553239126463,
+        "AvgTime/train_epoch_std": 5.3968337794358385,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9597050547599792,
+      "test_best_rerun_accuracy": 0.7055543065071106,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26422950625419617,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2512415051460266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2640002965927124,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24929329752922058,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3954465687274933,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36901214718818665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42432576417922974,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4718465805053711,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5517992377281189,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5395752191543579,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6512720584869385,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 20.16637349683185,
+        "AvgTime/train_epoch_std": 5.971998240283306,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9454864263534546,
+      "test_best_rerun_accuracy": 0.7062801122665405,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.26273971796035767,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24807089567184448,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.275154709815979,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2500191032886505,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3971273601055145,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3665291368961334,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4339139759540558,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4694017767906189,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5460309982299805,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5323554277420044,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6463442444801331,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 20.197375655174255,
+        "AvgTime/train_epoch_std": 5.552008049788003,
+        "model/params/total": 90893,
+        "model/params/trainable": 90893,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 6.988730430603027,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7.104135513305664,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.005118253251661141,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.6430089473724365,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.019173731301960192
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4582.43896484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3475494095444634
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.482297420501709,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0018477578094040139
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5169.45263671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6906416348321643
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.463369369506836,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0237162084365344
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147442.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4238107090609327
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8412.9345703125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5898846284050273
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36838.59765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8882873369342354
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2039.60205078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3625959201388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 687784.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.780102909403527
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205100.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4130545571031567
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1751232147216797,
+        "AvgTime/train_epoch_std": 0.0684837399208715,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 3.562770366668701,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.3960840702056885,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.002446746448274992,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.8627616167068481,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00980400850898341
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3776.8046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2864470752749336
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.0386996269226074,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0006871249163878016
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5298.8115234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7079240512274549
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.932209014892578,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.014621942154484091
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153284.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5594525734952627
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7792.34521484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5463711411333438
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37919.171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.943675835511815
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1971.0528564453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3504093967013889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 698051.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.896245743922718
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200825.09375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.341904943171418
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2080479218409612,
+        "AvgTime/train_epoch_std": 0.08048851401849917,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 3.9526679515838623,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.917156457901001,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0028221588313407787,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.349188804626465,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.012364151603297183
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3092.641357421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.23455755460158323
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.9093997478485107,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0013176271479098452
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4517.17041015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6034963807823981
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.964560508728027,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.013786321682839402
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139656.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.243008951792681
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7272.61083984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5099292413296698
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35628.6171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8262656818647804
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1878.747314453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.33399952256944443
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 676856.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.656485074035949
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 197961.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.294259782753399
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.223036728043487,
+        "AvgTime/train_epoch_std": 0.0824239334500014,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.3691171407699585,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.2730733156204224,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.006700385871686434,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107.35331726074219,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07734388851638486
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10973.4775390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8322698171454305
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130.6167449951172,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.044023169866908386
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7468.779296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9978329053941216
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.11007690429688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10372200078091268
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171489.875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9822096182426154
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14083.2099609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9874638873185738
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45969.26171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.356310508931775
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3493.8076171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6211213541666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 752710.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.514538533760167
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257262.1875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.281067470420847
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0853987771111566,
+        "AvgTime/train_epoch_std": 0.08907103310259286,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.1049165725708008,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.095245599746704,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.005764450524982653,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149.63348388671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10780510366478296
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12429.5380859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9427029265026545
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 215.45689392089844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07261776000030282
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7675.5498046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.025457555736473
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132.35275268554688,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1142942596593669
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 174769.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.058377139257849
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14714.525390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.031729448227808
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46404.0625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.378597698498129
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3590.0576171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6382324652777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755515.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.54626469124351
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259068.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.31112218769241
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.0997733789331772,
+        "AvgTime/train_epoch_std": 0.07601965200015247,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.0615342855453491,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.0841174125671387,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.005705881118774414,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129.9648895263672,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09363464663282939
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11352.7626953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8610362302095184
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180.10354614257812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.06070224002109138
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7690.98681640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.02751994875167
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132.64093017578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11454311759566602
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173386.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.02625380248003
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14562.9599609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0211022269623826
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46268.09375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.371628158798503
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3530.75244140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6276893229166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 755784.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.549307574403583
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259669.40625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.321125692676351
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.108360948562622,
+        "AvgTime/train_epoch_std": 0.08900135301117212,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 227.1359405517578,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 226.9077911376953,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.017209540473090278,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.202491760253906,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03616894219038466
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83.2292709350586,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.43804879439504524
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.78718566894531,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.013746944950773613
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2219.261474609375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.29649451898588847
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60.602012634277344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05233334424376282
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83749.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.9447776855378043
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3386.0517578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.23741773648944747
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22610.66015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1589861169844686
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 784.4486694335938,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1394575412326389
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 546209.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.1786357646233725
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132430.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.203755273076731
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.234224028057522,
+        "AvgTime/train_epoch_std": 0.02526367290405807,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 261.31134033203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 251.36398315429688,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.019064390076169654,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.905517578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.11736708759230907
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 244.30908203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2858372738486843
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72.18171691894531,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02432818231174429
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2137.453857421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2855649776114729
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182.79066467285156,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.1578503149161067
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77926.921875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8095606974503065
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3253.29296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.22810916903309494
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21355.86328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0946672449254191
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 768.5011596679688,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13662242838541666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 525729.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.946960934583668
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127781.734375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1263996534538134
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.263343529267744,
+        "AvgTime/train_epoch_std": 0.01776845281937994,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 210.68978881835938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 213.10231018066406,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.016162480863152376,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.78974533081055,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03659203554092979
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 72.52252960205078,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3816975242213199
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.24239158630371,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0064854707065398415
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2240.7177734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2993610919756179
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.8818359375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.050847872139464595
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80700.4453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.8739653843697752
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3247.9853515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.22773701805935354
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21980.404296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1266802140999026
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 780.8963623046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13882601996527777
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 532810.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.0270685101184345
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 126752.5859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.1092737246850715
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 4.275947690010071,
+        "AvgTime/train_epoch_std": 0.019874387001555107,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.978485584259033,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.817856550216675,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0009497325750646022,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.177885055541992,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.004450925832523049
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.872107028961182,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.030905826468216744
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3404.1865234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2581863119785741
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4794.94091796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6406066690673012
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.28940963745117,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03220156272664177
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 135608.03125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1489882790730075
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7388.7158203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5180701037941733
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36473.07421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8695511927187451
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2024.9552001953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.35999203559027776
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 677507.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.6638540264470665
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201166.4375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3475852012713627
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.318919243812561,
+        "AvgTime/train_epoch_std": 0.08279016571356514,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 3.15012526512146,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.1434426307678223,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0010594683622405872,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.071830749511719,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.010858667686968098
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.988350868225098,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.031517636148553144
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4698.22900390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3563313616917899
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5404.740234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7220761836172345
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.61091232299805,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04284189319775306
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144324.46875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.351394871586476
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8264.634765625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5794863809861871
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38554.89453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9762619576221232
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2260.470703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4018614583333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 693062.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.839811007544993
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 209878.671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.492564389779176
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.360842329263687,
+        "AvgTime/train_epoch_std": 0.10509698138627739,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.5270895957946777,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.6440351009368896,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0008911476578823355,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.249407768249512,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.01026614392525181
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.695605278015137,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0562926593579744
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3744.90869140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.284027962943212
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5116.3017578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.683540649006346
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.0560417175293,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03977205675088886
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137247.578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.187060610370611
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7740.53564453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5427384409291298
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36730.94140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8827690505023322
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2075.04443359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.36889678819444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 675979.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.646567424182437
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 200370.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3343398461551264
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.3229980585051746,
+        "AvgTime/train_epoch_std": 0.08586528434269718,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 913.6141357421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 968.2998657226562,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.12936537952206495,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.531349182128906,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.03424448788337817
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.057254791259766,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2581960778487356
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5540.6025390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4202201394814183
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.8349838256836,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.029266930847887965
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.34651184082031,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0391593366501039
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40831.6015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9481609131176854
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1441.3211669921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.10106024169065962
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14620.4384765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7494201894798554
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230.38348388671875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.04095706380208333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 439906.28125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.976146525004808
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87475.9765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4556766439102724
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.862218585507623,
+        "AvgTime/train_epoch_std": 0.08676234674590579,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1303.432373046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1384.7613525390625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.18500485671864564,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83.91523742675781,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.060457663852130986
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105.31732940673828,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5543017337196752
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7521.0498046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5704247102531286
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.1404037475586,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.025325380433959755
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.41754150390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07462654706727656
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48576.73828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1280126853346182
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2021.865234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.14176589779659235
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18244.15625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9351661412681327
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 496.5647888183594,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.08827818467881944
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 483042.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.4640927061298825
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108740.2109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8095320742432563
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8329280813535054,
+        "AvgTime/train_epoch_std": 0.061604429186564766,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1092.6331787109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1161.8941650390625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.1552296813679442,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32.53087615966797,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02343723066258499
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.404415130615234,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.21265481647692228
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2963.138427734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22473556524341107
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80.09439086914062,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.026995076127111772
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.47732162475586,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.033227393458338396
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42705.74609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.9916808957307728
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1644.683837890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.11531929868816611
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15806.287109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8102048854054539
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 339.32269287109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.060324034288194446
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 452579.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.119501035032748
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97135.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6164146094387033
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8774409691492717,
+        "AvgTime/train_epoch_std": 0.04509680946647582,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 31.740549087524414,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 32.94670104980469,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.02845138259914049,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.81585693359375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04957914764668138
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.506036758422852,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.039505456623278166
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4371.697265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3315659662969283
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62.75005340576172,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.021149327066316722
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3801.064697265625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5078242748517869
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102506.3515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.380325830450028
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5315.90185546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3727318647783446
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32010.560546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6408099106502128
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1752.8546142578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.31161859809027775
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 633845.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.169956760517177
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181345.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0177493114838665
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.2095745710226207,
+        "AvgTime/train_epoch_std": 0.09663886956262605,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 20.609155654907227,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20.9927921295166,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.018128490612708638,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.343446731567383,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.01465666191035114
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.842657089233398,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.030750826785438938
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3365.450927734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.25524845868292567
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.572660446166992,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.010641274164532184
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5506.44677734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7356642321100535
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152242.609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5352640111229796
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8229.388671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5770150520175992
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37074.00390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9003538831436773
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1960.96337890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.34861571180555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 693051.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.839681628451523
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 198992.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3114100227979963
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.1499418827795214,
+        "AvgTime/train_epoch_std": 0.06814691571014604,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 22.324901580810547,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 23.104507446289062,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.01995207896916154,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.39346981048584,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.008208551736661268
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.48477029800415,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03413036998949553
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1911.672119140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14498840494051005
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.885597229003906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008724501930907956
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4407.49755859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5888440292042418
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130192.3203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.023228690147223
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6876.10302734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.48212754363649907
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32602.18359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6711355576272489
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1582.5562744140625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.28134333767361114
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 651962.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.374890416614821
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179982.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.995067281130914
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.146078120107236,
+        "AvgTime/train_epoch_std": 0.07809749616523733,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 20247.12109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12817.9150390625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.2976480363891533,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2847.689697265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.0516496377994415
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3090.297607421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 16.264724249588816
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3757.988037109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2850199497238813
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2448.61962890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.825284674387007
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2207.3359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2949012608550434
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2902.708984375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.506657154037133
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1538.3223876953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.10786161742359504
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5121.77587890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.26253400373705726
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2270.2919921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4036074652777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 231558.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.619353627704942
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32573.9296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.5420586372372822
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 16.276850318908693,
+        "AvgTime/train_epoch_std": 5.549389069134211,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 7582.11865234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5454.80615234375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.1266674287651809,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1160.0931396484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.8358019738101135
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1264.7244873046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.656444670024671
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1621.395263671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.12297271624360068
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 886.832275390625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2988986435425093
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1032.7957763671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.13798206765092685
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1163.8377685546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.0050412509107838
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 841.4653930664062,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.05900051837515119
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1859.9322509765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.09533713931911234
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 902.6427001953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.16046981336805555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 189727.515625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.1461660308473696
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16896.017578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2811644880123309
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 16.301369786262512,
+        "AvgTime/train_epoch_std": 5.215641956579615,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 22189.41015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 13985.6865234375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.32476515241123677,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2262.313720703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.6299090206794848
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2664.170166015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.0219482421875
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 826.3495483398438,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0626734583496279
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1764.4166259765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.5946803592775741
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1625.8187255859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21721025057928356
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2422.352783203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.091841781695272
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 869.5165405273438,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.06096736366059064
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4559.80517578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.23372828826599262
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1674.617919921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.29770985243055553
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210610.265625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.3823882178772213
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28938.380859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4815599297651141
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 16.154973476163804,
+        "AvgTime/train_epoch_std": 6.362396468796133,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1627.1536865234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1702.6378173828125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.119382822702483,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 454.5842590332031,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3275102730786766
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 447.4007263183594,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.3547406648334706
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16890.55078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.2810429109783845
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212.48202514648438,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07161510790242143
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1607.14111328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21471491159402137
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 364.5633544921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3148215496478303
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44307.25,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.028869821660784
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17380.107421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8908763863793634
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 595.7940063476562,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10591893446180556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 457857.65625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.179209486669005
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106441.0078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.7712713263192053
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8515260219573975,
+        "AvgTime/train_epoch_std": 0.03838862087541736,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1745.908203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1844.54296875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.12933270009465714,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89.0087661743164,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06412735315152479
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.39376068115234,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4810197930586965
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3022.59130859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22924469538064088
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.34618377685547,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.023035451222398202
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1941.137451171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2593370008245658
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.5245361328125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.065219806677731
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73018.4296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.695579362983002
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17698.75,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9072094930544877
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254.60354614257812,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.04526285264756944
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 502503.9375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.684240778027895
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107062.2109375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.7816086888239895
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 3.8253283609043467,
+        "AvgTime/train_epoch_std": 1.673612308011045,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1552.1356201171875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1640.20556640625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.11500529844385429,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 263.4385681152344,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.18979723927610545
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.30242919921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.5331706799958882
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5934.630859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.45010472956958664
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 172.82083129882812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.05824766811554706
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1633.34716796875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.21821605450484302
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243.9993438720703,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.21070755083943896
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52259.76171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2135371010298626
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15339.6298828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7862847856277871
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 376.4209899902344,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.066919287109375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 445730.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.0420255817110275
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93646.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5583551224768275
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8440836668014526,
+        "AvgTime/train_epoch_std": 0.03407482906135092,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 5453.99658203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5744.51708984375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.2944547178145343,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 470.0746765136719,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3386705162202247
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 573.4939575195312,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.0183892501027962
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1659.8475341796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.1258890810906096
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434.5840148925781,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14647253619567852
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 498.9566650390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.06666087709272712
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 513.4473876953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.44339152650717834
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21012.357421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.48793324869670723
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 942.455322265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0660815679614097
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 424.6211242675781,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.07548819986979166
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 259430.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.9346310362770494
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42363.98046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7049736320162082
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 5.470672845840454,
+        "AvgTime/train_epoch_std": 1.1781102960604581,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 4955.41796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5262.59521484375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.2697521766796735,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 922.217529296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.6644218510784402
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1114.5460205078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.866031686883224
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3024.41552734375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22938305099307926
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 813.0733032226562,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.27403886188832366
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 639.8042602539062,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0854781910826862
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 967.2515869140625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.8352777089067898
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16194.1904296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.37604937835982494
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 803.9661865234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.056371209264018896
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 693.5872802734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.12330440538194444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 239250.796875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.7063651332533962
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38396.5546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.6389522022115721
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.243515555451556,
+        "AvgTime/train_epoch_std": 2.4971481715319834,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 3111.5791015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3308.9443359375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.16961117104605566,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 277.16082763671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.19968359339821234
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 306.3345031738281,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.6122868588096217
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1278.708740234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.09698208117060106
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.7545471191406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10069246616755667
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279.38330078125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.037325758287408146
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 276.8744812011719,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.23909713402519162
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10396.3583984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.24141645918719812
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 543.4137573242188,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.038102212685753666
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 298.55633544921875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.05307668185763889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202242.984375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.28773892712917
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25434.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.42325359234852644
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 6.204936975524539,
+        "AvgTime/train_epoch_std": 2.4176112892497588,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 325.08001708984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 344.7570495605469,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.06129014214409722,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101.6806411743164,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07325694609100605
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.84524154663086,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.2518170607717414
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3459.900146484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.26241184273677476
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75.000732421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.025278305501137514
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2746.91552734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.36698938241065465
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.35768508911133,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03657831182133966
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 101136.4296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.348514529247167
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2673.0263671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.18742296782972234
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20718.669921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.062005736935517
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 563556.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.374853653156567
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121812.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.0270697606210373
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.525458812713623,
+        "AvgTime/train_epoch_std": 0.09933911798303423,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 340.251708984375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 353.9718322753906,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.06292832573784722,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.68832778930664,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.035078045957713716
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.690223693847656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.19836959838867188
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3311.3759765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2511472109641638
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53.43596649169922,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.018010099929794143
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2018.79931640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2697126675225451
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.868385314941406,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.03874644673138291
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75732.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.758605650891696
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1990.3402099609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.13955547678873492
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18034.78515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9244341153442001
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 513801.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.812033386876011
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107755.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.7931513445825638
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5281574144596006,
+        "AvgTime/train_epoch_std": 0.05729848665196002,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 215.79373168945312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 226.0823211669922,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.040192412651909724,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 113.77631378173828,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08197140762373074
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.290931701660156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.22258385106136924
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5305.44140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4023846345278726
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50.11216735839844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.016889844070912853
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3292.8857421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4399312948814295
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.959083557128906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04141544348629439
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91000.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.113137568502694
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2255.074951171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.15811772200055216
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20321.69921875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0416576564021733
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 542752.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.139522272999785
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109297.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8188100111493852
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5473639705906743,
+        "AvgTime/train_epoch_std": 0.07857192755995918,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 65670.9765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 30392.583984375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.34379584385569495,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11960.0478515625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.616749172595462
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12320.7333984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 64.84596525493421
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16608.166015625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.259625788064088
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12086.1162109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.073514058286991
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9850.5,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.3160320641282566
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11850.8720703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 10.233913704933075
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7822.716796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.18165327876822868
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8361.1669921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.586254872541544
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8562.2421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.43888677981957047
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10137.9580078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.8023036458333332
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6790.33154296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.11299704696002447
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 41.67217695713043,
+        "AvgTime/train_epoch_std": 7.388498239179855,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 129148.0234375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 66051.1484375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.7471595809814147,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22239.078125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 16.02239057997118
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22000.40625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 115.79161184210527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28361.51953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.1510443330489193
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24255.568359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.175115726112235
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18856.19140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.519197248663995
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21769.998046875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 18.79965289022021
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12045.79296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.2797183951502415
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20632.46875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.4466742918244286
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15145.4267578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7763302454155774
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20589.41796875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.6603409722222224
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14172.818359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.23584807480696587
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 44.39575782872863,
+        "AvgTime/train_epoch_std": 8.222410621359623,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 104169.0859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 52196.7578125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.5904410236360756,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21953.169921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 15.816404842849424
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23217.935546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 122.19966077302631
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14661.330078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.1119704268581723
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20617.41015625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.948908040529154
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17670.150390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.3607415351536405
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22377.669921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 19.324412713190846
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7615.20263671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.1768345401430139
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13962.92578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.979029994478334
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12908.5078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6616693737505767
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18996.373046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.377132986111111
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9380.5576171875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.15610067091320953
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 57.67902208841764,
+        "AvgTime/train_epoch_std": 15.313545170027155,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 8050.40771484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 7554.0849609375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.1257065708308372,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5481.94189453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.9495258606132926
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6172.62890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 32.48752055921052
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3632.049072265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2754682648665624
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4505.08740234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5183981807697169
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4462.75732421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5962267634226787
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5596.30517578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.832733312419041
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5879.927734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.13653928419039105
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2447.665283203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.17162146145022614
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4131.09228515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.21175315419325696
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4059.580078125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.721703125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106162.265625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.2008898524371345
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 32.9314705715623,
+        "AvgTime/train_epoch_std": 11.460842832516931,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 20871.935546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 22028.99609375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.36658173320935883,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11343.45703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 8.172519474963977
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12366.29296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 65.08575246710527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6858.146484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5201476286973834
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10089.619140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.4006131245786992
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9348.7529296875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.2489983873997996
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11600.1103515625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 10.017366452126511
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15546.712890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3610141392026983
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5536.83447265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.38822286303858156
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10086.5302734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5170193384303399
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9154.9814453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.6275522569444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185983.78125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.1038175316448537
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 27.490000228881836,
+        "AvgTime/train_epoch_std": 10.088888931279596,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "loopy_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 9591.830078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10157.7080078125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.16903313210877308,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5778.66845703125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.163305804777558
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6540.58642578125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 34.42413908305921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4591.2685546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.34821907885381115
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4748.3544921875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.6003891109496124
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5054.77685546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6753208891741816
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5946.4189453125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.135076809423575
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11495.119140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.26693105936803363
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2658.32666015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.18639227739140724
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5071.916015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.25997826724204215
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4437.10107421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.78881796875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 133889.921875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.5145404779815164
+        }
+      },
+      "output_dir": "/home/yeli/Desktop/topobench-main/logs/train/runs/notebook_gu_grid_2026-07-28_15-11-41__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 27.15464738897375,
+        "AvgTime/train_epoch_std": 10.381379838707787,
+        "model/params/total": 89658,
+        "model/params/trainable": 89658,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/configs/model/graph/loopy.yaml
+++ b/configs/model/graph/loopy.yaml
@@ -1,0 +1,41 @@
+_target_: topobench.model.TBModel
+
+model_name: loopy
+model_domain: graph
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.graph.Loopy
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  num_layers: 2
+  dropout: 0.0
+  r: 2 # Maximal neighbourhood order; must match the r_neighbourhood transform
+  nonlinearity: relu
+  norm: BatchNorm1d
+  shared: false # If true, one convolution is shared across the orders
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.LoopyWrapper
+  _partial_: true
+  wrapper_name: LoopyWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: NoReadOut #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/transforms/data_manipulations/r_neighbourhood.yaml
+++ b/configs/transforms/data_manipulations/r_neighbourhood.yaml
@@ -1,0 +1,3 @@
+transform_name: "RNeighbourhood"
+transform_type: "data manipulation"
+r: 2 # Maximal neighbourhood order; must match model.backbone.r

--- a/configs/transforms/model_defaults/loopy.yaml
+++ b/configs/transforms/model_defaults/loopy.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - data_manipulations@RNeighbourhood: r_neighbourhood

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -308,13 +308,22 @@ def random_graph_input():
     """
     num_nodes = 8
     d_feat = 12
-    x = torch.randn(num_nodes, 12)
-    edges_1 = torch.randint(0, num_nodes, (2, num_nodes*2))
-    edges_2 = torch.randint(0, num_nodes, (2, num_nodes*2))
+    # Use a dedicated generator so the fixture does not depend on the
+    # ambient RNG state, i.e. on which tests ran before. Consumers assume
+    # the edges cover every node (a dense adjacency is built from them),
+    # which only holds for some global seeds.
+    generator = torch.Generator().manual_seed(0)
+    x = torch.randn(num_nodes, 12, generator=generator)
+    edges_1 = torch.randint(
+        0, num_nodes, (2, num_nodes * 2), generator=generator
+    )
+    edges_2 = torch.randint(
+        0, num_nodes, (2, num_nodes * 2), generator=generator
+    )
 
     d_feat_1, d_feat_2 = 5, 17
 
-    x_1 = torch.randn(num_nodes*2, d_feat_1)
-    x_2 = torch.randn(num_nodes*2, d_feat_2)
+    x_1 = torch.randn(num_nodes*2, d_feat_1, generator=generator)
+    x_2 = torch.randn(num_nodes*2, d_feat_2, generator=generator)
 
     return x, x_1, x_2, edges_1, edges_2

--- a/test/nn/backbones/graph/test_loopy.py
+++ b/test/nn/backbones/graph/test_loopy.py
@@ -1,0 +1,197 @@
+"""Unit tests for the Loopy backbone."""
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from topobench.dataloader.dataload_dataset import DataloadDataset
+from topobench.dataloader.utils import collate_fn
+from topobench.nn.backbones.graph.loopy import (
+    ACTIVATIONS,
+    CustomGINConv,
+    Loopy,
+    LoopyLayer,
+    MLP,
+    _path_propagate,
+    get_activation,
+)
+from topobench.nn.wrappers.graph.loopy_wrapper import LoopyWrapper
+from topobench.transforms.data_manipulations.r_neighbourhood import (
+    RNeighbourhood,
+)
+
+TRIANGLE_TAIL = ([[0, 1], [1, 2], [2, 0], [2, 3]], 4)
+SQUARE = ([[0, 1], [1, 2], [2, 3], [3, 0]], 4)
+
+
+def _assembled(graphs, hidden, r=2):
+    """Return ``(x, loopy_n, loopy_a, num_nodes)`` for direct layer tests."""
+    datas = []
+    for edges, n in graphs:
+        edge_index = torch.tensor(edges, dtype=torch.long).t()
+        edge_index = torch.cat([edge_index, edge_index.flip(0)], dim=1)
+        data = Data(
+            x_0=torch.randn(n, hidden),
+            edge_index=edge_index,
+            y=torch.zeros(n, dtype=torch.long),
+            num_nodes=n,
+        )
+        data.batch_0 = torch.zeros(n, dtype=torch.long)
+        datas.append(RNeighbourhood(r=r, transform_name="RN")(data))
+    dataset = DataloadDataset(datas)
+    batch = collate_fn([dataset.get(i) for i in range(len(datas))])
+    loopy_n, loopy_a = LoopyWrapper._assemble_paths(batch)
+    return batch.x_0, loopy_n, loopy_a, batch.x_0.shape[0]
+
+
+class TestGetActivation:
+    """Test the activation resolver."""
+
+    @pytest.mark.parametrize("name", sorted(ACTIVATIONS))
+    def test_known(self, name):
+        act = get_activation(name)
+        assert isinstance(act, torch.nn.Module)
+        assert act(torch.randn(3, 2)).shape == (3, 2)
+
+    def test_invalid(self):
+        with pytest.raises(ValueError, match="Unsupported activation"):
+            get_activation("nope")
+
+
+class TestPathPropagate:
+    """Test the path-neighbour convolution."""
+
+    def test_documented_example(self):
+        x = torch.tensor([[1.0], [5.0]]).unsqueeze(1)  # (2, 1, 1)
+        out = _path_propagate(x)
+        assert torch.equal(out.squeeze(), torch.tensor([5.0, 1.0]))
+
+    def test_shape_preserved(self):
+        x = torch.randn(4, 6, 8)
+        assert _path_propagate(x).shape == x.shape
+
+    def test_middle_node_sums_both_neighbours(self):
+        x = torch.tensor([[1.0], [2.0], [4.0]]).unsqueeze(1)  # (3, 1, 1)
+        out = _path_propagate(x).squeeze()
+        assert out[1] == 5.0  # 1 + 4
+
+
+class TestMLP:
+    """Test the internal MLP."""
+
+    def test_forward_shape(self):
+        assert MLP(8, 5)(torch.randn(6, 8)).shape == (6, 5)
+
+    @pytest.mark.parametrize("num_layers", [2, 3])
+    def test_num_layers(self, num_layers):
+        mlp = MLP(8, 8, num_layers=num_layers)
+        assert len(mlp.lins) == num_layers
+
+    def test_batchnorm(self):
+        mlp = MLP(8, 8, norm="BatchNorm1d")
+        assert isinstance(mlp.norm, torch.nn.BatchNorm1d)
+        assert mlp(torch.randn(4, 8)).shape == (4, 8)
+
+    def test_reset_parameters(self):
+        MLP(8, 8, norm="BatchNorm1d").reset_parameters()
+
+
+class TestCustomGINConv:
+    """Test the path GIN convolution."""
+
+    def test_forward_shape(self):
+        conv = CustomGINConv(MLP(8, 8), in_channels=8, num_embeddings=4)
+        x = torch.randn(3, 5, 8)  # (path_length, num_paths, channels)
+        atomic = torch.randint(0, 4, (3, 5))
+        assert conv(x, atomic).shape == (5, 8)
+
+    def test_reset_parameters(self):
+        CustomGINConv(MLP(8, 8), 8, 4).reset_parameters()
+
+
+class TestLoopyLayer:
+    """Test a single loopy layer."""
+
+    def test_forward_shape(self):
+        x, ln, la, n = _assembled([TRIANGLE_TAIL], hidden=8)
+        layer = LoopyLayer(8, 8, r=2)
+        assert layer(x, ln, la, n).shape == (n, 8)
+
+    def test_shared_uses_single_conv(self):
+        assert len(LoopyLayer(8, 8, r=3, shared=True).convs) == 1
+        assert len(LoopyLayer(8, 8, r=3, shared=False).convs) == 3
+
+    def test_chunk_size_invariant(self):
+        x, ln, la, n = _assembled([SQUARE, TRIANGLE_TAIL], hidden=8)
+        torch.manual_seed(0)
+        big = LoopyLayer(8, 8, r=2, path_chunk_size=10**9).eval()
+        torch.manual_seed(0)
+        small = LoopyLayer(8, 8, r=2, path_chunk_size=1).eval()
+        out_big = big(x, ln, la, n)
+        out_small = small(x, ln, la, n)
+        assert torch.allclose(out_big, out_small, atol=1e-5)
+
+    def test_checkpoint_backward(self):
+        x, ln, la, n = _assembled([SQUARE], hidden=8)
+        x = x.clone().requires_grad_(True)
+        layer = LoopyLayer(8, 8, r=2, path_chunk_size=1).train()
+        layer(x, ln, la, n).sum().backward()
+        assert x.grad is not None
+
+
+class TestLoopy:
+    """Test the full backbone."""
+
+    def _run(self, graphs, hidden=8, **kw):
+        x, ln, la, n = _assembled(graphs, hidden=hidden, r=kw.get("r", 2))
+        model = Loopy(hidden, hidden, **kw)
+        return model, model(x, None, loopy_n=ln, loopy_a=la), n
+
+    def test_init_attributes(self):
+        model = Loopy(8, 8, num_layers=3, r=2)
+        assert model.out_channels == 8
+        assert model.r == 2
+        assert len(model.layers) == 3
+
+    def test_forward_shape(self):
+        _, out, n = self._run([TRIANGLE_TAIL])
+        assert out.shape == (n, 8)
+        assert torch.isfinite(out).all()
+
+    def test_backward_all_params(self):
+        x, ln, la, n = _assembled([SQUARE, TRIANGLE_TAIL], hidden=8)
+        model = Loopy(8, 8, num_layers=2, r=2).train()
+        model(x, None, loopy_n=ln, loopy_a=la).sum().backward()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, f"no gradient for {name}"
+
+    @pytest.mark.parametrize("r", [1, 2, 3])
+    def test_forward_different_r(self, r):
+        _, out, n = self._run([SQUARE], r=r)
+        assert out.shape == (n, 8)
+
+    def test_dropout_and_kwargs_ignored(self):
+        model, out, n = self._run(
+            [TRIANGLE_TAIL], dropout=0.5, unused="x"
+        )
+        assert out.shape == (n, 8)
+
+    def test_eval_is_deterministic(self):
+        x, ln, la, n = _assembled([SQUARE], hidden=8)
+        model = Loopy(8, 8, num_layers=2, r=2, dropout=0.5).eval()
+        a = model(x, None, loopy_n=ln, loopy_a=la)
+        b = model(x, None, loopy_n=ln, loopy_a=la)
+        assert torch.allclose(a, b)
+
+    def test_isolated_nodes(self):
+        # Graph with an isolated node (no paths touch it).
+        x, ln, la, n = _assembled([([[0, 1], [1, 2], [2, 0]], 5)], hidden=8)
+        out = Loopy(8, 8, num_layers=1, r=2)(x, None, loopy_n=ln, loopy_a=la)
+        assert out.shape == (n, 8)
+        assert torch.isfinite(out).all()
+
+    def test_end_to_end_via_wrapper(self):
+        x, ln, la, n = _assembled([TRIANGLE_TAIL, SQUARE], hidden=8)
+        model = Loopy(8, 8, num_layers=2, r=2)
+        out = model(x, None, loopy_n=ln, loopy_a=la)
+        assert out.shape == (n, 8)

--- a/test/nn/wrappers/graph/test_loopy_wrapper.py
+++ b/test/nn/wrappers/graph/test_loopy_wrapper.py
@@ -1,0 +1,116 @@
+"""Unit tests for the LoopyWrapper."""
+
+import torch
+from torch_geometric.data import Data
+
+from topobench.dataloader.dataload_dataset import DataloadDataset
+from topobench.dataloader.utils import collate_fn
+from topobench.nn.backbones.graph.loopy import Loopy
+from topobench.nn.wrappers.graph.loopy_wrapper import LoopyWrapper
+from topobench.transforms.data_manipulations.r_neighbourhood import (
+    RNeighbourhood,
+)
+
+TRIANGLE_TAIL = ([[0, 1], [1, 2], [2, 0], [2, 3]], 4)
+SQUARE_ISOLATED = ([[0, 1], [1, 2], [2, 3], [3, 0]], 5)  # node 4 isolated
+
+
+def _graph(edges, num_nodes, feat, r):
+    """Build a single transformed graph with a per-graph batch vector."""
+    edge_index = torch.tensor(edges, dtype=torch.long).t()
+    edge_index = torch.cat([edge_index, edge_index.flip(0)], dim=1)
+    data = Data(
+        x_0=torch.randn(num_nodes, feat),
+        edge_index=edge_index,
+        y=torch.zeros(num_nodes, dtype=torch.long),
+        num_nodes=num_nodes,
+    )
+    data.batch_0 = torch.zeros(num_nodes, dtype=torch.long)
+    return RNeighbourhood(r=r, transform_name="RNeighbourhood")(data)
+
+
+def _batch(graphs, feat=8, r=2):
+    """Collate several graphs the way the TopoBench dataloader does."""
+    datas = [_graph(edges, n, feat, r) for edges, n in graphs]
+    dataset = DataloadDataset(datas)
+    return collate_fn([dataset.get(i) for i in range(len(datas))])
+
+
+class TestAssemblePaths:
+    """Test the graph-local to batch-global index reconstruction."""
+
+    def test_shapes_and_transpose(self):
+        batch = _batch([TRIANGLE_TAIL])
+        loopy_n, loopy_a = LoopyWrapper._assemble_paths(batch)
+        for order in range(3):
+            if loopy_n[order].numel():
+                assert loopy_n[order].shape[0] == order + 2
+                assert loopy_n[order].shape == loopy_a[order].shape
+
+    def test_single_graph_indices_unchanged(self):
+        batch = _batch([TRIANGLE_TAIL])
+        loopy_n, _ = LoopyWrapper._assemble_paths(batch)
+        # With a single graph the offset is zero, so indices stay in range.
+        assert loopy_n[1].max() < batch.x_0.shape[0]
+
+    def test_two_graphs_offset(self):
+        batch = _batch([TRIANGLE_TAIL, SQUARE_ISOLATED])
+        loopy_n, _ = LoopyWrapper._assemble_paths(batch)
+        # The square lives in the second graph -> its order-2 paths must
+        # reference the second graph's node block (indices 4..8).
+        counts = batch["loopyNcount2"]
+        graph_of_path = torch.repeat_interleave(torch.arange(2), counts)
+        square_paths = loopy_n[2].t()[graph_of_path == 1]
+        assert square_paths.numel() > 0
+        assert square_paths.min() >= 4
+
+    def test_indices_within_own_graph(self):
+        batch = _batch([TRIANGLE_TAIL, SQUARE_ISOLATED])
+        loopy_n, _ = LoopyWrapper._assemble_paths(batch)
+        node_counts = torch.bincount(batch.batch_0)
+        node_ptr = torch.cat([node_counts.new_zeros(1), node_counts.cumsum(0)])
+        for order in range(3):
+            if not loopy_n[order].numel():
+                continue
+            counts = batch[f"loopyNcount{order}"]
+            gid = torch.repeat_interleave(torch.arange(2), counts)
+            glob = loopy_n[order].t()
+            lo = node_ptr[gid].unsqueeze(1)
+            hi = node_ptr[gid + 1].unsqueeze(1)
+            assert torch.all((glob >= lo) & (glob < hi))
+
+    def test_empty_order_handled(self):
+        # A pure triangle has no order-2 (length-4) paths.
+        batch = _batch([([[0, 1], [1, 2], [2, 0]], 3)])
+        loopy_n, loopy_a = LoopyWrapper._assemble_paths(batch)
+        assert loopy_n[2].shape[1] == 0
+        assert loopy_a[2].shape[1] == 0
+
+
+class TestLoopyWrapperForward:
+    """Test the wrapper forward pass with a real backbone."""
+
+    def _wrapper(self, hidden=8):
+        backbone = Loopy(
+            in_channels=hidden, hidden_channels=hidden, num_layers=2, r=2
+        )
+        return LoopyWrapper(
+            backbone, out_channels=hidden, num_cell_dimensions=1
+        )
+
+    def test_output_keys(self):
+        batch = _batch([TRIANGLE_TAIL, SQUARE_ISOLATED])
+        out = self._wrapper()(batch)
+        assert set(out.keys()) >= {"labels", "batch_0", "x_0"}
+
+    def test_output_shape(self):
+        batch = _batch([TRIANGLE_TAIL, SQUARE_ISOLATED])
+        out = self._wrapper(hidden=8)(batch)
+        assert out["x_0"].shape == (batch.x_0.shape[0], 8)
+        assert torch.isfinite(out["x_0"]).all()
+
+    def test_labels_and_batch_preserved(self):
+        batch = _batch([TRIANGLE_TAIL])
+        out = self._wrapper()(batch)
+        assert torch.equal(out["batch_0"], batch.batch_0)
+        assert torch.equal(out["labels"], batch.y)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = ["graph/gcn", "graph/loopy", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/test/transforms/data_manipulations/test_r_neighbourhood.py
+++ b/test/transforms/data_manipulations/test_r_neighbourhood.py
@@ -1,0 +1,216 @@
+"""Unit tests for the RNeighbourhood (loopy) transform."""
+
+import networkx as nx
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from topobench.transforms import TRANSFORMS
+from topobench.transforms.data_manipulations.r_neighbourhood import (
+    RNeighbourhood,
+    _bounded_simple_cycles,
+    r_neighborhood,
+)
+
+
+def _undirected(edges, num_nodes, feat=4):
+    """Build a Data object with both edge orientations."""
+    edge_index = torch.tensor(edges, dtype=torch.long).t()
+    edge_index = torch.cat([edge_index, edge_index.flip(0)], dim=1)
+    return Data(
+        x_0=torch.randn(num_nodes, feat),
+        edge_index=edge_index,
+        num_nodes=num_nodes,
+    )
+
+
+TRIANGLE = ([[0, 1], [1, 2], [2, 0]], 3)
+SQUARE = ([[0, 1], [1, 2], [2, 3], [3, 0]], 4)
+TRIANGLE_TAIL = ([[0, 1], [1, 2], [2, 0], [2, 3]], 4)
+PATH = ([[0, 1], [1, 2], [2, 3]], 4)
+
+
+class TestBoundedSimpleCycles:
+    """Test the environment-safe cycle enumeration."""
+
+    def _graph(self, edges):
+        g = nx.Graph()
+        g.add_edges_from(edges)
+        return g
+
+    def test_triangle_found(self):
+        cycles = _bounded_simple_cycles(self._graph(TRIANGLE[0]), 4)
+        assert len(cycles) == 1
+        assert sorted(cycles[0]) == [0, 1, 2]
+
+    def test_square_found(self):
+        cycles = _bounded_simple_cycles(self._graph(SQUARE[0]), 4)
+        assert len(cycles) == 1
+        assert len(cycles[0]) == 4
+
+    def test_length_bound_excludes_longer(self):
+        # A 4-cycle is not returned when the bound only allows length 3.
+        cycles = _bounded_simple_cycles(self._graph(SQUARE[0]), 3)
+        assert cycles == []
+
+    def test_path_has_no_cycles(self):
+        assert _bounded_simple_cycles(self._graph(PATH[0]), 4) == []
+
+    def test_each_cycle_returned_once(self):
+        # Two triangles sharing nothing -> exactly two cycles, deduped.
+        edges = [[0, 1], [1, 2], [2, 0], [3, 4], [4, 5], [5, 3]]
+        cycles = _bounded_simple_cycles(self._graph(edges), 4)
+        assert len(cycles) == 2
+
+    def test_min_node_first(self):
+        cycles = _bounded_simple_cycles(self._graph(TRIANGLE[0]), 4)
+        assert cycles[0][0] == min(cycles[0])
+
+
+class TestRNeighborhoodFunction:
+    """Test the ``r_neighborhood`` helper."""
+
+    def _graph(self, edges):
+        g = nx.Graph()
+        g.add_edges_from(edges)
+        return g
+
+    def test_returns_three_dicts(self):
+        paths, hops, edge_attr_idx = r_neighborhood(
+            self._graph(TRIANGLE[0]), r=2
+        )
+        assert isinstance(paths, dict)
+        assert isinstance(hops, dict)
+        assert isinstance(edge_attr_idx, dict)
+
+    def test_paths_keyed_by_order(self):
+        paths, _, _ = r_neighborhood(self._graph(SQUARE[0]), r=2)
+        assert set(paths.keys()) == {0, 1, 2}
+
+    def test_triangle_appears_at_order_one(self):
+        paths, _, _ = r_neighborhood(self._graph(TRIANGLE[0]), r=2)
+        assert paths[1].shape == (1, 3)  # one length-3 cycle
+        assert paths[2].shape[0] == 0  # no length-4 cycle
+
+    def test_square_appears_at_order_two(self):
+        paths, _, _ = r_neighborhood(self._graph(SQUARE[0]), r=2)
+        assert paths[2].shape == (1, 4)
+        assert paths[1].shape[0] == 0
+
+    def test_hops_are_symmetric_distances(self):
+        _, hops, _ = r_neighborhood(self._graph(TRIANGLE[0]), r=2)
+        assert hops[0, 0] == 0
+        assert hops[0, 1] == 1
+        assert hops[1, 2] == 1
+
+    def test_directed_graph_is_undirected(self):
+        digraph = nx.DiGraph()
+        digraph.add_edges_from(TRIANGLE[0])
+        paths, _, _ = r_neighborhood(digraph, r=2)
+        assert paths[1].shape == (1, 3)
+
+
+class TestRNeighbourhoodTransform:
+    """Test the ``RNeighbourhood`` transform."""
+
+    def test_init_stores_params(self):
+        t = RNeighbourhood(r=3, transform_name="RNeighbourhood", foo="bar")
+        assert t.r == 3
+        assert t.parameters["transform_name"] == "RNeighbourhood"
+        assert t.parameters["foo"] == "bar"
+
+    def test_registered_in_transforms(self):
+        assert "RNeighbourhood" in TRANSFORMS
+
+    def test_adds_all_orders(self):
+        data = _undirected(*TRIANGLE_TAIL)
+        out = RNeighbourhood(r=2)(data)
+        for order in range(3):
+            assert f"loopyN{order}" in out
+            assert f"loopyA{order}" in out
+            assert f"loopyNcount{order}" in out
+
+    def test_order_zero_is_directed_edges(self):
+        data = _undirected(*TRIANGLE)
+        out = RNeighbourhood(r=2)(data)
+        # 3 undirected edges -> 6 directed (centre, neighbour) rows.
+        assert out["loopyN0"].shape == (6, 2)
+        # Every hop row of a direct neighbour is [0, 1].
+        assert torch.equal(
+            out["loopyA0"], torch.tensor([[0, 1]]).repeat(6, 1)
+        )
+
+    def test_shapes_and_alignment(self):
+        data = _undirected(*SQUARE)
+        out = RNeighbourhood(r=2)(data)
+        for order in range(3):
+            n, a = out[f"loopyN{order}"], out[f"loopyA{order}"]
+            assert n.shape == a.shape
+            assert n.shape[1] == order + 2
+            assert out[f"loopyNcount{order}"].item() == n.shape[0]
+
+    def test_square_produces_four_rotations(self):
+        data = _undirected(*SQUARE)
+        out = RNeighbourhood(r=2)(data)
+        assert out["loopyN2"].shape == (4, 4)  # one 4-cycle, four centres
+        assert out["loopyN1"].shape[0] == 0  # no triangle
+
+    def test_centre_hop_is_zero(self):
+        data = _undirected(*TRIANGLE)
+        out = RNeighbourhood(r=2)(data)
+        # Column 0 is the centre, whose hop distance to itself is 0.
+        assert torch.all(out["loopyA1"][:, 0] == 0)
+
+    def test_node_indices_in_range(self):
+        data = _undirected(*TRIANGLE_TAIL)
+        out = RNeighbourhood(r=2)(data)
+        for order in range(3):
+            paths = out[f"loopyN{order}"]
+            if paths.numel():
+                assert paths.min() >= 0
+                assert paths.max() < data.num_nodes
+
+    def test_dtype_is_long(self):
+        out = RNeighbourhood(r=2)(_undirected(*TRIANGLE))
+        assert out["loopyN0"].dtype == torch.long
+        assert out["loopyA0"].dtype == torch.long
+        assert out["loopyNcount0"].dtype == torch.long
+
+    @pytest.mark.parametrize("r", [0, 1, 2, 3])
+    def test_orders_match_r(self, r):
+        out = RNeighbourhood(r=r)(_undirected(*SQUARE))
+        assert all(f"loopyN{order}" in out for order in range(r + 1))
+        assert f"loopyN{r + 1}" not in out
+
+    def test_order_zero_only_when_r_zero(self):
+        out = RNeighbourhood(r=0)(_undirected(*TRIANGLE))
+        assert out["loopyN0"].shape[0] == 6
+        assert "loopyN1" not in out
+
+    def test_empty_graph(self):
+        data = Data(
+            x_0=torch.randn(3, 4),
+            edge_index=torch.empty((2, 0), dtype=torch.long),
+            num_nodes=3,
+        )
+        out = RNeighbourhood(r=2)(data)
+        for order in range(3):
+            assert out[f"loopyN{order}"].shape == (0, order + 2)
+            assert out[f"loopyNcount{order}"].item() == 0
+
+    def test_no_dict_fields(self):
+        out = RNeighbourhood(r=2)(_undirected(*SQUARE))
+        assert not any(
+            isinstance(out[key], dict) for key in out.keys()
+        )
+
+    def test_dispatch_via_data_transform(self):
+        from topobench.transforms.data_transform import DataTransform
+
+        t = DataTransform(
+            transform_name="RNeighbourhood",
+            transform_type="data manipulation",
+            r=2,
+        )
+        out = t(_undirected(*TRIANGLE))
+        assert "loopyN1" in out

--- a/topobench/nn/backbones/graph/coo_gnn.py
+++ b/topobench/nn/backbones/graph/coo_gnn.py
@@ -1,0 +1,1 @@
+"Cooperative Graph Neural Networks"

--- a/topobench/nn/backbones/graph/coo_gnn.py
+++ b/topobench/nn/backbones/graph/coo_gnn.py
@@ -1,1 +1,0 @@
-"Cooperative Graph Neural Networks"

--- a/topobench/nn/backbones/graph/loopy.py
+++ b/topobench/nn/backbones/graph/loopy.py
@@ -1,0 +1,457 @@
+"""Loopy backbone: message passing over r-neighbourhood paths.
+
+Port of the `"loopy" <https://github.com/RPaolino/loopy>`_ layers to the
+TopoBench node-to-node backbone contract. The r-neighbourhood paths are
+precomputed by the ``RNeighbourhood`` transform and handed in by ``LoopyWrapper`` as the
+``loopy_n`` / ``loopy_a`` dictionaries.
+"""
+
+import torch
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+from torch_geometric.utils import scatter
+
+ACTIVATIONS = {
+    "relu": nn.ReLU,
+    "elu": nn.ELU,
+    "gelu": nn.GELU,
+    "tanh": nn.Tanh,
+    "sigmoid": nn.Sigmoid,
+    "identity": nn.Identity,
+}
+
+
+def get_activation(name):
+    """Resolve an activation module from its name.
+
+    Parameters
+    ----------
+    name : str
+        Name of the activation, one of the keys of ``ACTIVATIONS``.
+
+    Returns
+    -------
+    torch.nn.Module
+        A freshly built activation module.
+    """
+    if name not in ACTIVATIONS:
+        raise ValueError(
+            f"Unsupported activation '{name}'. "
+            f"Available options: {sorted(ACTIVATIONS)}."
+        )
+    return ACTIVATIONS[name]()
+
+
+def _path_propagate(x):
+    """Sum each path node's features with those of its path neighbours.
+
+    In a path every node is linked to the previous and next node, so
+    aggregating over the path neighbourhood is a convolution with the
+    kernel ``[1, 0, 1]`` (zero padded at the two ends) along the path
+    dimension.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Tensor of shape ``(path_length, num_paths, channels)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape holding, at each position, the sum of the
+        two path-neighbours' features.
+    """
+    out = torch.zeros_like(x)
+    out[:-1] = out[:-1] + x[1:]
+    out[1:] = out[1:] + x[:-1]
+    return out
+
+
+class MLP(nn.Module):
+    """Two or more layer MLP with an optional normalization.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features.
+    out_channels : int
+        Number of output features.
+    num_layers : int, optional
+        Total number of linear layers.
+    nonlinearity : str, optional
+        Name of the activation applied between layers.
+    norm : str, optional
+        Name of a ``torch.nn`` normalization class applied between layers,
+        e.g. ``"BatchNorm1d"`` or ``"Identity"``.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        num_layers=2,
+        nonlinearity="relu",
+        norm="Identity",
+    ):
+        super().__init__()
+        self.lins = nn.ModuleList([nn.Linear(in_channels, out_channels)])
+        for _ in range(num_layers - 1):
+            self.lins.append(nn.Linear(out_channels, out_channels))
+        self.norm = getattr(nn, norm)(out_channels)
+        self.act = get_activation(nonlinearity)
+
+    def reset_parameters(self):
+        """Reset the parameters of the linear layers and the norm."""
+        for lin in self.lins:
+            lin.reset_parameters()
+        if hasattr(self.norm, "reset_parameters"):
+            self.norm.reset_parameters()
+
+    def forward(self, x):
+        """Apply the MLP.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor whose last dimension is ``in_channels``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor whose last dimension is ``out_channels``.
+        """
+        x = self.lins[0](x)
+        for lin in self.lins[1:]:
+            x = self.norm(x)
+            x = self.act(x)
+            x = lin(x)
+        return x
+
+
+class CustomGINConv(nn.Module):
+    """GIN-style convolution along a path, aware of hop distances.
+
+    Parameters
+    ----------
+    mlp : torch.nn.Module
+        Update network applied after aggregation.
+    in_channels : int
+        Number of input features.
+    num_embeddings : int
+        Number of distinct hop distances to embed.
+    train_eps : bool, optional
+        Whether ``eps`` is learnable.
+    """
+
+    def __init__(self, mlp, in_channels, num_embeddings, train_eps=True):
+        super().__init__()
+        self.mlp = mlp
+        self.eps = nn.Parameter(torch.ones(1), requires_grad=train_eps)
+        self.embedding = nn.Embedding(num_embeddings, in_channels)
+        self.transform = nn.Linear(2 * in_channels, in_channels)
+
+    def reset_parameters(self):
+        """Reset the parameters of the submodules."""
+        self.mlp.reset_parameters()
+        self.embedding.reset_parameters()
+        self.transform.reset_parameters()
+
+    def forward(self, x, atomic_type):
+        """Aggregate a path and return one vector per path.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Path node features of shape ``(path_length, num_paths,
+            in_channels)``.
+        atomic_type : torch.Tensor
+            Hop distance of each path node to the centre, of shape
+            ``(path_length, num_paths)``.
+
+        Returns
+        -------
+        torch.Tensor
+            One embedding per path, of shape ``(num_paths, out_channels)``.
+        """
+        out = self.transform(
+            torch.cat([x, self.embedding(atomic_type)], dim=-1)
+        )
+        out = _path_propagate(out)
+        out = self.mlp((1 + self.eps) * x + out)
+        return out.sum(0)
+
+
+class LoopyLayer(nn.Module):
+    """One loopy layer aggregating all r-neighbourhood orders.
+
+    The layer requires ``in_channels == out_channels`` because the order-0
+    (direct neighbour) contribution keeps the input width while the higher
+    order contributions are summed with it.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features.
+    out_channels : int
+        Number of output features (equal to ``in_channels``).
+    r : int
+        Maximal neighbourhood order.
+    nonlinearity : str, optional
+        Activation used by the final MLP.
+    norm : str, optional
+        Normalization used by the final MLP.
+    shared : bool, optional
+        Whether a single convolution is shared across the orders instead of
+        one per order.
+    path_chunk_size : int, optional
+        Number of paths processed per gradient-checkpointed chunk.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        r,
+        nonlinearity="relu",
+        norm="BatchNorm1d",
+        shared=False,
+        path_chunk_size=8192,
+    ):
+        super().__init__()
+        self.r = r
+        self.shared = shared
+        self.path_chunk_size = path_chunk_size
+        self.eps = nn.Parameter(torch.zeros(1))
+        self.r_eps = nn.Parameter(torch.zeros(r + 1))
+        num_embeddings = r + 2
+        num_convs = 1 if shared else r
+        self.convs = nn.ModuleList(
+            [
+                CustomGINConv(
+                    MLP(in_channels, out_channels, num_layers=2),
+                    in_channels=in_channels,
+                    num_embeddings=num_embeddings,
+                )
+                for _ in range(num_convs)
+            ]
+        )
+        self.conv_final = MLP(
+            in_channels,
+            out_channels,
+            num_layers=2,
+            nonlinearity=nonlinearity,
+            norm=norm,
+        )
+
+    def forward(self, x, loopy_n, loopy_a, num_nodes):
+        """Aggregate every neighbourhood order onto the nodes.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``(num_nodes, channels)``.
+        loopy_n : dict[int, torch.Tensor]
+            Per-order node-index paths of shape ``(L + 2, num_paths)`` with
+            global indices.
+        loopy_a : dict[int, torch.Tensor]
+            Per-order hop distances of shape ``(L + 2, num_paths)``.
+        num_nodes : int
+            Number of nodes in the batch.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated node features of shape ``(num_nodes, channels)``.
+        """
+        x = x.float()
+        r_contribution = 0
+        for order in range(self.r + 1):
+            paths = loopy_n[order]
+            num_paths = paths.shape[1]
+            if num_paths == 0:
+                continue
+            conv = (
+                None
+                if order == 0
+                else (self.convs[0] if self.shared else self.convs[order - 1])
+            )
+            centres = paths[0]
+            node_idx = paths[1:]
+            hops = loopy_a[order][1:]
+            # Process the paths in chunks and scatter each chunk onto its
+            # centre nodes. The per-chunk work is gradient-checkpointed while
+            # training, so activations are recomputed in the backward pass
+            # rather than stored: this bounds the memory to one chunk, which
+            # dense graphs (with very many paths) would otherwise blow past.
+            acc = x.new_zeros(num_nodes, x.shape[1])
+            for start in range(0, num_paths, self.path_chunk_size):
+                end = min(start + self.path_chunk_size, num_paths)
+                contribution = self._process_chunk(
+                    conv, x, node_idx[:, start:end], hops[:, start:end]
+                )
+                acc = acc + scatter(
+                    contribution,
+                    centres[start:end],
+                    dim=0,
+                    dim_size=num_nodes,
+                    reduce="sum",
+                )
+            r_contribution = r_contribution + (1 + self.r_eps[order]) * acc
+        return self.conv_final((1 + self.eps) * x + r_contribution)
+
+    def _process_chunk(self, conv, x, node_idx, hops):
+        """Gather and convolve one chunk of paths.
+
+        Parameters
+        ----------
+        conv : torch.nn.Module or None
+            Convolution for this order, or ``None`` for the order-0 (direct
+            neighbour) chunk.
+        x : torch.Tensor
+            Node features of shape ``(num_nodes, channels)``.
+        node_idx : torch.Tensor
+            Global indices of the non-centre path nodes, of shape
+            ``(L + 1, chunk)``.
+        hops : torch.Tensor
+            Hop distances of the non-centre path nodes, of shape
+            ``(L + 1, chunk)``.
+
+        Returns
+        -------
+        torch.Tensor
+            One embedding per path in the chunk, of shape
+            ``(chunk, channels)``.
+        """
+
+        def run(node_features):
+            """Gather node features and apply the convolution.
+
+            Parameters
+            ----------
+            node_features : torch.Tensor
+                Node features of shape ``(num_nodes, channels)``.
+
+            Returns
+            -------
+            torch.Tensor
+                One embedding per path in the chunk.
+            """
+            gathered = node_features[node_idx]
+            if conv is None:
+                return gathered.squeeze(0)
+            return conv(gathered, hops)
+
+        if self.training and x.requires_grad:
+            return checkpoint(run, x, use_reentrant=False)
+        return run(x)
+
+
+class Loopy(nn.Module):
+    """Loopy backbone stacking several loopy layers.
+
+    Maps node features to node embeddings. The order-``L`` path tensors are
+    supplied by ``LoopyWrapper`` and must cover ``L`` in ``0 .. r``, with
+    ``r`` matching the ``RNeighbourhood`` transform.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input features.
+    hidden_channels : int
+        Number of hidden features (kept constant across the layers).
+    num_layers : int, optional
+        Number of loopy layers.
+    r : int, optional
+        Maximal neighbourhood order; must match the transform.
+    dropout : float, optional
+        Dropout probability applied between layers.
+    nonlinearity : str, optional
+        Activation used by the layer MLPs.
+    norm : str, optional
+        Normalization used by the final MLP of each layer.
+    shared : bool, optional
+        Whether each layer shares one convolution across the orders.
+    path_chunk_size : int, optional
+        Number of paths processed per gradient-checkpointed chunk.
+    **kwargs : dict, optional
+        Ignored, kept for compatibility with the TopoBench model
+        instantiation.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels,
+        num_layers=2,
+        r=2,
+        dropout=0.0,
+        nonlinearity="relu",
+        norm="BatchNorm1d",
+        shared=False,
+        path_chunk_size=8192,
+        **kwargs,
+    ):
+        super().__init__()
+        self.r = r
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = hidden_channels
+        self.encoder = nn.Linear(in_channels, hidden_channels)
+        self.layers = nn.ModuleList(
+            [
+                LoopyLayer(
+                    hidden_channels,
+                    hidden_channels,
+                    r=r,
+                    nonlinearity=nonlinearity,
+                    norm=norm,
+                    shared=shared,
+                    path_chunk_size=path_chunk_size,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        x,
+        edge_index,
+        batch=None,
+        loopy_n=None,
+        loopy_a=None,
+        edge_weight=None,
+        **kwargs,
+    ):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features of shape ``(num_nodes, in_channels)``.
+        edge_index : torch.Tensor
+            Edge indices; unused, kept for signature compatibility.
+        batch : torch.Tensor, optional
+            Batch assignment vector; unused, pooling is delegated to the
+            readout.
+        loopy_n : dict[int, torch.Tensor]
+            Per-order node-index paths of shape ``(L + 2, num_paths)`` with
+            global indices.
+        loopy_a : dict[int, torch.Tensor]
+            Per-order hop distances of shape ``(L + 2, num_paths)``.
+        edge_weight : torch.Tensor, optional
+            Unused, kept for signature compatibility.
+        **kwargs : dict, optional
+            Ignored.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings of shape ``(num_nodes, hidden_channels)``.
+        """
+        x = self.encoder(x)
+        num_nodes = x.shape[0]
+        for layer in self.layers:
+            x = layer(x, loopy_n, loopy_a, num_nodes)
+            x = self.dropout(x)
+        return x

--- a/topobench/nn/wrappers/graph/loopy_wrapper.py
+++ b/topobench/nn/wrappers/graph/loopy_wrapper.py
@@ -1,0 +1,91 @@
+"""Wrapper for the loopy (r-neighbourhood) models."""
+
+import torch
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class LoopyWrapper(AbstractWrapper):
+    r"""Wrapper for the loopy r-neighbourhood models.
+
+    The :class:`RNeighbourhood` transform stores, for every order ``L``, the
+    path tensors ``loopyN{L}`` and ``loopyA{L}`` with **graph-local** node
+    indices, plus ``loopyNcount{L}`` (the number of paths per graph). This
+    wrapper shifts the local indices to their global positions in the
+    batched graph — using the per-graph node offsets derived from
+    ``batch_0`` — and hands the assembled paths to the backbone. The
+    backbone returns the embeddings of the rank-0 cells.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the loopy wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data. Expected to carry
+            ``loopyN{L}``, ``loopyA{L}`` and ``loopyNcount{L}`` for every
+            ``L`` in ``0 .. r``.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the updated model output.
+        """
+        loopy_n, loopy_a = self._assemble_paths(batch)
+
+        x_0 = self.backbone(
+            batch.x_0,
+            batch.edge_index,
+            batch=batch.batch_0,
+            loopy_n=loopy_n,
+            loopy_a=loopy_a,
+            edge_weight=batch.get("edge_weight", None),
+        )
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+
+        return model_out
+
+    @staticmethod
+    def _assemble_paths(batch):
+        r"""Shift path node indices from graph-local to batch-global.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data.
+
+        Returns
+        -------
+        loopy_n : dict[int, torch.Tensor]
+            Per-order node-index paths of shape ``(L + 2, num_paths)`` with
+            batch-global indices.
+        loopy_a : dict[int, torch.Tensor]
+            Per-order hop distances of shape ``(L + 2, num_paths)``, aligned
+            with ``loopy_n``.
+        """
+        batch_0 = batch.batch_0
+        num_graphs = int(batch_0.max().item()) + 1 if batch_0.numel() else 0
+        node_counts = torch.bincount(batch_0, minlength=num_graphs)
+        node_offset = torch.cat(
+            [node_counts.new_zeros(1), node_counts.cumsum(0)]
+        )
+
+        loopy_n = {}
+        loopy_a = {}
+        order = 0
+        while f"loopyN{order}" in batch:
+            paths = batch[f"loopyN{order}"]
+            if paths.numel() > 0:
+                counts = batch[f"loopyNcount{order}"]
+                graph_of_path = torch.repeat_interleave(
+                    torch.arange(num_graphs, device=paths.device), counts
+                )
+                paths = paths + node_offset[graph_of_path].unsqueeze(1)
+            loopy_n[order] = paths.t()
+            loopy_a[order] = batch[f"loopyA{order}"].t()
+            order += 1
+
+        return loopy_n, loopy_a

--- a/topobench/transforms/data_manipulations/r_neighbourhood.py
+++ b/topobench/transforms/data_manipulations/r_neighbourhood.py
@@ -31,7 +31,6 @@ def _bounded_simple_cycles(graph: nx.Graph, max_length: int) -> list:
             node, path = stack.pop()
             for neighbour in adjacency[node]:
                 if neighbour == start and len(path) >= 3:
-                    # Canonicalise direction to dedupe the two traversals.
                     reverse = (path[0], *path[:0:-1])
                     found[min(path, reverse)] = list(min(path, reverse))
                 elif (
@@ -79,15 +78,13 @@ def r_neighborhood(
     }
     edge_attr_idx = {}
     for L in range(2, r + 3):
-        # Initializing, useful to have an array of dim (L+1, 0)
+        # Initialization
         paths[L - 2] = np.zeros((0, L), dtype=int)
         edge_attr_idx[L - 2] = np.zeros((L - 1, 0))
         # Dividing the simple cycles depending on the length
         L_long_cycles = [cycle for cycle in cycles if len(cycle) == L]
         if L_long_cycles:
-            # Adding center of neighborhood as last element; useful to compute
-            # the index of each edge_attr. Note that paths[L-2] has dim.
-            # (num. paths, L+3)
+            # Adding center of neighborhood as last element
             paths[L - 2] = np.array(sorted(L_long_cycles))
 
     return paths, hops, edge_attr_idx
@@ -145,9 +142,7 @@ class RNeighbourhood(torch_geometric.transforms.BaseTransform):
                     for neighbour in graph.neighbors(centre):
                         rows[(centre, neighbour)] = [0, 1]
             else:
-                # One rotation per node as centre; the reverse traversal is
-                # omitted because it yields an identical per-path contribution
-                # after the layer's order-invariant path aggregation.
+                # One rotation per node as centre;
                 for cycle in paths[order]:
                     cycle = [int(node) for node in cycle]
                     for shift in range(length):

--- a/topobench/transforms/data_manipulations/r_neighbourhood.py
+++ b/topobench/transforms/data_manipulations/r_neighbourhood.py
@@ -1,0 +1,174 @@
+"""R-neighbourhood structural transform for the loopy models."""
+
+import networkx as nx
+import numpy as np
+import torch
+import torch_geometric
+
+
+def _bounded_simple_cycles(graph: nx.Graph, max_length: int) -> list:
+    """Enumerate simple cycles of length 3 to ``max_length`` inclusive.
+
+    Parameters
+    ----------
+    graph : networkx.Graph
+        The undirected input graph.
+    max_length : int
+        Maximum cycle length to enumerate.
+
+    Returns
+    -------
+    list
+        One representative node list per undirected simple cycle.
+    """
+    adjacency = {node: sorted(graph.neighbors(node)) for node in graph.nodes}
+    found = {}
+    for start in sorted(graph.nodes):
+        # Forcing ``start`` to be the smallest node of every cycle it closes
+        # means each cycle is discovered from a single starting node.
+        stack = [(start, (start,))]
+        while stack:
+            node, path = stack.pop()
+            for neighbour in adjacency[node]:
+                if neighbour == start and len(path) >= 3:
+                    # Canonicalise direction to dedupe the two traversals.
+                    reverse = (path[0], *path[:0:-1])
+                    found[min(path, reverse)] = list(min(path, reverse))
+                elif (
+                    neighbour > start
+                    and neighbour not in path
+                    and len(path) < max_length
+                ):
+                    stack.append((neighbour, (*path, neighbour)))
+    return list(found.values())
+
+
+def r_neighborhood(
+    G: nx.Graph,
+    r: int,
+) -> tuple[dict, dict]:
+    """Compute the r-neighbourhood cycles and pairwise node distances.
+
+    Parameters
+    ----------
+    G : networkx.Graph
+        The input graph.
+    r : int
+        Maximal neighbourhood order.
+
+    Returns
+    -------
+    paths : dict
+        Mapping from order ``L`` to the array of length ``L + 2`` simple
+        cycles, of shape ``(num_cycles, L + 2)``.
+    hops : dict
+        Mapping from a pair of nodes ``(s, t)`` to their shortest path
+        distance in the graph.
+    edge_attr_idx : dict
+        Unused placeholder kept for compatibility, one empty array per order.
+    """
+    cycles = _bounded_simple_cycles(
+        G.to_undirected() if G.is_directed() else G, max_length=r + 2
+    )
+    distances = dict(nx.all_pairs_shortest_path_length(G))
+    paths = {}
+    hops = {
+        (source, target): d
+        for source, target_dict in distances.items()
+        for target, d in target_dict.items()
+    }
+    edge_attr_idx = {}
+    for L in range(2, r + 3):
+        # Initializing, useful to have an array of dim (L+1, 0)
+        paths[L - 2] = np.zeros((0, L), dtype=int)
+        edge_attr_idx[L - 2] = np.zeros((L - 1, 0))
+        # Dividing the simple cycles depending on the length
+        L_long_cycles = [cycle for cycle in cycles if len(cycle) == L]
+        if L_long_cycles:
+            # Adding center of neighborhood as last element; useful to compute
+            # the index of each edge_attr. Note that paths[L-2] has dim.
+            # (num. paths, L+3)
+            paths[L - 2] = np.array(sorted(L_long_cycles))
+
+    return paths, hops, edge_attr_idx
+
+
+class RNeighbourhood(torch_geometric.transforms.BaseTransform):
+    r"""Precompute the loopy r-neighbourhood path tensors on a graph.
+
+    For every order ``L`` in ``0 .. r`` it adds ``loopyN{L}`` (the paths),
+    ``loopyA{L}`` (the hop distances) and ``loopyNcount{L}`` (the per-graph
+    path count) to each data object.
+
+    Parameters
+    ----------
+    r : int, optional
+        Maximal neighbourhood order; the longest path has ``r + 2`` nodes.
+    **kwargs : dict, optional
+        Extra arguments forwarded by the TopoBench transform dispatch (e.g.
+        ``transform_name``); stored but unused.
+    """
+
+    def __init__(self, r: int = 2, **kwargs):
+        super().__init__()
+        self.r = r
+        self.parameters = kwargs
+
+    def forward(
+        self, data: torch_geometric.data.Data
+    ) -> torch_geometric.data.Data:
+        r"""Add the loopy path tensors to the data object.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            Input graph. Only ``edge_index`` is read; node indices in the
+            output refer to the rows of ``data.x_0`` / ``data.x``.
+
+        Returns
+        -------
+        torch_geometric.data.Data
+            The same object with ``loopyN{L}``, ``loopyA{L}`` and
+            ``loopyNcount{L}`` fields added for every ``L`` in ``0 .. r``.
+        """
+        graph = nx.Graph()
+        graph.add_edges_from(data.edge_index.t().cpu().tolist())
+        paths, hops, _ = r_neighborhood(graph, r=self.r)
+
+        for order in range(self.r + 1):
+            length = order + 2
+            # Map each directed path (node tuple) to its hop row.
+            rows = {}
+            if length == 2:
+                # Direct neighbours: both orientations of every edge.
+                for centre in graph.nodes:
+                    for neighbour in graph.neighbors(centre):
+                        rows[(centre, neighbour)] = [0, 1]
+            else:
+                # One rotation per node as centre; the reverse traversal is
+                # omitted because it yields an identical per-path contribution
+                # after the layer's order-invariant path aggregation.
+                for cycle in paths[order]:
+                    cycle = [int(node) for node in cycle]
+                    for shift in range(length):
+                        rolled = cycle[shift:] + cycle[:shift]
+                        path = tuple(rolled)
+                        centre = path[0]
+                        rows[path] = [hops[centre, node] for node in path]
+
+            ordered = sorted(rows)
+            if ordered:
+                node_rows = np.asarray(ordered, dtype=np.int64)
+                hop_rows = np.asarray(
+                    [rows[path] for path in ordered], dtype=np.int64
+                )
+            else:
+                node_rows = np.zeros((0, length), dtype=np.int64)
+                hop_rows = np.zeros((0, length), dtype=np.int64)
+
+            data[f"loopyN{order}"] = torch.from_numpy(node_rows)
+            data[f"loopyA{order}"] = torch.from_numpy(hop_rows)
+            data[f"loopyNcount{order}"] = torch.tensor(
+                [node_rows.shape[0]], dtype=torch.long
+            )
+        return data


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.


## Description

This is the implementation of **r-ℓMPNN ("Loopy")** from *"Weisfeiler and Leman Go Loopy: A New Hierarchy for Graph Representational Learning"* by Paolino et al. (NeurIPS 2024). The official implementation can be found here: https://github.com/RPaolino/loopy.

**r-ℓMPNN** is a GNN framework that can count cycles up to length `r+2`, giving it expressivity beyond 1-WL while remaining a message-passing model.

## What's included

- **Backbone** — `topobench/nn/backbones/graph/loopy.py` (`Loopy`): the r-ℓMPNN layers (path-wise GIN with hop-distance embeddings) ported to TopoBench's node→node backbone contract.
- **Transform** — `topobench/transforms/data_manipulations/r_neighbourhood.py` (`RNeighbourhood`): precomputes the r-neighbourhood path tensors per graph.
- **Wrapper** — `topobench/nn/wrappers/graph/loopy_wrapper.py` (`LoopyWrapper`).
- **Configs** — `configs/model/graph/loopy.yaml`, plus the transform config and a `model_defaults` entry so the r-neighbourhood precompute auto-attaches (the notebook only needs `MODEL_CONFIG = "graph/loopy"`).
- **Tests** — unit tests for all three modules (100% line coverage), with `graph/loopy` added to `test/pipeline/test_pipeline.py`.
- **Results** — `results.json` from the evaluation notebook.

## Additional context

The port is faithful to the official repo but adapted to keep the contribution **purely additive** (no changes to shared TopoBench infrastructure) and to run on constrained hardware:

- **Batching without dataloader changes** — path tensors are stored row-oriented so they survive the default collation, and node indices are shifted from graph-local to batch-global inside the wrapper.
- **Environment-safe cycle enumeration** — cycles are found with a bounded DFS rather than `networkx.simple_cycles(length_bound=...)` (only available in networkx ≥ 3.1), so it runs on the pinned environment.
- **Memory** — path processing is gradient-checkpointed in chunks to bound training memory on dense graphs.
- **Deviations from the reference** (all behaviour-preserving) — the reverse-direction path expansion is dropped (provably redundant after the layer's order-invariant aggregation); `conv3d` path propagation is replaced with equivalent tensor shifts; and `segment_csr` with `scatter`.


