### PR TITLE
Track: Track2;  Team name: howyadoin;  Model: CTNN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-29_17-16-55/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-29_17-16-55/results.json
@@ -1,0 +1,5776 @@
+{
+  "metadata": {
+    "study_id": "2026-07-29_17-16-55",
+    "model_config": "simplicial/ctnn_diag",
+    "generated_at_utc": "2026-07-29T19:14:18.086750+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1844875812530518,
+      "test_best_rerun_accuracy": 0.32118573784828186,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32279011607170105,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3190847337245941,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31996333599090576,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32263731956481934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3172511160373688,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32263731956481934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31243792176246643,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.33734434843063354,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32783252000808716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34276872873306274,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3263809382915497,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.232325710467438,
+        "AvgTime/train_epoch_std": 0.10114103569126276,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1743581295013428,
+      "test_best_rerun_accuracy": 0.3265337347984314,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32554054260253906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3223317265510559,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3265719413757324,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32508212327957153,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3205363154411316,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32878753542900085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3172893226146698,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34131714701652527,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3318435251712799,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3451371490955353,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32725954055786133,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.276607821969425,
+        "AvgTime/train_epoch_std": 0.09609509032229756,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1831727027893066,
+      "test_best_rerun_accuracy": 0.3257315158843994,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32622814178466797,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31885552406311035,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.325464129447937,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32714492082595825,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3215295374393463,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3278707265853882,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3154939115047455,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3417755365371704,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3302009403705597,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3458247482776642,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3284819424152374,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5482525490877923,
+        "AvgTime/train_epoch_std": 0.2075721251900289,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1703197956085205,
+      "test_best_rerun_accuracy": 0.32431814074516296,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3232867419719696,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3117121160030365,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3183971345424652,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31354573369026184,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31530293822288513,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3061731159687042,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3043777346611023,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31683093309402466,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3138895332813263,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31545573472976685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3057147264480591,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2324097615021925,
+        "AvgTime/train_epoch_std": 0.14813177602130623,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1740355491638184,
+      "test_best_rerun_accuracy": 0.32767972350120544,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3225991427898407,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3061349093914032,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31790053844451904,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3125525116920471,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3139277398586273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30200931429862976,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30430132150650024,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3135075271129608,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31587591767311096,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31220871210098267,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2803054846726454,
+        "AvgTime/train_epoch_std": 0.1612913640268801,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.1698737144470215,
+      "test_best_rerun_accuracy": 0.3265719413757324,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3215295374393463,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30758652091026306,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3175949156284332,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3126671314239502,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31492093205451965,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29956451058387756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3028497099876404,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31557032465934753,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.314042329788208,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.31736573576927185,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31167393922805786,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.293551060090582,
+        "AvgTime/train_epoch_std": 0.20633756124118977,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1057262420654297,
+      "test_best_rerun_accuracy": 0.3475055396556854,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3174421191215515,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3084269165992737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3371533453464508,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3375735282897949,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3232867419719696,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3653067350387573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35090532898902893,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39391854405403137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37783634662628174,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44621437788009644,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4419359862804413,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.514309755393437,
+        "AvgTime/train_epoch_std": 0.14026920230432685,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1164774894714355,
+      "test_best_rerun_accuracy": 0.349148154258728,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32236993312835693,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31503552198410034,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34059134125709534,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34009474515914917,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3240889310836792,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35961493849754333,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34739094972610474,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38979294896125793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3726029396057129,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4384215772151947,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43223318457603455,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.378268112154568,
+        "AvgTime/train_epoch_std": 0.09912723057515817,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.104240894317627,
+      "test_best_rerun_accuracy": 0.3503323495388031,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31874093413352966,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3119795322418213,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33814653754234314,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3418901264667511,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32363054156303406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36492475867271423,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3517839312553406,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3972037732601166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.376537561416626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45014896988868713,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4390709698200226,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.5663726614482365,
+        "AvgTime/train_epoch_std": 0.11159930621844705,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1369516849517822,
+      "test_best_rerun_accuracy": 0.3371151387691498,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3161815404891968,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30934372544288635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3420047461986542,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34089693427085876,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33081212639808655,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3480403423309326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3416609466075897,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39617234468460083,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38780656456947327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43154558539390564,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4343723654747009,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4212540222538843,
+        "AvgTime/train_epoch_std": 0.12742077162411747,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1432695388793945,
+      "test_best_rerun_accuracy": 0.33894872665405273,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31843534111976624,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3157613277435303,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34185194969177246,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3355107307434082,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32649552822113037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34169912338256836,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34085872769355774,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.387997567653656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3820383548736572,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41989457607269287,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4245549738407135,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4073424441473823,
+        "AvgTime/train_epoch_std": 0.10447221274701736,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.130474805831909,
+      "test_best_rerun_accuracy": 0.3429597318172455,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32214072346687317,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.315952330827713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3450607359409332,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34307435154914856,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3308503329753876,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3463595509529114,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34639772772789,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39323094487190247,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38245856761932373,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42382916808128357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42650318145751953,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.395520261971347,
+        "AvgTime/train_epoch_std": 0.15031551140122212,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9616305828094482,
+      "test_best_rerun_accuracy": 0.39999234676361084,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27687370777130127,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2707616984844208,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27454352378845215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2710673213005066,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36905035376548767,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4074031710624695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4087783694267273,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5028268098831177,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4747115969657898,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5485904216766357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5265108346939087,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.534195459052308,
+        "AvgTime/train_epoch_std": 0.1719777899172297,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9578602313995361,
+      "test_best_rerun_accuracy": 0.4026281535625458,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28497210144996643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27641531825065613,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2727099061012268,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2721368968486786,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3715333342552185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39808234572410583,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39659255743026733,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5004966259002686,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.47203758358955383,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5372832417488098,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5060356259346008,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.457746514791175,
+        "AvgTime/train_epoch_std": 0.16420970417202066,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9594539403915405,
+      "test_best_rerun_accuracy": 0.40029796957969666,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27905112504959106,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2716403007507324,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27343571186065674,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.273244708776474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37023454904556274,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4064481556415558,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4036213755607605,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5001528263092041,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.47054779529571533,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5405684113502502,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5133699774742126,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4521758913993836,
+        "AvgTime/train_epoch_std": 0.16538067975486004,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.032208204269409,
+      "test_best_rerun_accuracy": 0.3730231523513794,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28145772218704224,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2784017026424408,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26419129967689514,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2683168947696686,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3897547423839569,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3844067454338074,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39800596237182617,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4808236062526703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46798840165138245,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5235694050788879,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5254412293434143,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.22975267225237,
+        "AvgTime/train_epoch_std": 0.12926135161233385,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0341644287109375,
+      "test_best_rerun_accuracy": 0.3749713599681854,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28119030594825745,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2823363244533539,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2643823027610779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27003592252731323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3867751657962799,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3885323405265808,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40056535601615906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48441439867019653,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46867600083351135,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5260142087936401,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5326228141784668,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2814502581744125,
+        "AvgTime/train_epoch_std": 0.18267155925044595,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0338833332061768,
+      "test_best_rerun_accuracy": 0.3755061626434326,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28489571809768677,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2831385135650635,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2652609050273895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2707616984844208,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.387157142162323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.387997567653656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.39961037039756775,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.48323020339012146,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.47192299365997314,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5242570042610168,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.530445396900177,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.058578126358263,
+        "AvgTime/train_epoch_std": 0.07212922093588721,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8397676944732666,
+      "test_best_rerun_accuracy": 0.4452593922615051,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2608678936958313,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.25292229652404785,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.289288729429245,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2714875042438507,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38219115138053894,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3402857482433319,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.439376562833786,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49423179030418396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4604629874229431,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5911452174186707,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5939720273017883,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.301013861383711,
+        "AvgTime/train_epoch_std": 0.04654640755485295,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8516340255737305,
+      "test_best_rerun_accuracy": 0.4465581774711609,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2660630941390991,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2554435133934021,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2876843214035034,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27549850940704346,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38585835695266724,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34551912546157837,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43945297598838806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4988921880722046,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46134158968925476,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5974100232124329,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5961876511573792,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.3229921843907606,
+        "AvgTime/train_epoch_std": 0.05216629198202531,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8462984561920166,
+      "test_best_rerun_accuracy": 0.44621437788009644,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2645733058452606,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2570860981941223,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29177170991897583,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27859270572662354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38612574338912964,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3429597318172455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4402933716773987,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.49598899483680725,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46214377880096436,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5961494445800781,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5982504487037659,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.303596084768122,
+        "AvgTime/train_epoch_std": 0.038639516831464986,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7871170043945312,
+      "test_best_rerun_accuracy": 0.463060587644577,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27060890197753906,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26270151138305664,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28294751048088074,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27740851044654846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39663076400756836,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36507755517959595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4466727674007416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5111162066459656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4879288077354431,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6085644364356995,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6429826617240906,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2149424090314267,
+        "AvgTime/train_epoch_std": 0.05983961773120623,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8029029369354248,
+      "test_best_rerun_accuracy": 0.45423638820648193,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.271334707736969,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26552829146385193,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2815341055393219,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2752692997455597,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39307814836502075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3678661584854126,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4414011836051941,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5055007934570312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4872030019760132,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6029490232467651,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6377874612808228,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2020635101157175,
+        "AvgTime/train_epoch_std": 0.05305026184515857,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.8051538467407227,
+      "test_best_rerun_accuracy": 0.45836198329925537,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.27045610547065735,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2652609050273895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27996790409088135,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2744289040565491,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3958285450935364,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3665291368961334,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4422033727169037,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5069524049758911,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.48907479643821716,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6046298146247864,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.642486035823822,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1971856319543086,
+        "AvgTime/train_epoch_std": 0.06108020526890159,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.4908756017684937,
+      "test_best_rerun_accuracy": 0.5593628287315369,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25723889470100403,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2406218945980072,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2506684958934784,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24440370500087738,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4015967547893524,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37607914209365845,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4009091556072235,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41618916392326355,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5347620248794556,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6210176348686218,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.620368242263794,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.502451985795921,
+        "AvgTime/train_epoch_std": 0.19878462605595792,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.486745834350586,
+      "test_best_rerun_accuracy": 0.5558866262435913,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2509740889072418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.243334099650383,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24627549946308136,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23596149682998657,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3986935615539551,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3685537576675415,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3907097578048706,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40805256366729736,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5278096199035645,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6136832237243652,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6175414323806763,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4038334041833878,
+        "AvgTime/train_epoch_std": 0.1501790481056371,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.488389253616333,
+      "test_best_rerun_accuracy": 0.5636793971061707,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2531515061855316,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23909389972686768,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2520054876804352,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23917029798030853,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4006417691707611,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3689357340335846,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3977385461330414,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40885475277900696,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5346856117248535,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.619566023349762,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6270914673805237,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.46027837143288,
+        "AvgTime/train_epoch_std": 0.15213828897728446,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5056363344192505,
+      "test_best_rerun_accuracy": 0.5526396036148071,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25387731194496155,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24367789924144745,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2438689023256302,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24692489206790924,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3959813714027405,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.38138896226882935,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3905569612979889,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4177553653717041,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.561693012714386,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6308350563049316,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6680036783218384,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.351762056350708,
+        "AvgTime/train_epoch_std": 0.14792558944474188,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.5313208103179932,
+      "test_best_rerun_accuracy": 0.5436626076698303,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.24448010325431824,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23794789612293243,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23798608779907227,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2380242943763733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3892199695110321,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37199175357818604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38658416271209717,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4097333550453186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.550347626209259,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6227366328239441,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6581862568855286,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.360694206367105,
+        "AvgTime/train_epoch_std": 0.12764518931573027,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.519562005996704,
+      "test_best_rerun_accuracy": 0.5493544340133667,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2513178884983063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24004890024662018,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24329589307308197,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2399342954158783,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39823517203330994,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37798914313316345,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3855145573616028,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4086637496948242,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5592482089996338,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6311788558959961,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6617388725280762,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.2723681795728075,
+        "AvgTime/train_epoch_std": 0.13394040174366287,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1805311441421509,
+      "test_best_rerun_accuracy": 0.6547864675521851,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23439529538154602,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22110168635845184,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25223469734191895,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23542669415473938,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38788294792175293,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3440675437450409,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4347161650657654,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44185957312583923,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5480556488037109,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5130261778831482,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6856902837753296,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.736052911456038,
+        "AvgTime/train_epoch_std": 0.09420947573971176,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1901270151138306,
+      "test_best_rerun_accuracy": 0.6487126350402832,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23378409445285797,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.221598282456398,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25276950001716614,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23729848861694336,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38685154914855957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34647414088249207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42868056893348694,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4395293891429901,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5460692048072815,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5155856013298035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6806860566139221,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8902983598306147,
+        "AvgTime/train_epoch_std": 0.14509563156989003,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.20645010471344,
+      "test_best_rerun_accuracy": 0.6473374366760254,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22832149267196655,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2123538851737976,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24856750667095184,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23214149475097656,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.37756896018981934,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33585453033447266,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4244403839111328,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43020856380462646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5377798080444336,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.510657787322998,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6796546578407288,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.8565719416647246,
+        "AvgTime/train_epoch_std": 0.2567244411706009,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0164073705673218,
+      "test_best_rerun_accuracy": 0.6984490752220154,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23760409653186798,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22442509233951569,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24677209556102753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23859728872776031,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.390977144241333,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3629765510559082,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4276491701602936,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4480861723423004,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.546413004398346,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5339980125427246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6469172835350037,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4374202082796796,
+        "AvgTime/train_epoch_std": 0.18784440449591588,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0365766286849976,
+      "test_best_rerun_accuracy": 0.6924134492874146,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23256169259548187,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22209489345550537,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24405989050865173,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23244708776474,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38413935899734497,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3556039333343506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42039117217063904,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44094276428222656,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.542631208896637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5294904112815857,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6437848806381226,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4041933922828,
+        "AvgTime/train_epoch_std": 0.11374856639782048,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0419865846633911,
+      "test_best_rerun_accuracy": 0.695163905620575,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23431889712810516,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22625869512557983,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2416914999485016,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23466269671916962,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38547635078430176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3603789508342743,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4224921762943268,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4434639811515808,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5454962253570557,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5360226035118103,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6487126350402832,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__community_detection__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4222606879014235,
+        "AvgTime/train_epoch_std": 0.13828417938957904,
+        "model/params/total": 147611,
+        "model/params/trainable": 147611,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 15.427412033081055,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15.40518856048584,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.01109883902052294,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.488010406494141,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.02362110740260074
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2983.95361328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22631426721890405
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.775611877441406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.013068962547165962
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4342.51953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5801629300267201
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.613128662109375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04284380713480948
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 124759.0703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.8970618222297047
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6914.31103515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4848065513361555
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32255.080078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6533435890166077
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1683.4949951171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2992879991319444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 635085.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.183978484893046
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182878.484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0432576901635797
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__00__h_lo__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6714146417729996,
+        "AvgTime/train_epoch_std": 0.07618818410398298,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 18.203229904174805,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18.459257125854492,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.013299176603641565,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.007285118103027,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.021090974305805407
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3148.019287109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.23875762511258058
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.1202392578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.011162871337314627
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4453.462890625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5949850221275885
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44.69875717163086,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.038599963015225267
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125289.203125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.9093721699099016
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6959.0966796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4879467591983943
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32458.556640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6637734707378646
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1712.4404296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3044338541666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 634517.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.177551949594471
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182026.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.029086686469306
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__00__h_lo__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6337628251030332,
+        "AvgTime/train_epoch_std": 0.08835984730688627,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 20.00456428527832,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 19.775230407714844,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.014247284155414153,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.0530900955200195,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.037121526818526415
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2998.2529296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2273987811670459
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.41558837890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.011936497599900994
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4412.65478515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5895330374290247
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.297149658203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04170738312452774
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 125119.0390625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.905420747317945
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7055.86181640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4947315815738501
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32468.423828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.6642792469180892
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1773.9967041015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3153771918402778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 636450.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.1994212583283375
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 184051.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.0627727543141465
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__00__h_lo__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7496807018915812,
+        "AvgTime/train_epoch_std": 0.12851264689661474,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.06464117765426636,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.06211983412504196,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0003269464953949577,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.44398498535156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.056515839326622165
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7850.953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.595445819112628
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59.382389068603516,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02001428684482761
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6551.21484375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8752458041082164
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89.91788482666016,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07764929605065644
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157022.796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.646265950097529
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11510.3310546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8070628982392021
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41782.18359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1416876105259113
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2823.656005859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5019832899305555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 718276.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.125020502697872
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233821.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.890989799144659
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__01__h_lo__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5653457321146482,
+        "AvgTime/train_epoch_std": 0.08097172349283549,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.09634778648614883,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.0955759584903717,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0005030313604756406,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.62263488769531,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0566445496309044
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7832.966796875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5940816683257489
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59.87809371948242,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.02018135952796846
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6570.1865234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8777804306529726
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90.52254486083984,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07817145497481852
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157049.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.6468747823007615
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11524.1962890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8080350784646263
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41827.70703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1440210688015786
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2840.6728515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5050085069444444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 718266.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.12490950533353
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233392.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8838519045479507
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__01__h_lo__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5888756838711826,
+        "AvgTime/train_epoch_std": 0.08471184970180823,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.10427428781986237,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.09606171399354935,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.0005055879683871018,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.55579376220703,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.05371454882003388
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7702.89990234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5842169057522754
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.21263122558594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.021305234656415886
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6490.88623046875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8671858691341016
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88.93270874023438,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07679853949933883
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156172.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.626513372538547
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11435.0390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8017836953092133
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41489.26171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.126672905774258
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2795.682861328125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.49701028645833334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 715629.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.095085856814814
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 232306.5625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.865784076348327
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__01__h_lo__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5640660009266418,
+        "AvgTime/train_epoch_std": 0.10370823355657209,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1235.4832763671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1188.318359375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.0901265346511187,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 322.87890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.23262169038184438
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 573.461669921875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 3.0182193153782895
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 316.6961364746094,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1067395134730736
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3842.530517578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5133641306049599
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 330.670654296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2855532420525691
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107598.015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.498560645202489
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5420.328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3800538581545365
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28584.623046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4652018579565842
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1571.5191650390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.27938118489583336
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 588712.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.659421908758753
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155521.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.5880075986387765
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__02__h_lo__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6741260290145874,
+        "AvgTime/train_epoch_std": 0.013982461159008185,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1333.503662109375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1305.57373046875,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.09901962309205536,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 546.2186889648438,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.3935293148161699
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1013.4088745117188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 5.33373091848273
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 339.9526062011719,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11457789221475291
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4391.46826171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5867025065756513
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 595.701171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.514422428216753
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109957.6171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.5533535479170535
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5842.5869140625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.40966112144597533
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30287.009765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.5524634663809012
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1838.2034912109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3267917317708333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 597882.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.76315071321109
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158434.921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.636495463281913
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__02__h_lo__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8690409660339355,
+        "AvgTime/train_epoch_std": 0,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 1241.72216796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1228.234130859375,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.09315389691766211,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 188.35614013671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1357032709918723
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 325.0787353515625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.7109407123766447
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 410.4725341796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1383459838826045
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3691.69677734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4932126623037742
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 191.16526794433594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.16508226938198267
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 105246.3359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.443951698344325
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5676.87255859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3980418285369338
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28095.8203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4401466150238351
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1751.7181396484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.31141655815972225
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 583172.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.596751524269538
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153977.796875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.5623250108165676
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__02__h_lo__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.761547565460205,
+        "AvgTime/train_epoch_std": 0.02434213305679116,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 10.400124549865723,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10.735973358154297,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.003618460855461509,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.422138214111328,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.021197505917947643
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.0020036697387695,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.021063177209151417
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4371.240234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3315313033276451
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5193.09326171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6938000349657648
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.47998809814453,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04877373756316453
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136708.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.1745349218604866
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8347.212890625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5852764612694573
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36034.078125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8470489581731508
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2049.107177734375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.36428572048611113
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 667767.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.55367394206079
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201288.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3496185079792986
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__03__h_lo__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7573241197837974,
+        "AvgTime/train_epoch_std": 0.08783283094322139,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 10.138708114624023,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9.531933784484863,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0032126504160717435,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.963319778442383,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.023028328370635724
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.251648902893066,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.02764025738364772
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4391.458984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.33306476938756163
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5271.97119140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7043381685245491
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.850948333740234,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.04477629389787585
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137131.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.184375653097715
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8362.359375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5863384781236853
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36314.48828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.86142233232098
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2050.08984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3644604166666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 668619.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.563314451998235
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 201608.546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.3549422873712413
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__03__h_lo__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5977321559307622,
+        "AvgTime/train_epoch_std": 0.13476688481396898,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 10.726226806640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10.962980270385742,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.0036949714426645574,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.3050594329834,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.019672233020881412
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.331247091293335,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.01753287942785966
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4649.90087890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.35266597488860446
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5372.4541015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7177627390197061
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.47102737426758,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.050493115176396874
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139622.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2422154380689205
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8819.849609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6184160432881083
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36670.51953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8796719222538316
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2183.1728515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.38811961805555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 674585.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.630793072633281
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 206508.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.4364851667415506
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__03__h_lo__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.825191354751587,
+        "AvgTime/train_epoch_std": 0.13013561974564514,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1578.805908203125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1539.1800537109375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.2056352777168921,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 282.81793212890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2037593170957538
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156.38092041015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8230574758429277
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2127.0029296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16131990365472126
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 501.5192565917969,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.16903244239696558
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 279.6717224121094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2415127136546713
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 66033.9453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5333908905930709
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2950.909912109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.2069071597328127
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14250.51171875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7304583381388078
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1350.8616943359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.24015319010416666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 425847.1875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.817112400031673
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86554.5078125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.440342599179605
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__04__h_mid__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.7445410531142662,
+        "AvgTime/train_epoch_std": 0.13901738805160666,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1676.8385009765625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1714.912353515625,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.22911320688251502,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 256.157958984375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.18455184364868515
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123.29680633544922,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.648930559660259
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1913.995849609375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.14516464540078688
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 871.71240234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.29380262970803844
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 199.39520263671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.17218929415951534
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71772.296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6666425988064277
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3461.974365234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.24274115588517564
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15031.6865234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7705001037181557
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 983.6814575195312,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.1748767035590278
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 439356.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.969927844643282
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95375.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5871240722713127
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__04__h_mid__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0607799323829443,
+        "AvgTime/train_epoch_std": 0.20441861540990336,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3044.57421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3126.999267578125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.4177687732235304,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 278.4084777832031,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.20058247678905125
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 343.00177001953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.8052724737870065
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1841.56787109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.13967143504692833
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 748.9375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.25242248062015504
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 237.680908203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2052512160648748
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91957.734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1353737315391044
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5603.1923828125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3928756403598724
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24386.998046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.2500383436811215
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2012.8802490234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3578453776041667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 540853.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.118038980577582
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136146.84375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.26560237881284
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__04__h_mid__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.1160216331481934,
+        "AvgTime/train_epoch_std": 0.23091518923711246,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 62.46367645263672,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 65.77420043945312,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.05679982766792152,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.05256271362305,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02669492990895032
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.141712188720703,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0375879588880037
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4924.95263671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3735269349047213
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.47314453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.009933651678884395
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5580.67578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7455812667000667
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142815.984375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3163659756409065
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8976.6484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6294102115762166
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37791.5859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9371359853144703
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2236.062255859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.39752217881944446
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 685404.4375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.753180746128525
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211317.578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.516509046394755
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__05__h_mid__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8724455833435059,
+        "AvgTime/train_epoch_std": 0.11326360702514648,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 66.32701110839844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 70.21175384521484,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.06063191178343251,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.66289520263672,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.030016495102764208
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.200654983520508,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.09579292096589741
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4321.94580078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.32779262804560105
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23.767868041992188,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008010740829791772
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5451.52001953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7283259879133267
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139049.84375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.2289114747817202
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8636.126953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6055340732803954
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36937.2734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8933452989645805
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2210.173583984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.39291974826388887
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 675774.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.644248498354128
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 205649.46875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.422186756360974
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__05__h_mid__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8312265872955322,
+        "AvgTime/train_epoch_std": 0.07474600678341527,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 65.67422485351562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 69.16413116455078,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.05972722898493159,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.232452392578125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.026824533424047642
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.335151672363281,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.04913237722296464
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5101.59228515625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3869239503341866
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.138689041137695,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.006113477937693864
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5463.24267578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7298921410529392
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141911.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.295359450469069
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9293.2822265625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6516114308345604
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36944.953125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8937389474088882
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2269.70654296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4035033854166667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 679745.875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.689172030360961
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 211479.8125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.519208768076149
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__05__h_mid__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.678021001815796,
+        "AvgTime/train_epoch_std": 0.051249882055301205,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 106195.0859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 68409.7734375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.5885605944060004,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2397.06396484375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.7269913291381485
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2308.860107421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 12.151895302220394
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16886.732421875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.2807533122392871
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3141.55859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.0588333649309067
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5948.49267578125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7947218003715765
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2535.72900390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.1897487080364852
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14385.453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0086560878558406
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21158.89453125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0845709432185144
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8224.1689453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.4620744791666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 409407.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.631147981403346
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99511.890625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6559647650308689
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__06__h_mid__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.909591833750407,
+        "AvgTime/train_epoch_std": 0.06155657302341277,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 109990.7734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 70585.84375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.639091671697938,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2138.031982421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.5403688634163364
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1248.7574462890625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 6.572407612047697
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17667.0703125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.3399370733788396
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4474.66845703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.5081457556559656
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6684.201171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8930128486138944
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1594.315673828125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.3767838288671201
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16217.091796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1370839851966765
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22803.50390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1688709778179303
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8334.689453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.4817225694444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 416083.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.706671082994921
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 103066.8828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.715122939651873
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__06__h_mid__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8700486024220784,
+        "AvgTime/train_epoch_std": 0.06805405251268776,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 102514.3671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 67018.25,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 1.556247677874791,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3568.146240234375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.5707105477192904
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6339.81396484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 33.36744192023026
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7397.74072265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5610724856015359
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3274.11083984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1035088776015336
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3976.325439453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.5312392036677521
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4239.96435546875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 3.6614545384013386
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6999.35498046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.49076952604604895
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18113.423828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.9284650073363576
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4224.36572265625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7509983506944444
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 423921.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.795324395099714
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100492.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6722756810277404
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__06__h_mid__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.900434414545695,
+        "AvgTime/train_epoch_std": 0.12620199422118533,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 2925.513427734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2965.759033203125,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.2079483265462856,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 735.311279296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.5297631695222442
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 505.47235107421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.660380795127467
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2730.055908203125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.20705771014054797
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 463.5108947753906,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.15622207441031027
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2486.938232421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.33225627687667003
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 560.4383544921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.48397094515732947
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63878.765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.483344919770574
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15279.337890625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7831943149636066
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1547.06298828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.2750334201388889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 418386.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.732713751230162
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 92895.2421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5458579566255637
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__07__h_mid__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.800671034389072,
+        "AvgTime/train_epoch_std": 0.09055613738577983,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3657.02587890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3460.72998046875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.24265390411364116,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 604.0347290039062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4351835223371083
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 275.20135498046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.4484281841077302
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2922.9794921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.22168976049962077
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 528.3010864257812,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.17805901126585144
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2925.59912109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3908616060245491
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 444.6404113769531,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3839727213963326
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70767.140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6433016121354262
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16816.970703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8620109028204931
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1673.05126953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.29743133680555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 430544.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.870241960114476
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95189.6484375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5840388803604413
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__07__h_mid__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.839144915342331,
+        "AvgTime/train_epoch_std": 0.11932162157053108,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 3380.21923828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3377.960693359375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.2368504202327426,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 684.0902709960938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.4928604257896929
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 364.3582763671875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.917675138774671
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2034.680419921875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.15431781721060864
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 422.70648193359375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.14246932319972827
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2343.778076171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3131300034965765
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 435.2166442871094,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.37583475327038807
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69472.1796875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6132309977591492
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16113.9619140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.8259758016332206
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1478.2650146484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.26280266927083334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 436577.59375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.93849296686764
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99762.828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6601405841778576
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__07__h_mid__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.6797478822561411,
+        "AvgTime/train_epoch_std": 0.10247293178240637,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 9550.7822265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9905.1640625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.5077227978112666,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2181.65380859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.5717966920704252
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1904.923583984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 10.025913599917763
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12203.50390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9255596440083428
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14569.23046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 4.910424829373104
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2727.0,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.36432865731462927
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1979.802490234375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.7096739984752807
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61742.0078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.4337267279514212
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19913.353515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.3962525252857243
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3105.281982421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.5520501302083334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 335976.15625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.800506275239528
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 73607.96875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2249008827983292
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__08__h_hi__d_lo__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.651335672898726,
+        "AvgTime/train_epoch_std": 0.04094432679028249,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 9333.9775390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9230.7978515625,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.4731558691661541,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2039.9156494140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.4696798626902468
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1659.5706787109375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 8.73458251953125
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21231.109375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.6102472032612818
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24152.224609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.14028466780418
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2738.649658203125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.365885057876169
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1940.235595703125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.675505695771265
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64967.89453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.508635856661016
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38305.28515625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 2.685828436141495
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5120.2490234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.9102664930555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 327633.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.706130589459634
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 87601.4921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4577653335247034
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__08__h_hi__d_lo__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5805704063839383,
+        "AvgTime/train_epoch_std": 0.04065438302318228,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 8270.1103515625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8477.6787109375,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.4345521918569635,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2176.941162109375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.568401413623469
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1857.647705078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 9.77709318462171
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18556.33984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.4073826199279484
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18072.302734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.091103044952814
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2553.0302734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3410862088760855
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1623.060791015625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.4016069007043395
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60254.74609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3991906486566505
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26394.88671875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.8507142559774226
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3934.310791015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6994330295138889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 312444.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.5343151533319004
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74014.25,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.2316617576090394
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__08__h_hi__d_lo__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.5534074748003925,
+        "AvgTime/train_epoch_std": 0.04337201983822258,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 858.6163330078125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 904.650634765625,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.16082677951388888,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96.35257720947266,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.06941828329212728
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.71498107910156,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.298499900416324
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2174.142333984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.16489513340799203
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 502.0934753417969,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.1692259775334671
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2856.394287109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3816158032210254
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107.84925079345703,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.093134068042709
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95518.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.218058804918261
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5021.93896484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3521202471493304
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22336.365234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.1449261999269569
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 518221.21875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.862032043595805
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131167.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.182746170519029
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__09__h_hi__d_lo__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.4710221954538851,
+        "AvgTime/train_epoch_std": 0.03788521000636715,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1016.6004638671875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1066.0048828125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.18951197916666668,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 128.65989685058594,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.09269445018053742
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.22040557861328,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.45379160830849097
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2620.51123046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.19874942969046264
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 629.7162475585938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.21224005647407945
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3077.44482421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.41114827310871743
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123.0707015991211,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.10627867150183169
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102293.484375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.37538278782742
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5814.65771484375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4077028267314367
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23317.380859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.195211484923625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 537770.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.083168840423967
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137835.140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.293697113224502
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__09__h_hi__d_lo__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.672115575976488,
+        "AvgTime/train_epoch_std": 0.21224831327147245,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1644.6702880859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1748.1553955078125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.3107831814236111,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.281009674072266,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.04559150552887051
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.016944885253906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.24745760465923108
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2648.5087890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.2008728698568449
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70.57726287841797,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.023787415867346805
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4522.98388671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6042730643578824
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78.29060363769531,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06760846600837246
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123449.2265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.866645610312558
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6888.19921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.4829756849495162
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32019.802734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.641283650334461
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 626824.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.09053213691843
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 180399.453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.002004445193284
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__09__h_hi__d_lo__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 1.8000079154968263,
+        "AvgTime/train_epoch_std": 0.12357147798663251,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 323241.75,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 205624.859375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 2.3259941334004504,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 250311.28125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 180.3395398054755
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 271454.09375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1428.7057565789473
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71572.296875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.428312239287068
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 129580.15625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 43.67379718570947
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 182789.140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 24.42072687040748
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 214949.578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 185.6213973445596
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 75714.9140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.7581951064113877
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54332.7109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.8096137244075163
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134149.5,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 6.8762878671382435
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97883.9296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 17.4015875
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108171.765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.8000726478125573
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__10__h_hi__d_hi__pl_lo__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4864856067456698,
+        "AvgTime/train_epoch_std": 0.11808971225439635,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 234976.546875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 178872.5,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 2.0233759035326857,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 116150.6171875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 83.68200085554756
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 154917.03125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 815.3527960526316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86531.6328125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 6.562884551573758
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71620.2421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 24.138942429221437
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68462.4453125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 9.146619280227121
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91347.484375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 78.88383797495682
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86525.9296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.009240425587498
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 160774.5625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 11.27293244285514
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60368.8984375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.094412755010508
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49104.21875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 8.72963888888889
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252491.203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.20167412385802
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__10__h_hi__d_hi__pl_lo__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.4275790214538575,
+        "AvgTime/train_epoch_std": 0.11748811010046901,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 299109.90625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 193064.53125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 2.183913795346312,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147682.828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 106.39973207853026
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 173869.859375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 915.1045230263157
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46404.42578125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.519486217766401
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41174.8515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 13.877604166666666
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 130532.34375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 17.439190881763526
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131315.203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 113.39827558290155
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69705.7578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6186549742824634
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56671.234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.973582553288459
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138468.140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 7.097654447947101
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86812.03125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 15.43325
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82627.703125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3749971398498992
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__10__h_hi__d_hi__pl_lo__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.418115162849426,
+        "AvgTime/train_epoch_std": 0.20331943292947927,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 47659.7890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 46555.0078125,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.7747159870950028,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107715.046875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 77.60450063040346
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 127535.71875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 671.240625
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23600.453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.7899471463784604
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26944.119140625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 9.081266983695652
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84328.1328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 11.266283608884436
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 99313.9375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 85.76333117443869
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51629.171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1988940153028051
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12267.9560546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.860184830646999
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78761.5859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 4.037192369547388
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68705.6953125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 12.214345833333333
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245558.03125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.7777115171430835
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__11__h_hi__d_hi__pl_hi__s42",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0015468380667945,
+        "AvgTime/train_epoch_std": 0.02593100902788079,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 55883.8046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 54334.7265625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.9041773012247682,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 88846.9453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 64.01076751621038
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106026.484375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 558.0341282894736
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20353.15234375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.5436596392681077
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18498.154296875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.234632388565892
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71998.6171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 9.61905373246493
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81679.1171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 70.53464351252158
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47060.48046875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0928032804372563
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13511.4912109375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.9473770306364816
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70464.515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 3.611897874058127
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54339.1171875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 9.6602875
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 243618.234375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 2.755768858240105
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__11__h_hi__d_hi__pl_hi__s43",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0425361678713845,
+        "AvgTime/train_epoch_std": 0.04051005363782927,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "ctnn_diag_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 96721.7734375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 90323.3515625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 1.5030594505599655,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3240.9423828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.334972898279899
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2926.450439453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 15.402370733963815
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13400.22265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.016323295885476
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3552.281982421875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1972638970077099
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6019.2138671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8041701893370073
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2856.686767578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.466914307062284
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69129.5703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6052751790939068
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10069.59375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.70604359486748
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22775.392578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.16743003629735
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8225.4287109375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.4622984375
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 399845.5,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.522985645283531
+        }
+      },
+      "output_dir": "/home/neervana/repos/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-29_17-16-55__triangle_counting__11__h_hi__d_hi__pl_hi__s44",
+      "wandb_config": {
+        "AvgTime/train_epoch_mean": 2.0293556690216064,
+        "AvgTime/train_epoch_std": 0.013520519572304025,
+        "model/params/total": 146376,
+        "model/params/trainable": 146376,
+        "model/params/non_trainable": 0
+      }
+    }
+  ]
+}

--- a/2026_tdl_challenge/run_evaluation.ipynb
+++ b/2026_tdl_challenge/run_evaluation.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "53c1d2fb",
    "metadata": {},
    "outputs": [],
@@ -98,13 +98,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "config_cell",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Your model configuration (e.g., \"graph/gcn\", \"graph/gin\", \"graph/gat\")\n",
-    "MODEL_CONFIG = \"graph/gin\""
+    "MODEL_CONFIG = \"simplicial/ctnn_diag\""
    ]
   },
   {
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "id": "f52c90bd",
    "metadata": {},
    "outputs": [],
@@ -140,6 +140,7 @@
     "import hashlib\n",
     "import json\n",
     "import warnings\n",
+    "\n",
     "\n",
     "def hash_remaining_cells(\n",
     "    notebook_path: str, marker_string: str = \"# UNIQUE_HASH_MARKER\"\n",
@@ -176,7 +177,9 @@
     "        )\n",
     "\n",
     "    # Join with an explicit separator between cells so a cell boundary is never ambiguous with in-cell content\n",
-    "    cell_sources = [\"\".join(cell.get(\"source\", [])) for cell in cells[start_index:]]\n",
+    "    cell_sources = [\n",
+    "        \"\".join(cell.get(\"source\", [])) for cell in cells[start_index:]\n",
+    "    ]\n",
     "    content_to_hash = \"\\n\".join(cell_sources)\n",
     "\n",
     "    normalized = \" \".join(content_to_hash.split())\n",
@@ -193,7 +196,7 @@
     "        stacklevel=2,\n",
     "    )\n",
     "else:\n",
-    "    print(\"Notebook content is verified.\")\n"
+    "    print(\"Notebook content is verified.\")"
    ]
   },
   {
@@ -295,7 +298,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tb",
+   "display_name": "topobench (3.11.11)",
    "language": "python",
    "name": "python3"
   },
@@ -309,7 +312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/configs/model/simplicial/ctnn.yaml
+++ b/configs/model/simplicial/ctnn.yaml
@@ -1,0 +1,82 @@
+# Copresheaf Topological Neural Network (CTNN) with SheafFC transport maps.
+# Hajij et al., "Copresheaf Topological Neural Networks: A Generalized Deep
+# Learning Framework", NeurIPS 2025 (https://arxiv.org/abs/2505.21251).
+#
+# Layer. Definition 10 of the paper, instantiated with copresheaf attention as
+# the message function (Definition 11 within a rank, Definition 16 across
+# ranks) and a residual MLP with normalisation as the update. This is the
+# Copresheaf Cellular Transformer that Appendix H.5 evaluates on simplicial
+# complexes.
+#
+# Transport maps. `sheaf_fc` is the SheafFC map of Table 18, which Appendix
+# H.5 instantiates: rho = Id + tanh(W [q_x; k_y]) with W zero-initialised, so
+# every map starts at the identity. The two other entries of the catalogue that
+# the paper applies to topological domains ship as the sibling configs
+# `simplicial/ctnn_spd` and `simplicial/ctnn_diag`.
+_target_: topobench.model.TBModel
+
+model_name: ctnn
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
+
+backbone:
+  _target_: topobench.nn.backbones.CopresheafTNN
+  channels: ${model.feature_encoder.out_channels}
+  # The collection N = {N_k} of Definition 10. Every entry names one copresheaf
+  # adjacency or incidence matrix (Definition 8) to transport along. These are
+  # the three message paths of the layer displayed in Appendix H.5, all of them
+  # into rank 0: 0 <- 0, 0 <- 1, and 0 <- 2. The last one is direct, matching
+  # the paper's `rho_{t->v}^{(0<-2)}` for `t` containing `v`; `2-down_incidence-2`
+  # is the composite `incidence_1 . incidence_2`, whose support is exactly
+  # {(v, t) : v in t}. Appendix H.5 has no upward route, so ranks 1 and 2 are
+  # not updated by the backbone and reach the readout as encoder features.
+  #
+  # Deviation: Appendix H.5 defines its 0 <-> 0 adjacency through 2-cells,
+  # `{w | exists t in X^2 : v, w in t}`, which is `2-up_adjacency-0` here. We
+  # use `up_adjacency-0` (adjacency through 1-cells) because GraphUniverse
+  # graphs have average degree 1-5, so triangle-adjacency is nearly empty and
+  # would silence the 0 <- 0 path on most nodes.
+  neighborhoods:
+    - up_adjacency-0
+    - down_incidence-1
+    - 2-down_incidence-2
+  layers: 2 # Section 6.1 and Appendix H.5 both use two transformer layers
+  # Stalk dimension d = channels / heads = 4. The SheafFC transport carries
+  # W in R^{2d x d^2} per head (Table 18), so d drives the parameter count
+  # quadratically: d=16 puts 59% of the backbone's weights in the transport
+  # maps and overfits GraphUniverse. d=4 is the stalk width the paper uses for
+  # its classification tasks (Section 6.3, Appendix H.3.1, Appendix H.4); the
+  # d=16 of Section 6.1 and Appendix H.5 is for physics regression.
+  heads: 16
+  copresheaf_map: sheaf_fc # Table 18 SheafFC, the map of Appendix H.5
+  dropout: 0.2 # Appendix H.5 reports layer norm and grad clipping, no dropout.
+  # We turn dropout on to avoid overfitting on small datasets.
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: TuneWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/simplicial/ctnn_diag.yaml
+++ b/configs/model/simplicial/ctnn_diag.yaml
@@ -1,0 +1,87 @@
+# Copresheaf Topological Neural Network (CTNN) with diagonal transport maps.
+# Hajij et al., "Copresheaf Topological Neural Networks: A Generalized Deep
+# Learning Framework", NeurIPS 2025 (https://arxiv.org/abs/2505.21251).
+#
+# Layer. Definition 10 of the paper, instantiated with copresheaf attention as
+# the message function (Definition 11 within a rank, Definition 16 across
+# ranks) and a residual MLP with normalisation as the update. This is the
+# Copresheaf Cellular Transformer that Appendix H.5 evaluates on simplicial
+# complexes.
+#
+# Transport maps. `diagonal` is the Diagonal MLP Map of Table 18,
+# rho = diag(sigma(MLP[q_x, k_y])). Confining transport to the diagonal is the
+# d^2 -> d reduction that Table 19 notes: it is the cheapest way to run the
+# layer on a complex whose higher-rank neighborhoods are dense, and it is the
+# parameterisation the copresheaf GCN and GraphSAGE of Section 6.2 use. Unlike
+# the SheafFC and SheafSPD maps it carries no identity term, so a message can be
+# gated off entirely.
+#
+# This config differs from `simplicial/ctnn` in exactly one entry,
+# `backbone.copresheaf_map`; every other hyperparameter is identical.
+_target_: topobench.model.TBModel
+
+model_name: ctnn_diag
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
+
+backbone:
+  _target_: topobench.nn.backbones.CopresheafTNN
+  channels: ${model.feature_encoder.out_channels}
+  # The collection N = {N_k} of Definition 10. Every entry names one copresheaf
+  # adjacency or incidence matrix (Definition 8) to transport along. These are
+  # the three message paths of the layer displayed in Appendix H.5, all of them
+  # into rank 0: 0 <- 0, 0 <- 1, and 0 <- 2. The last one is direct, matching
+  # the paper's `rho_{t->v}^{(0<-2)}` for `t` containing `v`; `2-down_incidence-2`
+  # is the composite `incidence_1 . incidence_2`, whose support is exactly
+  # {(v, t) : v in t}. Appendix H.5 has no upward route, so ranks 1 and 2 are
+  # not updated by the backbone and reach the readout as encoder features.
+  #
+  # Deviation: Appendix H.5 defines its 0 <-> 0 adjacency through 2-cells,
+  # `{w | exists t in X^2 : v, w in t}`, which is `2-up_adjacency-0` here. We
+  # use `up_adjacency-0` (adjacency through 1-cells) because GraphUniverse
+  # graphs have average degree 1-5, so triangle-adjacency is nearly empty and
+  # would silence the 0 <- 0 path on most nodes.
+  neighborhoods:
+    - up_adjacency-0
+    - down_incidence-1
+    - 2-down_incidence-2
+  layers: 2 # Section 6.1 and Appendix H.5 both use two transformer layers
+  # Stalk dimension d = channels / heads = 4. Transport parameters scale with d
+  # faster than linearly for every map of Table 18, so d=16 puts most of the
+  # backbone's weights in the transport maps and overfits GraphUniverse. d=4 is
+  # the stalk width the paper uses for its classification tasks (Section 6.3,
+  # Appendix H.3.1, Appendix H.4); the d=16 of Section 6.1 and Appendix H.5 is
+  # for physics regression.
+  heads: 16
+  copresheaf_map: diagonal # Table 18 Diagonal MLP Map, O(d) instead of O(d^2)
+  dropout: 0.5 # Appendix H.5 reports layer norm and grad clipping, no dropout.
+  # We turn dropout on to avoid overfitting on small datasets.
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: TuneWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/simplicial/ctnn_spd.yaml
+++ b/configs/model/simplicial/ctnn_spd.yaml
@@ -1,0 +1,86 @@
+# Copresheaf Topological Neural Network (CTNN) with SheafSPD transport maps.
+# Hajij et al., "Copresheaf Topological Neural Networks: A Generalized Deep
+# Learning Framework", NeurIPS 2025 (https://arxiv.org/abs/2505.21251).
+#
+# Layer. Definition 10 of the paper, instantiated with copresheaf attention as
+# the message function (Definition 11 within a rank, Definition 16 across
+# ranks) and a residual MLP with normalisation as the update. This is the
+# Copresheaf Cellular Transformer that Appendix H.5 evaluates on simplicial
+# complexes.
+#
+# Transport maps. `sheaf_spd` is the SheafSPD map of Table 18, which Appendix
+# H.5 offers as the constrained alternative to the SheafFC map of
+# `simplicial/ctnn`: rho = Id + Q Q^T is symmetric positive definite with every
+# eigenvalue at least one, so transport can stretch a stalk but never reflect
+# or contract it. Appendix H.1 credits that alignment with a diffusion tensor
+# for the gain on viscous flow.
+#
+# This config differs from `simplicial/ctnn` in exactly one entry,
+# `backbone.copresheaf_map`; every other hyperparameter is identical.
+_target_: topobench.model.TBModel
+
+model_name: ctnn_spd
+model_domain: simplicial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
+
+backbone:
+  _target_: topobench.nn.backbones.CopresheafTNN
+  channels: ${model.feature_encoder.out_channels}
+  # The collection N = {N_k} of Definition 10. Every entry names one copresheaf
+  # adjacency or incidence matrix (Definition 8) to transport along. These are
+  # the three message paths of the layer displayed in Appendix H.5, all of them
+  # into rank 0: 0 <- 0, 0 <- 1, and 0 <- 2. The last one is direct, matching
+  # the paper's `rho_{t->v}^{(0<-2)}` for `t` containing `v`; `2-down_incidence-2`
+  # is the composite `incidence_1 . incidence_2`, whose support is exactly
+  # {(v, t) : v in t}. Appendix H.5 has no upward route, so ranks 1 and 2 are
+  # not updated by the backbone and reach the readout as encoder features.
+  #
+  # Deviation: Appendix H.5 defines its 0 <-> 0 adjacency through 2-cells,
+  # `{w | exists t in X^2 : v, w in t}`, which is `2-up_adjacency-0` here. We
+  # use `up_adjacency-0` (adjacency through 1-cells) because GraphUniverse
+  # graphs have average degree 1-5, so triangle-adjacency is nearly empty and
+  # would silence the 0 <- 0 path on most nodes.
+  neighborhoods:
+    - up_adjacency-0
+    - down_incidence-1
+    - 2-down_incidence-2
+  layers: 2 # Section 6.1 and Appendix H.5 both use two transformer layers
+  # Stalk dimension d = channels / heads = 4. Transport parameters scale with d
+  # faster than linearly for every map of Table 18, so d=16 puts most of the
+  # backbone's weights in the transport maps and overfits GraphUniverse. d=4 is
+  # the stalk width the paper uses for its classification tasks (Section 6.3,
+  # Appendix H.3.1, Appendix H.4); the d=16 of Section 6.1 and Appendix H.5 is
+  # for physics regression.
+  heads: 16
+  copresheaf_map: sheaf_spd # Table 18 SheafSPD, the constrained option of Appendix H.5
+  dropout: 0.2 # Appendix H.5 reports layer norm and grad clipping, no dropout.
+  # We turn dropout on to avoid overfitting on small datasets.
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.${model.backbone_wrapper.wrapper_name}
+  _partial_: true
+  wrapper_name: TuneWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown #  Use <NoReadOut> in case readout is not needed Options: PropagateSignalDown
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}} # The highest order of cell dimensions to consider
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}} # Handles the edge case of node-inductive task
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/docs/api/topobench.nn.backbones.simplicial.ctnn.rst
+++ b/docs/api/topobench.nn.backbones.simplicial.ctnn.rst
@@ -1,0 +1,7 @@
+topobench.nn.backbones.simplicial.ctnn module
+=============================================
+
+.. automodule:: topobench.nn.backbones.simplicial.ctnn
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/topobench.nn.backbones.simplicial.rst
+++ b/docs/api/topobench.nn.backbones.simplicial.rst
@@ -12,4 +12,5 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   topobench.nn.backbones.simplicial.ctnn
    topobench.nn.backbones.simplicial.sccnn

--- a/test/nn/backbones/simplicial/test_ctnn.py
+++ b/test/nn/backbones/simplicial/test_ctnn.py
@@ -1,0 +1,699 @@
+r"""Unit tests for the Copresheaf Topological Neural Network (CTNN).
+
+The tests are organised around the claims of Hajij et al., "Copresheaf
+Topological Neural Networks: A Generalized Deep Learning Framework", NeurIPS
+2025 (https://arxiv.org/abs/2505.21251), referred to as [1]:
+
+* the attention coefficients of [1], Definition 11, Eq. (7) and Definition 16,
+  Eq. (12) normalise over ``N_k(x)``, so they are row-stochastic per receiver
+  and per head;
+* the layer of [1], Definition 10 with those attention messages, checked
+  against a dense Python replay of the same algebra, including the transport
+  step ``rho_{y->x}(v_y)`` and the summation that instantiates ``otimes``;
+* the structural guarantees of the transport maps of [1], Table 18: SheafFC
+  starts at the identity, SheafSPD is symmetric positive definite with
+  eigenvalues bounded below by one, and the diagonal map is a gate;
+* directionality, ``rho_{y->x} != rho_{x->y}^T``, which is what separates a
+  copresheaf from a cellular sheaf ([1], Table 7) and what makes the
+  containment of [1], Theorem 4 strict. A cellular-sheaf transport is used as
+  the negative control;
+* ``rho = Id`` recovering the Cellular Transformer, as observed in [1],
+  Appendix H.5.
+"""
+
+import math
+
+import pytest
+import torch
+import torch_geometric
+from torch_geometric.utils import to_undirected
+
+from topobench.nn.backbones.simplicial.ctnn import (
+    COPRESHEAF_MAPS,
+    CopresheafAttention,
+    CopresheafTNN,
+    CopresheafTNNLayer,
+    DiagonalMLPMap,
+    HeadwiseLinear,
+    SheafFCMap,
+    SheafSPDMap,
+)
+from topobench.transforms.liftings.graph2simplicial import (
+    SimplicialCliqueLifting,
+)
+
+MAP_NAMES = sorted(COPRESHEAF_MAPS)
+
+#: Deliberately wider than the shipped `configs/model/simplicial/ctnn.yaml`,
+#: which carries only the three downward paths of [1], Appendix H.5. The upward
+#: routes are here so the tests also cover a rank that both sends and receives,
+#: and a receiver rank fed by two neighborhoods at once.
+NEIGHBORHOODS = [
+    "up_adjacency-0",
+    "down_incidence-1",
+    "up_incidence-0",
+    "down_incidence-2",
+    "up_incidence-1",
+]
+
+CHANNELS = 12
+HEADS = 3
+
+
+def lifted_complex(channels=CHANNELS, seed=0, neighborhoods=None):
+    """Build a small 2-dimensional simplicial complex with random features.
+
+    Two overlapping cliques, so every rank holds several cells and every
+    neighborhood gives most receivers more than one sender. A receiver with a
+    single sender has a degenerate softmax, which hides errors in the attention
+    weights.
+
+    Parameters
+    ----------
+    channels : int, optional
+        Feature width assigned to every rank. Default is ``CHANNELS``.
+    seed : int, optional
+        Seed for the feature draw. Default is 0.
+    neighborhoods : list of str, optional
+        Neighborhood names to materialise. Default is ``NEIGHBORHOODS``.
+
+    Returns
+    -------
+    torch_geometric.data.Data
+        Lifted complex carrying ``x_0``, ``x_1``, ``x_2`` and one sparse matrix
+        per neighborhood.
+    """
+    torch.manual_seed(seed)
+    edges = torch.tensor(
+        [
+            [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5],
+            [1, 2, 3, 2, 3, 3, 4, 5, 4, 5, 6, 5, 6, 6],
+        ]
+    )
+    graph = torch_geometric.data.Data(
+        x=torch.zeros(7, 1), edge_index=to_undirected(edges), num_nodes=7
+    )
+    lifting = SimplicialCliqueLifting(
+        complex_dim=2,
+        neighborhoods=NEIGHBORHOODS
+        if neighborhoods is None
+        else neighborhoods,
+    )
+    data = lifting(graph)
+    for rank in range(3):
+        data[f"x_{rank}"] = torch.randn(data[f"x_{rank}"].shape[0], channels)
+    return data
+
+
+def nonzero_pairs(neighborhood):
+    r"""Directed pairs ``y -> x`` carrying a map, per [1], Definition 7.
+
+    The support of a neighborhood matrix is its set of *nonzeros*, which is
+    narrower than its sparsity pattern: toponetx stores ``adjacency_matrix``
+    with an explicit zero on the diagonal.
+
+    Parameters
+    ----------
+    neighborhood : torch.Tensor
+        Sparse neighborhood matrix of shape ``[num_receivers, num_senders]``.
+
+    Returns
+    -------
+    torch.Tensor
+        Receiver and sender indices, of shape ``[2, num_pairs]``.
+    """
+    neighborhood = neighborhood.coalesce()
+    return neighborhood.indices()[:, neighborhood.values().flatten() != 0]
+
+
+def dense_attention_message(module, x_receiver, x_sender, neighborhood):
+    r"""Recompute ``m_x`` of [1], Eq. (7) and (12) with an explicit loop.
+
+    Reuses the module's own projections and transport parameters, but derives
+    the softmax scoping, the transport application and the aggregation
+    independently, one directed pair at a time.
+
+    Parameters
+    ----------
+    module : CopresheafAttention
+        Attention module whose parameters to reuse.
+    x_receiver : torch.Tensor
+        Receiver features of shape ``[num_receivers, channels]``.
+    x_sender : torch.Tensor
+        Sender features of shape ``[num_senders, channels]``.
+    neighborhood : torch.Tensor
+        Sparse neighborhood matrix of shape ``[num_receivers, num_senders]``.
+
+    Returns
+    -------
+    torch.Tensor
+        Messages of shape ``[num_receivers, channels]``.
+    """
+    heads, stalk_dim = module.heads, module.stalk_dim
+    # `dense[receiver].nonzero()` below already scopes the softmax to the true
+    # support of Definition 3, so this reference is unaffected by the explicit
+    # zeros that TopoBench stores in `up_adjacency-r`.
+    query = module.lin_query(x_receiver).view(-1, heads, stalk_dim)
+    key = module.lin_key(x_sender).view(-1, heads, stalk_dim)
+    value = module.lin_value(x_sender).view(-1, heads, stalk_dim)
+
+    dense = neighborhood.coalesce().to_dense()
+    message = torch.zeros_like(query)
+    for receiver in range(x_receiver.shape[0]):
+        senders = dense[receiver].nonzero().flatten().tolist()
+        if not senders:
+            continue
+        for head in range(heads):
+            scores = torch.stack(
+                [
+                    query[receiver, head] @ key[sender, head]
+                    for sender in senders
+                ]
+            ) / math.sqrt(stalk_dim)
+            weights = torch.softmax(scores, dim=0)
+            for weight, sender in zip(weights, senders, strict=True):
+                pair_query = query[receiver, head].view(1, 1, -1)
+                pair_key = key[sender, head].view(1, 1, -1)
+                rho = module.transport(
+                    pair_query.expand(1, heads, -1),
+                    pair_key.expand(1, heads, -1),
+                )[0, head]
+                transported = (
+                    rho * value[sender, head]
+                    if module.transport.is_diagonal
+                    else rho @ value[sender, head]
+                )
+                message[receiver, head] = (
+                    message[receiver, head] + weight * transported
+                )
+    return message.flatten(start_dim=1)
+
+
+class TestPaperEquations:
+    """Check the implementation against the equations of [1]."""
+
+    @pytest.mark.parametrize("copresheaf_map", MAP_NAMES)
+    def test_attention_is_row_stochastic(self, copresheaf_map):
+        """Eq. (7) and (12) normalise over ``N_k(x)``, per receiver and head.
+
+        Recovers the coefficients by transporting one-hot value vectors, which
+        turns the message into the attention weights themselves.
+
+        Parameters
+        ----------
+        copresheaf_map : str
+            Transport parameterisation under test.
+        """
+        data = lifted_complex()
+        module = CopresheafAttention(CHANNELS, HEADS, copresheaf_map).eval()
+        neighborhood = data["up_adjacency-0"].coalesce()
+        receiver, sender = nonzero_pairs(neighborhood)
+
+        query = module.lin_query(data["x_0"]).view(-1, HEADS, module.stalk_dim)
+        key = module.lin_key(data["x_0"]).view(-1, HEADS, module.stalk_dim)
+        score = (query[receiver] * key[sender]).sum(-1) / math.sqrt(
+            module.stalk_dim
+        )
+        weights = torch_geometric.utils.softmax(
+            score, receiver, num_nodes=data["x_0"].shape[0]
+        )
+
+        totals = torch.zeros(data["x_0"].shape[0], HEADS)
+        totals.index_add_(0, receiver, weights)
+        # Every 0-cell of two overlapping cliques has a neighbour.
+        torch.testing.assert_close(
+            totals, torch.ones_like(totals), atol=1e-5, rtol=1e-5
+        )
+
+    @pytest.mark.parametrize("copresheaf_map", MAP_NAMES)
+    def test_message_matches_dense_reference(self, copresheaf_map):
+        """The aggregated message reproduces Eq. (7) and (12) pair by pair.
+
+        Parameters
+        ----------
+        copresheaf_map : str
+            Transport parameterisation under test.
+        """
+        data = lifted_complex()
+        module = CopresheafAttention(CHANNELS, HEADS, copresheaf_map).eval()
+        # A cross-rank route, so this exercises Definition 16 as well.
+        neighborhood = data["down_incidence-1"]
+
+        with torch.no_grad():
+            actual = module(data["x_0"], data["x_1"], neighborhood)
+            expected = dense_attention_message(
+                module, data["x_0"], data["x_1"], neighborhood
+            )
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-4)
+
+    def test_neighborhoods_are_combined_by_summation(self):
+        """``otimes`` of Definition 10 is the sum used in Appendix H.5.
+
+        Builds a layer over two neighborhoods that both target rank 0 and
+        checks its update against the same update driven by the sum of the two
+        single-neighborhood messages.
+        """
+        names = ["up_adjacency-0", "down_incidence-1"]
+        data = lifted_complex(neighborhoods=names)
+        routes = [[0, 0], [1, 0]]
+        layer = CopresheafTNNLayer(
+            CHANNELS, routes, HEADS, "sheaf_fc", dropout=0.0
+        ).eval()
+        features = {rank: data[f"x_{rank}"] for rank in range(2)}
+
+        with torch.no_grad():
+            actual = layer(features, [data[name] for name in names])[0]
+
+            total = layer.attentions[0](
+                features[0], features[0], data[names[0]]
+            ) + layer.attentions[1](features[0], features[1], data[names[1]])
+            hidden = layer.norm_message["0"](features[0] + total)
+            expected = layer.norm_update["0"](
+                hidden + layer.update["0"](hidden)
+            )
+
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
+
+    def test_stored_zeros_are_not_neighbours(self):
+        r"""A zero entry carries no map, so it sends no message.
+
+        [1], Definition 7 puts a map at each nonzero of the binary matrix of
+        Definition 3. TopoBench materialises ``up_adjacency-0`` from toponetx,
+        which keeps an explicit zero on the diagonal, so reading the sparsity
+        pattern instead of the support would give every 0-cell a self-loop
+        ``y = x`` that no neighborhood function asked for.
+        """
+        data = lifted_complex()
+        adjacency = data["up_adjacency-0"].coalesce()
+        # The matrix under test must actually exercise the distinction.
+        assert (adjacency.values() == 0).any()
+
+        module = CopresheafAttention(CHANNELS, HEADS, "sheaf_fc").eval()
+        pairs = nonzero_pairs(adjacency)
+        pruned = torch.sparse_coo_tensor(
+            pairs, torch.ones(pairs.shape[1]), adjacency.shape
+        )
+
+        with torch.no_grad():
+            torch.testing.assert_close(
+                module(data["x_0"], data["x_0"], adjacency),
+                module(data["x_0"], data["x_0"], pruned),
+                atol=1e-6,
+                rtol=1e-6,
+            )
+
+    def test_sheaf_fc_starts_at_the_identity(self):
+        """Table 18 zero-initialises SheafFC, so ``rho = Id`` before training."""
+        stalk_dim = 4
+        transport = SheafFCMap(HEADS, stalk_dim)
+        rho = transport(
+            torch.randn(5, HEADS, stalk_dim), torch.randn(5, HEADS, stalk_dim)
+        )
+
+        torch.testing.assert_close(
+            rho, torch.eye(stalk_dim).expand_as(rho), atol=1e-7, rtol=0.0
+        )
+
+    def test_identity_transport_recovers_plain_attention(self):
+        """Appendix H.5: ``rho = Id`` leaves the Cellular Transformer.
+
+        At initialisation SheafFC is the identity, so the message must equal
+        plain attention-weighted value aggregation with no transport.
+        """
+        data = lifted_complex()
+        module = CopresheafAttention(CHANNELS, HEADS, "sheaf_fc").eval()
+        neighborhood = data["up_adjacency-0"].coalesce()
+        receiver, sender = nonzero_pairs(neighborhood)
+        num_cells = data["x_0"].shape[0]
+
+        with torch.no_grad():
+            query = module.lin_query(data["x_0"]).view(
+                num_cells, HEADS, module.stalk_dim
+            )
+            key = module.lin_key(data["x_0"]).view(
+                num_cells, HEADS, module.stalk_dim
+            )
+            value = module.lin_value(data["x_0"]).view(
+                num_cells, HEADS, module.stalk_dim
+            )
+            score = (query[receiver] * key[sender]).sum(-1) / math.sqrt(
+                module.stalk_dim
+            )
+            weights = torch_geometric.utils.softmax(
+                score, receiver, num_nodes=num_cells
+            )
+            expected = torch.zeros_like(value)
+            expected.index_add_(
+                0, receiver, weights.unsqueeze(-1) * value[sender]
+            )
+
+            actual = module(data["x_0"], data["x_0"], neighborhood)
+
+        torch.testing.assert_close(
+            actual, expected.flatten(start_dim=1), atol=1e-5, rtol=1e-5
+        )
+
+    def test_spd_transport_is_positive_definite(self):
+        """SheafSPD of Table 18 gives ``Id + Q Q^T``, eigenvalues at least one."""
+        stalk_dim = 5
+        torch.manual_seed(0)
+        transport = SheafSPDMap(HEADS, stalk_dim)
+        rho = transport(
+            torch.randn(6, HEADS, stalk_dim), torch.randn(6, HEADS, stalk_dim)
+        )
+
+        torch.testing.assert_close(
+            rho, rho.transpose(-1, -2), atol=1e-6, rtol=1e-6
+        )
+        assert torch.linalg.eigvalsh(rho).min() >= 1.0 - 1e-5
+
+    def test_diagonal_transport_is_a_gate(self):
+        """The Diagonal MLP Map of Table 18 is ``O(d)`` and lands in ``(0, 1)``."""
+        stalk_dim = 5
+        torch.manual_seed(0)
+        transport = DiagonalMLPMap(HEADS, stalk_dim)
+        rho = transport(
+            torch.randn(6, HEADS, stalk_dim), torch.randn(6, HEADS, stalk_dim)
+        )
+
+        assert transport.is_diagonal
+        assert rho.shape == (6, HEADS, stalk_dim)
+        assert torch.all((rho > 0.0) & (rho < 1.0))
+
+    @pytest.mark.parametrize("copresheaf_map", ["sheaf_fc", "sheaf_spd"])
+    def test_transport_is_directional(self, copresheaf_map):
+        """``rho_{y->x} != rho_{x->y}^T``, unlike a cellular sheaf.
+
+        Table 7 of [1] contrasts a copresheaf, whose maps are attached to
+        directed edges, with a cellular sheaf, whose transport across an
+        undirected edge is ``F_{x<|e}^T F_{y<|e}`` and therefore satisfies
+        ``rho_{x->y} = rho_{y->x}^T``. The proof of [1], Theorem 4 turns exactly
+        that reciprocity into the strictness of ``F_SNN`` inside ``F_CTNN``. A
+        sheaf-style transport built from two restriction maps is the control: it
+        must satisfy the identity that the copresheaf map violates.
+
+        Parameters
+        ----------
+        copresheaf_map : str
+            Transport parameterisation under test.
+        """
+        stalk_dim = 4
+        torch.manual_seed(0)
+        transport = COPRESHEAF_MAPS[copresheaf_map](HEADS, stalk_dim)
+        # SheafFC is the identity at initialisation, which is reciprocal, so
+        # the weights are perturbed to reach a generic point of the family.
+        for parameter in transport.parameters():
+            parameter.data.normal_(std=0.5)
+
+        first = torch.randn(1, HEADS, stalk_dim)
+        second = torch.randn(1, HEADS, stalk_dim)
+        forward = transport(first, second)
+        backward = transport(second, first)
+
+        assert not torch.allclose(
+            forward, backward.transpose(-1, -2), atol=1e-3
+        )
+
+        # Control: a cellular sheaf transports through the shared edge stalk.
+        restriction_x = torch.randn(stalk_dim, stalk_dim)
+        restriction_y = torch.randn(stalk_dim, stalk_dim)
+        torch.testing.assert_close(
+            restriction_x.T @ restriction_y,
+            (restriction_y.T @ restriction_x).T,
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_routes_follow_the_neighborhood_names(self):
+        """Each neighborhood name fixes its sender and receiver rank."""
+        model = CopresheafTNN(CHANNELS, NEIGHBORHOODS, heads=HEADS)
+
+        assert model.routes == [[0, 0], [1, 0], [0, 1], [2, 1], [1, 2]]
+        assert model.max_rank == 2
+
+    def test_untargeted_ranks_pass_through(self):
+        """Definition 10 leaves ``h_x`` alone when every ``N_k(x)`` is empty.
+
+        With only ``down_incidence-1`` no 1-cell or 2-cell receives a message,
+        so those stalks must come out of the layer untouched.
+        """
+        names = ["down_incidence-1"]
+        data = lifted_complex(neighborhoods=names)
+        model = CopresheafTNN(CHANNELS, names, layers=2, heads=HEADS).eval()
+
+        with torch.no_grad():
+            out = model(data)
+
+        assert not torch.allclose(out[0], data["x_0"])
+        torch.testing.assert_close(out[1], data["x_1"])
+
+
+class TestCopresheafTNN:
+    """Check construction, propagation and gradients of the backbone."""
+
+    def test_default_construction(self):
+        """Defaults follow the Appendix H.5 instantiation of [1]."""
+        model = CopresheafTNN(64, NEIGHBORHOODS)
+
+        assert model.copresheaf_map == "sheaf_fc"
+        assert len(model.layers) == 2
+        assert model.layers[0].attentions[0].heads == 4
+        assert model.layers[0].attentions[0].stalk_dim == 16
+
+    def test_empty_neighborhoods_rejected(self):
+        """The collection ``N`` of Definition 10 cannot be empty."""
+        with pytest.raises(ValueError, match="at least one neighborhood"):
+            CopresheafTNN(CHANNELS, [])
+
+    def test_unknown_copresheaf_map_rejected(self):
+        """Only the transport maps of Table 18 that are wired up are accepted."""
+        with pytest.raises(ValueError, match="Unknown copresheaf_map"):
+            CopresheafTNN(CHANNELS, NEIGHBORHOODS, copresheaf_map="outer")
+
+    @pytest.mark.parametrize("heads", [0, 5])
+    def test_indivisible_head_count_rejected(self, heads):
+        """A head count that does not divide the width would truncate it.
+
+        Parameters
+        ----------
+        heads : int
+            Invalid head count under test.
+        """
+        with pytest.raises(ValueError, match="must be positive and divide"):
+            CopresheafTNN(CHANNELS, NEIGHBORHOODS, heads=heads)
+
+    @pytest.mark.parametrize("copresheaf_map", MAP_NAMES)
+    @pytest.mark.parametrize("layers", [1, 3])
+    def test_forward_preserves_cell_counts(self, copresheaf_map, layers):
+        """Every rank keeps its cell count and its width.
+
+        Parameters
+        ----------
+        copresheaf_map : str
+            Transport parameterisation under test.
+        layers : int
+            Number of message-passing layers.
+        """
+        data = lifted_complex()
+        model = CopresheafTNN(
+            CHANNELS,
+            NEIGHBORHOODS,
+            layers=layers,
+            heads=HEADS,
+            copresheaf_map=copresheaf_map,
+        ).eval()
+
+        with torch.no_grad():
+            out = model(data)
+
+        assert sorted(out) == [0, 1, 2]
+        for rank in out:
+            assert out[rank].shape == data[f"x_{rank}"].shape
+            assert torch.all(torch.isfinite(out[rank]))
+
+    @pytest.mark.parametrize("copresheaf_map", MAP_NAMES)
+    def test_every_parameter_receives_gradient(self, copresheaf_map):
+        """No dead parameters: the layer uses every weight it registers.
+
+        Parameters
+        ----------
+        copresheaf_map : str
+            Transport parameterisation under test.
+        """
+        data = lifted_complex()
+        model = CopresheafTNN(
+            CHANNELS, NEIGHBORHOODS, heads=HEADS, copresheaf_map=copresheaf_map
+        )
+        out = model(data)
+        sum((value**2).sum() for value in out.values()).backward()
+
+        for name, parameter in model.named_parameters():
+            assert parameter.grad is not None, f"{name} got no gradient"
+            assert parameter.grad.abs().sum() > 0, f"{name} has zero gradient"
+
+    def test_messages_stay_inside_the_neighborhood(self):
+        """One layer moves information only along ``N_k``.
+
+        Perturbing a single 0-cell must leave every 0-cell that is not adjacent
+        to it unchanged. Batched complexes are a disjoint union, so this is also
+        what keeps attention from crossing complex boundaries.
+        """
+        data = lifted_complex()
+        model = CopresheafTNN(
+            CHANNELS, NEIGHBORHOODS, layers=1, heads=HEADS
+        ).eval()
+        adjacency = data["up_adjacency-0"].coalesce().to_dense()
+        perturbed_cell = 0
+
+        with torch.no_grad():
+            before = model(data)[0]
+            data["x_0"] = data["x_0"].clone()
+            data["x_0"][perturbed_cell] += 1.0
+            after = model(data)[0]
+
+        changed = (~torch.isclose(before, after, atol=1e-6)).any(dim=1)
+        expected = adjacency[:, perturbed_cell] != 0
+        expected[perturbed_cell] = True
+        torch.testing.assert_close(changed, expected)
+
+    @pytest.mark.parametrize(
+        "neighborhoods",
+        [
+            NEIGHBORHOODS,
+            # The shipped config: the 2 -> 0 route is the composite
+            # `incidence_1 . incidence_2`, and TopoBench builds it by dividing
+            # the product's values by themselves. A triangle-free complex makes
+            # `incidence_2` a zero matrix of width 0, so this is the case where
+            # that division could produce NaN or fail outright.
+            ["up_adjacency-0", "down_incidence-1", "2-down_incidence-2"],
+        ],
+        ids=["test_neighborhoods", "shipped_config"],
+    )
+    @pytest.mark.parametrize(
+        "edges",
+        [[[0, 1, 2], [1, 2, 3]], [[0], [1]], [[], []]],
+        ids=["path", "single_edge", "isolated_nodes"],
+    )
+    def test_degenerate_complex_still_runs(self, neighborhoods, edges):
+        """Empty 2-cells, and even empty 1-cells, must propagate finitely.
+
+        GraphUniverse draws average degrees as low as 1, so triangle-free and
+        edge-free complexes reach the model in the challenge grid.
+
+        Parameters
+        ----------
+        neighborhoods : list of str
+            Neighborhood collection under test.
+        edges : list of list of int
+            Edge index of the graph to lift, possibly empty.
+        """
+        edge_index = torch.tensor(edges, dtype=torch.long).reshape(2, -1)
+        graph = torch_geometric.data.Data(
+            x=torch.zeros(4, 1),
+            edge_index=to_undirected(edge_index),
+            num_nodes=4,
+        )
+        data = SimplicialCliqueLifting(
+            complex_dim=2, neighborhoods=neighborhoods
+        )(graph)
+        for rank in range(3):
+            data[f"x_{rank}"] = torch.randn(
+                data[f"x_{rank}"].shape[0], CHANNELS
+            )
+        model = CopresheafTNN(CHANNELS, neighborhoods, heads=HEADS).eval()
+
+        with torch.no_grad():
+            out = model(data)
+
+        assert out[2].shape == (0, CHANNELS)
+        assert torch.all(torch.isfinite(out[0]))
+
+    def test_eval_is_deterministic_and_train_is_not(self):
+        """Dropout is active in training mode only."""
+        data = lifted_complex()
+        model = CopresheafTNN(
+            CHANNELS, NEIGHBORHOODS, heads=HEADS, dropout=0.5
+        )
+
+        model.eval()
+        with torch.no_grad():
+            torch.testing.assert_close(model(data)[0], model(data)[0])
+
+        model.train()
+        torch.manual_seed(0)
+        first = model(data)[0]
+        torch.manual_seed(1)
+        assert not torch.allclose(first, model(data)[0])
+
+    @pytest.mark.parametrize("copresheaf_map", MAP_NAMES)
+    def test_overfits_a_single_complex(self, copresheaf_map):
+        """The backbone has enough capacity to drive a toy loss to zero.
+
+        Separates a wrong hyperparameter from a broken model: if transport or
+        aggregation were disconnected from the parameters, this would plateau.
+        The update of Appendix H.5 ends in a normalisation, so the target is
+        normalised too; an arbitrary Gaussian target is outside the layer's
+        image and would cap the achievable loss whatever the model does.
+
+        Parameters
+        ----------
+        copresheaf_map : str
+            Transport parameterisation under test.
+        """
+        data = lifted_complex()
+        torch.manual_seed(0)
+        target = torch.nn.functional.layer_norm(
+            torch.randn_like(data["x_0"]), (CHANNELS,)
+        )
+        model = CopresheafTNN(
+            CHANNELS, NEIGHBORHOODS, heads=HEADS, copresheaf_map=copresheaf_map
+        )
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-2)
+
+        for _ in range(300):
+            optimizer.zero_grad()
+            loss = torch.nn.functional.mse_loss(model(data)[0], target)
+            loss.backward()
+            optimizer.step()
+
+        assert loss.item() < 1e-2
+
+
+class TestHeadwiseLinear:
+    """Check the per-head linear map backing the transport parameterisations."""
+
+    def test_heads_are_independent(self):
+        """Each head owns its weights, so zeroing one leaves the others alone."""
+        module = HeadwiseLinear(HEADS, 4, 5, bias=False)
+        x = torch.randn(2, HEADS, 4)
+
+        before = module(x)
+        module.weight.data[1].zero_()
+        after = module(x)
+
+        torch.testing.assert_close(after[:, 1], torch.zeros(2, 5))
+        torch.testing.assert_close(after[:, 0], before[:, 0])
+
+    def test_matches_per_head_matmul(self):
+        """The einsum agrees with an explicit per-head matrix product."""
+        module = HeadwiseLinear(HEADS, 4, 5)
+        x = torch.randn(6, HEADS, 4)
+
+        expected = torch.stack(
+            [
+                x[:, head] @ module.weight[head] + module.bias[head]
+                for head in range(HEADS)
+            ],
+            dim=1,
+        )
+
+        torch.testing.assert_close(module(x), expected)
+
+    def test_zero_initialisation(self):
+        """``zero_init`` makes the map output zero, as Table 18 requires."""
+        module = HeadwiseLinear(HEADS, 4, 5, bias=False, zero_init=True)
+
+        torch.testing.assert_close(
+            module(torch.randn(3, HEADS, 4)), torch.zeros(3, HEADS, 5)
+        )

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,14 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = [
+    "graph/gcn",
+    "cell/topotune",
+    "simplicial/topotune",
+    "simplicial/ctnn",  # CTNN, SheafFC transport maps
+    "simplicial/ctnn_spd",  # CTNN, SheafSPD transport maps
+    "simplicial/ctnn_diag",  # CTNN, diagonal transport maps
+]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/simplicial/ctnn.py
+++ b/topobench/nn/backbones/simplicial/ctnn.py
@@ -1,0 +1,619 @@
+r"""Copresheaf Topological Neural Networks (CTNNs) on a combinatorial complex.
+
+A CTNN [1] equips every cell of a combinatorial complex [2] with its own
+feature space (a stalk) and every directed neighbour relation ``y -> x`` with a
+learnable transport map ``rho_{y->x}: F(y) -> F(x)``. Messages are transported
+into the receiver's own frame *before* aggregation, which is what makes the
+propagation anisotropic and direction-aware, in contrast to a cellular sheaf,
+which glues data through a shared edge stalk and is therefore symmetric.
+
+Definition 10 of [1] states the higher-order layer over a collection of
+neighborhood functions ``N = {N_k}``:
+
+.. math::
+    \mathbf{h}_x^{(\ell+1)} = \beta\Biggl(
+        \mathbf{h}_x^{(\ell)},
+        \bigotimes_{k=1}^{n} \bigoplus_{y \in \mathcal{N}_k(x)}
+        \alpha_{\mathcal{N}_k}\bigl(
+            \mathbf{h}_x^{(\ell)},
+            \rho_{y \to x}^{\mathcal{N}_k}(\mathbf{h}_y^{(\ell)})
+        \bigr)
+    \Biggr)
+
+The concrete instantiation implemented here is the one [1] evaluates on
+topological domains, the *Copresheaf Cellular Transformer* of [1], Appendix
+H.5: the message function ``alpha`` is copresheaf attention and ``beta`` is a
+residual MLP with normalisation. Within a rank this is copresheaf
+self-attention, [1], Definition 11, Eq. (7); across ranks it is copresheaf
+cross-attention, [1], Definition 16, Eq. (12). Both compute
+
+.. math::
+    m_x = \sum_{y \in \mathcal{N}_k(x)} a_{xy}\, \rho_{y \to x}(v_y),
+    \qquad
+    a_{xy} = \frac{\exp(\langle q_x, k_y \rangle / \sqrt{p})}
+                  {\sum_{y' \in \mathcal{N}_k(x)}
+                   \exp(\langle q_x, k_{y'} \rangle / \sqrt{p})}
+
+with ``q_x = W_q h_x``, ``k_y = W_k h_y``, ``v_y = W_v h_y``. Together the two
+cases are the body of [1], Algorithm 1, restricted to the sparse neighborhoods
+that the complex actually provides. For rank ``0`` and the neighborhoods of
+[1], Appendix H.5 this is exactly its displayed layer, whose ``0 <- 0``,
+``0 <- 1`` and ``0 <- 2`` message paths are the routes ``up_adjacency-0``,
+``down_incidence-1`` and ``2-down_incidence-2`` of
+:attr:`CopresheafTNN.neighborhoods`. The last is a *direct* rank-2 to rank-0
+transport, as [1], Appendix H.5 writes it; TopoBench materialises it as the
+composite ``incidence_1 . incidence_2``, whose support is the set of pairs
+``(v, t)`` with ``v`` a vertex of the triangle ``t``.
+
+The transport maps come from the catalogue of [1], Table 18, exposed as
+:data:`COPRESHEAF_MAPS`. They act stalk-wise and are evaluated independently
+per attention head, so ``rho`` is a ``head_dim x head_dim`` operator
+conditioned on the pair ``(q_x, k_y)``. Setting ``rho = Id`` recovers the
+Cellular Transformer of [3], as [1], Appendix H.5 observes.
+
+Four conventions are worth stating because [1] leaves them open. The
+inter-neighborhood combination ``otimes`` of Definition 10 is summation, which
+is how [1], Appendix H.5 writes it. The query/key width ``p`` equals the stalk
+width ``head_dim``, which is the setting [1], Table 18 assumes when it sizes
+the transport parameters as ``W in R^{2d x d^2}``. ``beta`` runs once per
+layer over the combined message, following Definition 10 and the displayed
+layer of Appendix H.5; [1], Algorithm 1 instead writes two sequential updates,
+one after self-attention and one after cross-attention, which would make the
+result depend on the order the neighborhoods happen to be listed in. And the
+per-head messages are concatenated with no output projection: [1], Algorithm 1
+writes none, though the cost accounting under [1], Table 19 charges an
+``O(n d^2)`` step to "combine head outputs". The ``beta`` that immediately
+follows is a full-width MLP, so heads are mixed there instead.
+
+[1] Hajij, Bastian, Osentoski, Kabaria, Davenport, Dawood, Cherukuri,
+    Kocheemoolayil, Shahmansouri, Lew, Papamarkou, Birdal. "Copresheaf
+    Topological Neural Networks: A Generalized Deep Learning Framework."
+    NeurIPS 2025. https://arxiv.org/abs/2505.21251
+[2] Hajij, Zamzmi, Papamarkou, Miolane, Guzman-Saenz, Ramamurthy, Birdal,
+    Schaub. "Topological Deep Learning: Going Beyond Graph Data."
+    https://arxiv.org/abs/2206.00606
+[3] Ballester, Barsbey, Papillon, Battiloro, Hajij, Miolane, Birdal.
+    "Attention Mechanisms for Topological Deep Learning: The Case of Cellular
+    Transformers." https://arxiv.org/abs/2405.14094
+"""
+
+import math
+
+import torch
+from torch import nn
+from torch_geometric.utils import scatter, softmax
+
+from topobench.data.utils import get_routes_from_neighborhoods
+
+
+class HeadwiseLinear(nn.Module):
+    r"""Linear map with independent weights per attention head.
+
+    The transport maps of [1], Table 18 are "evaluated independently for each
+    attention head", so their parameters carry a leading head axis instead of
+    being shared the way :class:`torch.nn.Linear` shares them.
+
+    Parameters
+    ----------
+    heads : int
+        Number of attention heads.
+    in_features : int
+        Width of the per-head input.
+    out_features : int
+        Width of the per-head output.
+    bias : bool, optional
+        Whether to add a per-head bias. Default is True.
+    zero_init : bool, optional
+        If True, initialise weight and bias to zero. [1], Table 18 zero-initialises
+        the SheafFC and SheafMLP maps so that ``rho = Id`` at the start of
+        training. Default is False.
+    """
+
+    def __init__(
+        self, heads, in_features, out_features, bias=True, zero_init=False
+    ):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.empty(heads, in_features, out_features)
+        )
+        self.bias = (
+            nn.Parameter(torch.empty(heads, out_features)) if bias else None
+        )
+        self.zero_init = zero_init
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Re-initialise the per-head weight and bias."""
+        if self.zero_init:
+            nn.init.zeros_(self.weight)
+        else:
+            # Same 1/sqrt(fan_in) scale as torch.nn.Linear, applied per head.
+            bound = 1.0 / math.sqrt(self.weight.size(1))
+            nn.init.uniform_(self.weight, -bound, bound)
+        if self.bias is not None:
+            nn.init.zeros_(self.bias)
+
+    def forward(self, x):
+        r"""Apply the per-head weights.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``[num_edges, heads, in_features]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output of shape ``[num_edges, heads, out_features]``.
+        """
+        out = torch.einsum("ehi,hio->eho", x, self.weight)
+        return out if self.bias is None else out + self.bias
+
+
+class SheafFCMap(nn.Module):
+    r"""SheafFC transport map of [1], Table 18.
+
+    .. math::
+        \rho_{y \to x} = \mathrm{Id}
+            + \tanh\bigl(W\,[q_x;\, k_y]\bigr),
+        \qquad W \in \mathbb{R}^{2d \times d^2}
+
+    ``W`` is zero-initialised, so every map starts at the identity and the layer
+    starts as the plain Cellular Transformer of [3]. This is the map [1],
+    Appendix H.5 instantiates for its simplicial-complex experiment.
+
+    Parameters
+    ----------
+    heads : int
+        Number of attention heads.
+    stalk_dim : int
+        Stalk width ``d`` per head, i.e. the size of the square transport map.
+    """
+
+    is_diagonal = False
+
+    def __init__(self, heads, stalk_dim):
+        super().__init__()
+        self.stalk_dim = stalk_dim
+        self.linear = HeadwiseLinear(
+            heads, 2 * stalk_dim, stalk_dim**2, bias=False, zero_init=True
+        )
+
+    def forward(self, query, key):
+        r"""Build one transport map per directed neighbour pair.
+
+        Parameters
+        ----------
+        query : torch.Tensor
+            Receiver queries ``q_x`` of shape ``[num_edges, heads, stalk_dim]``.
+        key : torch.Tensor
+            Sender keys ``k_y`` of shape ``[num_edges, heads, stalk_dim]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport maps of shape
+            ``[num_edges, heads, stalk_dim, stalk_dim]``.
+        """
+        delta = self.linear(torch.cat([query, key], dim=-1))
+        delta = delta.unflatten(-1, (self.stalk_dim, self.stalk_dim))
+        return torch.eye(
+            self.stalk_dim, device=delta.device, dtype=delta.dtype
+        ) + torch.tanh(delta)
+
+
+class SheafSPDMap(nn.Module):
+    r"""SheafSPD transport map of [1], Table 18.
+
+    .. math::
+        \rho_{y \to x} = \mathrm{Id} + QQ^{\top},
+        \qquad Q = W\,[q_x;\, k_y],
+        \qquad W \in \mathbb{R}^{2d \times d^2}
+
+    ``QQ^T`` is positive semidefinite, so ``rho`` is symmetric positive definite
+    with all eigenvalues at least one: transport can stretch a stalk but never
+    reflect or contract it. [1], Appendix H.5 offers this as the constrained
+    alternative to :class:`SheafFCMap`, and [1], Appendix H.1 attributes the
+    gain on viscous-diffusion problems to exactly this alignment with a
+    diffusion tensor. ``W`` carries no bias, per [1], Table 18.
+
+    Parameters
+    ----------
+    heads : int
+        Number of attention heads.
+    stalk_dim : int
+        Stalk width ``d`` per head, i.e. the size of the square transport map.
+    """
+
+    is_diagonal = False
+
+    def __init__(self, heads, stalk_dim):
+        super().__init__()
+        self.stalk_dim = stalk_dim
+        self.linear = HeadwiseLinear(
+            heads, 2 * stalk_dim, stalk_dim**2, bias=False
+        )
+
+    def forward(self, query, key):
+        r"""Build one symmetric positive definite map per neighbour pair.
+
+        Parameters
+        ----------
+        query : torch.Tensor
+            Receiver queries ``q_x`` of shape ``[num_edges, heads, stalk_dim]``.
+        key : torch.Tensor
+            Sender keys ``k_y`` of shape ``[num_edges, heads, stalk_dim]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport maps of shape
+            ``[num_edges, heads, stalk_dim, stalk_dim]``.
+        """
+        factor = self.linear(torch.cat([query, key], dim=-1))
+        factor = factor.unflatten(-1, (self.stalk_dim, self.stalk_dim))
+        return torch.eye(
+            self.stalk_dim, device=factor.device, dtype=factor.dtype
+        ) + factor @ factor.transpose(-1, -2)
+
+
+class DiagonalMLPMap(nn.Module):
+    r"""Diagonal MLP transport map of [1], Table 18.
+
+    .. math::
+        \rho_{y \to x} = \mathrm{diag}\bigl(
+            \sigma(\mathrm{MLP}[q_x, k_y])
+        \bigr)
+
+    with ``sigma`` the logistic function and a two-layer MLP of widths
+    ``2d -> 2d -> d``. Restricting transport to the diagonal replaces the
+    ``d^2`` parameters and the ``O(d^2)`` per-edge application of the full maps
+    by ``O(d)`` of each, the reduction noted under [1], Table 19. It is also the
+    parameterisation the copresheaf GCN and GraphSAGE of [1], Section 6.2 use.
+
+    Parameters
+    ----------
+    heads : int
+        Number of attention heads.
+    stalk_dim : int
+        Stalk width ``d`` per head, i.e. the length of the transport diagonal.
+    """
+
+    is_diagonal = True
+
+    def __init__(self, heads, stalk_dim):
+        super().__init__()
+        self.hidden = HeadwiseLinear(heads, 2 * stalk_dim, 2 * stalk_dim)
+        self.out = HeadwiseLinear(heads, 2 * stalk_dim, stalk_dim)
+
+    def forward(self, query, key):
+        r"""Build one transport diagonal per directed neighbour pair.
+
+        Parameters
+        ----------
+        query : torch.Tensor
+            Receiver queries ``q_x`` of shape ``[num_edges, heads, stalk_dim]``.
+        key : torch.Tensor
+            Sender keys ``k_y`` of shape ``[num_edges, heads, stalk_dim]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport diagonals of shape ``[num_edges, heads, stalk_dim]``.
+        """
+        hidden = torch.relu(self.hidden(torch.cat([query, key], dim=-1)))
+        return torch.sigmoid(self.out(hidden))
+
+
+#: The subset of the transport-map catalogue of [1], Table 18 that [1] applies
+#: to topological domains. ``sheaf_fc`` is what [1], Appendix H.5 instantiates,
+#: ``sheaf_spd`` is the positive-definite constraint it offers alongside, and
+#: ``diagonal`` is the ``O(d)`` map of [1], Section 6.2, kept because the full
+#: maps cost one ``d x d`` matrix per edge, per head and per neighborhood.
+COPRESHEAF_MAPS = {
+    "sheaf_fc": SheafFCMap,
+    "sheaf_spd": SheafSPDMap,
+    "diagonal": DiagonalMLPMap,
+}
+
+
+class CopresheafAttention(nn.Module):
+    r"""Copresheaf attention along a single neighborhood function.
+
+    Realises the message function ``alpha_{N_k}`` of [1], Definition 10 as
+    attention that transports each value vector into the receiver's stalk before
+    weighting it. When sender and receiver share a rank this is copresheaf
+    self-attention, [1], Definition 11; when they do not it is copresheaf
+    cross-attention, [1], Definition 16. The two differ only in which feature
+    matrices the projections read, so a single module covers both, matching the
+    shared body of the two loops of [1], Algorithm 1.
+
+    [1], Definition 16 allows the sender and receiver stalks to have different
+    widths. Every rank is projected to a common width by the feature encoder
+    upstream, so ``channels`` is used for both here.
+
+    Parameters
+    ----------
+    channels : int
+        Feature width of both sender and receiver cells.
+    heads : int
+        Number of attention heads. Must divide ``channels``.
+    copresheaf_map : str
+        Key of :data:`COPRESHEAF_MAPS` selecting the transport parameterisation.
+    """
+
+    def __init__(self, channels, heads, copresheaf_map):
+        super().__init__()
+        self.heads = heads
+        self.stalk_dim = channels // heads
+        self.lin_query = nn.Linear(channels, channels, bias=False)
+        self.lin_key = nn.Linear(channels, channels, bias=False)
+        self.lin_value = nn.Linear(channels, channels, bias=False)
+        self.transport = COPRESHEAF_MAPS[copresheaf_map](heads, self.stalk_dim)
+
+    def _project(self, linear, x, index):
+        r"""Project features and gather them onto the neighbour pairs.
+
+        Parameters
+        ----------
+        linear : torch.nn.Linear
+            One of the query, key or value projections.
+        x : torch.Tensor
+            Cell features of shape ``[num_cells, channels]``.
+        index : torch.Tensor
+            Cell index of each neighbour pair, of shape ``[num_edges]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Per-pair projections of shape
+            ``[num_edges, heads, stalk_dim]``.
+        """
+        projected = linear(x).view(-1, self.heads, self.stalk_dim)
+        return projected[index]
+
+    def forward(self, x_receiver, x_sender, neighborhood):
+        r"""Aggregate transported messages over one neighborhood.
+
+        Parameters
+        ----------
+        x_receiver : torch.Tensor
+            Features of the receiving cells, shape ``[num_receivers, channels]``.
+        x_sender : torch.Tensor
+            Features of the sending cells, shape ``[num_senders, channels]``.
+        neighborhood : torch.Tensor
+            Sparse neighborhood matrix of shape ``[num_receivers, num_senders]``
+            whose nonzero at ``(x, y)`` marks ``y in N_k(x)``, i.e. a directed
+            edge ``y -> x`` of the induced graph ``G_{N_k}`` of [1], Section 4.
+
+        Returns
+        -------
+        torch.Tensor
+            Messages ``m_x`` of shape ``[num_receivers, channels]``.
+        """
+        # Only the support is read: [1], Definition 7 builds the copresheaf
+        # neighborhood matrix by replacing each *nonzero* of the binary matrix
+        # of Definition 3 with a map, so the stored scalar carries no
+        # information beyond being nonzero. The zeros have to be filtered
+        # rather than taken from the sparsity pattern, because TopoBench
+        # materialises `up_adjacency-r` straight from toponetx, which stores an
+        # explicit zero on the diagonal; taking `indices()` alone would read
+        # those as a self-loop `y = x` on every cell.
+        neighborhood = neighborhood.coalesce()
+        support = neighborhood.values().flatten() != 0
+        receiver, sender = neighborhood.indices()[:, support]
+        num_receivers = x_receiver.size(0)
+
+        query = self._project(self.lin_query, x_receiver, receiver)
+        key = self._project(self.lin_key, x_sender, sender)
+        value = self._project(self.lin_value, x_sender, sender)
+
+        # a_xy = softmax_{y in N_k(x)}(<q_x, k_y> / sqrt(p)), Eq. (7) and (12).
+        score = (query * key).sum(dim=-1) / math.sqrt(self.stalk_dim)
+        attention = softmax(score, receiver, num_nodes=num_receivers)
+
+        # rho_{y->x}(v_y), the transport that distinguishes a copresheaf layer
+        # from plain attention.
+        rho = self.transport(query, key)
+        if self.transport.is_diagonal:
+            transported = rho * value
+        else:
+            transported = torch.einsum("ehij,ehj->ehi", rho, value)
+
+        message = attention.unsqueeze(-1) * transported
+        aggregated = scatter(
+            message, receiver, dim=0, dim_size=num_receivers, reduce="sum"
+        )
+        return aggregated.flatten(start_dim=1)
+
+
+class CopresheafTNNLayer(nn.Module):
+    r"""One layer of copresheaf-based higher-order message passing.
+
+    Implements [1], Definition 10 for a fixed collection of neighborhood
+    functions: every neighborhood contributes its own attention head group and
+    its own transport maps, the resulting messages are combined per receiving
+    rank by the inter-neighborhood aggregation ``otimes``, and the update
+    ``beta`` refreshes the cells that received anything.
+
+    ``otimes`` is summation and ``beta`` is a residual MLP with normalisation,
+    both as written in [1], Appendix H.5. Cells of a rank that no neighborhood
+    targets are passed through unchanged, since [1], Definition 10 leaves
+    ``h_x`` untouched when every ``N_k(x)`` is empty.
+
+    Parameters
+    ----------
+    channels : int
+        Feature width shared by all ranks.
+    routes : list of list of int
+        One ``[sender_rank, receiver_rank]`` pair per neighborhood, in the order
+        the neighborhoods are supplied.
+    heads : int
+        Number of attention heads per neighborhood.
+    copresheaf_map : str
+        Key of :data:`COPRESHEAF_MAPS` selecting the transport parameterisation.
+    dropout : float
+        Dropout applied to the aggregated message and to the update MLP.
+    """
+
+    def __init__(self, channels, routes, heads, copresheaf_map, dropout):
+        super().__init__()
+        self.routes = routes
+        self.attentions = nn.ModuleList(
+            CopresheafAttention(channels, heads, copresheaf_map)
+            for _ in routes
+        )
+        self.dropout = nn.Dropout(dropout)
+
+        receiver_ranks = sorted({receiver for _, receiver in routes})
+        self.norm_message = nn.ModuleDict(
+            {str(rank): nn.LayerNorm(channels) for rank in receiver_ranks}
+        )
+        self.norm_update = nn.ModuleDict(
+            {str(rank): nn.LayerNorm(channels) for rank in receiver_ranks}
+        )
+        self.update = nn.ModuleDict(
+            {
+                str(rank): nn.Sequential(
+                    nn.Linear(channels, 2 * channels),
+                    nn.GELU(),
+                    nn.Dropout(dropout),
+                    nn.Linear(2 * channels, channels),
+                )
+                for rank in receiver_ranks
+            }
+        )
+
+    def forward(self, features, neighborhoods):
+        r"""Update the cell features of every rank a neighborhood targets.
+
+        Parameters
+        ----------
+        features : dict
+            Cell features keyed by rank, each of shape ``[num_cells, channels]``.
+        neighborhoods : list of torch.Tensor
+            Sparse neighborhood matrices, aligned with ``routes``.
+
+        Returns
+        -------
+        dict
+            Updated cell features, keyed by rank.
+        """
+        messages = {}
+        for attention, (sender, receiver), neighborhood in zip(
+            self.attentions, self.routes, neighborhoods, strict=True
+        ):
+            message = attention(
+                features[receiver], features[sender], neighborhood
+            )
+            # otimes: accumulate across the neighborhoods sharing a receiver.
+            messages[receiver] = messages.get(receiver, 0) + message
+
+        updated = dict(features)
+        for rank, message in messages.items():
+            key = str(rank)
+            hidden = self.norm_message[key](
+                features[rank] + self.dropout(message)
+            )
+            updated[rank] = self.norm_update[key](
+                hidden + self.dropout(self.update[key](hidden))
+            )
+        return updated
+
+
+class CopresheafTNN(nn.Module):
+    r"""Copresheaf Topological Neural Network.
+
+    Stacks ``layers`` copies of :class:`CopresheafTNNLayer` over the
+    neighborhood collection ``N = {N_k}`` of [1], Definition 10. ``neighborhoods``
+    *is* that collection: each entry names one neighborhood matrix that the
+    lifting materialises, and TopoBench's route parser turns it into the sender
+    and receiver ranks. So the choice of neighborhoods, not the code, decides
+    which of the copresheaf adjacency and incidence matrices of [1],
+    Definition 8 the model transports along.
+
+    Parameters
+    ----------
+    channels : int
+        Feature width shared by all ranks. Must be divisible by ``heads``.
+    neighborhoods : list of str
+        Neighborhood names, e.g. ``up_adjacency-0`` or ``down_incidence-2``.
+    layers : int, optional
+        Number of message-passing layers. Default is 2.
+    heads : int, optional
+        Number of attention heads per neighborhood. Default is 4.
+    copresheaf_map : str, optional
+        Key of :data:`COPRESHEAF_MAPS` selecting the transport parameterisation.
+        Default is ``'sheaf_fc'``, the map of [1], Appendix H.5.
+    dropout : float, optional
+        Dropout applied inside every layer. Default is 0.0.
+
+    Raises
+    ------
+    ValueError
+        If ``neighborhoods`` is empty, if ``copresheaf_map`` is unknown, or if
+        ``heads`` does not divide ``channels``.
+    """
+
+    def __init__(
+        self,
+        channels,
+        neighborhoods,
+        layers=2,
+        heads=4,
+        copresheaf_map="sheaf_fc",
+        dropout=0.0,
+    ):
+        super().__init__()
+
+        if not neighborhoods:
+            raise ValueError(
+                "neighborhoods must name at least one neighborhood function; "
+                "it is the collection N of Definition 10"
+            )
+        if copresheaf_map not in COPRESHEAF_MAPS:
+            raise ValueError(
+                f"Unknown copresheaf_map {copresheaf_map!r}, "
+                f"expected one of {sorted(COPRESHEAF_MAPS)}"
+            )
+        if heads < 1 or channels % heads != 0:
+            raise ValueError(
+                f"heads={heads} must be positive and divide channels="
+                f"{channels}, otherwise the per-head stalk width truncates"
+            )
+
+        self.neighborhoods = list(neighborhoods)
+        self.routes = get_routes_from_neighborhoods(self.neighborhoods)
+        self.max_rank = max(max(route) for route in self.routes)
+        self.channels = channels
+        self.copresheaf_map = copresheaf_map
+        self.layers = nn.ModuleList(
+            CopresheafTNNLayer(
+                channels, self.routes, heads, copresheaf_map, dropout
+            )
+            for _ in range(layers)
+        )
+
+    def forward(self, batch):
+        r"""Propagate the features of every rank through the complex.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batched complex carrying ``x_{rank}`` features and one sparse matrix
+            per entry of ``neighborhoods``. Batching keeps every neighborhood
+            matrix block diagonal, so attention never crosses complexes.
+
+        Returns
+        -------
+        dict
+            Cell features keyed by rank, from ``0`` to ``max_rank``.
+        """
+        features = {
+            rank: batch[f"x_{rank}"] for rank in range(self.max_rank + 1)
+        }
+        neighborhoods = [batch[name] for name in self.neighborhoods]
+
+        for layer in self.layers:
+            features = layer(features, neighborhoods)
+        return features


### PR DESCRIPTION
## Track

Track 2 — Topological Neural Networks (TNNs)

## Team Name

howyadoin

- Dario Loi — Northeastern University
- Gabriele Onorato — Northeastern University

## Model

Copresheaf Topological Neural Network (CTNN)

## Status

Ready for review

## Summary

This PR contributes a TopoBench-native implementation of **Copresheaf
Topological Neural Networks (CTNN)** by Hajij et al. (NeurIPS 2025). A CTNN
gives every cell of a combinatorial complex its own feature space (a stalk)
and every directed neighbour relation `y -> x` a learnable transport map
`rho_{y->x}: F(y) -> F(x)`. Messages are carried into the receiver's frame
*before* aggregation, which makes propagation direction-aware; a cellular
sheaf glues data through a shared edge stalk instead and is therefore
symmetric.

## Implementation

- [x] Backbone with the transport-map catalogue of Table 18, copresheaf
      attention over one neighborhood, the Definition 10 layer, and the
      stacked model (`topobench/nn/backbones/simplicial/ctnn.py`).
- [x] Per-head linear map (`HeadwiseLinear`) so transport is evaluated
      independently per attention head, as Table 18 specifies, rather than
      sharing weights the way `torch.nn.Linear` would.
- [x] Hydra config `configs/model/simplicial/ctnn.yaml` (SheafFC, the map of
      Appendix H.5) plus `ctnn_spd.yaml` and `ctnn_diag.yaml` for the two
      other entries of the catalogue the paper applies to topological
      domains.
- [x] Unit tests asserting the paper's equations rather than tensor shapes:
      attention is row-stochastic per receiver and head, the aggregated
      message matches a dense per-pair reference for Eq. (7) and (12),
      `otimes` is summation, SheafFC starts at the identity, SheafSPD has
      eigenvalues at least one, the diagonal map gates into `(0, 1)`,
      transport is directional (`rho_{y->x} != rho_{x->y}^T`), and every
      registered parameter receives gradient. 44 tests in
      `test/nn/backbones/simplicial/test_ctnn.py`, including an overfit check
      and degenerate complexes with no 2-cells and no 1-cells.
- [x] All three configs added to `test/pipeline/test_pipeline.py` so CI
      exercises each transport map end to end.
- [x] Sphinx page for the new module (`docs/api/`).
- [x] Challenge notebook run end to end over the full GraphUniverse grid
      (12 settings × 3 seeds × 2 experiments = 72 runs); the auto-generated
      `results.json` is included. The grid was run with `simplicial/ctnn_diag`,
      with diagonal transport maps. More expressive variants are available, but led to
      severe overfitting on the small GraphUniverse datasets.

## Notes on faithfulness

Three conventions the paper leaves open, we collect our assumptions here and 
reiterate them in the docstrings:

- The query/key width `p` equals the stalk width, the setting Table 18 assumes
  when it sizes transport as `W in R^{2d x d^2}`.
- `beta` runs once per layer over the combined message, following
  Definition 10 and the layer displayed in Appendix H.5. Algorithm 1 instead
  writes two sequential updates, one after self-attention and one after
  cross-attention, which makes the result depend on the order the
  neighborhoods happen to be listed in.
- Per-head messages are concatenated with no output projection. Algorithm 1
  writes none; the cost accounting under Table 19 charges an `O(n d^2)` step
  to "combine head outputs", and the full-width `beta` that immediately
  follows mixes heads instead.

Two deliberate deviations from Appendix H.5, both flagged inline in the
configs:

- Appendix H.5 defines its `0 <-> 0` adjacency through 2-cells
  (`2-up_adjacency-0` here). GraphUniverse graphs have average degree 1-5, so
  triangle-adjacency is nearly empty and would silence the `0 <- 0` path on
  most nodes; the configs use `up_adjacency-0` instead.
- Stalk width is `d = 4` (`channels=64`, `heads=16`), which is what the paper
  uses for its classification tasks (Section 6.3, Appendix H.3.1, H.4). The
  `d = 16` of Section 6.1 and Appendix H.5 is for physics regression, and
  because SheafFC transport carries `W in R^{2d x d^2}` per head it puts 59%
  of the backbone's weights in the transport maps at that width, which
  overfits GraphUniverse.

One TopoBench integration detail: Definition 7 builds the
copresheaf neighborhood matrix by replacing each *nonzero* of the binary
matrix with a map, so the stored scalar carries no information beyond being
nonzero. The zeros have to be filtered by value rather than read off the
sparsity pattern, because TopoBench materialises `up_adjacency-r` straight
from toponetx, which stores an explicit zero on the diagonal; reading
`indices()` alone would treat those as a self-loop `y = x` on every cell.
`test_stored_zeros_are_not_neighbours` pins this down.

We have turned dropout to 0.5 to combat overfitting,achieving results that outmatch those of the average submission to the challenge. We speculate that with further regularization, the model could achieve even better results.

## Reference

Hajij, Bastian, Osentoski, Kabaria, Davenport, Dawood, Cherukuri,
Kocheemoolayil, Shahmansouri, Lew, Papamarkou, Birdal, "Copresheaf Topological
Neural Networks: A Generalized Deep Learning Framework," NeurIPS 2025.

- ArXiv: https://arxiv.org/abs/2505.21251
