### PR TITLE
Track: Track2; Team name: CoPreSheafers; Model: CTNN

### DIFF
--- a/2026_tdl_challenge/outputs/full_triangle_clique_gate2/results.json
+++ b/2026_tdl_challenge/outputs/full_triangle_clique_gate2/results.json
@@ -1,0 +1,5272 @@
+{
+  "metadata": {
+    "study_id": "full_triangle_clique_gate2",
+    "model_config": "combinatorial/copresheaf_cc_gated_dim2_gate2",
+    "generated_at_utc": "2026-07-29T17:07:27.311593+00:00",
+    "n_runs": 72,
+    "train_seeds": [
+      42,
+      43,
+      44
+    ],
+    "heatmap_note": "Cells show mean \u00b1 std over train_seeds (in-distribution test)."
+  },
+  "results": [
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.387424945831299,
+      "test_best_rerun_accuracy": 0.2913515269756317,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2788219153881073,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30158913135528564,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2891359031200409,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.31706011295318604,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2991825342178345,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32741233706474304,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3103751242160797,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3677515387535095,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3477347493171692,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.38834136724472046,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36007335782051086,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.427290678024292,
+      "test_best_rerun_accuracy": 0.29001450538635254,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2820689082145691,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2973107099533081,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2908167243003845,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.306440532207489,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2932233214378357,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3130873143672943,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3039575219154358,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.35082894563674927,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3409351408481598,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36477193236351013,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.34716174006462097,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 2.3740103244781494,
+      "test_best_rerun_accuracy": 0.28856292366981506,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27973872423171997,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.29520970582962036,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29165711998939514,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3086179196834564,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2924211025238037,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32130032777786255,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.30812132358551025,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3505997359752655,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.331194132566452,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3718007504940033,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3501795530319214,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.388819456100464,
+      "test_best_rerun_accuracy": 0.2745053172111511,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28080829977989197,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27630069851875305,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28634729981422424,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2876843214035034,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.285468727350235,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27668270468711853,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28214532136917114,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3155321180820465,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3148063123226166,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30754831433296204,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.29532432556152344,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.3929619789123535,
+      "test_best_rerun_accuracy": 0.2792420983314514,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2816869020462036,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27278631925582886,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2859271168708801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28241270780563354,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28245091438293457,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27603331208229065,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27614790201187134,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.30567651987075806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3043777346611023,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.30200931429862976,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28485751152038574,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 2.4017062187194824,
+      "test_best_rerun_accuracy": 0.2746199071407318,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2774849236011505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2731301188468933,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.28103750944137573,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2811139225959778,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2796241044998169,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27507829666137695,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.27645352482795715,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29914432764053345,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.302582323551178,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2936435043811798,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2813813090324402,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.204514503479004,
+      "test_best_rerun_accuracy": 0.33654212951660156,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2917335033416748,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2724043130874634,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32332491874694824,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3283291459083557,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3022385239601135,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.37539154291152954,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3612957298755646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4142027795314789,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.39472076296806335,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.49419358372688293,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.49190160632133484,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.244541645050049,
+      "test_best_rerun_accuracy": 0.33638933300971985,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.29123690724372864,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2774849236011505,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.32156771421432495,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3213385343551636,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.29967913031578064,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36847734451293945,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3587745428085327,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4020169675350189,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3872717618942261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4741385877132416,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4680647850036621,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 2.197002410888672,
+      "test_best_rerun_accuracy": 0.33818474411964417,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2897089123725891,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2726716995239258,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.31656351685523987,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32156771421432495,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3002903163433075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.36347314715385437,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35487812757492065,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3981969654560089,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3847123682498932,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.46718618273735046,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46661317348480225,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2290759086608887,
+      "test_best_rerun_accuracy": 0.32172054052352905,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2855833172798157,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.278936505317688,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.32401251792907715,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3266483247280121,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3133929371833801,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.35499274730682373,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.36236533522605896,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.41905418038368225,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.41389715671539307,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.47994500398635864,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4974406063556671,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2698287963867188,
+      "test_best_rerun_accuracy": 0.31992512941360474,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2861563265323639,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.28145772218704224,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.3166399300098419,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.32252272963523865,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3129345178604126,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.34716174006462097,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.35338833928108215,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4137825667858124,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4091603755950928,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4697073996067047,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4762013852596283,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 2.2579526901245117,
+      "test_best_rerun_accuracy": 0.3209947347640991,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.28199252486228943,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.27725571393966675,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.317862331867218,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3152265250682831,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3079303205013275,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.343418151140213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.3524715304374695,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4026663601398468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.4026663601398468,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4646649956703186,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.47734740376472473,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 2.0055770874023438,
+      "test_best_rerun_accuracy": 0.4133623540401459,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25127971172332764,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23664909601211548,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2602185010910034,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2555581033229828,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3828405439853668,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43739017844200134,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4428909718990326,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5580258369445801,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5451524257659912,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6172740459442139,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.626480221748352,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9530481100082397,
+      "test_best_rerun_accuracy": 0.4153105616569519,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2513943016529083,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2338222861289978,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.26503169536590576,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25918710231781006,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3881121575832367,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.44678738713264465,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4550003707408905,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5561158061027527,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5404156446456909,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.619604229927063,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.627244234085083,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 1.9927171468734741,
+      "test_best_rerun_accuracy": 0.41007715463638306,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25345709919929504,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23962870240211487,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2627778947353363,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2612881064414978,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3832225501537323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4416685700416565,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44392237067222595,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5601650476455688,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5430514216423035,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6163954734802246,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6296508312225342,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0581042766571045,
+      "test_best_rerun_accuracy": 0.3836427628993988,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.25330430269241333,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24554969370365143,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2544502913951874,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.26327449083328247,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39689815044403076,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.40369775891304016,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42612117528915405,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.538811206817627,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5404156446456909,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5764382481575012,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.5964932441711426,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0387163162231445,
+      "test_best_rerun_accuracy": 0.3845595419406891,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2521964907646179,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.24123309552669525,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.25723889470100403,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2607533037662506,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39758574962615967,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4106883704662323,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43509817123413086,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5417526364326477,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5415616035461426,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5904576182365417,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6121170520782471,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0392322540283203,
+      "test_best_rerun_accuracy": 0.3887997567653656,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2518908977508545,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.23810069262981415,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2512032985687256,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2570478916168213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.4014439582824707,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4132477641105652,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.436358779668808,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5430896282196045,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5448850393295288,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.5903430581092834,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6060050129890442,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.7915611267089844,
+      "test_best_rerun_accuracy": 0.4671097993850708,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22984948754310608,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.21281228959560394,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2626633048057556,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.24898770451545715,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40098556876182556,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3590037524700165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.46332797408103943,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5566506385803223,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.53892582654953,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6483306884765625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6595232486724854,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.79192316532135,
+      "test_best_rerun_accuracy": 0.4654289782047272,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23428069055080414,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2157536894083023,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2643823027610779,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25005730986595154,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3981587588787079,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3647337555885315,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.463060587644577,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5482084155082703,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5348765850067139,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6437848806381226,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6492092609405518,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 1.8148807287216187,
+      "test_best_rerun_accuracy": 0.47196120023727417,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.23894108831882477,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.22530369460582733,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.27248069643974304,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2621285021305084,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39987775683403015,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.36316755414009094,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4635953903198242,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5584841966629028,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5459927916526794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6558942794799805,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6666284799575806,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7746273279190063,
+      "test_best_rerun_accuracy": 0.47872260212898254,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22274428606033325,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2136908918619156,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2502864897251129,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2481091022491455,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.399381160736084,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3801283538341522,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4548475742340088,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5688364505767822,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5676522254943848,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6596378684043884,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6929864883422852,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.7664095163345337,
+      "test_best_rerun_accuracy": 0.475246399641037,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.21625028550624847,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.20612728595733643,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24268469214439392,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2430666983127594,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3962869644165039,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3715333342552185,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.45400717854499817,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.557987630367279,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5546260476112366,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6483306884765625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6811444759368896,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 1.774633765220642,
+      "test_best_rerun_accuracy": 0.47956299781799316,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.22167469561100006,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.2089540809392929,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.24872030317783356,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.25227290391921997,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3989609479904175,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37856215238571167,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4571395814418793,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5686072111129761,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5660096406936646,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6579188704490662,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6921460628509521,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.367738127708435,
+      "test_best_rerun_accuracy": 0.6123844385147095,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20605088770389557,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1888226717710495,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2081136852502823,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.21189548075199127,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.40247535705566406,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37665215134620667,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42096418142318726,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44036978483200073,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6018412113189697,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6819084882736206,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6914584636688232,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3721215724945068,
+      "test_best_rerun_accuracy": 0.6146764755249023,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2021544873714447,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.19111467897891998,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20299488306045532,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20899228751659393,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39919015765190125,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37321415543556213,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42191916704177856,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.43945297598838806,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.6015738248825073,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6796546578407288,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6909618973731995,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 1.3890044689178467,
+      "test_best_rerun_accuracy": 0.6060432195663452,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20058828592300415,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1880204677581787,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20719687640666962,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.20563067495822906,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.39838796854019165,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.37130415439605713,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.42111697793006897,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.438306987285614,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.597562849521637,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6729696989059448,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6873710751533508,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3462724685668945,
+      "test_best_rerun_accuracy": 0.6126518249511719,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.20165787637233734,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18702727556228638,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2056688815355301,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2077316790819168,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3932691514492035,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3703109622001648,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4075941741466522,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44040796160697937,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6078004240989685,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6769042611122131,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7068530917167664,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.376273274421692,
+      "test_best_rerun_accuracy": 0.6076858639717102,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.2021544873714447,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.18458247184753418,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20341508090496063,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.2018870860338211,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.38979294896125793,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3689739406108856,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4035831689834595,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4300939738750458,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.605241060256958,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.675376296043396,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7041791081428528,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.3689806461334229,
+      "test_best_rerun_accuracy": 0.6056230664253235,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.19741767644882202,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1828252673149109,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.19940407574176788,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19852547347545624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.387195348739624,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3675987422466278,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.39430055022239685,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.42149895429611206,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.6037130355834961,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.670830488204956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.6958515048027039,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.0486886501312256,
+      "test_best_rerun_accuracy": 0.702039897441864,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18412406742572784,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17384827136993408,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.2043318748474121,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.1964244842529297,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3753533363342285,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34154632687568665,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4366643726825714,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.44854459166526794,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5943158268928528,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5877454280853271,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.728588879108429,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.0539566278457642,
+      "test_best_rerun_accuracy": 0.7015050649642944,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1810680776834488,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.17079226672649384,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20074108242988586,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.18454428017139435,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3776835501194,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.3386431336402893,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43823057413101196,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4404843747615814,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5933990478515625,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5871724486351013,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7223240733146667,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1.050260305404663,
+      "test_best_rerun_accuracy": 0.7026892900466919,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.18370386958122253,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1756436675786972,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.20410268008708954,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.19573688507080078,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3752005398273468,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.34032392501831055,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.43750476837158203,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4438459873199463,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5848804116249084,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5775078535079956,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.7215982675552368,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9081141352653503,
+      "test_best_rerun_accuracy": 0.7417678833007812,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16166245937347412,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1536022573709488,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.184085875749588,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16510047018527985,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3517075479030609,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31942853331565857,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41431736946105957,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.429826557636261,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5725800395011902,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5774696469306946,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6929864883422852,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9029662013053894,
+      "test_best_rerun_accuracy": 0.7351210713386536,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.1649094671010971,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.15803346037864685,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18316906690597534,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.17220567166805267,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.3552219569683075,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.32045993208885193,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.41389715671539307,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4312399625778198,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5686836242675781,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5762472152709961,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6871418952941895,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "community_detection",
+      "wandb_project": "challenge_community_detection",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 0.9018756747245789,
+      "test_best_rerun_accuracy": 0.7345862984657288,
+      "test_best_rerun_mse": null,
+      "test_triangles_total_structural": null,
+      "test_mse_by_total_triangles": null,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.16674306988716125,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.1548246592283249,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.18454428017139435,
+          "test_best_rerun_mse": null
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.16880586743354797,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.34918633103370667,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.31874093413352966,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.4145083725452423,
+          "test_best_rerun_mse": null
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": 0.4273053705692291,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": 0.5672320127487183,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": 0.5704408288002014,
+          "test_best_rerun_mse": null
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": 0.6896630525588989,
+          "test_best_rerun_mse": null
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__community_detection__11__h_hi__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 0.49699148535728455,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.4927501976490021,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0003550073470093675,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.06595790386199951,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0003471468624315764
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.74209594726562,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.006958065676698189
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.651707649230957,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0015678151834280273
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.827192306518555,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.003049725091051243
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.38328540325164795,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0003309891219789706
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 969.4183349609375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.022511107536711348
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 82.10111999511719,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.005756634412783424
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 194.18829345703125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.009953779971143125
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.906874656677246,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0021167777167426217
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5128.10546875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.058008274252570616
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1555.5263671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.025885317211447257
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__00__h_lo__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 0.5528320670127869,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.5402688980102539,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.00038924272190940485,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.15366092324256897,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0008087417012766787
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 152.09243774414062,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.011535262627541952
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.069822311401367,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0027198592219081115
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.504268646240234,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.004476188195890479
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.6363037824630737,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0005494851316606854
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1427.7879638671875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.03315502423990311
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144.26100158691406,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.010115061112530785
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 258.2579040527344,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.013237885286418288
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.497297286987305,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0038217417399088543
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5156.578125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.05833035219393007
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2532.89013671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.042149503880963675
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__00__h_lo__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_lo__pl_lo",
+      "test_loss": 0.5122040510177612,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.5059329271316528,
+      "test_triangles_total_structural": 1388.0,
+      "test_mse_by_total_triangles": 0.0003645049907288565,
+      "ood_test": {
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.46724990010261536,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.002459210000540081
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.152211666107178,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.00031491935275746515
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.0875850915908813,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0003665605296902195
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.521491527557373,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0007376742187785401
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.45450708270072937,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.00039249316295399773
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.134599685668945,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0002585593462211812
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.314038038253784,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.00023236839421215708
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.070314884185791,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0003624129829404783
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4630115032196045,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.00026009093390570747
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.15727615356445,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.00045425241398554863
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.524314880371094,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.000624437370082557
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__00__h_lo__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.014058737084269524,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.014069471508264542,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 7.404985004349758e-05,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.7168216705322266,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0026778254110462725
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 59.23945999145508,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.004492943495749342
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.5107473731040955,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0001721426940020544
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 225.39979553222656,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.030113533137238017
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.661022424697876,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.00316150468454048
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3852.61572265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.08946256090136193
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 203.9596710205078,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.014300916492813617
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1382.206298828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.07084967444913245
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 81.51048278808594,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.014490752495659722
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25006.3125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.282867238668371
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5436.76513671875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.09047251987284292
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__01__h_lo__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.00537624629214406,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.004781342577189207,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 2.5164960932574775e-05,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.902700901031494,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0020912830699074164
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 139.01976013183594,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.010543781579964804
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.9621462225914001,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.00032428251519764074
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 387.006103515625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.05170422224657649
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.701048851013184,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0040596276779043036
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8813.59375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.2046626822868289
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 455.9821472167969,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0319718235322393
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2659.595947265625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.13632661578069738
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 150.88232421875,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.026823524305555554
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 50598.69921875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.5723640512058414
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13629.07421875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.2267996974481221
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__01__h_lo__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_lo__pl_hi",
+      "test_loss": 0.059524960815906525,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.059508342295885086,
+      "test_triangles_total_structural": 190.0,
+      "test_mse_by_total_triangles": 0.00031320180155728993,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.050045013427734,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.007240666436187129
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1481.1314697265625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.11233458245935249
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.7564290761947632,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0005919882292533749
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2139.426025390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.2858284603060287
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.03936767578125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.019032269150070166
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55791.5625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 1.2955499373026194
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3170.398681640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.22229692060304482
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15174.6416015625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.7778277513743657
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 843.5504150390625,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.14996451822916668
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 288652.53125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 3.265189317670215
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83240.0859375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 1.3851877246517896
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__01__h_lo__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 9.569892883300781,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 9.398648262023926,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.0007128288405023835,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.4662492275238037,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0024972977143543256
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.2627098560333252,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0013826834528069746
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.729696273803711,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0026052228762398757
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.88078498840332,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0023888824299804034
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.14851975440979,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0018553711177977461
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 362.8341064453125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.008425462252584816
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.35138511657715,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0014970821144704213
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.1507568359375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.006209993174224076
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.469143867492676,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0013278477986653646
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3904.274169921875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.04416449860210485
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 618.4909057617188,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.010292228808042847
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__02__h_lo__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 16.257854461669922,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 15.055940628051758,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.0011418991754305466,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.39335235953330994,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0002833950717098775
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.1485905796289444,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0007820556822576021
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.6350328922271729,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.00021403198255044584
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.558476209640503,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.00020821325446098904
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.30546835064888,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.00026378959468815197
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.975040435791016,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0010908192558933452
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.593113899230957,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0007427509395057466
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.612605571746826,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.00039020993242846
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.3636490106582642,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0002424264907836914
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 157.95628356933594,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.0017867751498177205
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 90.63580322265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0015082589190530719
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__02__h_lo__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_lo__d_hi__pl_lo",
+      "test_loss": 4.438241481781006,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.16895055770874,
+      "test_triangles_total_structural": 13185.0,
+      "test_mse_by_total_triangles": 0.00031618889326573684,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.084189414978027,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.010147110529523074
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.85309410095215,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10975312684711656
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.7333085536956787,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0005841956702715466
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.087869644165039,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0010805437066352757
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.043107986450195,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.013854151974482034
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.71776580810547,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0009455175043680445
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.5639827251434326,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0002498936141595451
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.590058326721191,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.000696604558240873
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.423573970794678,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0011419687059190538
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.25330352783203,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.0013602853243422964
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.06585693359375,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0011326753021748581
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__02__h_lo__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 0.8259676098823547,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.7998721599578857,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.00026958953823993454,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.6416730880737305,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.004064605971234676
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.11461079865694046,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0006032147297733709
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252.0741729736328,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.01911825354369608
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 784.9071655273438,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.10486401677052021
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.62472152709961,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.007447946051035932
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19302.884765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.4482371532051133
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 937.8446655273438,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.06575828534057943
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5664.53173828125,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.2903547971849531
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 280.1238708496094,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.04979979926215278
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114055.2109375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.2901735341278011
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28149.994140625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.46844048625671875
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__03__h_lo__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 0.4492896497249603,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.43709519505500793,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.00014731890632120254,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.848140001296997,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0013315129692341478
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.11675946414470673,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0006145234954984565
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.73046875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0025582456389836934
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 141.61817932128906,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.018920264438381972
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.0125789642333984,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0017379783801670108
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2975.904052734375,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.06910421820393775
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 144.49325561523438,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.010131345927305734
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 927.4879150390625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.047541540573020784
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.50917434692383,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.008623853217230902
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17617.6171875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.19928754892367906
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4151.1279296875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.06907839398411629
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__03__h_lo__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0-0.1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_lo",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_lo__d_hi__pl_hi",
+      "test_loss": 0.69633948802948,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.5780361890792847,
+      "test_triangles_total_structural": 2967.0,
+      "test_mse_by_total_triangles": 0.00019482176915378653,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.035788536071777,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.002907628628293788
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.8177096843719482,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.004303735180904991
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 353.5879211425781,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.02681743808438211
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 667.18505859375,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.08913628037324649
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.976140975952148,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.006887859219302374
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16766.640625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.3893423886540962
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 902.4281005859375,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.06327500354690349
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4748.15234375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.24338266152801272
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 252.17552185058594,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.04483120388454861
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91847.828125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 1.03896732152755
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24561.310546875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.40872165721257053
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__03__h_lo__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 28.860132217407227,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 27.057756423950195,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.003614930717962618,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.995766639709473,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.006481099884516911
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.4151110351085663,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.002184794921624033
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 229.2026824951172,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.017383593666675554
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.788787841796875,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.012736362602560457
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.550943374633789,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.004793560772568039
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 398.2969665527344,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.009248954266968567
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 190.32862854003906,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.013345156958353602
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.14839172363281,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0034931770835836184
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 39.88750076293945,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.007091111246744792
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 473.8670959472656,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.005360305599892149
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 845.0982055664062,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.014063172175900791
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__04__h_mid__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 3.8350391387939453,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 3.591717004776001,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.0004798553112593188,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.28999853134155273,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.00020893265946797748
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.1199425533413887,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0006312765965336247
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.129709005355835,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.00016152514261326013
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.221818923950195,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.001422925151314525
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.3022998571395874,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0002610534172189874
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.6734676361084,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0005032850556406372
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.9765141010284424,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0002788188263236883
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.665499687194824,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0005466963805010418
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.0160837173461914,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.00035841488308376734
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 89.92325592041016,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.001017196881558433
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.69729995727539,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.00031113939988476846
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__04__h_mid__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_lo__pl_lo",
+      "test_loss": 8.015253067016602,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 8.231904983520508,
+      "test_triangles_total_structural": 7485.0,
+      "test_mse_by_total_triangles": 0.0010997869049459597,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.022120475769043,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.002897781322600175
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.504195213317871,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.018443132701673005
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95.50530242919922,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.007243481412908549
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.87405776977539,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0036650009335272636
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.269852161407471,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0036872643880893527
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.90805053710938,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0038061501610883656
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 67.57572937011719,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.004738166412152376
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.78531837463379,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.001475489178052888
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.466571807861328,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.001860723876953125
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 483.59796142578125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.0054703795281357106
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 355.7089538574219,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0059193076374523135
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__04__h_mid__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 0.9845520257949829,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.9455640912055969,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.0008165493015592374,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.0302367210388184,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.000742245476252751
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.22691309452056885,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0011942794448450993
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 84.01312255859375,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.006371871259658229
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.238364219665527,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.002776664718458216
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.1103572845459,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.002953955549037528
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 85.41926574707031,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0019835423032479637
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.5700798034668,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.003966489959575571
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.81235885620117,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.002655818281623926
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.257668495178223,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0018235855102539061
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.7829132080078,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.0017621903465720372
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 311.79962158203125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.005188618001797735
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__05__h_mid__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 0.5323436856269836,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.5412935614585876,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.0004674383086861724,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.2353254556655884,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0008900039305948043
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.0757167786359787,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00039850936124199315
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 304.62567138671875,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.02310395687422971
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.627704620361328,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.004256051439285921
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 51.705482482910156,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.006907880091237162
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3276.3330078125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.07608055470491594
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 240.0492706298828,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.016831389049914654
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 493.0307922363281,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.025271966386607624
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.68745994567871,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0036777706570095487
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16896.796875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.19113374970306438
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6623.31103515625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.11021767984883847
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__05__h_mid__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_lo__pl_hi",
+      "test_loss": 2.0999250411987305,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 2.1711325645446777,
+      "test_triangles_total_structural": 1158.0,
+      "test_mse_by_total_triangles": 0.0018748985876897045,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.9838377833366394,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0007088168467843224
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.07471325248479843,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.00039322764465683384
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 40.668331146240234,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.003084439222316286
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.064516067504883,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.006762560184531474
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 142.3904571533203,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.01902344116944827
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1698.062744140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.03943114304617836
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.9039306640625,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.010931421305852089
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 746.2929077148438,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.03825377557613634
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.37318420410156,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.009310788302951388
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9322.1533203125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.10545064443867855
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2203.58642578125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0366696025457416
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__05__h_mid__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 812.6486206054688,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 569.002685546875,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.013212954800921304,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.65187644958496,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0155993346178566
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 36.6895751953125,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.19310302734375
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 29.011920928955078,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0022003732217637526
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.841773986816406,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008372690929159557
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.097121238708496,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0020169834654253167
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.173049926757812,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02173838508355597
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.39749526977539,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0024819446970814323
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 61.54094314575195,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0031544898839382823
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.854303359985352,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0019296539306640624
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2714.074951171875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.030701163435311866
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1019.5657348632812,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.016966464228167694
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__06__h_mid__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 212.00454711914062,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 190.31089782714844,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.004419257333901831,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.257429122924805,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.005949156428620176
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.3013651371002197,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0015861323005274723
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 161.84190368652344,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.012274698800646449
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.140430450439453,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007462227991385053
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 31.660667419433594,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.004229882086764675
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.222244739532471,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.003646152624812151
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138.49571228027344,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.009710819820521206
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.63406753540039,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.002902971322743369
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.46821594238281,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.005949905056423611
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 342.6747741699219,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.003876279924549188
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 295.3731689453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0049152674844875855
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__06__h_mid__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_mid__d_hi__pl_lo",
+      "test_loss": 315.3724060058594,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 210.6178436279297,
+      "test_triangles_total_structural": 43064.0,
+      "test_mse_by_total_triangles": 0.004890810041517966,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 222.3085174560547,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.16016463793663882
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 324.35076904296875,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 1.707109310752467
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.743389129638672,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0014974129032717992
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 123.38567352294922,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.041586003883703815
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 100.2545394897461,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.013394060052070287
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 254.71270751953125,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.21995916020684908
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30.67848014831543,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0021510643772483123
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 102.544677734375,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.005256275448991491
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110.90103912353516,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.01971574028862847
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1228.201904296875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.0138932152109869
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 249.414794921875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.004150480004690646
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__06__h_mid__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 10.31949234008789,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 10.604635238647461,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.0007435587742706115,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.449512481689453,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.01617400034703851
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 49.88030242919922,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.26252790752210114
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.669462203979492,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0004299933412195292
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.247356414794922,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0014315323271974795
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.102330207824707,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0012160761800701012
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.473222732543945,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.02286115952724002
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106.2955322265625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.002468315349864446
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 26.918136596679688,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.001379780439626823
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.660698413848877,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0011841241624620225
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 607.1409301757812,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.006867876997113008
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.79660034179688,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0021932105293760817
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__07__h_mid__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 26.35598373413086,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24.3808650970459,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.0017094983240110713,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.235239028930664,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.008094552614503361
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 19.059675216674805,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.10031408008776213
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.907100677490234,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.002571642068827473
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.966084957122803,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0026848955029062363
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.462047576904297,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.001397735147215003
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.162919998168945,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.011366943003600126
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 281.13201904296875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.006528237484742912
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 35.61639404296875,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.001825639143111833
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.663930416107178,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.001184698740641276
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 830.2382202148438,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.009391516353685325
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 613.5106811523438,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.010209353521247796
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__07__h_mid__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.4-0.6__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_mid",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_mid__d_hi__pl_hi",
+      "test_loss": 26.011133193969727,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 24.525352478027344,
+      "test_triangles_total_structural": 14262.0,
+      "test_mse_by_total_triangles": 0.0017196292580302442,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 41.30242919921875,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.029756793371195064
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 62.340518951416016,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.3281079944811369
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 34.96139144897461,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0026516034470212067
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 25.606149673461914,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008630316708278367
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 20.82440948486328,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0027821522357866775
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 45.114341735839844,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.038958844331467915
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.70782470703125,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0020134642556899323
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 28.209684371948242,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.001445983103795594
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 30.213972091674805,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.005371372816297743
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 532.6045532226562,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.006024733925575561
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 155.4785614013672,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.002587299043172536
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__07__h_mid__d_hi__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 61.84368896484375,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 60.27489471435547,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.0030895942751732776,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.2727820873260498,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.00091698997645969
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.9538977146148682,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.010283672182183517
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.780625343322754,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0006659556574382066
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.6062536835670471,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.00020433221556017767
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.684204578399658,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0008930133037274092
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.1066070795059204,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0009556192396424183
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 361.5439147949219,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.008395502387026795
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.686756134033203,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0010998987613261256
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.511350154876709,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0006242400275336371
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1710.77197265625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.019351967384096128
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 565.9049072265625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.009417151868380052
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__08__h_hi__d_lo__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 28.54022216796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 28.4366397857666,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.0014576164737181096,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.760534286499023,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.009913929601224081
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.599384307861328,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.07157570688348068
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.755430221557617,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0013466386212785451
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.75193977355957,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.008342413135678992
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.83299446105957,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.001580894383575093
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.00256633758545,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.011228468339883807
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 120.12067413330078,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.002789352455259632
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.157310485839844,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0011328923352853628
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.004502296447754,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0017785781860351563
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 609.2821044921875,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.006892097604065331
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 210.5372314453125,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.00350352339615783
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__08__h_hi__d_lo__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_lo__pl_lo",
+      "test_loss": 68.68037414550781,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 66.59066772460938,
+      "test_triangles_total_structural": 19509.0,
+      "test_mse_by_total_triangles": 0.003413330653780787,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.9205551147460938,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0028246074313732663
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.697305679321289,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.03524897725958573
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 14.564162254333496,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0011046008535709896
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.0689465999603271,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0003602785978969758
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.41115951538086,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.005666153575869187
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.062168121337891,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.004371475061604396
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 121.55621337890625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0028226874739667993
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.77433967590332,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0012462725898123208
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 10.642851829528809,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0018920625474717883
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 438.0425109863281,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.004955063866456208
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 283.7010803222656,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.004721033736412987
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__08__h_hi__d_lo__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 4.9428863525390625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 4.841331481933594,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.00086068115234375,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.4451812505722046,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0010411968664064874
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.12138225883245468,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0006388539938550246
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 4.442288398742676,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0003369198633858685
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.8610944747924805,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0013013463009074757
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.241606712341309,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.001234683595503181
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.9602264165878296,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0008292110678651378
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 143.25584411621094,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0033265800695757696
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.413649559020996,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0008002839404726543
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 53.06527328491211,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0027200406625102315
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 874.130615234375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.009888019809671335
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 217.16217041015625,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.003613768166178361
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__09__h_hi__d_lo__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 0.4583074450492859,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 0.4416292905807495,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 7.851187388102213e-05,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.34099188446998596,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.00024567138650575355
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.17510437965393066,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0009216019981785824
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.819878101348877,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0001380264013158041
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.7071878910064697,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0005753919416941253
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.6609665751457214,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 8.830548766141903e-05
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 0.294709712266922,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.000254498887967981
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 8.521356582641602,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.00019787656935355753
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.7794793844223022,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.00012477067623210646
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.060149908065796,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.00010559997478424296
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 24.43572425842285,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.00027641283959167507
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.386280059814453,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.00018947764398206867
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__09__h_hi__d_lo__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_1-2.5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_lo",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_lo__pl_hi",
+      "test_loss": 1.756951928138733,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 1.8170822858810425,
+      "test_triangles_total_structural": 5625.0,
+      "test_mse_by_total_triangles": 0.00032303685082329643,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.7047978639602661,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0012282405359944281
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.0241355895996094,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.01591650310315584
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 3.481677293777466,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0002640635035098571
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.647458553314209,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0008923015009485032
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.336177349090576,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0008465166799052206
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.7147401571273804,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0014807773377611229
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 83.9808578491211,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0019501406708415637
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 5.8621506690979,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.00041103286138675503
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.945350646972656,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0014324337816891003
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 594.8724365234375,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.006729097841967326
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 106.15141296386719,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.001766452215131
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__09__h_hi__d_lo__pl_hi__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_1.5-2__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 1133.2398681640625,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 887.6456298828125,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.01004089940254078,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.072476387023926,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0014931386073659407
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.609534740447998,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.008471235476042095
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 70.83244323730469,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.005372198956185415
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.680760383605957,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.003936892613281414
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.885759353637695,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.002523147542236165
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.2694976329803467,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0019598425155270697
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 379.6418762207031,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.008815759711608376
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 56.76166534423828,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.003979923246686179
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 109.5320816040039,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.005614438546517192
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 13.524992942810059,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0024044431898328994
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 490.25994873046875,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.008158353697277033
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__10__h_hi__d_hi__pl_lo__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_1.5-2__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 242.303466796875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 200.23440551757812,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.0022650182179063845,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.9743568897247314,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.0021429084219918813
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1.0590832233428955,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.0055741222281205025
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.935142517089844,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0012844249159719259
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.48333740234375,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.0042073937992395515
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 12.657174110412598,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.0016910052251720238
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 2.0543036460876465,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.0017740100570705064
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 42.37716293334961,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.0009840507833306152
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.805034637451172,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.001318541203018593
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.84518051147461,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.0008634568922791844
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 6.9069108963012695,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.001227895270453559
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 58.94181823730469,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0009808433301267151
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__10__h_hi__d_hi__pl_lo__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_1.5-2__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_lo",
+      "run_slug": "h_hi__d_hi__pl_lo",
+      "test_loss": 267.321044921875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 182.87442016601562,
+      "test_triangles_total_structural": 88403.0,
+      "test_mse_by_total_triangles": 0.002068644957365877,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.91421890258789,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.013626958863535944
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 17.02891731262207,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.08962588059274774
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 138.49171447753906,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.010503732611114074
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.593503952026367,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.007614932238633761
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 110.08941650390625,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.014708004876941383
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 15.383113861083984,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.01328420886103971
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 164.357421875,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.003816585126207505
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 158.08885192871094,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.011084620104383042
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.45420837402344,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.008378400142191985
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 55.08998107910156,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0097937744140625
+        },
+        "h_hi__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 86.93331909179688,
+          "test_triangles_total_structural": 60093.0,
+          "test_mse_by_total_triangles": 0.0014466463496879316
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__10__h_hi__d_hi__pl_lo__s44"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_4-5__s42",
+      "train_seed": 42,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 618.3060913085938,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 562.7892456054688,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.009365304538057157,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 114.92890930175781,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.08280180785429238
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 163.2441864013672,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.8591799284282483
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 68.04644775390625,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.00516089857822573
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 212.60336303710938,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.07165600371995598
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 46.95930480957031,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.006273788217711465
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 131.87371826171875,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.11388058571823727
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 388.1197509765625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.009012626578500894
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 95.178466796875,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.006673570803314753
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 54.41510009765625,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.002789230616518338
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 65.02070617675781,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.011559236653645834
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1620.8980712890625,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.018335328793016782
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__11__h_hi__d_hi__pl_hi__s42"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_4-5__s43",
+      "train_seed": 43,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 383.95672607421875,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 359.6330871582031,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.005984608642574062,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 16.46900749206543,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.011865279172957802
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 27.727811813354492,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.14593585164923417
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 21.083904266357422,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.0015990826140582042
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 7.161397933959961,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.002413683159406795
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 11.740606307983398,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.00156855127695169
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 18.213151931762695,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.015728110476479013
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 219.90484619140625,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.00510646586920412
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 22.978736877441406,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.0016111861504306132
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 48.59791564941406,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.002491051086647909
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 9.171412467956543,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.0016304733276367187
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 731.5293579101562,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.008274938157191002
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__11__h_hi__d_hi__pl_hi__s43"
+    },
+    {
+      "experiment": "triangle_counting",
+      "wandb_project": "challenge_triangle_counting",
+      "wandb_run_name": "copresheaf_cc_gated_dim2_gate2_hom_0.9-1__deg_4-5__gamma_4-5__s44",
+      "train_seed": 44,
+      "homophily": "h_hi",
+      "avg_degree": "d_hi",
+      "power_law": "pl_hi",
+      "run_slug": "h_hi__d_hi__pl_hi",
+      "test_loss": 566.4646606445312,
+      "test_best_rerun_accuracy": null,
+      "test_best_rerun_mse": 518.56884765625,
+      "test_triangles_total_structural": 60093.0,
+      "test_mse_by_total_triangles": 0.008629438497932372,
+      "ood_test": {
+        "h_lo__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 37.998939514160156,
+          "test_triangles_total_structural": 1388.0,
+          "test_mse_by_total_triangles": 0.02737675757504334
+        },
+        "h_lo__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 63.34916687011719,
+          "test_triangles_total_structural": 190.0,
+          "test_mse_by_total_triangles": 0.33341666773745887
+        },
+        "h_lo__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 91.48274230957031,
+          "test_triangles_total_structural": 13185.0,
+          "test_mse_by_total_triangles": 0.006938395321165742
+        },
+        "h_lo__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 38.1953239440918,
+          "test_triangles_total_structural": 2967.0,
+          "test_mse_by_total_triangles": 0.012873381848362588
+        },
+        "h_mid__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 52.257606506347656,
+          "test_triangles_total_structural": 7485.0,
+          "test_mse_by_total_triangles": 0.00698164415582467
+        },
+        "h_mid__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 47.20524978637695,
+          "test_triangles_total_structural": 1158.0,
+          "test_mse_by_total_triangles": 0.040764464409651945
+        },
+        "h_mid__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 434.9599914550781,
+          "test_triangles_total_structural": 43064.0,
+          "test_mse_by_total_triangles": 0.010100315610604638
+        },
+        "h_mid__d_hi__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 94.19975280761719,
+          "test_triangles_total_structural": 14262.0,
+          "test_mse_by_total_triangles": 0.006604946908401149
+        },
+        "h_hi__d_lo__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 147.31788635253906,
+          "test_triangles_total_structural": 19509.0,
+          "test_mse_by_total_triangles": 0.007551278197372446
+        },
+        "h_hi__d_lo__pl_hi": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 33.48666763305664,
+          "test_triangles_total_structural": 5625.0,
+          "test_mse_by_total_triangles": 0.005953185356987847
+        },
+        "h_hi__d_hi__pl_lo": {
+          "test_best_rerun_accuracy": null,
+          "test_best_rerun_mse": 1660.9776611328125,
+          "test_triangles_total_structural": 88403.0,
+          "test_mse_by_total_triangles": 0.01878870243241533
+        }
+      },
+      "output_dir": "/home/czeh/topobench/logs/train/runs/notebook_gu_grid_full_triangle_clique_gate2__triangle_counting__11__h_hi__d_hi__pl_hi__s44"
+    }
+  ]
+}

--- a/configs/model/combinatorial/copresheaf_cc_gated_dim2_gate2.yaml
+++ b/configs/model/combinatorial/copresheaf_cc_gated_dim2_gate2.yaml
@@ -1,0 +1,63 @@
+_target_: topobench.model.TBModel
+
+model_name: copresheaf_cc_gated_dim2_gate2
+model_domain: combinatorial
+
+feature_encoder:
+  _target_: topobench.nn.encoders.${model.feature_encoder.encoder_name}
+  encoder_name: CopresheafStructureFeatureEncoder
+  in_channels: ${infer_in_channels:${dataset},${oc.select:transforms,null}}
+  out_channels: 64
+  proj_dropout: 0.
+  structure_channels: 4
+  use_structure: true
+  selected_dimensions:
+    - 0
+    - 1
+    - 2
+
+backbone:
+  _target_: topobench.nn.backbones.CopresheafCC
+  in_channels: ${model.feature_encoder.out_channels}
+  hidden_channels: ${model.feature_encoder.out_channels}
+  out_channels: ${model.feature_encoder.out_channels}
+  neighborhoods:
+    - up_adjacency-0
+    - up_incidence-0
+    - down_incidence-1
+    - up_adjacency-1
+    - up_incidence-1
+    - down_incidence-2
+    - up_adjacency-2
+  num_layers: 3
+  heads: 4
+  stalk_dimension: 16
+  map_type: shared_local
+  aggr: mean
+  neighborhood_aggr: gated
+  route_self_bias: 1.0
+  message_schedule: null
+  message_type: identity
+  update_type: residual
+  message_gate_init: -2.0
+  dropout: 0.1
+
+backbone_wrapper:
+  _target_: topobench.nn.wrappers.combinatorial.CopresheafCCWrapper
+  _partial_: true
+  wrapper_name: CopresheafCCWrapper
+  out_channels: ${model.feature_encoder.out_channels}
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
+  residual_connections: false
+
+readout:
+  _target_: topobench.nn.readouts.${model.readout.readout_name}
+  readout_name: AllRankReadout
+  num_cell_dimensions: ${infer_topotune_num_cell_dimensions:${oc.select:model.backbone.neighborhoods}}
+  hidden_dim: ${model.feature_encoder.out_channels}
+  out_channels: ${dataset.parameters.num_classes}
+  task_level: ${define_task_level:${dataset.parameters.task_level},${dataset.split_params.learning_setting}}
+  pooling_type: sum
+  graph_dropout: ${model.backbone.dropout}
+
+compile: false

--- a/configs/transforms/liftings/graph2combinatorial/triangle_clique_cc.yaml
+++ b/configs/transforms/liftings/graph2combinatorial/triangle_clique_cc.yaml
@@ -1,0 +1,7 @@
+transform_type: "lifting"
+transform_name: "GraphTriangleCliqueCCLifting"
+
+complex_dim: 2
+preserve_edge_attr: false
+feature_lifting: ProjectionSum
+neighborhoods: ${oc.select:model.backbone.neighborhoods,${oc.select:model.preprocessing_params.neighborhoods,null}}

--- a/configs/transforms/model_defaults/copresheaf_cc_gated_dim2_gate2.yaml
+++ b/configs/transforms/model_defaults/copresheaf_cc_gated_dim2_gate2.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - /transforms/liftings/graph2combinatorial@graph2combinatorial_lifting: triangle_clique_cc

--- a/test/nn/backbones/combinatorial/test_copresheaf_cc.py
+++ b/test/nn/backbones/combinatorial/test_copresheaf_cc.py
@@ -1,0 +1,86 @@
+"""Tests for the combinatorial-complex copresheaf backbone."""
+
+import torch
+from torch_geometric.data import Data
+
+from topobench.nn.backbones.combinatorial.copresheaf_cc import CopresheafCC
+from topobench.nn.wrappers.combinatorial.copresheaf_cc_wrapper import (
+    CopresheafCCWrapper,
+)
+
+
+def _sparse(indices, size):
+    indices = torch.tensor(indices)
+    return torch.sparse_coo_tensor(
+        indices, torch.ones(indices.size(1)), size
+    ).coalesce()
+
+
+def _complex_data():
+    incidence = _sparse([[0, 1, 1, 2], [0, 0, 1, 1]], (3, 2))
+    fields = {
+        "x_0": torch.randn(3, 4),
+        "x_1": torch.randn(2, 4),
+        "batch_0": torch.zeros(3, dtype=torch.long),
+        "batch_1": torch.zeros(2, dtype=torch.long),
+        "up_incidence-0": incidence.t(),
+        "down_incidence-1": incidence,
+        "y": torch.tensor([1]),
+    }
+    return Data(**fields)
+
+
+def test_copresheaf_cc_updates_and_returns_every_rank():
+    """The higher-order backbone preserves cell counts at every rank."""
+    model = CopresheafCC(
+        in_channels=4,
+        hidden_channels=8,
+        out_channels=5,
+        neighborhoods=["up_incidence-0", "down_incidence-1"],
+        num_layers=2,
+        heads=2,
+        stalk_dimension=4,
+        map_type={
+            "up_incidence-0": "diagonal",
+            "down_incidence-1": "full",
+        },
+    )
+    batch = _complex_data()
+    output = model(
+        {0: batch.x_0, 1: batch.x_1},
+        {
+            "up_incidence-0": batch["up_incidence-0"],
+            "down_incidence-1": batch["down_incidence-1"],
+        },
+    )
+
+    assert output[0].shape == (3, 5)
+    assert output[1].shape == (2, 5)
+
+
+def test_copresheaf_cc_wrapper_follows_topobench_contract():
+    """The wrapper attaches labels and per-rank batch membership."""
+    model = CopresheafCC(
+        in_channels=4,
+        hidden_channels=4,
+        out_channels=4,
+        neighborhoods=["up_incidence-0", "down_incidence-1"],
+        num_layers=1,
+        heads=1,
+        map_type="identity",
+    )
+    wrapper = CopresheafCCWrapper(
+        model,
+        out_channels=4,
+        num_cell_dimensions=2,
+        residual_connections=False,
+    )
+    batch = _complex_data()
+
+    output = wrapper(batch)
+
+    assert output["x_0"].shape == batch.x_0.shape
+    assert output["x_1"].shape == batch.x_1.shape
+    assert torch.equal(output["labels"], batch.y)
+    assert torch.equal(output["batch_0"], batch.batch_0)
+    assert torch.equal(output["batch_1"], batch.batch_1)

--- a/test/nn/encoders/test_copresheaf_structure_encoder.py
+++ b/test/nn/encoders/test_copresheaf_structure_encoder.py
@@ -1,0 +1,46 @@
+"""Tests for the copresheaf structural feature encoder."""
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from topobench.nn.encoders.copresheaf_structure_encoder import (
+    CopresheafStructureFeatureEncoder,
+)
+
+
+def _data():
+    return Data(
+        x_0=torch.randn(3, 5),
+        x_1=torch.randn(2, 5),
+        structure_0=torch.randn(3, 4),
+        structure_1=torch.randn(2, 4),
+        batch_0=torch.zeros(3, dtype=torch.long),
+        batch_1=torch.zeros(2, dtype=torch.long),
+    )
+
+
+def test_structure_encoder_combines_signal_and_statistics():
+    """The encoder projects every rank without changing cell counts."""
+    encoder = CopresheafStructureFeatureEncoder(
+        in_channels=[5, 5],
+        out_channels=8,
+        selected_dimensions=[0, 1],
+    )
+
+    output = encoder(_data())
+
+    assert output.x_0.shape == (3, 8)
+    assert output.x_1.shape == (2, 8)
+
+
+def test_structure_encoder_requires_lifting_statistics():
+    """Missing structural inputs fail with the relevant rank name."""
+    data = _data()
+    del data.structure_1
+    encoder = CopresheafStructureFeatureEncoder(
+        in_channels=[5, 5], out_channels=8, selected_dimensions=[0, 1]
+    )
+
+    with pytest.raises(KeyError, match="structure_1"):
+        encoder(data)

--- a/test/nn/layers/__init__.py
+++ b/test/nn/layers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for reusable neural-network layers."""

--- a/test/nn/layers/test_copresheaf_maps.py
+++ b/test/nn/layers/test_copresheaf_maps.py
@@ -1,0 +1,65 @@
+"""Tests for learned copresheaf map families."""
+
+import pytest
+import torch
+
+from topobench.nn.layers.copresheaf import (
+    BaseCopresheafMap,
+    create_copresheaf_map,
+)
+
+
+@pytest.mark.parametrize(
+    "map_type",
+    ["identity", "diagonal", "full", "shared_local", "outer_product"],
+)
+def test_copresheaf_maps_have_expected_shape_and_finite_gradients(map_type):
+    """Every catalogue map is batched, multi-head, and differentiable."""
+    source = torch.randn(7, 8, requires_grad=True)
+    target = torch.randn(7, 8, requires_grad=True)
+    transport = create_copresheaf_map(
+        map_type, channels=8, heads=2, stalk_dimension=4
+    )
+
+    matrices = transport(source, target)
+
+    assert isinstance(transport, BaseCopresheafMap)
+    assert matrices.shape == (7, 2, 4, 4)
+    assert torch.isfinite(matrices).all()
+    if map_type == "identity":
+        assert not matrices.requires_grad
+    else:
+        matrices.sum().backward()
+        assert source.grad is not None
+
+
+def test_identity_map_returns_exact_identity():
+    """The identity ablation must not alter transported stalk values."""
+    transport = create_copresheaf_map(
+        "identity", channels=6, heads=3, stalk_dimension=2
+    )
+    matrices = transport(torch.randn(5, 6), torch.randn(5, 6))
+    expected = torch.eye(2).expand(5, 3, 2, 2)
+    torch.testing.assert_close(matrices, expected)
+
+
+def test_diagonal_map_has_no_off_diagonal_entries():
+    """The GCN/SAGE map family remains diagonal after learning."""
+    transport = create_copresheaf_map(
+        "diagonal", channels=4, heads=1, stalk_dimension=4
+    )
+    matrices = transport(torch.randn(3, 4), torch.randn(3, 4))
+    off_diagonal = matrices - torch.diag_embed(
+        matrices.diagonal(dim1=-2, dim2=-1)
+    )
+    torch.testing.assert_close(off_diagonal, torch.zeros_like(off_diagonal))
+
+
+def test_invalid_map_configuration_has_actionable_error():
+    """Invalid family names and incompatible stalk dimensions fail early."""
+    with pytest.raises(ValueError, match="unknown copresheaf map"):
+        create_copresheaf_map("mystery", channels=4)
+    with pytest.raises(ValueError, match=r"heads \* stalk_dimension"):
+        create_copresheaf_map(
+            "identity", channels=7, heads=2, stalk_dimension=4
+        )

--- a/test/nn/layers/test_copresheaf_message_passing.py
+++ b/test/nn/layers/test_copresheaf_message_passing.py
@@ -1,0 +1,183 @@
+"""Tests for generic copresheaf message passing."""
+
+import pytest
+import torch
+from torch import nn
+
+from topobench.nn.layers.copresheaf import (
+    CopresheafMessagePassing,
+    CopresheafRoute,
+    HigherOrderCopresheafLayer,
+)
+
+
+def _sparse(indices, values, size):
+    return torch.sparse_coo_tensor(
+        torch.tensor(indices), torch.tensor(values, dtype=torch.float), size
+    ).coalesce()
+
+
+def test_identity_transport_sum_matches_manual_aggregation():
+    """Identity rho reduces Definition 9 to ordinary sum aggregation."""
+    layer = CopresheafMessagePassing(
+        channels=2, map_type="identity", aggr="sum"
+    )
+    source = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    target = torch.zeros(2, 2)
+    edge_index = torch.tensor([[0, 1, 1], [0, 0, 1]])
+
+    output = layer(source, target, edge_index)
+
+    expected = torch.tensor([[4.0, 6.0], [3.0, 4.0]])
+    torch.testing.assert_close(output, expected)
+
+
+def test_message_aggregation_is_invariant_to_edge_order():
+    """Reordering a neighborhood edge list does not change the aggregate."""
+    torch.manual_seed(2)
+    layer = CopresheafMessagePassing(
+        channels=4, heads=2, map_type="full", aggr="mean"
+    )
+    x = torch.randn(4, 4)
+    edge_index = torch.tensor([[0, 1, 2, 3, 0], [1, 1, 1, 2, 2]])
+    permutation = torch.tensor([4, 2, 0, 3, 1])
+
+    first = layer(x, x, edge_index)
+    second = layer(x, x, edge_index[:, permutation])
+
+    torch.testing.assert_close(first, second)
+
+
+def test_structural_padding_outside_feature_range_is_ignored():
+    """Sparse padding for absent cell ranks cannot create phantom messages."""
+    layer = CopresheafMessagePassing(
+        channels=2, map_type="identity", aggr="sum"
+    )
+    features = torch.tensor([[1.0, 2.0]])
+    edge_index = torch.tensor([[0, 4], [0, 4]])
+
+    output = layer(features, features, edge_index)
+
+    torch.testing.assert_close(output, features)
+
+
+def test_route_parsing_and_connectivity_orientation():
+    """Selected TopoBench matrices are converted from target/source order."""
+    route = CopresheafRoute.from_neighborhood("up_incidence-0")
+    # Two rank-1 targets by three rank-0 sources.
+    connectivity = _sparse([[0, 0, 1], [0, 2, 1]], [1, 1, 1], (2, 3))
+
+    edge_index, weights = route.edge_index(connectivity)
+
+    assert (route.source_rank, route.target_rank) == (0, 1)
+    assert edge_index.tolist() == [[0, 2, 1], [0, 0, 1]]
+    assert weights.tolist() == [1.0, 1.0, 1.0]
+
+
+def test_higher_order_layer_supports_bidirectional_cross_rank_routes():
+    """Definition 10 updates both ranks through independent CIM routes."""
+    layer = HigherOrderCopresheafLayer(
+        channels=4,
+        neighborhoods=["up_incidence-0", "down_incidence-1"],
+        map_type="identity",
+        aggr="mean",
+    )
+    features = {0: torch.randn(3, 4), 1: torch.randn(2, 4)}
+    incidence = _sparse([[0, 0, 1, 1], [0, 1, 1, 2]], [1, 1, 1, 1], (2, 3))
+    connectivities = {
+        "up_incidence-0": incidence,
+        "down_incidence-1": incidence.t(),
+    }
+
+    output = layer(features, connectivities)
+
+    assert output[0].shape == features[0].shape
+    assert output[1].shape == features[1].shape
+    sum(value.square().sum() for value in output.values()).backward()
+    assert any(parameter.grad is not None for parameter in layer.parameters())
+
+
+def test_gated_route_aggregation_prefers_same_rank_at_initialization():
+    """Learned route mixing is normalized per target and starts conservatively."""
+    layer = HigherOrderCopresheafLayer(
+        channels=4,
+        neighborhoods=[
+            "up_adjacency-0",
+            "down_incidence-1",
+            "up_incidence-0",
+            "up_adjacency-1",
+        ],
+        map_type="identity",
+        neighborhood_aggr="gated",
+        route_self_bias=2.0,
+        message_gate_init=-3.0,
+    )
+
+    weights = layer.route_weights()
+
+    assert weights["up_adjacency-0"] > weights["down_incidence-1"]
+    assert weights["up_adjacency-1"] > weights["up_incidence-0"]
+    assert weights["up_adjacency-0"] + weights[
+        "down_incidence-1"
+    ] == pytest.approx(1.0)
+    assert float(torch.sigmoid(layer.updates["0"].message_gate)) < 0.05
+
+
+class _AddUpdate(nn.Module):
+    """Tiny deterministic update used to verify scheduled route order."""
+
+    def forward(self, features, message):
+        return features + message
+
+
+def test_scheduled_layer_applies_requested_up_down_route_order():
+    """A scheduled layer performs sequential, in-place rank updates."""
+    layer = HigherOrderCopresheafLayer(
+        channels=1,
+        neighborhoods=[
+            "up_incidence-0",
+            "up_incidence-1",
+            "down_incidence-2",
+            "down_incidence-1",
+        ],
+        map_type="identity",
+        aggr="sum",
+        message_schedule=[
+            "up_incidence-0",
+            "up_incidence-1",
+            "down_incidence-2",
+            "down_incidence-1",
+        ],
+    )
+    for rank in ("0", "1", "2"):
+        layer.updates[rank] = _AddUpdate()
+
+    features = {
+        0: torch.tensor([[1.0], [10.0]]),
+        1: torch.tensor([[100.0]]),
+        2: torch.tensor([[1000.0]]),
+    }
+    connectivities = {
+        "up_incidence-0": _sparse([[0, 0], [0, 1]], [1, 1], (1, 2)),
+        "up_incidence-1": _sparse([[0], [0]], [1], (1, 1)),
+        "down_incidence-2": _sparse([[0], [0]], [1], (1, 1)),
+        "down_incidence-1": _sparse([[0, 1], [0, 0]], [1, 1], (2, 1)),
+    }
+
+    output = layer(features, connectivities)
+
+    torch.testing.assert_close(output[0], torch.tensor([[1223.0], [1232.0]]))
+    torch.testing.assert_close(output[1], torch.tensor([[1222.0]]))
+    torch.testing.assert_close(output[2], torch.tensor([[1111.0]]))
+    assert layer.route_weights() == {}
+
+
+def test_scheduled_layer_rejects_unknown_neighborhood():
+    """A schedule typo should fail during construction, not mid-training."""
+    with pytest.raises(ValueError, match="unknown neighborhoods"):
+        HigherOrderCopresheafLayer(
+            channels=2,
+            neighborhoods=["up_incidence-0"],
+            map_type="identity",
+            message_schedule=["up_incidence-1"],
+        )

--- a/test/nn/readouts/test_all_rank.py
+++ b/test/nn/readouts/test_all_rank.py
@@ -1,0 +1,134 @@
+"""Tests for the all-rank copresheaf readout."""
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from topobench.nn.readouts.all_rank import AllRankReadout
+
+
+def _sparse_incidence(rows: int, cols: int) -> torch.Tensor:
+    indices = torch.stack([torch.arange(min(rows, cols))] * 2)
+    values = torch.ones(indices.shape[1])
+    return torch.sparse_coo_tensor(indices, values, (rows, cols)).coalesce()
+
+
+def test_all_rank_graph_readout_pools_every_rank():
+    """Graph tasks should predict from concatenated pooled rank features."""
+    readout = AllRankReadout(
+        hidden_dim=4,
+        out_channels=1,
+        task_level="graph",
+        pooling_type="sum",
+        num_cell_dimensions=3,
+        readout_name="AllRankReadout",
+    )
+    model_out = {
+        "x_0": torch.randn(5, 4),
+        "x_1": torch.randn(4, 4),
+        "x_2": torch.randn(2, 4),
+    }
+    batch = Data(
+        batch_0=torch.tensor([0, 0, 0, 1, 1]),
+        batch_1=torch.tensor([0, 0, 1, 1]),
+        batch_2=torch.tensor([0, 1]),
+        incidence_1=_sparse_incidence(5, 4),
+        incidence_2=_sparse_incidence(4, 2),
+    )
+
+    output = readout(model_out, batch)
+
+    assert output["graph_features"].shape == (2, 12)
+    assert output["logits"].shape == (2, 1)
+    assert set(output["readout_rank_pool_norms"]) == {"0", "1", "2"}
+
+
+def test_all_rank_graph_readout_handles_missing_high_rank_cells():
+    """Graphs with no high-rank cells should get zero pooled features."""
+    readout = AllRankReadout(
+        hidden_dim=4,
+        out_channels=1,
+        task_level="graph",
+        pooling_type="sum",
+        num_cell_dimensions=3,
+        readout_name="AllRankReadout",
+    )
+    model_out = {
+        "x_0": torch.randn(5, 4),
+        "x_1": torch.randn(4, 4),
+        "x_2": torch.randn(1, 4),
+    }
+    batch = Data(
+        batch_0=torch.tensor([0, 0, 0, 1, 1]),
+        batch_1=torch.tensor([0, 0, 1, 1]),
+        batch_2=torch.tensor([0]),
+        incidence_1=_sparse_incidence(5, 4),
+        incidence_2=_sparse_incidence(4, 1),
+    )
+
+    output = readout(model_out, batch)
+
+    assert output["graph_features"].shape == (2, 12)
+    assert output["logits"].shape == (2, 1)
+    torch.testing.assert_close(
+        output["graph_features"][1, 8:],
+        torch.zeros(4),
+    )
+
+
+def test_all_rank_graph_readout_raises_when_a_rank_has_no_batch_index():
+    """A rank with pooled features but no batch index fails loudly."""
+    readout = AllRankReadout(
+        hidden_dim=4,
+        out_channels=1,
+        task_level="graph",
+        pooling_type="sum",
+        num_cell_dimensions=3,
+        readout_name="AllRankReadout",
+    )
+    model_out = {
+        "x_0": torch.randn(5, 4),
+        "x_1": torch.randn(4, 4),
+        "x_2": torch.randn(2, 4),
+    }
+    batch = Data(
+        batch_0=torch.tensor([0, 0, 0, 1, 1]),
+        batch_1=torch.tensor([0, 0, 1, 1]),
+        incidence_1=_sparse_incidence(5, 4),
+        incidence_2=_sparse_incidence(4, 2),
+    )
+
+    with pytest.raises(ValueError, match="expected features and batch"):
+        readout(model_out, batch)
+
+
+def test_num_graphs_falls_back_when_rank_zero_batch_is_absent():
+    """_num_graphs falls back through num_graphs, then labels, then one."""
+    assert AllRankReadout._num_graphs(Data(num_graphs=3)) == 3
+    assert AllRankReadout._num_graphs(Data(y=torch.zeros(2))) == 2
+    assert AllRankReadout._num_graphs(Data()) == 1
+
+
+def test_all_rank_node_readout_uses_rank_zero_logits():
+    """Node tasks should retain the standard propagate-down behavior."""
+    readout = AllRankReadout(
+        hidden_dim=4,
+        out_channels=3,
+        task_level="node",
+        pooling_type="sum",
+        num_cell_dimensions=2,
+        readout_name="AllRankReadout",
+    )
+    model_out = {
+        "x_0": torch.randn(5, 4),
+        "x_1": torch.randn(4, 4),
+    }
+    batch = Data(
+        batch_0=torch.zeros(5, dtype=torch.long),
+        incidence_1=_sparse_incidence(5, 4),
+    )
+
+    output = readout(model_out, batch)
+
+    assert output["logits"].shape == (5, 3)
+    assert "graph_features" not in output

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -1,13 +1,16 @@
 """Test pipeline for a particular dataset and model."""
 
 import hydra
-import pytest
 
 from test._utils.simplified_pipeline import run
 
-
 DATASET = "graph/MUTAG"  # ADD YOUR DATASET HERE
-MODELS = ["graph/gcn", "cell/topotune", "simplicial/topotune"]  # ADD ONE OR SEVERAL MODELS
+MODELS = [
+    "graph/gcn",
+    "cell/topotune",
+    "simplicial/topotune",
+    "combinatorial/copresheaf_cc_gated_dim2_gate2",
+]  # ADD ONE OR SEVERAL MODELS
 
 
 class TestPipeline:
@@ -34,6 +37,6 @@ class TestPipeline:
                         "paths=test",
                         "callbacks=model_checkpoint",
                     ],
-                    return_hydra_config=True
+                    return_hydra_config=True,
                 )
                 run(cfg)

--- a/test/transforms/liftings/graph2combinatorial/test_triangle_clique_cc.py
+++ b/test/transforms/liftings/graph2combinatorial/test_triangle_clique_cc.py
@@ -1,0 +1,70 @@
+"""Tests for explicit triangle-clique combinatorial lifting."""
+
+import torch
+from torch_geometric.data import Data
+
+from topobench.transforms.liftings.graph2combinatorial.triangle_clique_cc import (
+    GraphTriangleCliqueCCLifting,
+)
+
+
+def _undirected_edge_index(edges):
+    directed = []
+    for source, target in edges:
+        directed.append((source, target))
+        directed.append((target, source))
+    return torch.tensor(directed, dtype=torch.long).t().contiguous()
+
+
+def test_triangle_clique_lifting_adds_one_rank2_cell_per_graph_triangle():
+    """Every graph triangle becomes an explicit rank-2 cell."""
+    data = Data(
+        x=torch.eye(4),
+        edge_index=_undirected_edge_index([(0, 1), (1, 2), (0, 2), (2, 3)]),
+    )
+    lifting = GraphTriangleCliqueCCLifting(
+        complex_dim=2,
+        neighborhoods=[
+            "up_incidence-0",
+            "up_incidence-1",
+            "down_incidence-2",
+            "up_adjacency-2",
+        ],
+    )
+
+    lifted = lifting(data)
+
+    assert lifted.x_0.shape == (4, 4)
+    assert lifted.x_1.shape == (4, 4)
+    assert lifted.x_2.shape == (1, 4)
+    assert lifted.incidence_2.shape == (4, 1)
+    assert lifted.incidence_2.coalesce().values().abs().sum() == 3
+    assert lifted["up_incidence-0"].shape == (4, 4)
+    assert lifted["up_incidence-1"].shape == (1, 4)
+    assert lifted["down_incidence-2"].shape == (4, 1)
+    assert lifted["up_adjacency-2"].shape == (1, 1)
+    assert lifted.structure_0.shape == (4, 4)
+    assert lifted.structure_1.shape == (4, 4)
+    assert lifted.structure_2.shape == (1, 4)
+    torch.testing.assert_close(
+        lifted.structure_2[:, 0],
+        torch.log1p(torch.tensor([3.0])),
+    )
+
+
+def test_triangle_clique_lifting_handles_graphs_without_triangles():
+    """Triangle-free graphs keep an empty but valid rank-2 representation."""
+    data = Data(
+        x=torch.ones(3, 2),
+        edge_index=_undirected_edge_index([(0, 1), (1, 2)]),
+    )
+    lifting = GraphTriangleCliqueCCLifting(
+        complex_dim=2,
+        neighborhoods=["up_incidence-1", "down_incidence-2"],
+    )
+
+    lifted = lifting(data)
+
+    assert lifted.x_2.shape == (0, 2)
+    assert lifted.incidence_2.shape == (2, 0)
+    assert lifted.structure_2.shape == (0, 4)

--- a/topobench/nn/backbones/combinatorial/copresheaf_cc.py
+++ b/topobench/nn/backbones/combinatorial/copresheaf_cc.py
@@ -1,0 +1,214 @@
+"""Higher-order copresheaf message passing on combinatorial complexes.
+
+Implements Copresheaf Topological Neural Networks (CTNNs) [1].
+
+[1] Hajij et al. "Copresheaf Topological Neural Networks: A Generalized
+Deep Learning Framework." Advances in Neural Information Processing
+Systems (NeurIPS), 2025.
+https://proceedings.neurips.cc/paper_files/paper/2025/file/dc62cd4ec77f3bbec8e6245d0bd91d08-Paper-Conference.pdf
+"""
+
+from collections.abc import Mapping, Sequence
+
+import torch
+from torch import nn
+
+from topobench.nn.layers.copresheaf import (
+    CopresheafRoute,
+    HigherOrderCopresheafLayer,
+)
+
+
+class CopresheafCC(nn.Module):
+    r"""A rank-aware Copresheaf Topological Neural Network.
+
+    The configured TopoBench neighborhoods induce directed graphs on cells.
+    Every route gets its own learned maps :math:`\rho_{y\to x}` and message
+    function, while messages arriving at the same rank are combined before a
+    rank-specific update. This realizes the message-passing form in
+    Definitions 9--10 of Copresheaf Topological Neural Networks [1]
+    (NeurIPS 2025).
+
+    Parameters
+    ----------
+    in_channels : int
+        Feature dimension shared by all input ranks.
+    hidden_channels : int
+        Hidden stalk feature dimension.
+    out_channels : int
+        Output feature dimension for every represented rank.
+    neighborhoods : sequence of str
+        TopoBench neighborhood names, for example ``up_incidence-0``.
+    num_layers : int, optional
+        Number of stacked ``HigherOrderCopresheafLayer`` blocks. Must be
+        at least one (default: 3).
+    heads : int, optional
+        Number of independent stalk bundles per route. Mutually
+        exclusive with ``num_heads``; leave at the default when passing
+        ``num_heads`` instead (default: 1).
+    stalk_dimension : int, optional
+        Dimension of one per-head stalk. By default,
+        ``hidden_channels // heads``.
+    map_type : str or mapping
+        One map family for all routes or a neighborhood-to-family mapping.
+    aggr : str, optional
+        Per-edge normalization used by every route's transport:
+        ``"sum"``, ``"mean"``, or ``"symmetric"`` (default: "mean").
+    neighborhood_aggr : str, optional
+        How messages from multiple routes landing on the same rank are
+        combined: ``"sum"``, ``"mean"``, or ``"gated"`` for a learned
+        softmax over routes (default: "sum").
+    message_type : str, optional
+        Message function applied per route: ``"identity"`` or ``"mlp"``
+        over the concatenated target and transported features
+        (default: "identity").
+    update_type : str, optional
+        Per-rank update function: ``"residual"`` for a gated residual
+        update, or ``"mlp"`` over the concatenated feature and message
+        (default: "residual").
+    dropout : float, optional
+        Dropout applied inside the transport maps, message functions,
+        and update functions (default: 0.0).
+    map_kwargs : mapping, optional
+        Extra constructor arguments forwarded to each route's transport
+        map (default: None).
+    num_heads : int, optional
+        Alternative spelling of ``heads``. Passing both ``num_heads``
+        and a non-default ``heads`` raises ``ValueError``
+        (default: None).
+    message_gate_init : float, optional
+        Initial value for a learned scalar gate applied to each
+        update's message term, passed through ``sigmoid``. By default,
+        no gate is used and the message term has weight 1.
+    route_self_bias : float, optional
+        Initial ``neighborhood_aggr="gated"`` logit bias favoring
+        routes whose source and target ranks match (default: 1.0).
+    message_schedule : sequence of str, optional
+        If provided, apply neighborhood updates sequentially in this order
+        inside each layer instead of aggregating all incoming routes
+        simultaneously.
+    **kwargs : dict, optional
+        Additional keyword arguments.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        neighborhoods: Sequence[str],
+        num_layers: int = 3,
+        heads: int = 1,
+        stalk_dimension: int | None = None,
+        map_type: str | Mapping[str, str] = "shared_local",
+        aggr: str = "mean",
+        neighborhood_aggr: str = "sum",
+        message_type: str = "identity",
+        update_type: str = "residual",
+        dropout: float = 0.0,
+        map_kwargs: Mapping | None = None,
+        num_heads: int | None = None,
+        message_gate_init: float | None = None,
+        route_self_bias: float = 1.0,
+        message_schedule: Sequence[str] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError("num_layers must be at least one")
+        if num_heads is not None:
+            if heads != 1:
+                raise ValueError("pass heads or num_heads, not both")
+            heads = num_heads
+
+        self.neighborhoods = list(neighborhoods)
+        self.message_schedule = (
+            tuple(message_schedule) if message_schedule is not None else None
+        )
+        self.routes = [
+            CopresheafRoute.from_neighborhood(name)
+            for name in self.neighborhoods
+        ]
+        self.ranks = sorted(
+            {route.source_rank for route in self.routes}
+            | {route.target_rank for route in self.routes}
+        )
+        self.input_projections = nn.ModuleDict(
+            {
+                str(rank): nn.Linear(in_channels, hidden_channels)
+                for rank in self.ranks
+            }
+        )
+        self.layers = nn.ModuleList(
+            [
+                HigherOrderCopresheafLayer(
+                    channels=hidden_channels,
+                    neighborhoods=self.neighborhoods,
+                    heads=heads,
+                    stalk_dimension=stalk_dimension,
+                    map_type=map_type,
+                    aggr=aggr,
+                    neighborhood_aggr=neighborhood_aggr,
+                    message_type=message_type,
+                    update_type=update_type,
+                    dropout=dropout,
+                    map_kwargs=map_kwargs,
+                    message_gate_init=message_gate_init,
+                    route_self_bias=route_self_bias,
+                    message_schedule=message_schedule,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.output_projections = nn.ModuleDict(
+            {
+                str(rank): nn.Linear(hidden_channels, out_channels)
+                for rank in self.ranks
+            }
+        )
+        self.activation = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        features: Mapping[int, torch.Tensor],
+        connectivities: Mapping[str, torch.Tensor],
+    ) -> dict[int, torch.Tensor]:
+        """Encode features on all configured cell ranks.
+
+        Parameters
+        ----------
+        features : mapping of int to torch.Tensor
+            Input features keyed by cell rank.
+        connectivities : mapping of str to torch.Tensor
+            Batched connectivity tensors keyed by neighborhood name.
+
+        Returns
+        -------
+        dict of int to torch.Tensor
+            Output features keyed by cell rank.
+        """
+        missing_ranks = set(self.ranks) - set(features)
+        if missing_ranks:
+            raise KeyError(
+                f"missing features for ranks {sorted(missing_ranks)}"
+            )
+
+        hidden = {
+            rank: self.dropout(
+                self.activation(
+                    self.input_projections[str(rank)](features[rank])
+                )
+            )
+            for rank in self.ranks
+        }
+        for layer in self.layers:
+            hidden = layer(hidden, connectivities)
+            hidden = {
+                rank: self.dropout(self.activation(value))
+                for rank, value in hidden.items()
+            }
+        return {
+            rank: self.output_projections[str(rank)](value)
+            for rank, value in hidden.items()
+        }

--- a/topobench/nn/encoders/copresheaf_structure_encoder.py
+++ b/topobench/nn/encoders/copresheaf_structure_encoder.py
@@ -1,0 +1,115 @@
+"""Feature encoder for copresheaf combinatorial-complex inputs."""
+
+import torch
+import torch_geometric
+
+from topobench.nn.encoders.all_cell_encoder import BaseEncoder
+from topobench.nn.encoders.base import AbstractFeatureEncoder
+
+
+class CopresheafStructureFeatureEncoder(AbstractFeatureEncoder):
+    """Encode cell signals together with scale-stable structural statistics.
+
+    The submitted graph-to-combinatorial lifting stores four log-scaled
+    statistics in
+    ``structure_{rank}``: cell size, lower incidence degree, same-rank degree,
+    and upper incidence degree. Keeping these separate from ``x_{rank}``
+    preserves TopoBench's input-channel inference while allowing the model to
+    retain multiplicity information lost by mean feature projection.
+
+    Parameters
+    ----------
+    in_channels : list[int]
+        Input feature dimension for each cell rank, before any
+        structural channels are appended.
+    out_channels : int
+        Output feature dimension shared by every encoded rank.
+    structure_channels : int, optional
+        Number of columns in each ``structure_{rank}`` tensor
+        (default: 4).
+    proj_dropout : float, optional
+        Dropout used inside each per-rank ``BaseEncoder`` (default: 0.0).
+    selected_dimensions : list[int], optional
+        Cell ranks to encode (default: all ranks in ``in_channels``).
+    use_structure : bool, optional
+        If ``True``, concatenate the structural statistics to the raw
+        features before projecting (default: True).
+    **kwargs : dict, optional
+        Additional keyword arguments.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels: int,
+        structure_channels: int = 4,
+        proj_dropout: float = 0.0,
+        selected_dimensions=None,
+        use_structure: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.structure_channels = structure_channels
+        self.use_structure = use_structure
+        self.dimensions = (
+            selected_dimensions
+            if selected_dimensions is not None
+            else range(len(in_channels))
+        )
+        extra_channels = structure_channels if use_structure else 0
+        for rank in self.dimensions:
+            setattr(
+                self,
+                f"encoder_{rank}",
+                BaseEncoder(
+                    in_channels[rank] + extra_channels,
+                    out_channels,
+                    dropout=proj_dropout,
+                ),
+            )
+
+    def forward(
+        self, data: torch_geometric.data.Data
+    ) -> torch_geometric.data.Data:
+        """Encode every selected cell rank in place.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            Input data object which should contain ``x_{rank}`` and,
+            when ``use_structure`` is set, ``structure_{rank}``
+            features for each selected rank.
+
+        Returns
+        -------
+        torch_geometric.data.Data
+            Data object with updated ``x_{rank}`` features.
+        """
+        if not hasattr(data, "x_0"):
+            data.x_0 = data.x
+        for rank in self.dimensions:
+            feature_key = f"x_{rank}"
+            if feature_key not in data:
+                continue
+            features = data[feature_key]
+            if self.use_structure:
+                structure_key = f"structure_{rank}"
+                if structure_key not in data:
+                    raise KeyError(
+                        f"missing structural features {structure_key!r}"
+                    )
+                structure = data[structure_key].to(
+                    device=features.device, dtype=features.dtype
+                )
+                if structure.size(1) != self.structure_channels:
+                    raise ValueError(
+                        f"expected {self.structure_channels} structural "
+                        f"channels at rank {rank}, got {structure.size(1)}"
+                    )
+                features = torch.cat((features, structure), dim=-1)
+            data[feature_key] = getattr(self, f"encoder_{rank}")(
+                features, data[f"batch_{rank}"]
+            )
+        return data

--- a/topobench/nn/layers/__init__.py
+++ b/topobench/nn/layers/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable neural-network layers."""

--- a/topobench/nn/layers/copresheaf/__init__.py
+++ b/topobench/nn/layers/copresheaf/__init__.py
@@ -1,0 +1,31 @@
+"""Copresheaf transport and message-passing layers."""
+
+from .maps import (
+    BaseCopresheafMap,
+    DiagonalCopresheafMap,
+    FullCopresheafMap,
+    IdentityCopresheafMap,
+    OuterProductCopresheafMap,
+    SharedLocalCopresheafMap,
+    create_copresheaf_map,
+)
+from .message_passing import (
+    CopresheafMessagePassing,
+    CopresheafUpdate,
+    HigherOrderCopresheafLayer,
+)
+from .routes import CopresheafRoute
+
+__all__ = [
+    "BaseCopresheafMap",
+    "CopresheafMessagePassing",
+    "CopresheafRoute",
+    "CopresheafUpdate",
+    "DiagonalCopresheafMap",
+    "FullCopresheafMap",
+    "HigherOrderCopresheafLayer",
+    "IdentityCopresheafMap",
+    "OuterProductCopresheafMap",
+    "SharedLocalCopresheafMap",
+    "create_copresheaf_map",
+]

--- a/topobench/nn/layers/copresheaf/maps.py
+++ b/topobench/nn/layers/copresheaf/maps.py
@@ -1,0 +1,431 @@
+"""Learnable directional maps for copresheaf message passing."""
+
+from abc import ABC, abstractmethod
+
+import torch
+from torch import nn
+
+
+class BaseCopresheafMap(nn.Module, ABC):
+    r"""Base class for maps :math:`\rho_{y\to x}:F(y)\to F(x)`.
+
+    A map is evaluated independently for every directed neighborhood edge and
+    every head. Subclasses return tensors of shape
+    ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+
+    Parameters
+    ----------
+    channels : int
+        Dimension of the cell features used to condition the map.
+    heads : int
+        Number of independent stalk bundles.
+    stalk_dimension : int, optional
+        Dimension of one stalk. By default, ``channels // heads``.
+    dropout : float
+        Dropout applied to learned map perturbations.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        heads: int = 1,
+        stalk_dimension: int | None = None,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        if channels <= 0:
+            raise ValueError("channels must be positive")
+        if heads <= 0:
+            raise ValueError("heads must be positive")
+
+        stalk_dimension = stalk_dimension or channels // heads
+        if heads * stalk_dimension != channels:
+            raise ValueError(
+                "channels must equal heads * stalk_dimension; got "
+                f"{channels}, {heads}, and {stalk_dimension}"
+            )
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError("dropout must be in [0, 1)")
+
+        self.channels = channels
+        self.heads = heads
+        self.stalk_dimension = stalk_dimension
+        self.dropout = nn.Dropout(dropout)
+        self.register_buffer(
+            "identity",
+            torch.eye(stalk_dimension).view(
+                1, 1, stalk_dimension, stalk_dimension
+            ),
+            persistent=False,
+        )
+
+    def _validate(self, source: torch.Tensor, target: torch.Tensor) -> None:
+        """Validate that edge features have a compatible shape.
+
+        Parameters
+        ----------
+        source : torch.Tensor
+            Source-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        target : torch.Tensor
+            Target-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        """
+        if source.ndim != 2 or target.ndim != 2:
+            raise ValueError(
+                "source and target features must be rank-2 tensors"
+            )
+        if source.shape != target.shape:
+            raise ValueError(
+                "source and target edge features must have the same shape"
+            )
+        if source.size(-1) != self.channels:
+            raise ValueError(
+                f"expected {self.channels} features, got {source.size(-1)}"
+            )
+
+    def _eye(self, num_edges: int) -> torch.Tensor:
+        """Broadcast the stored identity to a batch of edges.
+
+        Parameters
+        ----------
+        num_edges : int
+            Number of directed edges to broadcast the identity over.
+
+        Returns
+        -------
+        torch.Tensor
+            Identity transport of shape
+            ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+        """
+        return self.identity.expand(
+            num_edges,
+            self.heads,
+            self.stalk_dimension,
+            self.stalk_dimension,
+        )
+
+    @abstractmethod
+    def forward(
+        self, source: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        """Construct a transport matrix for each directed edge.
+
+        Parameters
+        ----------
+        source : torch.Tensor
+            Source-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        target : torch.Tensor
+            Target-cell features for each edge, shape
+            ``[num_edges, channels]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport tensor of shape
+            ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+        """
+
+
+class IdentityCopresheafMap(BaseCopresheafMap):
+    """Return identity transport on every edge.
+
+    This recovers ordinary message passing and is useful as a controlled
+    ablation of the learned copresheaf maps.
+    """
+
+    def forward(
+        self, source: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        """Return the identity transport for each edge.
+
+        Parameters
+        ----------
+        source : torch.Tensor
+            Source-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        target : torch.Tensor
+            Target-cell features for each edge, shape
+            ``[num_edges, channels]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Identity transport of shape
+            ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+        """
+        self._validate(source, target)
+        return self._eye(source.size(0))
+
+
+class DiagonalCopresheafMap(BaseCopresheafMap):
+    r"""Learn :math:`\rho=I+\operatorname{diag}(\tanh(W[h_x;h_y]))`.
+
+    This is the map used by the CopresheafGCN and CopresheafSAGE
+    experiments in Section 6.2 of the CTNN paper.
+
+    Parameters
+    ----------
+    *args : tuple
+        Positional arguments forwarded to
+        :class:`BaseCopresheafMap`.
+    init_std : float, optional
+        Standard deviation used to initialize the linear layer's
+        weights. By default, ``0.01``.
+    **kwargs : dict
+        Keyword arguments forwarded to :class:`BaseCopresheafMap`.
+    """
+
+    def __init__(self, *args, init_std: float = 0.01, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.linear = nn.Linear(2 * self.channels, self.channels)
+        nn.init.normal_(self.linear.weight, std=init_std)
+        nn.init.zeros_(self.linear.bias)
+
+    def forward(
+        self, source: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        """Construct a diagonal identity-plus-perturbation transport.
+
+        Parameters
+        ----------
+        source : torch.Tensor
+            Source-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        target : torch.Tensor
+            Target-cell features for each edge, shape
+            ``[num_edges, channels]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport tensor of shape
+            ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+        """
+        self._validate(source, target)
+        pair = torch.cat((target, source), dim=-1)
+        diagonal = torch.tanh(self.linear(pair)).view(
+            -1, self.heads, self.stalk_dimension
+        )
+        delta = torch.diag_embed(self.dropout(diagonal))
+        return self._eye(source.size(0)) + delta
+
+
+class FullCopresheafMap(BaseCopresheafMap):
+    r"""Learn a full SheafFC map :math:`\rho=I+\tanh(W[h_x;h_y])`.
+
+    The zero initialization makes every map initially equal to the identity,
+    as prescribed for the SheafFC family in the paper's map catalogue.
+
+    Parameters
+    ----------
+    *args : tuple
+        Positional arguments forwarded to
+        :class:`BaseCopresheafMap`.
+    zero_init : bool, optional
+        Whether to zero-initialize the linear layer so every map
+        starts as the identity. By default, ``True``.
+    **kwargs : dict
+        Keyword arguments forwarded to :class:`BaseCopresheafMap`.
+    """
+
+    def __init__(self, *args, zero_init: bool = True, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        output_size = self.heads * self.stalk_dimension * self.stalk_dimension
+        self.linear = nn.Linear(2 * self.channels, output_size)
+        if zero_init:
+            nn.init.zeros_(self.linear.weight)
+            nn.init.zeros_(self.linear.bias)
+
+    def forward(
+        self, source: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        """Construct a full identity-plus-perturbation transport.
+
+        Parameters
+        ----------
+        source : torch.Tensor
+            Source-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        target : torch.Tensor
+            Target-cell features for each edge, shape
+            ``[num_edges, channels]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport tensor of shape
+            ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+        """
+        self._validate(source, target)
+        pair = torch.cat((target, source), dim=-1)
+        delta = torch.tanh(self.linear(pair)).view(
+            -1,
+            self.heads,
+            self.stalk_dimension,
+            self.stalk_dimension,
+        )
+        return self._eye(source.size(0)) + self.dropout(delta)
+
+
+class SharedLocalCopresheafMap(BaseCopresheafMap):
+    r"""Modulate a full transport with a local edge gate.
+
+    This implements the CT-SharedLoc option from Section 6.3:
+    :math:`\rho=I+\sigma(g(h_x,h_y))\Delta(h_x,h_y)`.
+
+    Parameters
+    ----------
+    *args : tuple
+        Positional arguments forwarded to
+        :class:`BaseCopresheafMap`.
+    hidden_channels : int, optional
+        Width of the hidden layer in the map and gate MLPs. By
+        default, ``channels``.
+    **kwargs : dict
+        Keyword arguments forwarded to :class:`BaseCopresheafMap`.
+    """
+
+    def __init__(self, *args, hidden_channels: int | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        hidden_channels = hidden_channels or self.channels
+        pair_channels = 2 * self.channels
+        map_channels = self.heads * self.stalk_dimension * self.stalk_dimension
+        self.map_mlp = nn.Sequential(
+            nn.Linear(pair_channels, hidden_channels),
+            nn.ReLU(),
+            nn.Linear(hidden_channels, map_channels),
+        )
+        self.gate_mlp = nn.Sequential(
+            nn.Linear(pair_channels, hidden_channels),
+            nn.ReLU(),
+            nn.Linear(hidden_channels, self.heads),
+        )
+        nn.init.normal_(self.map_mlp[-1].weight, std=0.01)
+        nn.init.zeros_(self.map_mlp[-1].bias)
+
+    def forward(
+        self, source: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        """Construct a gated identity-plus-perturbation transport.
+
+        Parameters
+        ----------
+        source : torch.Tensor
+            Source-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        target : torch.Tensor
+            Target-cell features for each edge, shape
+            ``[num_edges, channels]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport tensor of shape
+            ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+        """
+        self._validate(source, target)
+        pair = torch.cat((target, source), dim=-1)
+        delta = torch.tanh(self.map_mlp(pair)).view(
+            -1,
+            self.heads,
+            self.stalk_dimension,
+            self.stalk_dimension,
+        )
+        gate = torch.sigmoid(self.gate_mlp(pair)).view(-1, self.heads, 1, 1)
+        return self._eye(source.size(0)) + self.dropout(gate * delta)
+
+
+class OuterProductCopresheafMap(BaseCopresheafMap):
+    r"""Learn an outer-product transport map.
+
+    Per head, :math:`\rho=I+\tanh((W_qh_x)(W_kh_y)^\top)`. The map is a
+    residualized version of the outer-product family used in the paper's
+    physics experiments, which keeps deep stacks stable at initialization.
+
+    Parameters
+    ----------
+    *args : tuple
+        Positional arguments forwarded to
+        :class:`BaseCopresheafMap`.
+    residual : bool, optional
+        Whether to add the identity to the outer-product term. By
+        default, ``True``.
+    **kwargs : dict
+        Keyword arguments forwarded to :class:`BaseCopresheafMap`.
+    """
+
+    def __init__(self, *args, residual: bool = True, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.residual = residual
+        self.query = nn.Linear(self.channels, self.channels, bias=False)
+        self.key = nn.Linear(self.channels, self.channels, bias=False)
+
+    def forward(
+        self, source: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        """Construct an outer-product transport for each edge.
+
+        Adds the identity to the outer-product term when
+        ``self.residual`` is ``True``; otherwise returns the
+        outer-product term unmodified.
+
+        Parameters
+        ----------
+        source : torch.Tensor
+            Source-cell features for each edge, shape
+            ``[num_edges, channels]``.
+        target : torch.Tensor
+            Target-cell features for each edge, shape
+            ``[num_edges, channels]``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transport tensor of shape
+            ``[num_edges, heads, stalk_dimension, stalk_dimension]``.
+        """
+        self._validate(source, target)
+        query = self.query(target).view(-1, self.heads, self.stalk_dimension)
+        key = self.key(source).view(-1, self.heads, self.stalk_dimension)
+        transport = torch.tanh(torch.einsum("ehd,ehk->ehdk", query, key))
+        transport = self.dropout(transport)
+        if self.residual:
+            transport = self._eye(source.size(0)) + transport
+        return transport
+
+
+COPRESHEAF_MAPS = {
+    "identity": IdentityCopresheafMap,
+    "diagonal": DiagonalCopresheafMap,
+    "full": FullCopresheafMap,
+    "outer_product": OuterProductCopresheafMap,
+    "shared_local": SharedLocalCopresheafMap,
+}
+
+
+def create_copresheaf_map(map_type: str, **kwargs) -> BaseCopresheafMap:
+    """Create a copresheaf map from its configuration name.
+
+    Parameters
+    ----------
+    map_type : str
+        One of ``COPRESHEAF_MAPS``, for example ``"diagonal"`` or ``"full"``.
+    **kwargs : dict
+        Constructor arguments forwarded to the selected map class, for
+        example ``channels``, ``heads``, and ``stalk_dimension``.
+
+    Returns
+    -------
+    BaseCopresheafMap
+        The instantiated map module.
+    """
+    try:
+        map_class = COPRESHEAF_MAPS[map_type.lower()]
+    except KeyError as error:
+        choices = ", ".join(sorted(COPRESHEAF_MAPS))
+        raise ValueError(
+            f"unknown copresheaf map {map_type!r}; choose from {choices}"
+        ) from error
+    return map_class(**kwargs)

--- a/topobench/nn/layers/copresheaf/message_passing.py
+++ b/topobench/nn/layers/copresheaf/message_passing.py
@@ -1,0 +1,597 @@
+"""Message passing with learned copresheaf transport maps."""
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+
+import torch
+from torch import nn
+
+from .maps import create_copresheaf_map
+from .routes import CopresheafRoute
+
+
+class CopresheafMessagePassing(nn.Module):
+    r"""Transport and aggregate messages along one directed neighborhood.
+
+    This layer implements the inner aggregation in Definition 9 of the CTNN
+    paper. The learned map :math:`\rho_{y\to x}` transports a source feature
+    into the target stalk before the optional message function ``alpha`` and
+    a permutation-invariant aggregation are applied.
+
+    Parameters
+    ----------
+    channels : int
+        Dimension of the source and target cell features.
+    heads : int
+        Number of independent stalk bundles.
+    stalk_dimension : int, optional
+        Dimension of one stalk. By default, ``channels // heads``.
+    map_type : str
+        Name of the transport map passed to ``create_copresheaf_map``.
+    aggr : str
+        Per-edge normalization: ``"sum"``, ``"mean"``, or ``"symmetric"``.
+    message_type : str
+        Message function: ``"identity"`` or an ``"mlp"`` over the
+        concatenated target and transported features.
+    dropout : float
+        Dropout applied inside the transport map and the ``mlp``
+        message function.
+    map_kwargs : Mapping, optional
+        Extra constructor arguments forwarded to the transport map.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        heads: int = 1,
+        stalk_dimension: int | None = None,
+        map_type: str = "diagonal",
+        aggr: str = "sum",
+        message_type: str = "identity",
+        dropout: float = 0.0,
+        map_kwargs: Mapping | None = None,
+    ) -> None:
+        super().__init__()
+        if aggr not in {"sum", "mean", "symmetric"}:
+            raise ValueError("aggr must be one of: sum, mean, symmetric")
+        if message_type not in {"identity", "mlp"}:
+            raise ValueError("message_type must be 'identity' or 'mlp'")
+
+        self.channels = channels
+        self.heads = heads
+        self.stalk_dimension = stalk_dimension or channels // heads
+        self.aggr = aggr
+        self.transport = create_copresheaf_map(
+            map_type,
+            channels=channels,
+            heads=heads,
+            stalk_dimension=self.stalk_dimension,
+            dropout=dropout,
+            **dict(map_kwargs or {}),
+        )
+        self.alpha = (
+            nn.Identity()
+            if message_type == "identity"
+            else nn.Sequential(
+                nn.Linear(2 * channels, channels),
+                nn.ReLU(),
+                nn.Dropout(dropout),
+                nn.Linear(channels, channels),
+            )
+        )
+
+    def _normalization(
+        self,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor,
+        num_source: int,
+        num_target: int,
+    ) -> torch.Tensor:
+        """Rescale edge weights according to ``self.aggr``.
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            ``[2, num_edges]`` ``(source, target)`` edge index.
+        edge_weight : torch.Tensor
+            One weight per edge, before normalization.
+        num_source : int
+            Number of source cells, used to size the degree buffer.
+        num_target : int
+            Number of target cells, used to size the degree buffer.
+
+        Returns
+        -------
+        torch.Tensor
+            One normalized weight per edge.
+        """
+        source, target = edge_index
+        if self.aggr == "sum":
+            return edge_weight
+
+        target_degree = edge_weight.new_zeros(num_target)
+        target_degree.index_add_(0, target, edge_weight)
+        if self.aggr == "mean":
+            return edge_weight / target_degree[target].clamp_min(1.0)
+
+        source_degree = edge_weight.new_zeros(num_source)
+        source_degree.index_add_(0, source, edge_weight)
+        denominator = (source_degree[source] * target_degree[target]).sqrt()
+        return edge_weight / denominator.clamp_min(1.0)
+
+    def forward(
+        self,
+        source_features: torch.Tensor,
+        target_features: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return one aggregated message for every target cell.
+
+        Parameters
+        ----------
+        source_features : torch.Tensor
+            ``[num_source, channels]`` features of the source cells.
+        target_features : torch.Tensor
+            ``[num_target, channels]`` features of the target cells.
+        edge_index : torch.Tensor
+            ``[2, num_edges]`` ``(source, target)`` edge index.
+        edge_weight : torch.Tensor, optional
+            One weight per edge. By default, every edge has weight 1.
+
+        Returns
+        -------
+        torch.Tensor
+            ``[num_target, channels]`` aggregated message per target
+            cell.
+        """
+        if edge_index.ndim != 2 or edge_index.size(0) != 2:
+            raise ValueError("edge_index must have shape [2, num_edges]")
+        if source_features.size(-1) != self.channels:
+            raise ValueError("source feature width does not match channels")
+        if target_features.size(-1) != self.channels:
+            raise ValueError("target feature width does not match channels")
+
+        edge_index = edge_index.to(source_features.device).long()
+        source, target = edge_index
+        if edge_weight is None:
+            edge_weight = source_features.new_ones(source.numel())
+        else:
+            edge_weight = edge_weight.to(
+                device=source_features.device, dtype=source_features.dtype
+            ).reshape(-1)
+        if edge_weight.numel() != source.numel():
+            raise ValueError("edge_weight must contain one value per edge")
+
+        # Some higher-order batches contain padded sparse connectivity blocks
+        # for ranks that are absent in one or more examples. Such structural
+        # padding is not a cell and must not generate a message.
+        valid = (
+            (source >= 0)
+            & (source < source_features.size(0))
+            & (target >= 0)
+            & (target < target_features.size(0))
+        )
+        source, target = source[valid], target[valid]
+        edge_weight = edge_weight[valid]
+        edge_index = torch.stack((source, target), dim=0)
+
+        source_on_edges = source_features[source]
+        target_on_edges = target_features[target]
+        transport = self.transport(source_on_edges, target_on_edges)
+        values = source_on_edges.view(-1, self.heads, self.stalk_dimension)
+        messages = torch.matmul(transport, values.unsqueeze(-1)).squeeze(-1)
+        messages = messages.reshape(-1, self.channels)
+        if not isinstance(self.alpha, nn.Identity):
+            messages = self.alpha(torch.cat((target_on_edges, messages), -1))
+
+        weights = self._normalization(
+            edge_index,
+            edge_weight,
+            source_features.size(0),
+            target_features.size(0),
+        )
+        messages = messages * weights.unsqueeze(-1)
+        output = target_features.new_zeros(
+            target_features.size(0), self.channels
+        )
+        output.index_add_(0, target, messages)
+        return output
+
+
+class CopresheafUpdate(nn.Module):
+    r"""Apply the CTNN update function :math:`\beta(h_x,m_x)`.
+
+    Parameters
+    ----------
+    channels : int
+        Dimension of the cell features.
+    update_type : str
+        ``"residual"`` for a gated residual update, or ``"mlp"`` for an
+        MLP over the concatenated feature and message.
+    dropout : float
+        Dropout applied inside the update MLP.
+    trainable_epsilon : bool
+        If ``True``, the residual mixing coefficient ``epsilon`` is a
+        learned parameter; otherwise it is a fixed buffer at zero.
+    message_gate_init : float, optional
+        Initial value for a learned scalar gate applied to the message
+        term, passed through ``sigmoid``. By default, no gate is used
+        and the message term has weight 1.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        update_type: str = "residual",
+        dropout: float = 0.0,
+        trainable_epsilon: bool = True,
+        message_gate_init: float | None = None,
+    ) -> None:
+        super().__init__()
+        if update_type not in {"residual", "mlp"}:
+            raise ValueError("update_type must be 'residual' or 'mlp'")
+        self.update_type = update_type
+        epsilon = torch.zeros(1)
+        if trainable_epsilon:
+            self.epsilon = nn.Parameter(epsilon)
+        else:
+            self.register_buffer("epsilon", epsilon)
+        if message_gate_init is None:
+            self.register_parameter("message_gate", None)
+        else:
+            self.message_gate = nn.Parameter(
+                torch.tensor(float(message_gate_init))
+            )
+        if update_type == "residual":
+            self.update = nn.Sequential(
+                nn.Linear(channels, channels), nn.Dropout(dropout)
+            )
+        else:
+            self.update = nn.Sequential(
+                nn.Linear(2 * channels, channels),
+                nn.ReLU(),
+                nn.Dropout(dropout),
+                nn.Linear(channels, channels),
+            )
+        self.norm = nn.LayerNorm(channels)
+
+    def forward(self, features: torch.Tensor, message: torch.Tensor):
+        """Combine the current stalk feature with its aggregate message.
+
+        Parameters
+        ----------
+        features : torch.Tensor
+            ``[num_cells, channels]`` current stalk features.
+        message : torch.Tensor
+            ``[num_cells, channels]`` aggregated incoming message.
+
+        Returns
+        -------
+        torch.Tensor
+            ``[num_cells, channels]`` updated and layer-normalized
+            features.
+        """
+        gate = (
+            1.0
+            if self.message_gate is None
+            else torch.sigmoid(self.message_gate)
+        )
+        if self.update_type == "residual":
+            update = (1.0 + self.epsilon) * features
+            update = update + gate * self.update(message)
+        else:
+            update = features + gate * self.update(
+                torch.cat((features, message), -1)
+            )
+        return self.norm(update)
+
+
+class HigherOrderCopresheafLayer(nn.Module):
+    r"""Apply Definition 10 over several rank-aware neighborhoods.
+
+    Each neighborhood owns a transport/message module. Messages that
+    arrive at the same target rank are combined by
+    ``neighborhood_aggr`` and passed to one rank-specific update
+    function. ``"sum"`` and ``"mean"`` are permutation-invariant;
+    ``"gated"`` instead weights each route with a softmax over a
+    learned per-route logit, computed separately for the routes that
+    feed each target rank, so unlike sum or mean the weighting is not
+    symmetric across routes.
+
+    Parameters
+    ----------
+    channels : int
+        Dimension of the cell features at every rank.
+    neighborhoods : Sequence of str
+        TopoBench neighborhood names, one per directed route.
+    heads : int
+        Number of independent stalk bundles.
+    stalk_dimension : int, optional
+        Dimension of one stalk. By default, ``channels // heads``.
+    map_type : str or Mapping of str to str
+        Transport map name used by every route, or a mapping from
+        neighborhood name to map name.
+    aggr : str
+        Per-edge normalization forwarded to each
+        ``CopresheafMessagePassing``: ``"sum"``, ``"mean"``, or
+        ``"symmetric"``.
+    neighborhood_aggr : str
+        How messages from different routes are combined at a shared
+        target rank: ``"sum"``, ``"mean"``, or ``"gated"``.
+    message_type : str
+        Message function forwarded to each route: ``"identity"`` or
+        ``"mlp"``.
+    update_type : str
+        Update function forwarded to each rank: ``"residual"`` or
+        ``"mlp"``.
+    dropout : float
+        Dropout forwarded to the transport maps, message functions,
+        and update functions.
+    map_kwargs : Mapping, optional
+        Extra constructor arguments forwarded to every transport map.
+    message_gate_init : float, optional
+        Initial value for each rank's learned message gate. By
+        default, no gate is used.
+    route_self_bias : float
+        Initial ``route_logits`` value for self-routes (routes whose
+        source and target rank match), used only when
+        ``neighborhood_aggr`` is ``"gated"``.
+    message_schedule : Sequence of str, optional
+        Ordered neighborhood names for sequential, rather than
+        simultaneous, route updates. By default, all routes update
+        simultaneously.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        neighborhoods: Sequence[str],
+        heads: int = 1,
+        stalk_dimension: int | None = None,
+        map_type: str | Mapping[str, str] = "diagonal",
+        aggr: str = "sum",
+        neighborhood_aggr: str = "sum",
+        message_type: str = "identity",
+        update_type: str = "residual",
+        dropout: float = 0.0,
+        map_kwargs: Mapping | None = None,
+        message_gate_init: float | None = None,
+        route_self_bias: float = 1.0,
+        message_schedule: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__()
+        if not neighborhoods:
+            raise ValueError("at least one neighborhood is required")
+        if neighborhood_aggr not in {"sum", "mean", "gated"}:
+            raise ValueError(
+                "neighborhood_aggr must be 'sum', 'mean', or 'gated'"
+            )
+
+        self.routes = [
+            CopresheafRoute.from_neighborhood(name) for name in neighborhoods
+        ]
+        if len({route.neighborhood for route in self.routes}) != len(
+            self.routes
+        ):
+            raise ValueError("neighborhood names must be unique")
+        self.neighborhood_aggr = neighborhood_aggr
+        self.message_schedule = (
+            tuple(message_schedule) if message_schedule is not None else None
+        )
+        route_lookup = {
+            route.neighborhood: index
+            for index, route in enumerate(self.routes)
+        }
+        if self.message_schedule is not None:
+            unknown = sorted(set(self.message_schedule) - set(route_lookup))
+            if unknown:
+                raise ValueError(
+                    "message_schedule contains unknown neighborhoods: "
+                    f"{unknown}"
+                )
+        self._route_lookup = route_lookup
+        initial_route_logits = torch.zeros(len(self.routes))
+        for index, route in enumerate(self.routes):
+            if route.source_rank == route.target_rank:
+                initial_route_logits[index] = route_self_bias
+        if neighborhood_aggr == "gated":
+            self.route_logits = nn.Parameter(initial_route_logits)
+        else:
+            self.register_buffer(
+                "route_logits", initial_route_logits, persistent=False
+            )
+        self.message_passing = nn.ModuleList()
+        for route in self.routes:
+            route_map_type = (
+                map_type[route.neighborhood]
+                if isinstance(map_type, Mapping)
+                else map_type
+            )
+            self.message_passing.append(
+                CopresheafMessagePassing(
+                    channels=channels,
+                    heads=heads,
+                    stalk_dimension=stalk_dimension,
+                    map_type=route_map_type,
+                    aggr=aggr,
+                    message_type=message_type,
+                    dropout=dropout,
+                    map_kwargs=map_kwargs,
+                )
+            )
+
+        ranks = sorted(
+            {route.source_rank for route in self.routes}
+            | {route.target_rank for route in self.routes}
+        )
+        self.updates = nn.ModuleDict(
+            {
+                str(rank): CopresheafUpdate(
+                    channels,
+                    update_type=update_type,
+                    dropout=dropout,
+                    message_gate_init=message_gate_init,
+                )
+                for rank in ranks
+            }
+        )
+
+    def forward(
+        self,
+        features: Mapping[int, torch.Tensor],
+        connectivities: Mapping[str, torch.Tensor],
+    ) -> dict[int, torch.Tensor]:
+        """Update every represented cell rank simultaneously.
+
+        Parameters
+        ----------
+        features : Mapping of int to torch.Tensor
+            Cell features keyed by rank.
+        connectivities : Mapping of str to torch.Tensor
+            Neighborhood matrices keyed by TopoBench neighborhood
+            name, one per entry of ``neighborhoods``.
+
+        Returns
+        -------
+        dict of int to torch.Tensor
+            Updated cell features keyed by rank.
+        """
+        if self.message_schedule is not None:
+            return self._forward_scheduled(features, connectivities)
+
+        messages = defaultdict(list)
+        for route_index, (route, passing) in enumerate(
+            zip(self.routes, self.message_passing, strict=True)
+        ):
+            if route.neighborhood not in connectivities:
+                raise KeyError(f"missing connectivity {route.neighborhood!r}")
+            try:
+                source_features = features[route.source_rank]
+                target_features = features[route.target_rank]
+            except KeyError as error:
+                raise KeyError(
+                    f"missing features for rank {error.args[0]}"
+                ) from error
+
+            edge_index, edge_weight = route.edge_index(
+                connectivities[route.neighborhood]
+            )
+            messages[route.target_rank].append(
+                (
+                    route_index,
+                    passing(
+                        source_features,
+                        target_features,
+                        edge_index,
+                        edge_weight,
+                    ),
+                )
+            )
+
+        output = {}
+        for rank, rank_features in features.items():
+            if messages[rank]:
+                route_indices, rank_messages = zip(
+                    *messages[rank], strict=True
+                )
+                stacked = torch.stack(rank_messages, dim=0)
+                if self.neighborhood_aggr == "gated":
+                    weights = torch.softmax(
+                        self.route_logits[list(route_indices)], dim=0
+                    )
+                    message = torch.einsum("r,rnc->nc", weights, stacked)
+                else:
+                    message = stacked.sum(dim=0)
+                    if self.neighborhood_aggr == "mean":
+                        message = message / len(rank_messages)
+            else:
+                message = torch.zeros_like(rank_features)
+            output[rank] = self.updates[str(rank)](rank_features, message)
+        return output
+
+    def _forward_scheduled(
+        self,
+        features: Mapping[int, torch.Tensor],
+        connectivities: Mapping[str, torch.Tensor],
+    ) -> dict[int, torch.Tensor]:
+        """Apply one directed neighborhood update at a time.
+
+        The default copresheaf layer aggregates all incoming neighborhoods for
+        a target rank before applying one simultaneous update.  A schedule
+        instead gives an explicit sequence of directed maps, for example
+        ``0->1, 1->2, 2->1, 1->0``.  Later steps see features already updated
+        by earlier steps, making ``num_layers`` the number of repeated
+        schedule sweeps.
+
+        Parameters
+        ----------
+        features : Mapping of int to torch.Tensor
+            Cell features keyed by rank.
+        connectivities : Mapping of str to torch.Tensor
+            Neighborhood matrices keyed by TopoBench neighborhood
+            name, one per entry of ``message_schedule``.
+
+        Returns
+        -------
+        dict of int to torch.Tensor
+            Updated cell features keyed by rank.
+        """
+        output = dict(features)
+        for neighborhood in self.message_schedule or ():
+            route_index = self._route_lookup[neighborhood]
+            route = self.routes[route_index]
+            passing = self.message_passing[route_index]
+            if route.neighborhood not in connectivities:
+                raise KeyError(f"missing connectivity {route.neighborhood!r}")
+            try:
+                source_features = output[route.source_rank]
+                target_features = output[route.target_rank]
+            except KeyError as error:
+                raise KeyError(
+                    f"missing features for rank {error.args[0]}"
+                ) from error
+
+            edge_index, edge_weight = route.edge_index(
+                connectivities[route.neighborhood]
+            )
+            message = passing(
+                source_features,
+                target_features,
+                edge_index,
+                edge_weight,
+            )
+            output[route.target_rank] = self.updates[str(route.target_rank)](
+                target_features, message
+            )
+        return output
+
+    def route_weights(self) -> dict[str, float]:
+        """Return current per-target normalized route weights for logging.
+
+        Returns
+        -------
+        dict of str to float
+            Softmax-normalized ``route_logits`` weight for every
+            neighborhood, or an empty dict when ``neighborhood_aggr``
+            is not ``"gated"`` or a ``message_schedule`` is set.
+        """
+        if (
+            self.message_schedule is not None
+            or self.neighborhood_aggr != "gated"
+        ):
+            return {}
+        weights = {}
+        target_ranks = sorted({route.target_rank for route in self.routes})
+        for rank in target_ranks:
+            indices = [
+                index
+                for index, route in enumerate(self.routes)
+                if route.target_rank == rank
+            ]
+            normalized = torch.softmax(self.route_logits[indices], dim=0)
+            for index, weight in zip(indices, normalized, strict=True):
+                weights[self.routes[index].neighborhood] = float(
+                    weight.detach().cpu()
+                )
+        return weights

--- a/topobench/nn/layers/copresheaf/routes.py
+++ b/topobench/nn/layers/copresheaf/routes.py
@@ -1,0 +1,70 @@
+"""Rank-aware neighborhood routes for copresheaf message passing."""
+
+from dataclasses import dataclass
+
+import torch
+
+from topobench.data.utils import get_routes_from_neighborhoods
+
+
+@dataclass(frozen=True)
+class CopresheafRoute:
+    """A directed message route induced by one neighborhood function."""
+
+    neighborhood: str
+    source_rank: int
+    target_rank: int
+
+    @classmethod
+    def from_neighborhood(cls, neighborhood: str) -> "CopresheafRoute":
+        """Parse a TopoBench neighborhood name into its directed ranks.
+
+        Parameters
+        ----------
+        neighborhood : str
+            TopoBench neighborhood name, for example ``up_incidence-0``.
+
+        Returns
+        -------
+        CopresheafRoute
+            The route induced by the named neighborhood.
+        """
+        try:
+            source_rank, target_rank = get_routes_from_neighborhoods(
+                [neighborhood]
+            )[0]
+        except (IndexError, TypeError, ValueError) as error:
+            raise ValueError(
+                f"invalid TopoBench neighborhood name: {neighborhood!r}"
+            ) from error
+        return cls(neighborhood, source_rank, target_rank)
+
+    def edge_index(
+        self, connectivity: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Convert a sparse connectivity matrix to ``source -> target`` edges.
+
+        TopoBench's selected neighborhood matrices consistently store target
+        cells on rows and source cells on columns. The returned PyG-style
+        index therefore reverses the matrix indices.
+
+        Parameters
+        ----------
+        connectivity : torch.Tensor
+            Sparse or dense neighborhood matrix with target cells on rows
+            and source cells on columns.
+
+        Returns
+        -------
+        tuple of torch.Tensor
+            A ``[2, num_edges]`` PyG-style ``(source, target)`` edge index
+            and the corresponding edge weights.
+        """
+        if not connectivity.is_sparse:
+            connectivity = connectivity.to_sparse()
+        connectivity = connectivity.coalesce()
+        row, column = connectivity.indices()
+
+        source, target = column, row
+        edge_index = torch.stack((source, target), dim=0)
+        return edge_index, connectivity.values().abs()

--- a/topobench/nn/readouts/all_rank.py
+++ b/topobench/nn/readouts/all_rank.py
@@ -1,0 +1,145 @@
+"""Task-agnostic readout that exposes all cell ranks to graph tasks."""
+
+from __future__ import annotations
+
+import torch
+from torch_geometric.utils import scatter
+
+from topobench.nn.readouts.propagate_signal_down import PropagateSignalDown
+
+
+class AllRankReadout(PropagateSignalDown):
+    r"""Readout for shared node-level and graph-level higher-order models.
+
+    Node-level tasks use the standard top-down propagation path and predict
+    from rank-0 features. Graph-level tasks first run the same propagation, then
+    pool every available rank separately and predict from the concatenated graph
+    representation. This keeps one readout class across tasks while avoiding a
+    graph-level bottleneck where all higher-order signal must be compressed into
+    nodes before pooling.
+
+    Parameters
+    ----------
+    graph_hidden_dim : int, optional
+        Hidden dimension of the graph-level MLP. Defaults to the
+        propagation hidden dimension when not given.
+    graph_dropout : float, optional
+        Dropout applied inside the graph-level MLP (default: 0.0).
+    **kwargs : dict
+        Additional keyword arguments forwarded to
+        ``PropagateSignalDown``, from which this class also reads
+        ``num_cell_dimensions`` and ``out_channels``.
+    """
+
+    def __init__(
+        self,
+        graph_hidden_dim: int | None = None,
+        graph_dropout: float = 0.0,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.num_cell_dimensions = kwargs["num_cell_dimensions"]
+        self.graph_hidden_dim = graph_hidden_dim or self.hidden_dim
+        self.graph_dropout = graph_dropout
+
+        if self.task_level == "graph":
+            self.graph_mlp = torch.nn.Sequential(
+                torch.nn.Linear(
+                    self.hidden_dim * self.num_cell_dimensions,
+                    self.graph_hidden_dim,
+                ),
+                torch.nn.ReLU(),
+                torch.nn.Dropout(self.graph_dropout),
+                torch.nn.Linear(self.graph_hidden_dim, kwargs["out_channels"]),
+            )
+
+    def __call__(self, model_out: dict, batch) -> dict:
+        """Run propagation and compute logits for the configured task level.
+
+        Parameters
+        ----------
+        model_out : dict
+            Dictionary containing the model output.
+        batch : torch_geometric.data.Data
+            Batch object containing the batched domain data.
+
+        Returns
+        -------
+        dict
+            Updated ``model_out``, with ``logits`` set and, for
+            graph-level tasks, ``graph_features`` and
+            ``readout_rank_pool_norms`` added.
+        """
+        model_out = self.forward(model_out, batch)
+        if self.task_level != "graph":
+            self.last_rank_pool_norms = None
+            if model_out.get("logits", None) is None:
+                model_out["logits"] = self.compute_logits(
+                    model_out["x_0"], batch["batch_0"]
+                )
+            return model_out
+
+        rank_pools = []
+        rank_pool_norms = {}
+        num_graphs = self._num_graphs(batch)
+        for rank in range(self.num_cell_dimensions):
+            features = model_out.get(f"x_{rank}")
+            batch_index = batch.get(f"batch_{rank}", None)
+            if features is None or batch_index is None:
+                continue
+            pooled = scatter(
+                features,
+                batch_index,
+                dim=0,
+                dim_size=num_graphs,
+                reduce=self.pooling_type,
+            )
+            rank_pools.append(pooled)
+            rank_pool_norms[str(rank)] = float(
+                pooled.detach().norm(dim=-1).mean().cpu()
+            )
+
+        if len(rank_pools) != self.num_cell_dimensions:
+            available = ", ".join(sorted(model_out))
+            msg = (
+                "AllRankReadout expected features and batch indices for "
+                f"{self.num_cell_dimensions} ranks; found {len(rank_pools)}. "
+                f"Available model_out keys: {available}"
+            )
+            raise ValueError(msg)
+
+        graph_features = torch.cat(rank_pools, dim=-1)
+        self.last_rank_pool_norms = rank_pool_norms
+        model_out["graph_features"] = graph_features
+        model_out["readout_rank_pool_norms"] = rank_pool_norms
+        model_out["logits"] = self.graph_mlp(graph_features)
+        return model_out
+
+    @staticmethod
+    def _num_graphs(batch) -> int:
+        """Infer batch size from rank-0 membership.
+
+        Higher ranks may be absent for some graphs, for example when an
+        explicit triangle lift sees a triangle-free graph. Rank 0 is the
+        stable source of graph membership for graph-level readout pooling.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batch object containing the batched domain data.
+
+        Returns
+        -------
+        int
+            Number of graphs represented in the batch.
+        """
+        batch_0 = batch.get("batch_0", None)
+        if batch_0 is not None and batch_0.numel():
+            return int(batch_0.max().item()) + 1
+        num_graphs = getattr(batch, "num_graphs", None)
+        if isinstance(num_graphs, int) and num_graphs > 0:
+            return num_graphs
+        labels = batch.get("y", None)
+        if labels is not None and labels.ndim > 0:
+            return int(labels.size(0))
+        return 1

--- a/topobench/nn/wrappers/combinatorial/copresheaf_cc_wrapper.py
+++ b/topobench/nn/wrappers/combinatorial/copresheaf_cc_wrapper.py
@@ -1,0 +1,36 @@
+"""TopoBench wrapper for the combinatorial copresheaf backbone."""
+
+from topobench.nn.wrappers.base import AbstractWrapper
+
+
+class CopresheafCCWrapper(AbstractWrapper):
+    """Extract rank features and neighborhoods from a TopoBench batch."""
+
+    def forward(self, batch):
+        """Run higher-order copresheaf message passing on ``batch``.
+
+        Parameters
+        ----------
+        batch : torch_geometric.data.Data
+            Batched combinatorial-complex data with per-rank features
+            ``x_{rank}``, per-rank batch indices ``batch_{rank}``, and one
+            connectivity tensor per configured neighborhood.
+
+        Returns
+        -------
+        dict
+            Per-rank output features, per-rank batch indices, and labels,
+            following the TopoBench wrapper contract.
+        """
+        features = {rank: batch[f"x_{rank}"] for rank in self.backbone.ranks}
+        connectivities = {
+            name: batch[name] for name in self.backbone.neighborhoods
+        }
+        output = self.backbone(features, connectivities)
+
+        model_out = {f"x_{rank}": value for rank, value in output.items()}
+        model_out.update(
+            {f"batch_{rank}": batch[f"batch_{rank}"] for rank in output}
+        )
+        model_out["labels"] = batch.y
+        return model_out

--- a/topobench/transforms/liftings/graph2combinatorial/triangle_clique_cc.py
+++ b/topobench/transforms/liftings/graph2combinatorial/triangle_clique_cc.py
@@ -1,0 +1,228 @@
+"""Triangle-clique lifting of graphs to combinatorial complexes."""
+
+import networkx as nx
+import torch
+import torch_geometric
+from toponetx.classes import CombinatorialComplex
+
+from topobench.data.utils import (
+    get_combinatorial_complex_connectivity,
+    select_neighborhoods_of_interest,
+)
+from topobench.transforms.liftings.graph2combinatorial.base import (
+    Graph2CombinatorialLifting,
+)
+
+
+class GraphTriangleCliqueCCLifting(Graph2CombinatorialLifting):
+    r"""Lift graph triangles as explicit rank-2 combinatorial cells.
+
+    Rank 0 is the input nodes, rank 1 is the input graph edges, and rank 2
+    contains one cell for every graph triangle. The lift gives the submitted
+    copresheaf model a deterministic topological domain while keeping the
+    preprocessing small and easy to audit.
+    """
+
+    def lift_topology(
+        self, data: torch_geometric.data.Data
+    ) -> torch_geometric.data.Data | dict:
+        """Lift one graph into a triangle combinatorial complex.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            The input graph data, expected to carry undirected edges
+            and node features ``data.x``.
+
+        Returns
+        -------
+        dict
+            The lifted topology: rank-0/1/2 connectivity, node features,
+            and structural features.
+        """
+        graph = self._generate_graph_from_data(data)
+        if graph.is_directed():
+            raise ValueError(
+                "GraphTriangleCliqueCCLifting expects undirected graphs"
+            )
+
+        combinatorial_complex = CombinatorialComplex(graph)
+        for triangle in self._triangles(graph):
+            combinatorial_complex.add_cell(triangle, rank=2)
+
+        lifted_topology = self._connectivity(combinatorial_complex)
+        lifted_topology["x_0"] = data.x
+        lifted_topology.update(
+            self._structural_features(
+                lifted_topology,
+                dtype=data.x.dtype,
+                device=data.x.device,
+            )
+        )
+        return lifted_topology
+
+    @staticmethod
+    def _triangles(graph: nx.Graph) -> list[tuple[int, int, int]]:
+        """Return sorted node triples that form graph triangles.
+
+        Parameters
+        ----------
+        graph : nx.Graph
+            The input undirected graph.
+
+        Returns
+        -------
+        list of tuple of int
+            Sorted node triples, one per triangle (3-clique) found
+            in ``graph``.
+        """
+        triangles = set()
+        for clique in nx.enumerate_all_cliques(graph):
+            if len(clique) < 3:
+                continue
+            if len(clique) > 3:
+                break
+            triangles.add(tuple(sorted(clique)))
+        return sorted(triangles)
+
+    def _connectivity(self, combinatorial_complex) -> dict[str, torch.Tensor]:
+        """Return the raw rank-0/1/2 connectivity of a complex.
+
+        Parameters
+        ----------
+        combinatorial_complex : CombinatorialComplex
+            The complex whose connectivity tensors are computed.
+
+        Returns
+        -------
+        dict
+            Connectivity tensors (incidence, adjacency, and
+            Laplacian matrices) for ranks ``0`` through
+            ``self.complex_dim``.
+        """
+        connectivity = get_combinatorial_complex_connectivity(
+            combinatorial_complex,
+            self.complex_dim,
+            neighborhoods=None,
+        )
+        if self.neighborhoods is not None:
+            connectivity.update(
+                select_neighborhoods_of_interest(
+                    connectivity, self.neighborhoods
+                )
+            )
+        return connectivity
+
+    def _structural_features(
+        self,
+        connectivity: dict[str, torch.Tensor],
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> dict[str, torch.Tensor]:
+        """Compute scale-stable size/degree features per complex rank.
+
+        Parameters
+        ----------
+        connectivity : dict
+            Rank connectivity tensors, including ``"shape"`` and,
+            for each rank, ``"incidence_{rank}"`` and
+            ``"adjacency_{rank}"``.
+        dtype : torch.dtype
+            Dtype used for the returned feature tensors.
+        device : torch.device
+            Device used for the returned feature tensors.
+
+        Returns
+        -------
+        dict
+            A ``"structure_{rank}"`` tensor for every rank from
+            ``0`` to ``self.complex_dim``, each stacking log1p-
+            scaled cell size, lower degree, same-rank degree, and
+            upper degree.
+        """
+        shape = list(connectivity["shape"])
+        output = {}
+        node_membership = None
+        for rank in range(self.complex_dim + 1):
+            num_cells = int(shape[rank]) if rank < len(shape) else 0
+            if rank == 0:
+                cell_size = torch.ones(num_cells, dtype=dtype, device=device)
+                lower_degree = torch.zeros(
+                    num_cells, dtype=dtype, device=device
+                )
+                node_membership = torch.eye(
+                    num_cells, dtype=dtype, device=device
+                )
+            else:
+                incidence = (
+                    connectivity[f"incidence_{rank}"].coalesce().to(device)
+                )
+                lower_degree = self._fit_length(
+                    torch.sparse.sum(incidence, dim=0).to_dense().to(dtype),
+                    num_cells,
+                )
+                if node_membership is None:
+                    node_membership = torch.zeros(
+                        shape[0], num_cells, dtype=dtype, device=device
+                    )
+                else:
+                    node_membership = (
+                        node_membership @ incidence.to_dense().abs().to(dtype)
+                    ).clamp_max(1)
+                cell_size = node_membership.sum(0)
+
+            adjacency = connectivity[f"adjacency_{rank}"].coalesce().to(device)
+            same_degree = self._fit_length(
+                torch.sparse.sum(adjacency, dim=1).to_dense().to(dtype),
+                num_cells,
+            )
+            if rank < self.complex_dim:
+                upper_incidence = (
+                    connectivity[f"incidence_{rank + 1}"].coalesce().to(device)
+                )
+                upper_degree = self._fit_length(
+                    torch.sparse.sum(upper_incidence, dim=1)
+                    .to_dense()
+                    .to(dtype),
+                    num_cells,
+                )
+            else:
+                upper_degree = torch.zeros(
+                    num_cells, dtype=dtype, device=device
+                )
+
+            output[f"structure_{rank}"] = torch.stack(
+                (
+                    torch.log1p(cell_size),
+                    torch.log1p(lower_degree),
+                    torch.log1p(same_degree),
+                    torch.log1p(upper_degree),
+                ),
+                dim=-1,
+            )
+        return output
+
+    @staticmethod
+    def _fit_length(values: torch.Tensor, length: int) -> torch.Tensor:
+        """Trim TopoNetX placeholder degrees or pad missing degrees.
+
+        Parameters
+        ----------
+        values : torch.Tensor
+            A 1-D tensor of degree values to resize.
+        length : int
+            Target number of entries.
+
+        Returns
+        -------
+        torch.Tensor
+            ``values`` trimmed to ``length`` entries, or right-
+            padded with zeros if it has fewer than ``length``
+            entries.
+        """
+        if values.numel() == length:
+            return values
+        if values.numel() > length:
+            return values[:length]
+        return torch.cat((values, values.new_zeros(length - values.numel())))


### PR DESCRIPTION
## Title

Add copresheaf TNN with triangle-clique lifting for GraphUniverse
Co-authored with @bastianlb.

## Summary

This PR adds a copresheaf-based model stack for the 2026 TDL Challenge, using an explicit triangle-clique graph-to-combinatorial lifting as the submission path.

The model is based on [Copresheaf Topological Neural Networks: A Generalized Deep Learning Framework](https://papers.neurips.cc/paper_files/paper/2025/hash/dc62cd4ec77f3bbec8e6245d0bd91d08-Abstract-Conference.html) by Hajij et al. [1]. From that work, we use the core copresheaf message-passing idea: cells carry stalk features, directed neighborhood routes learn transport maps between source and target stalks, transported messages are aggregated per target rank, and rank-specific update maps produce the next hidden representation.

In this implementation, the input graph is lifted into a rank-2 combinatorial complex: nodes are rank 0 cells, graph edges are rank 1 cells, and each graph triangle is represented as an explicit rank 2 cell. The copresheaf backbone then propagates information across the induced combinatorial neighborhoods. For graph-level tasks, the readout pools across all available ranks; for node-level tasks, it uses the propagated rank-0 features.

Main additions:

- add graph and combinatorial copresheaf backbones with learned route maps, message gates, and configurable neighborhood aggregation
- add `GraphTriangleCliqueCCLifting` for explicit rank-2 triangle cells
- add structural feature encoding for lifted cells
- add `AllRankReadout` for graph-level pooling across available ranks
- add Hydra configs for triangle-clique copresheaf experiments
- add resumable GraphUniverse experiment/export tooling and local experiment log handling
- add focused unit tests for the new lifting, layers, encoders, readout, wrappers, and pipeline coverage

## Testing

- Added tests under `test/nn/...` for copresheaf layers, backbones, encoders, wrappers, and readout behavior
- Added tests for `GraphTriangleCliqueCCLifting`
- Added `combinatorial/copresheaf_cc` to the pipeline smoke coverage

[1] M. Hajij et al., “Copresheaf Topological Neural Networks: A Generalized Deep Learning Framework,” Oct. 26, 2025