### PR TITLE
Track: Track2;  Team name: One Ring to Lift Them All;  Model: DiffLift-SMCN

### DIFF
--- a/2026_tdl_challenge/outputs/2026-07-27_05-00-00/results.json
+++ b/2026_tdl_challenge/outputs/2026-07-27_05-00-00/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "2026-07-27_05-00-00",
+    "model_config": "cell/smcn_difflift",
+    "generated_at_utc": "2026-07-30T23:44:13.694652+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.2066900730133057,
+      "test_best_rerun_accuracy": 0.3209565281867981,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3148063123226166,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23867370188236237,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3122469186782837,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30907630920410156,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29410192370414734,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2481091022491455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29043471813201904,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3034227192401886,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28841012716293335,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2842845022678375,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26014211773872375,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1740641593933105,
+      "test_best_rerun_accuracy": 0.3290167450904846,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.321682333946228,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2693101167678833,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3185499310493469,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31071892380714417,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30036672949790955,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2660630941390991,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29532432556152344,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3020475208759308,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2944457232952118,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.28512492775917053,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26552829146385193,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.1627745628356934,
+      "test_best_rerun_accuracy": 0.33058294653892517,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32214072346687317,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2824891209602356,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3183971345424652,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31274351477622986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3013981282711029,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2869967222213745,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29643210768699646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046451210975647,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.290396511554718,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.296890527009964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28012070059776306,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.199719190597534,
+      "test_best_rerun_accuracy": 0.31927573680877686,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.273282915353775,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.12770265340805054,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2798915207386017,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23947589099407196,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2906257212162018,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13156084716320038,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23920848965644836,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22358469665050507,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2651844918727875,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.15875926613807678,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19103828072547913,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.196962356567383,
+      "test_best_rerun_accuracy": 0.3234013319015503,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2562839090824127,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.11784704774618149,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.263694703578949,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23252348601818085,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2957063317298889,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.13274505734443665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24325770139694214,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23901750147342682,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2660630941390991,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18809688091278076,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21155168116092682,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.201883554458618,
+      "test_best_rerun_accuracy": 0.32130032777786255,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1881350725889206,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.07361143082380295,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1651768684387207,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.15291465818881989,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2784399092197418,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.07135763019323349,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.12712964415550232,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1460004597902298,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22201849520206451,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.08705783635377884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.10527924448251724,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.159822463989258,
+      "test_best_rerun_accuracy": 0.3378027379512787,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3061731159687042,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29345253109931946,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32550233602523804,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2996027171611786,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28187790513038635,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3239743411540985,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3056001365184784,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2918481230735779,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27767589688301086,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29414013028144836,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2843609154224396,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1397697925567627,
+      "test_best_rerun_accuracy": 0.3392161428928375,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30907630920410156,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2971961200237274,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32634273171424866,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3020857274532318,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28447550535202026,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3220643401145935,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30976393818855286,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2959737181663513,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28947970271110535,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30296432971954346,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29001450538635254,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.1387484073638916,
+      "test_best_rerun_accuracy": 0.3404003381729126,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3086179196834564,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29532432556152344,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.33260753750801086,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29627931118011475,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27973872423171997,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32767972350120544,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3167163133621216,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28539231419563293,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2763389050960541,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.311330109834671,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31152111291885376,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1871390342712402,
+      "test_best_rerun_accuracy": 0.3284055292606354,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2780196964740753,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.30090153217315674,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17656047642230988,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2660630941390991,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28122851252555847,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.213423490524292,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3130491375923157,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2717167139053345,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2707616984844208,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2818015217781067,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31629613041877747,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.1676273345947266,
+      "test_best_rerun_accuracy": 0.331958144903183,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2957827150821686,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29765450954437256,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2287798970937729,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28661471605300903,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2812667191028595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24745969474315643,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3088471293449402,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28298571705818176,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2765299081802368,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29654672741889954,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3092673122882843,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.198582172393799,
+      "test_best_rerun_accuracy": 0.32374513149261475,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25727710127830505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2954007089138031,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1353808492422104,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23729848861694336,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2818015217781067,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1427534520626068,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.296890527009964,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2508212924003601,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2775995135307312,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19990068674087524,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26625409722328186,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9686516523361206,
+      "test_best_rerun_accuracy": 0.40258994698524475,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2735503017902374,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2643823027610779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2411566972732544,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23088088631629944,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37500953674316406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3742837607860565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3644663393497467,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5105814337730408,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5094736218452454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5119184255599976,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5012605786323547,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0193889141082764,
+      "test_best_rerun_accuracy": 0.40965697169303894,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2701123058795929,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2569333016872406,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23344029486179352,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2253800928592682,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37714874744415283,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36614716053009033,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3609519302845001,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5199404358863831,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5173428058624268,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.50836580991745,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5012605786323547,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9514570236206055,
+      "test_best_rerun_accuracy": 0.4100389778614044,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28092291951179504,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26514631509780884,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24119490385055542,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22041408717632294,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3760409355163574,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3654213547706604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36523035168647766,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5217357873916626,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5042402148246765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5168461799621582,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4816640019416809,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0713672637939453,
+      "test_best_rerun_accuracy": 0.38234394788742065,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25158530473709106,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.26789671182632446,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.157957062125206,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22251509130001068,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3458247482776642,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.221598282456398,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3141569197177887,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42528077960014343,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5042402148246765,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3256169259548187,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3867751657962799,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0215933322906494,
+      "test_best_rerun_accuracy": 0.38711896538734436,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2539536952972412,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2701505124568939,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16777446866035461,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.23263809084892273,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34727632999420166,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24952250719070435,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3515547513961792,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.42528077960014343,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5077546238899231,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3668729364871979,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4626021981239319,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0429325103759766,
+      "test_best_rerun_accuracy": 0.3742837607860565,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23661088943481445,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2596836984157562,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16227366030216217,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.22515088319778442,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3298953175544739,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2486439049243927,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3474673330783844,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.418404757976532,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49407899379730225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3614485561847687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.41034457087516785,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8418092727661133,
+      "test_best_rerun_accuracy": 0.45114219188690186,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2535335123538971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23867370188236237,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26881352066993713,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26273971796035767,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3715333342552185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3342883288860321,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.45614638924598694,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4846054017543793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4699365794658661,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5885858535766602,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6246848702430725,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8441507816314697,
+      "test_best_rerun_accuracy": 0.4563755691051483,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2581939101219177,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24207349121570587,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2782489061355591,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26598671078681946,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3845977485179901,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34020933508872986,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46447399258613586,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.504622220993042,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.49396440386772156,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6089082360267639,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6232332587242126,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.841430902481079,
+      "test_best_rerun_accuracy": 0.4521735906600952,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25765910744667053,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24608449637889862,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27687370777130127,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26950111985206604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3774925470352173,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3390633463859558,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4528611898422241,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4933150112628937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4742913842201233,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.601421058177948,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6194896697998047,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.6764072179794312,
+      "test_best_rerun_accuracy": 0.5096263885498047,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23508289456367493,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22774849832057953,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24096569418907166,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2697302997112274,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3424249291419983,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3248911201953888,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4079379737377167,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4403315782546997,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4473603665828705,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5705172419548035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6748032569885254,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.6861006021499634,
+      "test_best_rerun_accuracy": 0.5101612210273743,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23875010013580322,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2408892959356308,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24803270399570465,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26694169640541077,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3693941533565521,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3455573320388794,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41038277745246887,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47005119919776917,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.47058600187301636,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5844220519065857,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6832836866378784,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.6853065490722656,
+      "test_best_rerun_accuracy": 0.49449920654296875,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23447169363498688,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23485369980335236,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.23321110010147095,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2641149163246155,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35254794359207153,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.33039194345474243,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39854076504707336,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.45549699664115906,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.46554359793663025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5652074217796326,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6663610935211182,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3577334880828857,
+      "test_best_rerun_accuracy": 0.6129956245422363,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23596149682998657,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22480708360671997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.22373749315738678,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2195354849100113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4045381546020508,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37214455008506775,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3957139551639557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4049965739250183,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6062724590301514,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6532584428787231,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6635724902153015,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3549846410751343,
+      "test_best_rerun_accuracy": 0.6079150438308716,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22316448390483856,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.210176482796669,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21158988773822784,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17789746820926666,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39785316586494446,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36179235577583313,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3755061626434326,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35621514916419983,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5923676490783691,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6300710439682007,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.623386025428772,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.363006591796875,
+      "test_best_rerun_accuracy": 0.6185346245765686,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22327908873558044,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2180456817150116,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.21311788260936737,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1938650757074356,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3960195481777191,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3651539385318756,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3825349509716034,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3598059415817261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.612078845500946,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6540988683700562,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6401176452636719,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.316772699356079,
+      "test_best_rerun_accuracy": 0.6150202751159668,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2221330851316452,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22178928554058075,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17969287931919098,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19898387789726257,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3675987422466278,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3731377422809601,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3065933287143707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3756207525730133,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.576858401298523,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5640996098518372,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.662311851978302,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3512225151062012,
+      "test_best_rerun_accuracy": 0.6098632216453552,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20971807837486267,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2112460881471634,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.16578806936740875,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20910687744617462,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3478493392467499,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.35690274834632874,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26858431100845337,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3665291368961334,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5674230456352234,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5475972294807434,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6444342732429504,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.26180100440979,
+      "test_best_rerun_accuracy": 0.6281992793083191,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2308426946401596,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23336389660835266,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1680418699979782,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19802887737751007,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3745129406452179,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37569713592529297,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3046451210975647,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.38287875056266785,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5916418433189392,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5974864363670349,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6712888479232788,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.2125365734100342,
+      "test_best_rerun_accuracy": 0.6514630317687988,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20750248432159424,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.189777672290802,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20265108346939087,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1871800720691681,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.36469554901123047,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32103294134140015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3952173590660095,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40232256054878235,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5485904216766357,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.535908043384552,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6812208890914917,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.1821550130844116,
+      "test_best_rerun_accuracy": 0.6747268438339233,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19871647655963898,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19042707979679108,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20887768268585205,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19187867641448975,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3607991337776184,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32145312428474426,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40339216589927673,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40194055438041687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5636412501335144,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5558102130889893,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6964244842529297,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.215095043182373,
+      "test_best_rerun_accuracy": 0.6646420955657959,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19978608191013336,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1922224760055542,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20605088770389557,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1890900731086731,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3667583465576172,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32622814178466797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39349836111068726,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4097333550453186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5683398246765137,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5611582398414612,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6953930854797363,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0103267431259155,
+      "test_best_rerun_accuracy": 0.7212544679641724,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18125906586647034,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18209947645664215,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.17629307508468628,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16987547278404236,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.313240110874176,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31056612730026245,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3604171574115753,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40094736218452454,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4846054017543793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5212010145187378,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6407288312911987,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.0253734588623047,
+      "test_best_rerun_accuracy": 0.7118191123008728,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16548246145248413,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.16811826825141907,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.1964244842529297,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18206126987934113,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.296928733587265,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29028192162513733,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37034913897514343,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4098861515522003,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.47707998752593994,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5112308263778687,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6333180665969849,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 1.038596510887146,
+      "test_best_rerun_accuracy": 0.685957670211792,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18152646720409393,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18553747236728668,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19268088042736053,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18118266761302948,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29562991857528687,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2970051169395447,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35063794255256653,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.40736496448516846,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.44258537888526917,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4777293801307678,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6056230664253235,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 46.65212631225586,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 44.64903259277344,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.032167890916983743,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.016980171203613,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.036931474585282176
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5877.064453125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4457386767633675
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 453.02032470703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.15268632447153058
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4723.65234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6310824774549099
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.81647491455078,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.05942700769823038
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 146669.0625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4058392741036596
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9320.4716796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.653517857221112
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37953.390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9454298336665128
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2410.054443359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4284541232638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 711151.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.044430760268316
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233755.0625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.889888381342253
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 26.067785263061523,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 25.985136032104492,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.018721279562034936,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.167674541473389,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0324614449551231
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7519.994140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5703446447193781
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.500457763671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.014324387517247008
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4964.71826171875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6632890129216766
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.68912506103516,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07917886447412362
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 149157.265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.4636184661201934
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10193.1171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7147046127822185
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34566.4296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.771819656953201
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2339.48681640625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4159087673611111
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 680737.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.700392662013733
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 223194.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.7141482785016557
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 31.16514778137207,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 31.06266975402832,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.022379445067743746,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.248449802398682,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.032886577907361485
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7145.20263671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5419190471534888
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 112.16200256347656,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.03780316904734633
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5085.6083984375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6794399997912491
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74.1353759765625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.06402018650825778
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151176.359375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.5105043510821106
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10870.333984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7621886120021736
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37257.875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.9097788200317802
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2586.058349609375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.45974370659722225
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 703504.25,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.9579228080495
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 230722.609375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.8394257130614213
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.3930020332336426,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.3915194272994995,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.00732378645947105,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 213.15867614746094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.15357253324745024
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12523.068359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9497966142870686
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 321.0513610839844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10820740178091823
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8189.09423828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.094067366503841
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.56570434570312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13693066005673846
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176907.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.10801002577559
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15633.580078125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0961702480805637
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47927.328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.4566778474037623
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3904.3857421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6941130208333334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 763458.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.636118825152993
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 265020.625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.41017464596542
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 1.5450373888015747,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.559107780456543,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.008205830423455488,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.1063690185547,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.10166164914881462
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12188.513671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9244227282423209
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 257.08740234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.08664893911147624
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7693.1806640625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.027813047970942
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147.65679931640625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12751018939240608
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 175214.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 4.068688463681962
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15085.775390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0577601592080352
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46230.96484375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.369724990709416
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3653.30908203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6494771701388888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 757116.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.564378471318847
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 261011.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.343466845140033
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.58748722076416,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.5619003772735596,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.013483686196176629,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.02519226074219,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08719394255096699
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11090.0087890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8411079855185817
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 179.08580017089844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.060359218122985656
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7557.84423828125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0097320291624916
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.6210174560547,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12057082681870007
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 171690.953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.9868789040730075
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14470.9814453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.0146530251936965
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46125.5546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.3643218354349274
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3614.02880859375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.6424940104166666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 753284.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.521031526079431
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258572.3125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.302869094570083
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 779.6406860351562,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 767.4700317382812,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.058207814314621256,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106.33373260498047,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07660931743874673
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221.70065307617188,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.1668455425061677
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 375.1925964355469,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.12645520607871483
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1792.1629638671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.23943392970837507
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 233.03500366210938,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.20123920868921363
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 69714.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6188601558146016
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3252.105224609375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.22802588869789475
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19735.40625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.0116052206673842
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1349.54443359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.23991901041666666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 469920.75,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.315665192357725
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121817.5234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.027149974830679
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 554.0148315429688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 551.199462890625,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.041805040795648465,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.19644165039062,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08731732107376847
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.40516662597656,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8284482453998766
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.34965896606445,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.012588358262913534
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2047.6878662109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2735721932145541
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.53245544433594,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13085704269804485
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71694.9765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.6648471243381944
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3606.58251953125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.2528805580936229
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21212.380859375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.087312566475729
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1516.733154296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.26964144965277775
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 485412.90625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 5.490909881451987
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 134468.015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.237665212670361
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 725.5968627929688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 701.8926391601562,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.05323417816914344,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 176.0872039794922,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.12686397981231426
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 272.8380432128906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.435989701120477
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 137.2767333984375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.04626785756603893
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2768.644287109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3698923563272378
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 224.97715759277344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.19428079239445029
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91306.1171875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.1202423645620474
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7562.544921875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5302583734311457
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29016.2265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.4873251608232099
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2235.060791015625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.397344140625
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 576987.125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 6.526782179337805
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 168950.6875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 2.8114869868370693
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 19.223955154418945,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 18.566162109375,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.006257553794868554,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185.4355926513672,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.13359913015228184
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 108.81855773925781,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.5727292512592517
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7331.32568359375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5560353191955821
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5111.93115234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6829567337800602
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136.42703247070312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11781263598506314
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153935.90625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.574584484720416
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9116.611328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6392239046504697
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36876.92578125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8902519750499769
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2223.5595703125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3952994791666667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 709353.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.024089963010304
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225760.0,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.756843559149984
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 30.910011291503906,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 30.12791633605957,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.010154336479966152,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.671566009521484,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.030743203176888678
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34.72745132446289,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.18277605960243626
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5970.9501953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.4528593246350019
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5214.50927734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6966612260980294
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81.49127197265625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07037242830108484
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 145728.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3839866245587964
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8897.5927734375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.6238671135491165
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37025.56640625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8978710547055204
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2264.10009765625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4025066840277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 685148.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.750287037770211
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210885.75,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.509323049273626
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 20.199167251586914,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 19.584903717041016,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.006600911262905634,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98.60877227783203,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.07104378406183864
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90.50471496582031,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.4763406050832648
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7137.21435546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5413131858527683
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5116.59912109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6835803768996326
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.59117126464844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.07909427570349606
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148874.4375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.457050842931451
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8169.4365234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5728114236038073
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36943.35546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.893657054116049
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2176.748046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.38697743055555556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 695108.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.862955018494848
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 218914.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.642936001281347
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 658.4976196289062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 662.6682739257812,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.08853283552782648,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 267.0015869140625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.19236425570177412
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.23203659057617,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.33280019258197985
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14277.5048828125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.0828596801526356
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1205.6234130859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.4063442578651626
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 107.53376007080078,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.09286162354991431
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45435.48828125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.05506892720718
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4368.60498046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.30631082460165127
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6829.67822265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3500783342383643
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1130.509033203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.20097938368055557
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 341355.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.8613589895139304
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80734.1953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3434875162248514
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 334.2834167480469,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 338.4892578125,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.04522234573313293,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203.78146362304688,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.14681661644311733
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.9066925048828,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8363510131835937
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4142.49755859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.3141825983006257
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1853.97998046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.624866862308308
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 151.9266815185547,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.13119747972241338
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47271.77734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0977098584374418
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1888.1573486328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.13239078310424993
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7382.92236328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.37843674013436107
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 578.4099731445312,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.10282843967013888
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 341799.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.8663814435030486
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67727.6640625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1270474774516166
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 702.3773803710938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 709.8505859375,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.09483641762692051,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 380.9185485839844,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.27443699465704924
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 185.3350067138672,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.9754474037571957
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10519.001953125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.7978006790386803
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9327.640625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.1437952898550723
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 148.53982543945312,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.12827273354011495
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54712.5546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2704940248815717
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5078.29150390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.3560714839367725
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11761.33203125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.6028669860705316
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 854.8287963867188,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.15196956380208335
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 389516.625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.406147133015848
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 97007.046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.6142819775181803
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 82.86609649658203,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 83.21942901611328,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07186479189647088,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 162.28199768066406,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1169178657641672
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.750020980834961,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07236853147807874
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6627.0712890625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5026220166145241
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1036.66845703125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.34939954736476236
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5930.1982421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.792277654266867
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 153868.421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.573017413036411
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10031.076171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7033428812140653
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42613.515625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.1843003549643756
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2800.858154296875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4979303385416667
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 727717.6875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.231821176883138
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 238994.15625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.9770714767110977
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 83.80009460449219,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 84.2988510131836,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07279693524454542,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 306.3573913574219,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2207185816696123
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.234469413757324,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.043339312703985916
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6445.9306640625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.48888363019055747
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3545.9892578125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 1.1951429921848669
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4497.5185546875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6008708823897796
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143074.21875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.3223625011610625
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8374.275390625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5871739861607769
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35878.8125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.8390902916602594
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2349.668212890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.4177187934027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 691384.0625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 7.820821267377804
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 221542.234375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 3.6866562557203
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 81.31417083740234,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 81.97187042236328,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.07078745286905291,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 181.77113342285156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.130959029843553
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.125442504882812,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.16381811844675165
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8434.5810546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.6397103568211984
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 333.3372497558594,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.11234824730564859
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5928.05126953125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.7919908175726453
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 159413.859375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 3.701789415172766
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11136.6904296875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7808645652564508
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40477.98828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 2.074836653916141
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2628.760498046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.46733519965277776
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 722828.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 8.176513381898804
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240699.125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 4.005443645682526
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 15256.8798828125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15431.4765625,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.3583382073773918,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1450.3135986328125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.044894523510672
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2801.13916015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.742837685032894
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34732.546875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 2.634247013651877
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6108.65087890625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.0588644687921303
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2778.94482421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3712685135896794
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2677.0390625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.3117781196027636
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4188.49267578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.2936819994237309
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6575.546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3370519696037726
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2371.3359375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.42157083333333334
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96114.671875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.087233146782349
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26348.953125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.4384695908841296
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 8416.265625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8383.5498046875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.19467652342298672,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4790.55029296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.451405110208033
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4860.958984375,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 25.583994654605263
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12392.0634765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.9398607111537732
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10432.2509765625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.5160940264787666
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7534.79345703125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.0066524324691049
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6929.34716796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 5.983892200318437
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7437.27392578125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5214748230108855
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4318.24560546875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.22134633274225998
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6309.4873046875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.1216866319444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96299.46875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.0893235382283406
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 60531.98828125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.0073051483741866
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 6754.87890625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 6827.896484375,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.15855230550750046,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1066.77880859375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.7685726286698487
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1391.000732421875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 7.321056486430921
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25809.80078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.9575123838642396
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2831.493896484375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.954328916914181
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 769.5245971679688,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.10280889741723029
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 559.175537109375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.48288042928270725
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2013.6060791015625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.14118679561783498
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3395.419677734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.17404375814928366
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2074.43603515625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3687886284722222
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 132911.09375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.5034681373935275
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49753.9453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8279491007688083
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 709.9461059570312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 706.3577880859375,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.04952726041831002,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2082.5263671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.5003792270803313
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 442.85406494140625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 2.3308108681126645
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7424.50244140625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.5631021950251233
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 305.4302978515625,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.10294246641441271
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2407.419677734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.3216325554755344
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 322.1719665527344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.27821413346522833
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37548.53515625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.8719240004702303
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9525.20703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4882468107668256
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 801.74658203125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.14253272569444445
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 293526.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.320323193217425
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50948.69140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.8478307191561413
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 462.0699157714844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 461.73114013671875,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.03237492218038976,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1264.36962890625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.9109291274540706
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 275.1059265136719,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.4479259290193256
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17200.09765625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.3045201104474782
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229.65318298339844,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07740248836649762
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1113.357666015625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.14874517916040414
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240.70449829101562,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.20786226104578207
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44602.09765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.035716553414685
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13063.8037109375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.669629592031242
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 770.743896484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.13702113715277778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 358311.84375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.05316384907752
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68088.515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.1330523625879887
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1835.535400390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1825.9566650390625,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.12802949551528975,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8431.828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.074804124639769
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 864.5658569335938,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 4.550346615439967
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55697.88671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 4.2243372558778916
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 761.925537109375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.2567999788032946
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8279.107421875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.1060931759352037
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1458.19921875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.2592393944300517
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 43494.546875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.0099978375208991
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9308.4638671875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.47713690436144857
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2379.740234375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.42306493055555555
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 272360.8125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.0809001108559664
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46463.05859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.7731858717945518
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 2435.5966796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2464.9921875,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.12635153967399662,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1921.2567138671875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.3841907160426423
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 236.23326110839844,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.2433329532020971
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47134.98046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 3.574894233503982
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 78022.078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 26.29662221941355
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1101.254638671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.14712820823939546
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 245.0066680908203,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.2115774335844735
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35414.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.822357421512168
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50488.61328125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 3.5400794615937454
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 349.8509521484375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.06219572482638889
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163003.640625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.8438700114815108
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28489.66015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.47409282539147657
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1533.098876953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1483.18798828125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.07602583362967093,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5253.828125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 3.785178764409222
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 365.0693054199219,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.9214173969469572
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 119980.84375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 9.099798540007585
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 98635.875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 33.244312436804854
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3043.5693359375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.4066224897712091
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 406.1756591796875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3507561823658787
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47890.51953125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1120778267520435
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85256.203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 5.977857462137147
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 529.7843017578125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.09418387586805556
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157738.375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.7843102044048278
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27515.072265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.45787483177117133
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 5329.23681640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 5247.220703125,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.26896410390717107,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6897.30322265625,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 4.969238633037644
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1963.6435546875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 10.334966077302632
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 74811.484375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 5.673984404626469
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 96758.3671875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 32.6115157355915
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6715.384765625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.8971789934034736
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2697.4296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 2.329386604058722
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51920.2578125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2056533952373212
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 93673.1171875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 6.568021118181181
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1899.659423828125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.3377172309027778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 156184.140625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.766728964231983
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 71096.265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.183103949295259
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 317.2769470214844,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 320.5833740234375,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.056992599826388886,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 202.99530029296875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.1462502163494011
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 364.8596496582031,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.9203139455694902
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11832.2197265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.8974000551052332
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18644.361328125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.28391012070273
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1400.2138671875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.18706932093353373
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 385.7881774902344,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.3331504123404442
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67233.0234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.5612349860091956
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15263.0234375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.070188152958912
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9148.4775390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.4689362621898867
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 387660.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.385148835446761
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86380.1328125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.437440846895645
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 494.561279296875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 498.13848876953125,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.08855795355902778,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3325.356689453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 2.395790122084384
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 80.24824523925781,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.42235918546977796
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23132.080078125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.7544239725540387
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10183.5302734375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.4322650062141893
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4494.921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.6005239645958583
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 291.9015197753906,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.25207385127408516
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59177.7265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3741809066157347
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10948.2783203125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.7676537877094727
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9200.998046875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.47162837904941307
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 381089.21875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 4.310817718290103
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84494.90625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.4060690305027208
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 271.8805847167969,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 275.00067138671875,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.048889008246527775,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 380.2723083496094,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.2739714037100932
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.97071838378906,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.6366879914936266
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16279.6083984375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 1.2347067423919227
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24399.689453125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 8.223690412243007
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1030.3441162109375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.13765452454387941
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 136.21368408203125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11762839730745359
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58118.16015625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.3495764479902006
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16607.14453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.1644330760938157
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6518.1494140625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.3341098679615818
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 348582.0,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.9431014784566134
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 77385.328125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.287759441615496
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 46556.75,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 46832.71484375,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.5297638637122043,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28285.533203125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 20.3786262270353
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21023.873046875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 110.65196340460527
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1021599.375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 77.48193970420932
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50640.23046875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 17.067822874536567
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24981.5625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 3.3375501002004007
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18580.5625,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 16.045390759930914
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 454065.0,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 10.543957830206205
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 64287.3984375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.507600507467396
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8672.232421875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.44452470254113485
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8155.333984375,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.4498371527777778
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94115.1015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.5661574819446524
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 55243.55859375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 55930.78125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.6326796743323191,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2693.04052734375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 1.9402309274810878
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2715.935791015625,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 14.294398900082237
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157546.671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 11.948932262040197
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6483.078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 2.185061720593192
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2456.075927734375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.32813305647753843
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2136.83154296875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 1.8452776709574699
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48067.234375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.1161813666867917
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5465.75,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.38323867620249613
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4051.214111328125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.20765872732216542
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6772.52685546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 1.2040047743055555
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8965.09765625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.14918705433661159
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 12883.3046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 13049.970703125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.14761909327879144,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7850.92919921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 5.656289048428494
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14592.3564453125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 76.80187602796053
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 299659.0,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 22.727265832385285
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144698.09375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 48.7691586619481
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7027.17919921875,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.9388348963552104
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13646.392578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 11.784449549330743
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89662.15625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 2.0820675332063905
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70646.546875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 4.953481059809284
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3107.521240234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.1592865467340394
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4671.453125,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.8304805555555556
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19552.982421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.3253787033743531
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 20170.51953125,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 20381.810546875,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.3391711272007555,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37342.09375,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 26.90352575648415
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42938.55078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 225.99237253289473
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 903981.5625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 68.56136234357224
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10427.005859375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 3.514326208080553
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21393.744140625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 2.8582156500501004
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 32005.9609375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 27.638999082469777
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 584962.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 13.58357183494334
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7434.94189453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.5213113093907762
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10889.7724609375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.5581922426027731
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12028.462890625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 2.1383934027777776
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 44471.203125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.503050836792869
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 12489.291015625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 12640.27734375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.21034525391892567,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40216.453125,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 28.974389859510087
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19595.33203125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 103.13332648026316
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 915462.1875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 69.43209613196815
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51040.74609375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 17.2028129739636
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38349.328125,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 5.123490731462926
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15991.88671875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 13.809919446243523
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 462450.34375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 10.738676011285529
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 23570.748046875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 1.652695838372949
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25921.947265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 1.3287173748334102
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18001.5625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 3.200277777777778
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56375.19140625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.6377067679405676
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "smcn_difflift_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 9318.8623046875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9319.6318359375,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.1550868127059308,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9270.857421875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 6.67929209068804
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6164.3955078125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 32.444186883223686
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 483439.78125,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 36.665891638225254
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18734.0078125,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 6.314124641894169
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10441.5234375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 1.394993111222445
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5023.5380859375,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 4.338115790965026
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 358684.9375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 8.329113354542077
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11656.814453125,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.8173337858031833
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7624.9775390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.39084409959826233
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4412.05810546875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.7843658854166666
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47380.71875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.535962792552289
+        }
+      },
+      "output_dir": "/scratch/work/francoj3/challengetopo/TopoBench/logs/train/runs/notebook_gu_grid_2026-07-27_05-00-00__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/cell/smcn.yaml
+++ b/configs/model/cell/smcn.yaml
@@ -1,0 +1,41 @@
+_target_: topobench.model.TBModel
+
+model_name: smcn
+model_domain: cell
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.cell.smcn.SMCN
+  in_channels: ${model.feature_encoder.out_channels}
+  sub_channels: 32
+  n_cin_layers: 1
+  n_scl_layers: 3
+  num_mlp_layers: 2
+  max_rank_out: 1
+  max_dist: 10
+  dropout: 0.0
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.SMCNWrapper
+  _partial_: true
+  wrapper_name: SMCNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/configs/model/cell/smcn_difflift.yaml
+++ b/configs/model/cell/smcn_difflift.yaml
@@ -1,0 +1,43 @@
+_target_: topobench.model.TBModel
+
+model_name: smcn_difflift
+model_domain: cell
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: AllCellFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.0
+
+backbone:
+  _target_: topobench.nn.backbones.cell.smcn.SMCN
+  in_channels: ${model.feature_encoder.out_channels}
+  sub_channels: 32
+  n_cin_layers: 1
+  n_scl_layers: 3
+  num_mlp_layers: 2
+  max_rank_out: 1
+  max_dist: 10
+  dropout: 0.0
+  learned_lifting: true # 2-cells selected end-to-end (DiffLift)
+  sharpening: 10.0
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.SMCNWrapper
+  _partial_: true
+  wrapper_name: SMCNWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: PropagateSignalDown
+  num_cell_dimensions: ${infer_num_cell_dimensions:${oc.select:model.feature_encoder.selected_dimensions,null},${model.feature_encoder.in_channels}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+
+# compile model for faster training with pytorch 2.0
+compile: false

--- a/test/nn/backbones/cell/test_smcn.py
+++ b/test/nn/backbones/cell/test_smcn.py
@@ -4,12 +4,6 @@ import pytest
 import torch
 
 from topobench.nn.backbones.cell.smcn import SMCN
-from topobench.nn.backbones.cell.smcn_utils.difflift import (
-    CellScorer,
-    DiffLift,
-    DiffLiftEncoder,
-    EdgeSampler,
-)
 from topobench.nn.backbones.cell.smcn_utils.layers import (
     BagInit,
     BagPool,
@@ -22,6 +16,12 @@ from topobench.nn.backbones.cell.smcn_utils.structures import (
     adjacency_from_incidence,
     build_smcn_structures,
     hop_distance_buckets,
+)
+from topobench.nn.liftings.difflift import (
+    CellScorer,
+    DiffLift,
+    DiffLiftEncoder,
+    EdgeSampler,
 )
 
 

--- a/test/nn/backbones/cell/test_smcn.py
+++ b/test/nn/backbones/cell/test_smcn.py
@@ -1,0 +1,337 @@
+"""Unit tests for the SMCN backbone."""
+
+import pytest
+import torch
+
+from topobench.nn.backbones.cell.smcn import SMCN
+from topobench.nn.backbones.cell.smcn_utils.difflift import (
+    CellScorer,
+    DiffLift,
+    DiffLiftEncoder,
+    EdgeSampler,
+)
+from topobench.nn.backbones.cell.smcn_utils.layers import (
+    BagInit,
+    BagPool,
+    CINBlock,
+    SafeBatchNorm,
+    SCLLayer,
+    TwoCellInit,
+)
+from topobench.nn.backbones.cell.smcn_utils.structures import (
+    adjacency_from_incidence,
+    build_smcn_structures,
+    hop_distance_buckets,
+)
+
+
+def _two_triangles():
+    """Two triangles sharing an edge: 4 nodes, 5 edges, 2 two-cells.
+
+    Returns
+    -------
+    tuple
+        Incidence matrices and batch vectors of a single graph.
+    """
+    i1 = torch.zeros(4, 5)
+    for e, (a, b) in enumerate([(0, 1), (0, 2), (1, 2), (1, 3), (2, 3)]):
+        i1[a, e] = 1
+        i1[b, e] = 1
+    i2 = torch.zeros(5, 2)
+    i2[[0, 1, 2], 0] = 1
+    i2[[2, 3, 4], 1] = 1
+    b0 = torch.zeros(4, dtype=torch.long)
+    b1 = torch.zeros(5, dtype=torch.long)
+    b2 = torch.zeros(2, dtype=torch.long)
+    return i1, i2, b0, b1, b2
+
+
+def _structures():
+    """Structures of the two-triangle fixture.
+
+    Returns
+    -------
+    SMCNStructures
+        The assembled structures.
+    """
+    i1, i2, b0, b1, b2 = _two_triangles()
+    return build_smcn_structures(
+        i1.to_sparse(), i2.to_sparse(), b0, b1, b2
+    )
+
+
+def test_adjacency_pairs():
+    """Adjacency pairs and bridges of the fixture are exact."""
+    s = _structures()
+    assert s.a01_pairs.shape[1] == 10  # 5 edges, both directions
+    assert s.a12_pairs.shape[1] == 12  # 2 cells x 6 ordered pairs
+    pairs = set(
+        map(
+            tuple,
+            torch.cat([s.a01_pairs, s.a01_bridge.unsqueeze(0)]).t().tolist(),
+        )
+    )
+    assert (0, 1, 0) in pairs and (1, 0, 0) in pairs
+    assert (2, 3, 4) in pairs and (3, 2, 4) in pairs
+
+
+def test_adjacency_invalid_incidence():
+    """A node-edge incidence column with one entry is rejected."""
+    bad = torch.zeros(3, 2)
+    bad[0, 0] = 1
+    bad[1, 0] = 1
+    bad[2, 1] = 1  # dangling edge
+    with pytest.raises(ValueError):
+        adjacency_from_incidence(bad, expected_size=2)
+
+
+def test_bag_layout_and_marking():
+    """Bag rows follow row(u, e) = u * n1 + e with min-endpoint marking."""
+    s = _structures()
+    assert s.bag_low_index.tolist()[:5] == [0, 0, 0, 0, 0]
+    assert s.bag_high_index.tolist()[:5] == [0, 1, 2, 3, 4]
+    # row(u=3, e0=(0,1)): d(3,0)=2, d(3,1)=1 -> 1
+    assert int(s.bag_marking[15]) == 1
+    # row(u=0, e0=(0,1)): endpoint -> 0
+    assert int(s.bag_marking[0]) == 0
+    assert s.bag_low_adj_pairs.shape[1] == 50  # 10 pairs x 5 copies
+    assert s.bag_inc_pairs.shape[1] == 50  # 10 incidences x 5 copies
+
+
+def test_hop_distance_buckets():
+    """Distances are exact up to the cutoff, then bucketed."""
+    adj = torch.zeros(16, 16, dtype=torch.bool)
+    for i in range(14):
+        adj[i, i + 1] = adj[i + 1, i] = True
+    dist = hop_distance_buckets(adj, max_dist=10)
+    assert int(dist[0, 5]) == 5
+    assert int(dist[0, 14]) == 10  # connected but farther
+    assert int(dist[0, 15]) == 11  # disconnected
+
+
+def test_batch_offsets():
+    """Batched structures equal per-graph structures plus offsets."""
+    i1, i2, b0, b1, b2 = _two_triangles()
+    single = _structures()
+    double = build_smcn_structures(
+        torch.block_diag(i1, i1).to_sparse(),
+        torch.block_diag(i2, i2).to_sparse(),
+        torch.cat([b0, b0 + 1]),
+        torch.cat([b1, b1 + 1]),
+        torch.cat([b2, b2 + 1]),
+    )
+    assert torch.equal(double.bag_marking[:20], single.bag_marking)
+    assert torch.equal(double.bag_marking[20:], single.bag_marking)
+    assert torch.equal(
+        double.bag_low_index[20:] - 4, single.bag_low_index
+    )
+    assert torch.equal(
+        double.bag_inc_pairs[:, 50:] - 20, single.bag_inc_pairs
+    )
+
+
+def test_layers_shapes_and_grads():
+    """Every layer produces the documented shapes and gradients."""
+    s = _structures()
+    dim = 16
+    x_0 = torch.randn(4, dim, requires_grad=True)
+    x_1 = torch.randn(5, dim)
+    x_2 = torch.zeros(2, dim)
+    x_2 = TwoCellInit(dim)(x_0, x_2, s.inc02_pairs)
+    assert x_2.shape == (2, dim)
+    x_0b, x_1b, x_2b = CINBlock(dim)(x_0, x_1, x_2, s)
+    bag = BagInit(dim)(x_0b, x_1b, s)
+    assert bag.shape == (20, dim)
+    bag = SCLLayer(dim, 12, edge_dim=dim)(bag, x_1b, s)
+    assert bag.shape == (20, 12)
+    bag = SCLLayer(12, dim, edge_dim=dim)(bag, x_1b, s)
+    p0, p1 = BagPool()(bag, s, 4, 5)
+    assert p0.shape == (4, dim) and p1.shape == (5, dim)
+    (p0.sum() + p1.sum()).backward()
+    assert x_0.grad is not None and x_0.grad.abs().sum() > 0
+
+
+def test_cin_block_max_rank():
+    """The reduced block leaves higher ranks untouched."""
+    s = _structures()
+    dim = 8
+    x = [torch.randn(n, dim) for n in (4, 5, 2)]
+    block = CINBlock(dim, max_rank=0)
+    y0, y1, y2 = block(*x, s)
+    assert torch.equal(y1, x[1]) and torch.equal(y2, x[2])
+    with pytest.raises(ValueError):
+        CINBlock(dim, max_rank=3)
+
+
+@pytest.mark.parametrize("learned_lifting", [False, True])
+def test_backbone_forward_backward(learned_lifting):
+    """The backbone runs and back-propagates in both variants."""
+    i1, i2, b0, b1, b2 = _two_triangles()
+    dim = 16
+    model = SMCN(
+        dim,
+        sub_channels=12,
+        n_scl_layers=2,
+        learned_lifting=learned_lifting,
+    )
+    x_0 = torch.randn(4, dim, requires_grad=True)
+    y0, y1, y2 = model(
+        x_0,
+        torch.randn(5, dim),
+        torch.zeros(2, dim),
+        i1.to_sparse(),
+        i2.to_sparse(),
+        b0,
+        b1,
+        b2,
+    )
+    assert y0.shape == (4, dim)
+    assert y1.shape == (5, dim)
+    assert y2.shape == (2, dim)
+    (y0.sum() + y1.sum() + y2.sum()).backward()
+    assert x_0.grad is not None and x_0.grad.abs().sum() > 0
+
+
+def test_backbone_no_two_cells():
+    """A tree graph (no cycles) runs through both variants."""
+    i1 = torch.zeros(4, 3)
+    for e, (a, b) in enumerate([(0, 1), (1, 2), (2, 3)]):
+        i1[a, e] = 1
+        i1[b, e] = 1
+    for learned in (False, True):
+        model = SMCN(8, n_scl_layers=2, learned_lifting=learned)
+        _, _, y2 = model(
+            torch.randn(4, 8),
+            torch.randn(3, 8),
+            torch.zeros(0, 8),
+            i1.to_sparse(),
+            torch.zeros(3, 0).to_sparse(),
+            torch.zeros(4, dtype=torch.long),
+            torch.zeros(3, dtype=torch.long),
+            torch.zeros(0, dtype=torch.long),
+        )
+        assert y2.shape == (0, 8)
+
+
+def test_safe_batch_norm_single_row():
+    """Single rows pass through in training; larger batches normalize."""
+    bn = SafeBatchNorm(8)
+    bn.train()
+    x1 = torch.randn(1, 8)
+    assert torch.equal(bn(x1), x1)
+    x4 = torch.randn(4, 8)
+    ref = torch.nn.BatchNorm1d(8)
+    ref.train()
+    assert torch.allclose(bn(x4), ref(x4))
+
+
+@pytest.mark.parametrize("learned_lifting", [False, True])
+def test_backbone_single_two_cell_training(learned_lifting):
+    """A batch whose graphs total a single 2-cell trains without error."""
+    i1 = torch.zeros(3, 3)
+    for e, (a, b) in enumerate([(0, 1), (0, 2), (1, 2)]):
+        i1[a, e] = 1
+        i1[b, e] = 1
+    i2 = torch.ones(3, 1)
+    model = SMCN(
+        8, sub_channels=6, n_scl_layers=2, learned_lifting=learned_lifting
+    )
+    model.train()
+    x_0 = torch.randn(3, 8, requires_grad=True)
+    y0, y1, y2 = model(
+        x_0,
+        torch.randn(3, 8),
+        torch.zeros(1, 8),
+        i1.to_sparse(),
+        i2.to_sparse(),
+        torch.zeros(3, dtype=torch.long),
+        torch.zeros(3, dtype=torch.long),
+        torch.zeros(1, dtype=torch.long),
+    )
+    assert y2.shape == (1, 8)
+    (y0.sum() + y1.sum() + y2.sum()).backward()
+    assert x_0.grad is not None
+
+
+def test_cell_scorer_rescue():
+    """The scorer gates cells and the rescue keeps one per graph."""
+    i1, i2, b0, b1, b2 = _two_triangles()
+    s = build_smcn_structures(i1.to_sparse(), i2.to_sparse(), b0, b1, b2)
+    z = torch.randn(4, 8, requires_grad=True)
+    scorer = CellScorer(8)
+    torch.nn.init.constant_(scorer.score[2].bias, -100.0)
+    torch.nn.init.zeros_(scorer.score[2].weight)
+    gate = scorer(z, s.inc02_pairs, b2)
+    assert gate.shape == (2,)
+    assert gate.detach().sum() >= 1.0
+    gate.sum().backward()
+    assert z.grad is not None
+
+
+def test_backbone_invalid_scl_layers():
+    """Fewer than two SCL layers is rejected."""
+    with pytest.raises(ValueError):
+        SMCN(8, n_scl_layers=1)
+
+
+def test_cell_scorer_hypergraph_and_stochastic():
+    """The scorer is domain-agnostic and supports Bernoulli sampling."""
+    membership = torch.tensor(
+        [[0, 1, 2, 1, 2, 3, 4], [0, 0, 0, 1, 1, 2, 2]]
+    )
+    hyperedge_batch = torch.tensor([0, 0, 1])
+    z = torch.randn(5, 8, requires_grad=True)
+    gate = CellScorer(8)(z, membership, hyperedge_batch)
+    assert gate.shape == (3,)
+    assert set(gate.detach().unique().tolist()) <= {0.0, 1.0}
+    gate.sum().backward()
+    assert z.grad is not None
+    stochastic = CellScorer(8, stochastic=True, rescue=False).train()
+    gate = stochastic(z.detach(), membership, hyperedge_batch)
+    assert set(gate.detach().unique().tolist()) <= {0.0, 1.0}
+
+
+def test_difflift_encoder_and_edge_sampler():
+    """Learned edges are new, deduplicated, and carry gradients."""
+    i1, _, b0, _, _ = _two_triangles()
+    s = build_smcn_structures(
+        i1.to_sparse(), torch.zeros(5, 0).to_sparse(), b0,
+        torch.zeros(5, dtype=torch.long), torch.zeros(0, dtype=torch.long),
+    )
+    x = torch.randn(4, 6, requires_grad=True)
+    z = DiffLiftEncoder(6, hidden_channels=16)(x, s.a01_pairs)
+    assert z.shape == (4, 16)
+    sampler = EdgeSampler(16, k_min=1, k_max=3)
+    pairs, gate = sampler(z, s.a01_pairs, b0)
+    assert pairs.shape[0] == 2 and gate.shape == (pairs.shape[1],)
+    observed = {
+        tuple(sorted(p)) for p in s.a01_pairs.t().tolist()
+    }
+    for a, b in pairs.t().tolist():
+        assert (a, b) not in observed  # only new edges
+    if gate.numel():
+        gate.sum().backward()
+        assert x.grad is not None
+    with pytest.raises(ValueError):
+        EdgeSampler(16, k_min=3, k_max=2)
+
+
+def test_difflift_full_recipe():
+    """The complete lifting returns a consistent gated complex."""
+    i1, _, b0, _, _ = _two_triangles()
+    s = build_smcn_structures(
+        i1.to_sparse(), torch.zeros(5, 0).to_sparse(), b0,
+        torch.zeros(5, dtype=torch.long), torch.zeros(0, dtype=torch.long),
+    )
+    x = torch.randn(4, 6, requires_grad=True)
+    lift = DiffLift(6, hidden_channels=16, max_cell_length=6)
+    out = lift(x, s.a01_pairs, b0)
+    n_cells = out["cell_batch"].numel()
+    assert out["cell_gate"].shape == (n_cells,)
+    assert out["x_2"].shape == (n_cells, 6)
+    assert out["cell_membership"].shape[0] == 2
+    total = out["x_2"].sum() + out["cell_gate"].sum()
+    if out["new_edge_gate"].numel():
+        total = total + out["new_edge_gate"].sum()
+    total.backward()
+    assert x.grad is not None and x.grad.abs().sum() > 0

--- a/test/nn/wrappers/cell/test_cell_wrappers.py
+++ b/test/nn/wrappers/cell/test_cell_wrappers.py
@@ -6,12 +6,14 @@ from ...._utils.nn_module_auto_test import NNModuleAutoTest
 from ...._utils.flow_mocker import FlowMocker
 from unittest.mock import MagicMock
 
+from topobench.nn.backbones.cell.smcn import SMCN
 from topobench.nn.wrappers import (
     AbstractWrapper,
     CCCNWrapper,
     CANWrapper,
     CCXNWrapper,
-    CWNWrapper
+    CWNWrapper,
+    SMCNWrapper,
 )
 from topomodelx.nn.cell.can import CAN
 from topomodelx.nn.cell.ccxn import CCXN
@@ -92,5 +94,27 @@ class TestCellWrappers:
         )
         out = wrapper(data)
 
+        for key in ["labels", "batch_0", "x_0", "x_1", "x_2"]:
+            assert key in out
+
+    def test_SMCNWrapper(self, sg1_cell_lifted):
+        """Test SMCNWrapper.
+
+        Parameters
+        ----------
+        sg1_cell_lifted : torch_geometric.data.Data
+            A fixture of simple graph 1 lifted with CellCycleLifting.
+        """
+        data = sg1_cell_lifted
+        out_dim = data.x_0.shape[1]
+        import torch
+        data.x_1 = torch.randn(data.incidence_1.shape[1], out_dim)
+        data.x_2 = torch.randn(data.incidence_2.shape[1], out_dim)
+        wrapper = SMCNWrapper(
+            SMCN(out_dim, n_scl_layers=2),
+            out_channels=out_dim,
+            num_cell_dimensions=3,
+        )
+        out = wrapper(data)
         for key in ["labels", "batch_0", "x_0", "x_1", "x_2"]:
             assert key in out

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -7,7 +7,7 @@ from test._utils.simplified_pipeline import run
 
 
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS   = ["cell/smcn", "cell/smcn_difflift"]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:

--- a/topobench/nn/backbones/cell/smcn.py
+++ b/topobench/nn/backbones/cell/smcn.py
@@ -1,0 +1,198 @@
+"""Scalable Multi-Cellular Network (SMCN) backbone.
+
+SMCN extends higher-order message passing with features indexed by
+(node, edge) pairs — a bag holding one marked copy of the node set per
+edge, processed with subgraph-GNN-style updates (SCL layers). This
+mitigates provable expressivity limitations of standard topological
+message passing (diameter, orientability, homology; Theorem 4.3 of the
+paper). The assembly follows the model the authors evaluate on graph
+benchmarks: CIN-style blocks, bag initialization with distance marking,
+a stack of SCL layers over the (0, 1) pair space (Eq. 55; the
+GNN-SSWL+ instantiation), and sum-pooling back to the cochains.
+
+The optional ``learned_lifting`` mode selects the 2-cells produced by
+the cycle lifting with a straight-through scorer (DiffLift), learning
+which cycles enter the complex end-to-end.
+
+References
+----------
+Eitan et al. "Topological Blindspots: Understanding and Extending
+Topological Deep Learning Through the Lens of Expressivity." ICLR 2025.
+https://arxiv.org/abs/2408.05486 (official implementation:
+https://github.com/yoavgelberg/SMCN)
+Franco et al. "Differentiable Lifting for Topological Neural Networks."
+https://openreview.net/forum?id=eC89CbINIw
+"""
+
+import torch
+from torch import nn
+
+from topobench.nn.backbones.cell.smcn_utils.difflift import (
+    CellScorer,
+    DiffLiftEncoder,
+)
+from topobench.nn.backbones.cell.smcn_utils.layers import (
+    BagInit,
+    BagPool,
+    CINBlock,
+    SCLLayer,
+    TwoCellInit,
+)
+from topobench.nn.backbones.cell.smcn_utils.structures import (
+    build_smcn_structures,
+)
+
+
+class SMCN(nn.Module):
+    """SMCN backbone operating on 2-dimensional cell complexes.
+
+    Parameters
+    ----------
+    in_channels : int
+        Feature dimension of all cochains (as produced by the feature
+        encoder); also the CIN-block width.
+    sub_channels : int, optional
+        Width of the subcomplex (SCL) layers. Default is ``in_channels``.
+    n_cin_layers : int, optional
+        Number of CIN blocks before the bag. Default is 1.
+    n_scl_layers : int, optional
+        Number of SCL layers (at least 2: the first maps into
+        ``sub_channels``, the last maps back). Default is 3.
+    num_mlp_layers : int, optional
+        Depth of the CIN convolution MLPs. Default is 2.
+    max_rank_out : int, optional
+        Highest rank updated by the final reduced CIN block. Default 1.
+    max_dist : int, optional
+        Distance cutoff of the bag marking. Default is 10.
+    dropout : float, optional
+        Dropout applied between stages. Default is 0.0.
+    learned_lifting : bool, optional
+        If True, candidate 2-cells are gated by a straight-through
+        scorer (DiffLift) instead of all being kept. Default is False.
+    sharpening : float, optional
+        Logit sharpening of the 2-cell scorer. Default is 10.0.
+
+    Raises
+    ------
+    ValueError
+        If ``n_scl_layers`` is smaller than 2.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        sub_channels=None,
+        n_cin_layers=1,
+        n_scl_layers=3,
+        num_mlp_layers=2,
+        max_rank_out=1,
+        max_dist=10,
+        dropout=0.0,
+        learned_lifting=False,
+        sharpening=10.0,
+    ):
+        super().__init__()
+        if n_scl_layers < 2:
+            raise ValueError("n_scl_layers must be at least 2")
+        sub_channels = sub_channels or in_channels
+        self.out_channels = in_channels
+        self.max_dist = max_dist
+        self.dropout = nn.Dropout(dropout)
+        self.learned_lifting = learned_lifting
+
+        if learned_lifting:
+            self.lift_encoder = DiffLiftEncoder(in_channels)
+            self.select = CellScorer(32, sharpening=sharpening)
+
+        self.two_cell_init = TwoCellInit(in_channels, num_mlp_layers)
+        self.cin_blocks = nn.ModuleList(
+            CINBlock(in_channels, num_mlp_layers) for _ in range(n_cin_layers)
+        )
+        self.bag_init = BagInit(in_channels, max_dist)
+        dims = (
+            [(in_channels, sub_channels)]
+            + [(sub_channels, sub_channels)] * (n_scl_layers - 2)
+            + [(sub_channels, in_channels)]
+        )
+        self.scl_layers = nn.ModuleList(
+            SCLLayer(d_in, d_out, edge_dim=in_channels, max_dist=max_dist)
+            for d_in, d_out in dims
+        )
+        self.bag_pool = BagPool()
+        self.final_block = CINBlock(
+            in_channels, num_mlp_layers, max_rank=max_rank_out
+        )
+
+    def forward(
+        self,
+        x_0,
+        x_1,
+        x_2,
+        incidence_1,
+        incidence_2,
+        batch_0,
+        batch_1,
+        batch_2,
+    ):
+        """Run the SMCN forward pass.
+
+        Parameters
+        ----------
+        x_0 : torch.Tensor
+            Node features ``[n0, in_channels]``.
+        x_1 : torch.Tensor
+            Edge features ``[n1, in_channels]``.
+        x_2 : torch.Tensor
+            2-cell features ``[n2, in_channels]``.
+        incidence_1 : torch.Tensor
+            Node-edge incidence ``[n0, n1]`` (sparse or dense).
+        incidence_2 : torch.Tensor
+            Edge-2-cell incidence ``[n1, n2]`` (sparse or dense).
+        batch_0 : torch.Tensor
+            Graph index of every node, ``[n0]``.
+        batch_1 : torch.Tensor
+            Graph index of every edge, ``[n1]``.
+        batch_2 : torch.Tensor
+            Graph index of every 2-cell, ``[n2]``.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Updated ``(x_0, x_1, x_2)``.
+        """
+        with torch.no_grad():
+            structures = build_smcn_structures(
+                incidence_1,
+                incidence_2,
+                batch_0,
+                batch_1,
+                batch_2,
+                max_dist=self.max_dist,
+            )
+        s = structures
+
+        gate = None
+        if self.learned_lifting:
+            z = self.lift_encoder(x_0, s.a01_pairs)
+            gate = self.select(z, s.inc02_pairs, batch_2)
+
+        x_2 = self.two_cell_init(x_0, x_2, s.inc02_pairs)
+        if gate is not None:
+            x_2 = gate.unsqueeze(-1) * x_2
+
+        a12_gate = gate[s.a12_bridge] if gate is not None else None
+        for block in self.cin_blocks:
+            x_0, x_1, x_2 = block(x_0, x_1, x_2, s, a12_gate=a12_gate)
+            if gate is not None:
+                x_2 = gate.unsqueeze(-1) * x_2
+            x_0, x_1 = self.dropout(x_0), self.dropout(x_1)
+
+        x_bag = self.bag_init(x_0, x_1, s)
+        for layer in self.scl_layers:
+            x_bag = self.dropout(layer(x_bag, x_1, s))
+        x_0, x_1 = self.bag_pool(x_bag, s, x_0.size(0), x_1.size(0))
+
+        x_0, x_1, x_2 = self.final_block(x_0, x_1, x_2, s, a12_gate=a12_gate)
+        if gate is not None:
+            x_2 = gate.unsqueeze(-1) * x_2
+        return x_0, x_1, x_2

--- a/topobench/nn/backbones/cell/smcn.py
+++ b/topobench/nn/backbones/cell/smcn.py
@@ -27,10 +27,6 @@ https://openreview.net/forum?id=eC89CbINIw
 import torch
 from torch import nn
 
-from topobench.nn.backbones.cell.smcn_utils.difflift import (
-    CellScorer,
-    DiffLiftEncoder,
-)
 from topobench.nn.backbones.cell.smcn_utils.layers import (
     BagInit,
     BagPool,
@@ -40,6 +36,10 @@ from topobench.nn.backbones.cell.smcn_utils.layers import (
 )
 from topobench.nn.backbones.cell.smcn_utils.structures import (
     build_smcn_structures,
+)
+from topobench.nn.liftings.difflift import (
+    CellScorer,
+    DiffLiftEncoder,
 )
 
 

--- a/topobench/nn/backbones/cell/smcn_utils/__init__.py
+++ b/topobench/nn/backbones/cell/smcn_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the SMCN backbone."""

--- a/topobench/nn/backbones/cell/smcn_utils/difflift.py
+++ b/topobench/nn/backbones/cell/smcn_utils/difflift.py
@@ -1,0 +1,425 @@
+"""Differentiable lifting (DiffLift) modules.
+
+Implements the DiffLift recipe for learning graph liftings end-to-end
+(Franco et al.): a GNN computes node embeddings (Step 1), candidate
+cells are elicited per dimension (Step 2), and a permutation-invariant
+scorer accepts or rejects each candidate (Step 3), with gradients
+propagated through the discrete decisions by the straight-through
+estimator. Both the stochastic (Bernoulli) sampling of the paper and
+its deterministic thresholded variant are provided.
+
+The components are deliberately modular:
+
+- :class:`DiffLiftEncoder` — Step 1, node embeddings.
+- :class:`CellScorer` — Step 3, multiset scorer for any candidate cell
+  given node-to-cell membership pairs (works for hyperedges, 1-cells,
+  or 2-cells alike).
+- :class:`EdgeSampler` — the ``D = 1`` iteration for cell complexes:
+  adaptive-size kNN candidate edges added on top of the observed ones.
+- :class:`DiffLift` — the full graph-to-cell-complex recipe
+  (``D_max = 2``): learned edges, then cycle-basis candidates of the
+  augmented graph scored as 2-cells.
+
+The SMCN backbone in this package instantiates the encoder + scorer
+over the cycle-lifting candidates (rank-2 selection only), since its
+subcomplex marking machinery is anchored to the observed graph.
+
+References
+----------
+Franco et al. "Differentiable Lifting for Topological Neural Networks."
+https://openreview.net/forum?id=eC89CbINIw
+"""
+
+import networkx as nx
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch_geometric.nn.conv import GINConv
+
+
+class DiffLiftEncoder(nn.Module):
+    """Node-embedding GNN of the lifting (Step 1 of the recipe).
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the input node features.
+    hidden_channels : int, optional
+        Embedding dimension. Default is 32.
+    num_layers : int, optional
+        Number of GIN layers. Default is 1.
+    """
+
+    def __init__(self, in_channels, hidden_channels=32, num_layers=1):
+        super().__init__()
+        self.convs = nn.ModuleList()
+        dim = in_channels
+        for _ in range(num_layers):
+            mlp = nn.Sequential(
+                nn.Linear(dim, hidden_channels),
+                nn.ReLU(),
+                nn.Linear(hidden_channels, hidden_channels),
+            )
+            self.convs.append(GINConv(mlp, train_eps=True))
+            dim = hidden_channels
+
+    def forward(self, x, edge_pairs):
+        """Embed the nodes.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features ``[n, in_channels]``.
+        edge_pairs : torch.Tensor
+            Graph connectivity as node pairs ``[2, P]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Node embeddings ``[n, hidden_channels]``.
+        """
+        z = x
+        for conv in self.convs:
+            z = conv(z, edge_pairs)
+        return z
+
+
+class CellScorer(nn.Module):
+    """Accept/reject scorer over candidate cells (Step 3 of the recipe).
+
+    The acceptance probability of a candidate is a learned function of
+    the multiset of its member-node embeddings (mean pooling followed by
+    an MLP). The forward pass returns hard 0/1 gates with
+    straight-through gradients; decisions are either thresholded (the
+    deterministic variant of the paper) or sampled from a Bernoulli.
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the node embeddings.
+    hidden_channels : int, optional
+        Hidden width of the scoring MLP. Default is 32.
+    sharpening : float, optional
+        Multiplier applied to the logits before the sigmoid. Default is
+        10.0.
+    stochastic : bool, optional
+        If True, sample decisions from a Bernoulli; otherwise threshold
+        the probability at 0.5. Default is False.
+    rescue : bool, optional
+        If True, force-keep the highest-scoring candidate of any graph
+        whose candidates were all rejected. Default is True.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels=32,
+        sharpening=10.0,
+        stochastic=False,
+        rescue=True,
+    ):
+        super().__init__()
+        self.sharpening = sharpening
+        self.stochastic = stochastic
+        self.rescue = rescue
+        self.score = nn.Sequential(
+            nn.Linear(in_channels, hidden_channels),
+            nn.ReLU(),
+            nn.Linear(hidden_channels, 1),
+        )
+
+    def forward(self, z, membership_pairs, cell_batch):
+        """Gate every candidate cell.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Node embeddings ``[n, in_channels]``.
+        membership_pairs : torch.Tensor
+            Node-to-cell membership pairs ``[2, I]``.
+        cell_batch : torch.Tensor
+            Graph index of every candidate cell ``[n_cells]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Gates ``[n_cells]``: hard 0/1 forward values with soft
+            gradients.
+        """
+        n_cells = cell_batch.size(0)
+        if n_cells == 0:
+            return z.new_zeros(0)
+        pooled = z.new_zeros(n_cells, z.size(1)).index_add_(
+            0, membership_pairs[1], z[membership_pairs[0]]
+        )
+        counts = torch.bincount(membership_pairs[1], minlength=n_cells)
+        pooled = pooled / counts.clamp(min=1).unsqueeze(1)
+        probs = torch.sigmoid(self.sharpening * self.score(pooled).squeeze(-1))
+        if self.stochastic and self.training:
+            hard = torch.bernoulli(probs)
+        else:
+            hard = (probs > 0.5).float()
+        if self.rescue:
+            num_graphs = int(cell_batch.max()) + 1
+            best = probs.new_full((num_graphs,), -1.0)
+            best = best.scatter_reduce(
+                0, cell_batch, probs, reduce="amax", include_self=True
+            )
+            kept = hard.new_zeros(num_graphs).scatter_add_(0, cell_batch, hard)
+            lift = (kept == 0)[cell_batch] & (probs == best[cell_batch])
+            hard = torch.where(lift, torch.ones_like(hard), hard)
+        return hard + (probs - probs.detach())
+
+
+class EdgeSampler(nn.Module):
+    """Learned 1-cells: the ``D = 1`` iteration for cell complexes.
+
+    For each node, a neighborhood size ``k_v`` is drawn from a
+    categorical distribution parameterized by its embedding
+    (Gumbel-softmax with hard samples), candidate edges connect the node
+    to its ``k_v`` nearest neighbors in embedding space, and a pair
+    scorer gates each candidate. Learned edges are *added* to the
+    observed ones, never removing them.
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the node embeddings.
+    k_min : int, optional
+        Smallest neighborhood size. Default is 1.
+    k_max : int, optional
+        Largest neighborhood size. Default is 3.
+    sharpening : float, optional
+        Logit sharpening of the pair scorer. Default is 10.0.
+    stochastic : bool, optional
+        Sample the pair decisions from a Bernoulli. Default is False.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        k_min=1,
+        k_max=3,
+        sharpening=10.0,
+        stochastic=False,
+    ):
+        super().__init__()
+        if not 1 <= k_min <= k_max:
+            raise ValueError("need 1 <= k_min <= k_max")
+        self.k_min = k_min
+        self.k_max = k_max
+        self.k_logits = nn.Linear(in_channels, k_max - k_min + 1)
+        self.pair_scorer = CellScorer(
+            in_channels,
+            sharpening=sharpening,
+            stochastic=stochastic,
+            rescue=False,
+        )
+
+    def forward(self, z, edge_pairs, batch):
+        """Propose and gate new edges.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Node embeddings ``[n, d]``.
+        edge_pairs : torch.Tensor
+            Observed edges as node pairs ``[2, P]`` (both directions).
+        batch : torch.Tensor
+            Graph index of every node ``[n]``.
+
+        Returns
+        -------
+        new_pairs : torch.Tensor
+            Undirected candidate edges ``[2, E_new]`` (one direction),
+            disjoint from the observed edges.
+        gate : torch.Tensor
+            Straight-through gate of each candidate ``[E_new]``.
+        """
+        from torch_cluster import knn_graph
+
+        n = z.size(0)
+        # Adaptive neighborhood sizes (Gumbel-softmax, hard samples).
+        k_probs = F.gumbel_softmax(self.k_logits(z), tau=1.0, hard=True)
+        k_values = self.k_min + k_probs.argmax(dim=-1)  # [n]
+
+        candidates = knn_graph(z.detach(), k=self.k_max, batch=batch)
+        src, dst = candidates[0], candidates[1]
+        # Keep each source only among its k_dst nearest neighbours: the
+        # kNN output lists neighbours per target node in order, so rank
+        # them and compare against the sampled k of the target.
+        order = torch.argsort(dst, stable=True)
+        src, dst = src[order], dst[order]
+        ranks = torch.arange(src.size(0), device=z.device)
+        first = torch.zeros(n, dtype=torch.long, device=z.device)
+        counts = torch.bincount(dst, minlength=n)
+        first[1:] = torch.cumsum(counts, 0)[:-1]
+        ranks = ranks - first[dst]
+        keep = ranks < k_values[dst]
+
+        # Drop candidates that already exist as observed edges and
+        # deduplicate the two orientations.
+        a = torch.minimum(src[keep], dst[keep])
+        b = torch.maximum(src[keep], dst[keep])
+        cand = torch.unique(torch.stack([a, b], dim=0), dim=1)
+        if edge_pairs.numel():
+            ea = torch.minimum(edge_pairs[0], edge_pairs[1])
+            eb = torch.maximum(edge_pairs[0], edge_pairs[1])
+            existing = set(
+                map(tuple, torch.stack([ea, eb], dim=0).t().tolist())
+            )
+            mask = torch.tensor(
+                [
+                    (int(x), int(y)) not in existing
+                    for x, y in cand.t().tolist()
+                ],
+                dtype=torch.bool,
+                device=z.device,
+            )
+            cand = cand[:, mask]
+        if cand.numel() == 0:
+            return cand, z.new_zeros(0)
+        # Score each candidate pair from its two endpoints.
+        members = torch.cat([cand[0], cand[1]])
+        cells = torch.arange(cand.size(1), device=z.device).repeat(2)
+        gate = self.pair_scorer(
+            z,
+            torch.stack([members, cells], dim=0),
+            batch[cand[0]],
+        )
+        # Gumbel gradient path for the neighborhood sizes.
+        k_grad = k_probs.sum() - k_probs.sum().detach()
+        return cand, gate + 0.0 * k_grad
+
+
+class DiffLift(nn.Module):
+    """Complete graph-to-cell-complex lifting (``D_max = 2``).
+
+    Runs the full recipe: node embeddings, learned 1-cells added to the
+    observed edges, cycle-basis candidates of the augmented graph, and
+    gated 2-cells, with scaled-sum feature lifting.
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the input node features.
+    hidden_channels : int, optional
+        Embedding dimension of the lifting GNN. Default is 32.
+    k_min : int, optional
+        Smallest learned-edge neighborhood size. Default is 1.
+    k_max : int, optional
+        Largest learned-edge neighborhood size. Default is 3.
+    max_cell_length : int, optional
+        Longest cycle admitted as a 2-cell candidate. Default is 10.
+    sharpening : float, optional
+        Logit sharpening of the scorers. Default is 10.0.
+    stochastic : bool, optional
+        Sample accept/reject decisions instead of thresholding.
+        Default is False.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels=32,
+        k_min=1,
+        k_max=3,
+        max_cell_length=10,
+        sharpening=10.0,
+        stochastic=False,
+    ):
+        super().__init__()
+        self.max_cell_length = max_cell_length
+        self.encoder = DiffLiftEncoder(in_channels, hidden_channels)
+        self.edge_sampler = EdgeSampler(
+            hidden_channels,
+            k_min=k_min,
+            k_max=k_max,
+            sharpening=sharpening,
+            stochastic=stochastic,
+        )
+        self.cell_scorer = CellScorer(
+            hidden_channels,
+            sharpening=sharpening,
+            stochastic=stochastic,
+        )
+
+    def forward(self, x, edge_pairs, batch):
+        """Lift a batch of graphs to gated 2-dimensional cell complexes.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Node features ``[n, in_channels]``.
+        edge_pairs : torch.Tensor
+            Observed edges as node pairs ``[2, P]`` (both directions).
+        batch : torch.Tensor
+            Graph index of every node ``[n]``.
+
+        Returns
+        -------
+        dict
+            ``new_edge_pairs`` ``[2, E_new]`` and ``new_edge_gate``
+            ``[E_new]`` (learned 1-cells); ``cell_membership``
+            ``[2, I]`` node-to-2-cell pairs, ``cell_gate``
+            ``[n_cells]``, and ``cell_batch`` ``[n_cells]``; ``x_2``
+            ``[n_cells, in_channels]`` scaled-sum features of the
+            2-cells.
+        """
+        z = self.encoder(x, edge_pairs)
+        new_pairs, edge_gate = self.edge_sampler(z, edge_pairs, batch)
+
+        # Candidate 2-cells: cycle basis of the augmented graph.
+        graph = nx.Graph()
+        graph.add_nodes_from(range(x.size(0)))
+        graph.add_edges_from(edge_pairs.t().tolist())
+        graph.add_edges_from(new_pairs.t().tolist())
+        cycles = [
+            c
+            for c in nx.cycle_basis(graph)
+            if 3 <= len(c) <= self.max_cell_length
+        ]
+        cycles.sort(key=lambda c: (len(c), tuple(sorted(c))))
+
+        if cycles:
+            members = torch.tensor(
+                [v for c in cycles for v in c],
+                dtype=torch.long,
+                device=x.device,
+            )
+            cells = torch.tensor(
+                [i for i, c in enumerate(cycles) for _ in c],
+                dtype=torch.long,
+                device=x.device,
+            )
+            membership = torch.stack([members, cells], dim=0)
+            cell_batch = batch[
+                torch.tensor(
+                    [c[0] for c in cycles],
+                    dtype=torch.long,
+                    device=x.device,
+                )
+            ]
+        else:
+            membership = edge_pairs.new_zeros(2, 0)
+            cell_batch = batch.new_zeros(0)
+
+        cell_gate = self.cell_scorer(z, membership, cell_batch)
+
+        # Scaled-sum feature lifting for the accepted 2-cells.
+        n_cells = cell_batch.size(0)
+        x_2 = x.new_zeros(n_cells, x.size(1))
+        if n_cells:
+            x_2 = x_2.index_add_(0, membership[1], x[membership[0]])
+            sizes = torch.bincount(membership[1], minlength=n_cells)
+            x_2 = x_2 / sizes.clamp(min=1).unsqueeze(1)
+            x_2 = cell_gate.unsqueeze(-1) * x_2
+
+        return {
+            "new_edge_pairs": new_pairs,
+            "new_edge_gate": edge_gate,
+            "cell_membership": membership,
+            "cell_gate": cell_gate,
+            "cell_batch": cell_batch,
+            "x_2": x_2,
+        }

--- a/topobench/nn/backbones/cell/smcn_utils/layers.py
+++ b/topobench/nn/backbones/cell/smcn_utils/layers.py
@@ -1,0 +1,505 @@
+"""Neural building blocks of the SMCN backbone.
+
+These layers implement the components of Scalable Multi-Cellular
+Networks: the CIN-style higher-order message-passing block, the marked
+subcomplex-bag layers (SCL), and the bag initialization/pooling. The
+semantics follow the official SMCN implementation
+(https://github.com/yoavgelberg/SMCN); the code here is written for the
+batched structures of
+:mod:`topobench.nn.backbones.cell.smcn_utils.structures`.
+
+References
+----------
+Eitan et al. "Topological Blindspots: Understanding and Extending
+Topological Deep Learning Through the Lens of Expressivity." ICLR 2025.
+https://arxiv.org/abs/2408.05486
+Bodnar et al. "Weisfeiler and Lehman Go Cellular: CW Networks."
+NeurIPS 2021. https://arxiv.org/abs/2106.12575
+"""
+
+import torch
+from torch import nn
+from torch_geometric.nn import MessagePassing
+from torch_geometric.nn.conv import GINConv
+
+
+class SafeBatchNorm(nn.BatchNorm1d):
+    """Batch norm that passes single-row inputs through unchanged.
+
+    A batch can contain a single 2-cell in total (sparse graphs under
+    the cycle lifting), and batch statistics are undefined for one row,
+    so :class:`torch.nn.BatchNorm1d` raises during training. Evaluation
+    mode is unaffected: it uses the running statistics.
+    """
+
+    def forward(self, x):
+        """Normalize ``x``, skipping single-row batches in training.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input features of shape ``[n, dim]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Normalized features (or ``x`` itself when ``n < 2`` in
+            training mode).
+        """
+        if self.training and x.size(0) < 2:
+            return x
+        return super().forward(x)
+
+
+def homp_mlp(dim, num_layers=2):
+    """Build the width-preserving MLP used by the CIN-block convolutions.
+
+    Parameters
+    ----------
+    dim : int
+        Input, hidden, and output dimension.
+    num_layers : int, optional
+        Number of Linear-BatchNorm-ReLU stages. Default is 2.
+
+    Returns
+    -------
+    torch.nn.Sequential
+        The MLP.
+    """
+    layers = []
+    for _ in range(num_layers):
+        layers += [
+            nn.Linear(dim, dim),
+            SafeBatchNorm(dim),
+            nn.ReLU(),
+        ]
+    return nn.Sequential(*layers)
+
+
+def scl_mlp(in_dim, hidden_dim):
+    """Build the two-stage MLP used by the subcomplex convolutions.
+
+    Parameters
+    ----------
+    in_dim : int
+        Input dimension.
+    hidden_dim : int
+        Hidden and output dimension.
+
+    Returns
+    -------
+    torch.nn.Sequential
+        The MLP.
+    """
+    return nn.Sequential(
+        nn.Linear(in_dim, hidden_dim),
+        SafeBatchNorm(hidden_dim),
+        nn.ReLU(),
+        nn.Linear(hidden_dim, hidden_dim),
+        SafeBatchNorm(hidden_dim),
+        nn.ReLU(),
+    )
+
+
+class BridgeGIN(MessagePassing):
+    """GIN convolution whose messages carry the mediating-cell features.
+
+    Messages between two cells adjacent through a common higher-rank
+    cell (the *bridge*) concatenate the source features with the bridge
+    features, pass through a linear layer and a ReLU, and are
+    sum-aggregated before the usual GIN update.
+
+    Parameters
+    ----------
+    mlp : torch.nn.Module
+        Update network applied after aggregation; its first layer
+        defines the input width.
+    edge_dim : int
+        Dimension of the bridge features.
+    train_eps : bool, optional
+        Whether the GIN epsilon is learnable. Default is True.
+    """
+
+    def __init__(self, mlp, edge_dim, train_eps=True):
+        super().__init__(aggr="add")
+        self.mlp = mlp
+        in_dim = mlp[0].in_features
+        self.lin = nn.Linear(in_dim + edge_dim, in_dim)
+        if train_eps:
+            self.eps = nn.Parameter(torch.zeros(1))
+        else:
+            self.register_buffer("eps", torch.zeros(1))
+
+    def forward(self, x, edge_index, edge_attr, edge_weight=None):
+        """Run the bridge-aware GIN update.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Cell features of shape ``[n, in_dim]``.
+        edge_index : torch.Tensor
+            Adjacency pairs of shape ``[2, P]``.
+        edge_attr : torch.Tensor
+            Bridge features of shape ``[P, edge_dim]``.
+        edge_weight : torch.Tensor, optional
+            Multiplicative per-pair gate of shape ``[P]`` (used by the
+            learned-lifting variant). Default is None.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated features of shape ``[n, out_dim]``.
+        """
+        out = self.propagate(
+            edge_index, x=x, edge_attr=edge_attr, edge_weight=edge_weight
+        )
+        out = out + (1 + self.eps) * x
+        return self.mlp(out)
+
+    def message(self, x_j, edge_attr, edge_weight):
+        """Compute one bridge-aware message.
+
+        Parameters
+        ----------
+        x_j : torch.Tensor
+            Source-cell features of shape ``[P, in_dim]``.
+        edge_attr : torch.Tensor
+            Bridge features of shape ``[P, edge_dim]``.
+        edge_weight : torch.Tensor or None
+            Optional per-pair gate of shape ``[P]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Messages of shape ``[P, in_dim]``.
+        """
+        msg = self.lin(torch.cat([x_j, edge_attr], dim=-1)).relu()
+        if edge_weight is not None:
+            msg = msg * edge_weight.unsqueeze(-1)
+        return msg
+
+
+class ConcatHead(nn.Module):
+    """Merge concatenated branch outputs back to the embedding width.
+
+    Parameters
+    ----------
+    num_branches : int
+        Number of concatenated branches.
+    dim : int
+        Embedding dimension of each branch and of the output.
+    """
+
+    def __init__(self, num_branches, dim):
+        super().__init__()
+        self.head = nn.Sequential(
+            nn.Linear(num_branches * dim, dim),
+            SafeBatchNorm(dim),
+            nn.ReLU(),
+        )
+
+    def forward(self, parts):
+        """Concatenate the branch outputs and apply the head.
+
+        Parameters
+        ----------
+        parts : list of torch.Tensor
+            Branch outputs, each of shape ``[n, dim]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Merged features of shape ``[n, dim]``.
+        """
+        return self.head(torch.cat(parts, dim=-1))
+
+
+class MarkingEmbedding(nn.Module):
+    """Embedding of the bucketed hop-distance marking of bag rows.
+
+    Parameters
+    ----------
+    dim : int
+        Embedding dimension.
+    max_dist : int, optional
+        Distance cutoff used by the marking buckets. Default is 10.
+    """
+
+    def __init__(self, dim, max_dist=10):
+        super().__init__()
+        self.embed = nn.Embedding(max_dist + 2, dim)
+
+    def forward(self, marking):
+        """Embed the marking buckets.
+
+        Parameters
+        ----------
+        marking : torch.Tensor
+            Bucketed distances of shape ``[R]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Embeddings of shape ``[R, dim]``.
+        """
+        return self.embed(marking)
+
+
+class TwoCellInit(nn.Module):
+    """Initialize 2-cell features from their constituent nodes.
+
+    A GIN update over the node-to-2-cell incidence, so every 2-cell
+    aggregates the features of its boundary nodes (CIN-style
+    initialization).
+
+    Parameters
+    ----------
+    dim : int
+        Embedding dimension.
+    num_mlp_layers : int, optional
+        Depth of the update MLP. Default is 2.
+    """
+
+    def __init__(self, dim, num_mlp_layers=2):
+        super().__init__()
+        self.conv = GINConv(homp_mlp(dim, num_mlp_layers), train_eps=True)
+
+    def forward(self, x_0, x_2, inc02_pairs):
+        """Compute the initial 2-cell features.
+
+        Parameters
+        ----------
+        x_0 : torch.Tensor
+            Node features of shape ``[n0, dim]``.
+        x_2 : torch.Tensor
+            Incoming 2-cell features of shape ``[n2, dim]``.
+        inc02_pairs : torch.Tensor
+            Node-2-cell incidence pairs of shape ``[2, I]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Initialized 2-cell features of shape ``[n2, dim]``.
+        """
+        return self.conv(x=(x_0, x_2), edge_index=inc02_pairs)
+
+
+class CINBlock(nn.Module):
+    """One CIN-style higher-order message-passing block.
+
+    Updates the three cochains sequentially (each update sees the ones
+    already computed in this block, as in the reference): nodes from
+    edge-mediated adjacency, edges from node incidence and 2-cell
+    mediated adjacency, and 2-cells from edge incidence.
+
+    Parameters
+    ----------
+    dim : int
+        Embedding dimension of all ranks.
+    num_mlp_layers : int, optional
+        Depth of the convolution MLPs. Default is 2.
+    max_rank : int, optional
+        Highest rank updated by the block (0, 1, or 2). Default is 2.
+    """
+
+    def __init__(self, dim, num_mlp_layers=2, max_rank=2):
+        super().__init__()
+        if max_rank not in (0, 1, 2):
+            raise ValueError("max_rank must be 0, 1, or 2")
+        self.max_rank = max_rank
+        self.node_conv = BridgeGIN(homp_mlp(dim, num_mlp_layers), edge_dim=dim)
+        self.node_head = ConcatHead(1, dim)
+        if max_rank >= 1:
+            self.edge_inc_conv = GINConv(
+                homp_mlp(dim, num_mlp_layers), train_eps=True
+            )
+            self.edge_adj_conv = BridgeGIN(
+                homp_mlp(dim, num_mlp_layers), edge_dim=dim
+            )
+            self.edge_head = ConcatHead(2, dim)
+        if max_rank >= 2:
+            self.cell_conv = GINConv(
+                homp_mlp(dim, num_mlp_layers), train_eps=True
+            )
+            self.cell_head = ConcatHead(1, dim)
+
+    def forward(self, x_0, x_1, x_2, structures, a12_gate=None):
+        """Run the block.
+
+        Parameters
+        ----------
+        x_0 : torch.Tensor
+            Node features ``[n0, dim]``.
+        x_1 : torch.Tensor
+            Edge features ``[n1, dim]``.
+        x_2 : torch.Tensor
+            2-cell features ``[n2, dim]``.
+        structures : SMCNStructures
+            Batch connectivity structures.
+        a12_gate : torch.Tensor, optional
+            Per-pair gate on the 2-cell-mediated edge adjacency (used by
+            the learned-lifting variant). Default is None.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            Updated ``(x_0, x_1, x_2)``.
+        """
+        s = structures
+        x_0 = self.node_head(
+            [self.node_conv(x_0, s.a01_pairs, edge_attr=x_1[s.a01_bridge])]
+        )
+        if self.max_rank >= 1:
+            x_1 = self.edge_head(
+                [
+                    self.edge_inc_conv(x=(x_0, x_1), edge_index=s.inc01_pairs),
+                    self.edge_adj_conv(
+                        x_1,
+                        s.a12_pairs,
+                        edge_attr=x_2[s.a12_bridge],
+                        edge_weight=a12_gate,
+                    ),
+                ]
+            )
+        if self.max_rank >= 2:
+            x_2 = self.cell_head(
+                [self.cell_conv(x=(x_1, x_2), edge_index=s.inc12_pairs)]
+            )
+        return x_0, x_1, x_2
+
+
+class BagInit(nn.Module):
+    """Initialize the subcomplex-bag features.
+
+    Every bag row ``(u, e)`` concatenates the features of node ``u``,
+    edge ``e``, and the embedded distance marking, merged by a linear
+    head.
+
+    Parameters
+    ----------
+    dim : int
+        Embedding dimension.
+    max_dist : int, optional
+        Marking distance cutoff. Default is 10.
+    """
+
+    def __init__(self, dim, max_dist=10):
+        super().__init__()
+        self.marking = MarkingEmbedding(dim, max_dist)
+        self.head = ConcatHead(3, dim)
+
+    def forward(self, x_0, x_1, structures):
+        """Build the initial bag features.
+
+        Parameters
+        ----------
+        x_0 : torch.Tensor
+            Node features ``[n0, dim]``.
+        x_1 : torch.Tensor
+            Edge features ``[n1, dim]``.
+        structures : SMCNStructures
+            Batch structures with the bag indices.
+
+        Returns
+        -------
+        torch.Tensor
+            Bag features of shape ``[R, dim]``.
+        """
+        s = structures
+        return self.head(
+            [
+                x_0[s.bag_low_index],
+                x_1[s.bag_high_index],
+                self.marking(s.bag_marking),
+            ]
+        )
+
+
+class SCLLayer(nn.Module):
+    """One subcomplex (SCL) layer.
+
+    The bag features are updated by the sum of three branches: a GIN
+    over the marked-row broadcast edges, a bridge-aware GIN over the
+    replicated node adjacency (bridge features taken from the edge
+    cochain), and a re-embedded distance marking.
+
+    Parameters
+    ----------
+    in_dim : int
+        Input bag-feature dimension.
+    hidden_dim : int
+        Hidden and output dimension.
+    edge_dim : int
+        Dimension of the (frozen) edge features used as bridges.
+    max_dist : int, optional
+        Marking distance cutoff. Default is 10.
+    """
+
+    def __init__(self, in_dim, hidden_dim, edge_dim, max_dist=10):
+        super().__init__()
+        self.inc_conv = GINConv(scl_mlp(in_dim, hidden_dim), train_eps=True)
+        self.low_conv = BridgeGIN(
+            scl_mlp(in_dim, hidden_dim), edge_dim=edge_dim
+        )
+        self.marking = MarkingEmbedding(hidden_dim, max_dist)
+
+    def forward(self, x_bag, x_1, structures):
+        """Run the layer.
+
+        Parameters
+        ----------
+        x_bag : torch.Tensor
+            Bag features of shape ``[R, in_dim]``.
+        x_1 : torch.Tensor
+            Edge features used as bridge attributes, ``[n1, edge_dim]``.
+        structures : SMCNStructures
+            Batch structures.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated bag features of shape ``[R, hidden_dim]``.
+        """
+        s = structures
+        out = self.inc_conv(x=x_bag, edge_index=s.bag_inc_pairs)
+        out = out + self.low_conv(
+            x_bag,
+            s.bag_low_adj_pairs,
+            edge_attr=x_1[s.bag_low_adj_bridge],
+        )
+        return out + self.marking(s.bag_marking)
+
+
+class BagPool(nn.Module):
+    """Sum-pool the bag features back to nodes and edges."""
+
+    def forward(self, x_bag, structures, num_nodes, num_edges):
+        """Pool the bag.
+
+        Parameters
+        ----------
+        x_bag : torch.Tensor
+            Bag features of shape ``[R, dim]``.
+        structures : SMCNStructures
+            Batch structures with the bag indices.
+        num_nodes : int
+            Total number of nodes in the batch.
+        num_edges : int
+            Total number of edges in the batch.
+
+        Returns
+        -------
+        x_0 : torch.Tensor
+            Node features of shape ``[num_nodes, dim]``.
+        x_1 : torch.Tensor
+            Edge features of shape ``[num_edges, dim]``.
+        """
+        s = structures
+        dim = x_bag.size(1)
+        x_0 = x_bag.new_zeros(num_nodes, dim).index_add_(
+            0, s.bag_low_index, x_bag
+        )
+        x_1 = x_bag.new_zeros(num_edges, dim).index_add_(
+            0, s.bag_high_index, x_bag
+        )
+        return x_0, x_1

--- a/topobench/nn/backbones/cell/smcn_utils/structures.py
+++ b/topobench/nn/backbones/cell/smcn_utils/structures.py
@@ -1,0 +1,370 @@
+"""Batched structure builders for the SMCN backbone.
+
+SMCN processes, besides the usual cell-complex neighborhoods, a *bag of
+marked subcomplexes* over the rank pair (0, 1): one copy of the node set
+per edge, marked with hop distances to that edge. The reference
+implementation precomputes these structures per sample; here they are
+built on the fly from the batched incidence matrices, which keeps the
+data pipeline unchanged and works for any batch composition.
+
+The construction follows the official SMCN implementation
+(https://github.com/yoavgelberg/SMCN, ``data/utils.py``): bag rows are
+laid out as ``row(u, e) = u * n_edges + e`` within each graph, the bag
+low-adjacency replicates the node adjacency once per edge copy, and the
+marking of row ``(u, e)`` is the shortest-path distance from node ``u``
+to the closest endpoint of edge ``e``, bucketed as in the reference
+(distances above ``max_dist`` map to ``max_dist``, disconnected pairs to
+``max_dist + 1``).
+
+References
+----------
+Eitan et al. "Topological Blindspots: Understanding and Extending
+Topological Deep Learning Through the Lens of Expressivity." ICLR 2025.
+https://arxiv.org/abs/2408.05486
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class SMCNStructures:
+    """Connectivity and subcomplex-bag structures for one batch.
+
+    All index tensors are global with respect to the batch: cell indices
+    are offset per graph, and bag-row indices are offset by the number of
+    bag rows of the preceding graphs.
+
+    Attributes
+    ----------
+    a01_pairs : torch.Tensor
+        Ordered node pairs adjacent through an edge, shape ``[2, P0]``.
+    a01_bridge : torch.Tensor
+        Mediating edge index of every pair in ``a01_pairs``, shape ``[P0]``.
+    a12_pairs : torch.Tensor
+        Ordered edge pairs adjacent through a 2-cell, shape ``[2, P1]``.
+    a12_bridge : torch.Tensor
+        Mediating 2-cell index of every pair in ``a12_pairs``, shape ``[P1]``.
+    inc01_pairs : torch.Tensor
+        Node-edge incidence pairs, shape ``[2, I0]``.
+    inc12_pairs : torch.Tensor
+        Edge-2-cell incidence pairs, shape ``[2, I1]``.
+    inc02_pairs : torch.Tensor
+        Node-2-cell incidence pairs, shape ``[2, I2]``.
+    bag_low_index : torch.Tensor
+        Node index of every bag row, shape ``[R]``.
+    bag_high_index : torch.Tensor
+        Edge index of every bag row, shape ``[R]``.
+    bag_marking : torch.Tensor
+        Bucketed hop-distance marking of every bag row, shape ``[R]``.
+    bag_low_adj_pairs : torch.Tensor
+        Bag-row pairs of the replicated node adjacency, shape ``[2, Q]``.
+    bag_low_adj_bridge : torch.Tensor
+        Mediating edge index of every bag adjacency pair, shape ``[Q]``.
+    bag_inc_pairs : torch.Tensor
+        Bag-row pairs broadcasting each marked row to the rows of the
+        same node, shape ``[2, S]``.
+    bag_batch : torch.Tensor
+        Graph index of every bag row, shape ``[R]``.
+    """
+
+    a01_pairs: torch.Tensor
+    a01_bridge: torch.Tensor
+    a12_pairs: torch.Tensor
+    a12_bridge: torch.Tensor
+    inc01_pairs: torch.Tensor
+    inc12_pairs: torch.Tensor
+    inc02_pairs: torch.Tensor
+    bag_low_index: torch.Tensor
+    bag_high_index: torch.Tensor
+    bag_marking: torch.Tensor
+    bag_low_adj_pairs: torch.Tensor
+    bag_low_adj_bridge: torch.Tensor
+    bag_inc_pairs: torch.Tensor
+    bag_batch: torch.Tensor
+
+
+def sparse_pairs(matrix):
+    """Return the (row, col) index pairs of a sparse or dense matrix.
+
+    Parameters
+    ----------
+    matrix : torch.Tensor
+        Sparse (COO/CSR) or dense matrix.
+
+    Returns
+    -------
+    torch.Tensor
+        Long tensor of shape ``[2, nnz]`` with row/column indices.
+    """
+    if matrix.is_sparse or matrix.layout == torch.sparse_csr:
+        coo = matrix.to_sparse_coo().coalesce()
+        return coo.indices().long()
+    return torch.nonzero(matrix, as_tuple=False).t().long()
+
+
+def adjacency_from_incidence(incidence, expected_size=None):
+    """Build ordered cell pairs mediated by a higher-rank cell.
+
+    Two rank-``r`` cells are adjacent whenever they are both contained in
+    a common rank-``(r + 1)`` cell; that common cell is the *bridge* and
+    its features are used as edge features by the message passing.
+
+    Parameters
+    ----------
+    incidence : torch.Tensor
+        Incidence matrix of shape ``[n_low, n_high]`` (sparse or dense).
+    expected_size : int, optional
+        If given, every column must have exactly this many nonzero
+        entries (e.g. 2 for a node-edge incidence). Default is None.
+
+    Returns
+    -------
+    pairs : torch.Tensor
+        Ordered pairs of low-rank cells, shape ``[2, P]``.
+    bridge : torch.Tensor
+        Mediating high-rank cell of each pair, shape ``[P]``.
+
+    Raises
+    ------
+    ValueError
+        If ``expected_size`` is given and some column violates it.
+    """
+    idx = sparse_pairs(incidence)
+    if idx.numel() == 0:
+        empty = idx.new_zeros(0)
+        return idx.new_zeros(2, 0), empty
+    rows, cols = idx[0], idx[1]
+    order = torch.argsort(cols, stable=True)
+    rows, cols = rows[order], cols[order]
+    counts = torch.bincount(cols, minlength=int(cols.max()) + 1)
+    counts = counts[counts > 0]
+    if expected_size is not None and not bool((counts == expected_size).all()):
+        raise ValueError(
+            "every column of the incidence must have exactly "
+            f"{expected_size} nonzero entries"
+        )
+    pairs_src, pairs_dst, bridges = [], [], []
+    unique_cols = torch.unique_consecutive(cols)
+    start = 0
+    sizes = counts.tolist()
+    for col, size in zip(unique_cols.tolist(), sizes, strict=False):
+        members = rows[start : start + size]
+        start += size
+        if size < 2:
+            continue
+        grid_a = members.repeat_interleave(size)
+        grid_b = members.repeat(size)
+        keep = grid_a != grid_b
+        pairs_src.append(grid_a[keep])
+        pairs_dst.append(grid_b[keep])
+        bridges.append(torch.full_like(grid_a[keep], fill_value=col))
+    if not pairs_src:
+        empty = idx.new_zeros(0)
+        return idx.new_zeros(2, 0), empty
+    pairs = torch.stack([torch.cat(pairs_src), torch.cat(pairs_dst)], dim=0)
+    return pairs, torch.cat(bridges)
+
+
+def hop_distance_buckets(adjacency, max_dist):
+    """Compute bucketed all-pairs hop distances of one graph.
+
+    Follows the reference marking semantics: exact distances up to
+    ``max_dist``; nodes that are connected but farther than ``max_dist``
+    receive ``max_dist``; disconnected pairs receive ``max_dist + 1``.
+
+    Parameters
+    ----------
+    adjacency : torch.Tensor
+        Dense boolean adjacency of shape ``[n, n]``.
+    max_dist : int
+        Largest exact distance to resolve.
+
+    Returns
+    -------
+    torch.Tensor
+        Long tensor of shape ``[n, n]`` with values in
+        ``[0, max_dist + 1]``.
+    """
+    n = adjacency.size(0)
+    device = adjacency.device
+    dist = torch.full((n, n), max_dist + 1, dtype=torch.long, device=device)
+    dist.fill_diagonal_(0)
+    reach = torch.eye(n, dtype=torch.bool, device=device)
+    adj = adjacency.bool() | reach
+    frontier = reach
+    for d in range(1, max_dist + 1):
+        frontier = (frontier.float() @ adj.float()) > 0
+        newly = frontier & (dist == max_dist + 1)
+        dist[newly] = d
+    # Distinguish "connected but farther" from "disconnected" by closing
+    # the reachability transitively (log-doubling).
+    closure = frontier
+    steps = max(1, (n - 1).bit_length())
+    for _ in range(steps):
+        closure = (closure.float() @ closure.float()) > 0
+    far = closure & (dist == max_dist + 1)
+    dist[far] = max_dist
+    return dist
+
+
+def build_smcn_structures(
+    incidence_1,
+    incidence_2,
+    batch_0,
+    batch_1,
+    batch_2,
+    max_dist=10,
+):
+    """Build all SMCN connectivity/bag structures for a batch.
+
+    Parameters
+    ----------
+    incidence_1 : torch.Tensor
+        Block-diagonal node-edge incidence ``[n_nodes, n_edges]``.
+    incidence_2 : torch.Tensor
+        Block-diagonal edge-2-cell incidence ``[n_edges, n_cells]``.
+    batch_0 : torch.Tensor
+        Graph index of every node, shape ``[n_nodes]``.
+    batch_1 : torch.Tensor
+        Graph index of every edge, shape ``[n_edges]``.
+    batch_2 : torch.Tensor
+        Graph index of every 2-cell, shape ``[n_cells]``.
+    max_dist : int, optional
+        Marking distance cutoff. Default is 10.
+
+    Returns
+    -------
+    SMCNStructures
+        The assembled batch structures.
+    """
+    device = batch_0.device
+    num_graphs = int(batch_0.max()) + 1 if batch_0.numel() else 0
+
+    inc01 = sparse_pairs(incidence_1)
+    inc12 = (
+        sparse_pairs(incidence_2)
+        if incidence_2 is not None and incidence_2.numel()
+        else batch_0.new_zeros(2, 0)
+    )
+    a01_pairs, a01_bridge = adjacency_from_incidence(
+        incidence_1, expected_size=2
+    )
+    a12_pairs, a12_bridge = adjacency_from_incidence(incidence_2)
+
+    # Node-to-2-cell incidence via the edge memberships.
+    if inc12.numel():
+        dense_1 = incidence_1
+        if dense_1.is_sparse or dense_1.layout == torch.sparse_csr:
+            dense_1 = dense_1.to_dense()
+        dense_2 = incidence_2
+        if dense_2.is_sparse or dense_2.layout == torch.sparse_csr:
+            dense_2 = dense_2.to_dense()
+        membership = (dense_1.abs() @ dense_2.abs()) > 0
+        inc02 = torch.nonzero(membership, as_tuple=False).t().long()
+    else:
+        inc02 = batch_0.new_zeros(2, 0)
+
+    n0 = torch.bincount(batch_0, minlength=num_graphs)
+    n1 = torch.bincount(batch_1, minlength=num_graphs)
+    node_off = torch.cumsum(n0, 0) - n0
+    edge_off = torch.cumsum(n1, 0) - n1
+    rows_per_graph = n0 * n1
+    row_off = torch.cumsum(rows_per_graph, 0) - rows_per_graph
+
+    bag_low, bag_high, bag_mark, bag_batch = [], [], [], []
+    bl_pairs, bl_bridge, bi_pairs = [], [], []
+
+    pair_graph = batch_1[a01_bridge] if a01_bridge.numel() else a01_bridge
+    inc_graph = batch_1[inc01[1]] if inc01.numel() else inc01.new_zeros(0)
+
+    for g in range(num_graphs):
+        nl, nh = int(n0[g]), int(n1[g])
+        if nl == 0 or nh == 0:
+            continue
+        n_offset, e_offset, r_offset = (
+            int(node_off[g]),
+            int(edge_off[g]),
+            int(row_off[g]),
+        )
+        rows = torch.arange(nl * nh, device=device)
+        bag_low.append(rows // nh + n_offset)
+        bag_high.append(rows % nh + e_offset)
+        bag_batch.append(
+            torch.full((nl * nh,), g, dtype=torch.long, device=device)
+        )
+
+        # Local structures of this graph.
+        pair_mask = pair_graph == g
+        loc_pairs = a01_pairs[:, pair_mask] - n_offset
+        loc_bridge = a01_bridge[pair_mask] - e_offset
+        inc_mask = inc_graph == g
+        loc_inc = inc01[:, inc_mask].clone()
+        loc_inc[0] -= n_offset
+        loc_inc[1] -= e_offset
+
+        # Distance marking: min over the endpoints of each edge copy.
+        adj = torch.zeros(nl, nl, dtype=torch.bool, device=device)
+        adj[loc_pairs[0], loc_pairs[1]] = True
+        dist = hop_distance_buckets(adj, max_dist)
+        endpoints = torch.full((nh, 2), -1, dtype=torch.long, device=device)
+        edge_sorted = torch.argsort(loc_inc[1], stable=True)
+        sorted_nodes = loc_inc[0][edge_sorted]
+        endpoints[:, 0] = sorted_nodes[0::2]
+        endpoints[:, 1] = sorted_nodes[1::2]
+        marking = dist[:, endpoints].min(dim=-1).values  # [nl, nh]
+        bag_mark.append(marking.reshape(-1))
+
+        # Bag low-adjacency: node adjacency replicated once per edge copy.
+        copies = torch.arange(nh, device=device)
+        src = (loc_pairs[0].unsqueeze(1) * nh + copies).reshape(-1)
+        dst = (loc_pairs[1].unsqueeze(1) * nh + copies).reshape(-1)
+        bl_pairs.append(torch.stack([src, dst], dim=0) + r_offset)
+        bl_bridge.append((loc_bridge + e_offset).repeat_interleave(nh))
+
+        # Bag incidence: marked row (u, e) broadcasts to all rows of u.
+        marked = loc_inc[0] * nh + loc_inc[1]
+        targets = (loc_inc[0].unsqueeze(1) * nh + copies).reshape(-1)
+        sources = marked.repeat_interleave(nh)
+        bi_pairs.append(torch.stack([sources, targets], dim=0) + r_offset)
+
+    def _cat(parts, like, width=None):
+        """Concatenate chunks, or make an empty tensor when none exist.
+
+        Parameters
+        ----------
+        parts : list of torch.Tensor
+            Per-graph chunks to concatenate along the last dimension.
+        like : torch.Tensor
+            Tensor providing the dtype and device for the empty case.
+        width : int, optional
+            First dimension of the empty tensor, used for pair tensors.
+
+        Returns
+        -------
+        torch.Tensor
+            Concatenated tensor, or an empty one if ``parts`` is empty.
+        """
+        if parts:
+            return torch.cat(parts, dim=-1)
+        if width is not None:
+            return like.new_zeros(width, 0)
+        return like.new_zeros(0)
+
+    return SMCNStructures(
+        a01_pairs=a01_pairs,
+        a01_bridge=a01_bridge,
+        a12_pairs=a12_pairs,
+        a12_bridge=a12_bridge,
+        inc01_pairs=inc01,
+        inc12_pairs=inc12,
+        inc02_pairs=inc02,
+        bag_low_index=_cat(bag_low, batch_0),
+        bag_high_index=_cat(bag_high, batch_0),
+        bag_marking=_cat(bag_mark, batch_0),
+        bag_low_adj_pairs=_cat(bl_pairs, batch_0, width=2),
+        bag_low_adj_bridge=_cat(bl_bridge, batch_0),
+        bag_inc_pairs=_cat(bi_pairs, batch_0, width=2),
+        bag_batch=_cat(bag_batch, batch_0),
+    )

--- a/topobench/nn/liftings/__init__.py
+++ b/topobench/nn/liftings/__init__.py
@@ -1,0 +1,28 @@
+"""Learnable lifting modules applied inside models.
+
+Unlike :mod:`topobench.transforms.liftings`, which compute a fixed
+complex during preprocessing, the liftings in this package are
+trainable components: the topology they produce is differentiable and
+is learned end to end with the downstream network.
+
+A backbone plugs a learnable lifting in by instantiating it (or its
+pieces) in its constructor and multiplying the gates it produces into
+the affected features and messages. The components work for cell
+complexes and hypergraphs alike: gates can select 2-cells, learned
+edges, or candidate hyperedges. ``model=cell/smcn_difflift`` is a
+working example of the plug-in pattern.
+"""
+
+from topobench.nn.liftings.difflift import (
+    CellScorer,
+    DiffLift,
+    DiffLiftEncoder,
+    EdgeSampler,
+)
+
+__all__ = [
+    "CellScorer",
+    "DiffLift",
+    "DiffLiftEncoder",
+    "EdgeSampler",
+]

--- a/topobench/nn/liftings/difflift.py
+++ b/topobench/nn/liftings/difflift.py
@@ -8,7 +8,7 @@ propagated through the discrete decisions by the straight-through
 estimator. Both the stochastic (Bernoulli) sampling of the paper and
 its deterministic thresholded variant are provided.
 
-The components are deliberately modular:
+The components are modular:
 
 - :class:`DiffLiftEncoder` — Step 1, node embeddings.
 - :class:`CellScorer` — Step 3, multiset scorer for any candidate cell
@@ -20,9 +20,11 @@ The components are deliberately modular:
   (``D_max = 2``): learned edges, then cycle-basis candidates of the
   augmented graph scored as 2-cells.
 
-The SMCN backbone in this package instantiates the encoder + scorer
-over the cycle-lifting candidates (rank-2 selection only), since its
-subcomplex marking machinery is anchored to the observed graph.
+The recipe is not tied to a target domain: the scorer accepts any
+candidate given its node membership, so the same components lift
+graphs to cell complexes (:class:`DiffLift`) or select hyperedges for
+a hypergraph model (pass candidate hyperedge memberships to
+:class:`CellScorer`).
 
 References
 ----------

--- a/topobench/nn/wrappers/cell/smcn_wrapper.py
+++ b/topobench/nn/wrappers/cell/smcn_wrapper.py
@@ -1,0 +1,66 @@
+"""Wrapper for the SMCN model."""
+
+import torch
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class SMCNWrapper(AbstractWrapper):
+    r"""Wrapper for the SMCN model.
+
+    This wrapper defines the forward pass of the model. The SMCN model
+    returns the embeddings of the cells of rank 0, 1, and 2.
+    """
+
+    def forward(self, batch):
+        r"""Forward pass for the SMCN wrapper.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched data.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the updated model output.
+        """
+
+        def _batch_vector(rank, size):
+            """Return the batch vector of a rank, or zeros if absent.
+
+            Parameters
+            ----------
+            rank : int
+                Cell rank whose batch vector is requested.
+            size : int
+                Number of cells of that rank in the batch.
+
+            Returns
+            -------
+            torch.Tensor
+                Long tensor assigning each cell to its graph.
+            """
+            vec = batch.get(f"batch_{rank}", None)
+            if not torch.is_tensor(vec):
+                vec = torch.zeros(
+                    size, dtype=torch.long, device=batch.x_0.device
+                )
+            return vec
+
+        x_0, x_1, x_2 = self.backbone(
+            batch.x_0,
+            batch.x_1,
+            batch.x_2,
+            batch.incidence_1,
+            batch.incidence_2,
+            _batch_vector(0, batch.x_0.size(0)),
+            _batch_vector(1, batch.x_1.size(0)),
+            _batch_vector(2, batch.x_2.size(0)),
+        )
+
+        model_out = {"labels": batch.y, "batch_0": batch.batch_0}
+        model_out["x_0"] = x_0
+        model_out["x_1"] = x_1
+        model_out["x_2"] = x_2
+        return model_out


### PR DESCRIPTION
## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] My pull request passes the Linting test.
- [x] I added appropriate unit tests and I made sure the code passes all unit tests.
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines.
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.

## Description

Team: **One Ring to Lift Them All** — Jorge Luiz Franco.

This PR adds DiffLift (Differentiable Lifting for Topological Neural Networks) and  SMCN (Scalable Multi-Cellular Networks) for Track 2 as `model=cell/smcn`, plus a variant where the 2-cells of the SMCN are selected by a learned lifting (`model=cell/smcn_difflift`), based on our DiffLift work.

![DiffLift overview](https://raw.githubusercontent.com/JorgeLuizFranco/TopoBench/assets/difflift_overview.png)

*DiffLift in one picture: a GNN embeds the nodes, candidate cells are accepted or rejected by small set functions with straight-through gradients, and the accepted cells form the complex the TNN consumes. In this PR it selects the 2-cells for SMCN.*

References:
- SMCN: Eitan, Gelberg, Bar-Shalom, Frasca, Bronstein, Maron. *Topological Blindspots: Understanding and Extending Topological Deep Learning Through the Lens of Expressivity.* ICLR 2025 (oral). https://arxiv.org/abs/2408.05486
- Official SMCN code: https://github.com/yoavgelberg/SMCN
- DiffLift: Franco et al. *Differentiable Lifting for Topological Neural Networks.* https://openreview.net/forum?id=eC89CbINIw
- CIN, which SMCN uses as its message-passing block (Appendix G of the SMCN paper): Bodnar et al. *Weisfeiler and Lehman Go Cellular: CW Networks.* NeurIPS 2021. https://arxiv.org/abs/2106.12575

Implementation notes:
- `topobench/nn/backbones/cell/smcn.py` follows the model the SMCN authors run on graph benchmarks: CIN blocks, then a bag of (node, edge) pairs — one marked copy of the node set per edge, where the marking is the hop distance from the node to the edge, capped at 10 — updated by a stack of SCL layers (the instantiation the paper points out recreates GNN-SSWL+ on the augmented Hasse graph), sum-pooled back into the node and edge features, and a final reduced CIN block.
- The bag and all its connectivity are built inside the forward pass from the batched incidence matrices (`smcn_utils/structures.py`). This way the standard `graph2cell` cycle lifting is used as-is, with no custom transforms or data classes.
- The official SMCN repo has no license file, so no code was taken from it. I wrote the implementation from the paper and only ran their code to cross-check my bag construction, index by index, on small fixtures (including the far-distance and disconnected marking buckets).
- One adaptation: 2-cells come from TopoBench's cycle lifting (`nx.cycle_basis`, max length 10) rather than the paper's enumeration of all simple cycles up to length 18. The subcomplex machinery only involves nodes and edges, so it is unaffected by this, and it keeps the comparison with the other cell models on the leaderboard under the same lifting.
- The DiffLift pipeline itself lives in its own package, `topobench/nn/liftings/` — the learnable, in-model counterpart of `topobench/transforms/liftings`, since a learned lifting has parameters and cannot run as a preprocessing transform. It follows our DiffLift preprint, and any backbone — cell or hypergraph — can import it independently of SMCN: `DiffLiftEncoder` (node embeddings), `CellScorer` (accept/reject over candidate cells given node-to-cell membership, with straight-through gradients; both the paper's Bernoulli sampling and its deterministic thresholded variant — it is not tied to the cell domain, one of the tests uses it to select hyperedges), `EdgeSampler` (the D=1 step: kNN candidate edges with per-node neighborhood sizes sampled via Gumbel-softmax, added on top of the observed edges), and `DiffLift` (the full D_max=2 recipe: learned 1-cells, then cycle-basis candidates of the augmented graph gated as 2-cells, with scaled-sum feature lifting).
- `cell/smcn_difflift` (same backbone, `learned_lifting: true`) plugs the general module into SMCN: the encoder and scorer select among the candidate 2-cells of the standard cycle lifting. I deliberately do not sample edges here: SMCN's markings are hop distances on the observed graph, so learned edges would be invisible to them. The full `DiffLift` with edge learning is there for models that consume the learned complex directly. Rejected cells contribute exact zeros to every 2-cell-mediated message, and each graph always keeps at least one cell.
- Cost: the bag updates are O(deg · n0 · n1); building the structures is integer index arithmetic, about the price of one extra message-passing operation.
- Tests mirror the source layout (`test/nn/backbones/cell/test_smcn.py`, plus the wrapper test in `test/nn/wrappers/cell/test_cell_wrappers.py`) and cover the bag layout and markings against hand-computed values, batch-offset equivalence, the distance buckets, both variants forward and backward, graphs with no 2-cells, the scorer rescue path, and the error paths. `test/pipeline/test_pipeline.py` runs both configs on `graph/MUTAG`.
- `results.json` (the full 72-run grid: 12 GraphUniverse settings × 3 seeds × both tasks, produced with the official evaluation utilities) is at `2026_tdl_challenge/outputs/2026-07-27_05-00-00/results.json`, with the generated heatmaps committed alongside:

![Community detection heatmap](https://raw.githubusercontent.com/JorgeLuizFranco/TopoBench/assets/heatmap_community_detection_accuracy.png)

![Triangle counting heatmap](https://raw.githubusercontent.com/JorgeLuizFranco/TopoBench/assets/heatmap_triangle_mse_over_triangles.png)

## Issue

Submission to the TDL Challenge 2026 (Track 2 — TNNs). Please add the `track-2-tnn` label.

Related issues and PRs:
- #397 also submits SMCN, as a combinatorial-domain model built on rank-(0, 2) incident tuples with a binary incidence marking and a GCCN-style backbone. This PR implements, in the cell domain, the configuration the paper evaluates on graph benchmarks, and keeps the two ingredients its expressivity results rest on. (i) The bag contains every (node, edge) pair of the graph, and each copy is marked with the bucketed hop distance from the node to the edge: the distance marking is what takes the model beyond HOMP expressivity — it is how the rank-(0, 1) instantiation recreates GNN-SSWL+ — whereas incidence alone is information the model already receives through the incidence matrices. (ii) The subcomplex layers are combined with CIN blocks, the higher-order message-passing component the paper's construction is built from (Appendix G). The learned 2-cell lifting is added on top of this base.
- #363 implements CIN as its core model. No duplication here: in this PR CIN blocks are only the internal message-passing component of SMCN, as in the SMCN paper, and the core model is SMCN — the subcomplex and marking machinery is what goes beyond HOMP expressivity.
- #330 (evaluation-notebook integrity check on clean clones, made non-blocking by the maintainers): the `results.json` here is produced with the official evaluation utilities from `2026_tdl_challenge/utils.py`.
